### PR TITLE
Fix virtual import resolution edge cases

### DIFF
--- a/api/src/core/module_cache_sync.py
+++ b/api/src/core/module_cache_sync.py
@@ -99,6 +99,11 @@ def _candidate_storage_paths(path: str) -> list[str]:
     return [rooted]
 
 
+def candidate_module_paths(path: str) -> list[str]:
+    """Storage paths that may contain a concrete module file."""
+    return _candidate_storage_paths(path)
+
+
 def candidate_index_prefixes(base_path: str) -> list[str]:
     """Storage-path prefixes to scan the module index with, for namespace-package
     (PEP 420) detection of ``base_path`` (e.g. "modules").

--- a/api/src/services/execution/virtual_import.py
+++ b/api/src/services/execution/virtual_import.py
@@ -32,6 +32,7 @@ from typing import Any
 
 from src.core.module_cache_sync import (
     candidate_index_prefixes,
+    candidate_module_paths,
     get_module_index_sync,
     get_module_sync,
     solution_has_submodules,
@@ -258,12 +259,12 @@ class VirtualModuleFinder(MetaPathFinder):
     """
     Meta path finder that loads workspace modules from Redis cache.
 
-    Converts Python module names to file paths and fetches directly
-    from Redis. Each import attempt does a Redis GET for the module path.
+    Converts Python module names to file paths, confirms they are workspace
+    modules via the module index, then fetches the source from Redis/API/S3.
 
     Key design points:
-    - No hardcoded prefix required - works with any module name
-    - Direct Redis fetch - newly-added modules are immediately available
+    - Module index is the source of truth for workspace module ownership
+    - Non-workspace third-party imports fall through to normal import handling
     - Supports both modules (.py) and packages (__init__.py)
     """
 
@@ -319,16 +320,17 @@ class VirtualModuleFinder(MetaPathFinder):
 
         Separated from find_spec to keep the recursion guard clean.
 
-        We fetch directly from Redis without checking an index first.
-        This ensures newly-added modules are immediately available
-        without needing to refresh a cached index.
+        The module index determines whether a name belongs to workspace code
+        before we attempt any module fetch. This avoids probing third-party
+        dependency imports through Redis/API/S3 during import resolution.
         """
-        # Convert module name to potential file paths
         possible_paths = self._module_name_to_paths(fullname)
+        module_index = get_module_index_sync()
 
         for file_path, is_package in possible_paths:
-            # Fetch directly from Redis - no index check needed
-            # This ensures newly-added modules are immediately available
+            if not self._module_path_is_indexed(file_path, module_index):
+                continue
+
             cached = get_module_sync(file_path)
             if not cached:
                 continue
@@ -354,7 +356,6 @@ class VirtualModuleFinder(MetaPathFinder):
         # When a Solution is active these are _solutions/{id}/-rooted (with the
         # bare prefix only if global_repo_access is on), so a solution's
         # namespace packages are detected without colliding with _repo/.
-        module_index = get_module_index_sync()
         prefixes = candidate_index_prefixes(base_path)
         has_submodules = any(
             entry.startswith(p) for entry in module_index for p in prefixes
@@ -380,6 +381,10 @@ class VirtualModuleFinder(MetaPathFinder):
 
         # Not in our cache - let filesystem finder handle it
         return None
+
+    def _module_path_is_indexed(self, file_path: str, module_index: set[str]) -> bool:
+        """Return True when the module index says this concrete file is workspace code."""
+        return any(path in module_index for path in candidate_module_paths(file_path))
 
     def _module_name_to_paths(self, fullname: str) -> list[tuple[str, bool]]:
         """
@@ -410,7 +415,7 @@ class VirtualModuleFinder(MetaPathFinder):
         ]
 
     def invalidate_index(self) -> None:
-        """No-op for API compatibility. Index is no longer used."""
+        """No-op for API compatibility. Index reads are delegated to module_cache_sync."""
         pass
 
 
@@ -444,10 +449,10 @@ def install_virtual_import_hook() -> VirtualModuleFinder:
     # might try to fetch from Redis before Redis can even connect.
     _preload_required_modules()
 
-    # Create finder and install the hook
-    # No index pre-loading needed - we fetch modules directly from Redis
+    # Create finder and install the hook before filesystem resolution so
+    # workspace packages cannot be shadowed by platform modules on sys.path.
     _finder = VirtualModuleFinder()
-    sys.meta_path.append(_finder)
+    sys.meta_path.insert(0, _finder)
 
     logger.info("Virtual import hook installed")
     return _finder

--- a/api/tests/unit/services/test_virtual_import.py
+++ b/api/tests/unit/services/test_virtual_import.py
@@ -3,15 +3,16 @@ Unit tests for the virtual import hook.
 
 Tests the MetaPathFinder implementation that loads modules from Redis cache.
 
-The implementation uses a direct-fetch approach:
-- Each import attempt calls get_module_sync() to fetch from Redis
-- No index caching - modules are fetched directly by path
-- Thread-local recursion guard prevents infinite loops during Redis calls
+The implementation uses the module index to identify workspace-owned imports:
+- Third-party imports not in the index fall through to normal import handling
+- Workspace imports call get_module_sync() only after index membership is known
+- Thread-local recursion guard prevents infinite loops during Redis/API/S3 calls
 """
 
+import importlib
 import sys
 from types import ModuleType
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -94,9 +95,15 @@ class TestVirtualModuleFinder:
                 return {"content": "x = 1", "path": "shared/halopsa.py", "hash": "abc"}
             return None
 
-        with patch(
-            "src.services.execution.virtual_import.get_module_sync",
-            side_effect=mock_get_module,
+        with (
+            patch(
+                "src.services.execution.virtual_import.get_module_index_sync",
+                return_value={"shared/halopsa.py"},
+            ),
+            patch(
+                "src.services.execution.virtual_import.get_module_sync",
+                side_effect=mock_get_module,
+            ),
         ):
             spec = finder.find_spec("shared.halopsa")
 
@@ -115,9 +122,15 @@ class TestVirtualModuleFinder:
                 return {"content": "# package", "path": "shared/__init__.py", "hash": "abc"}
             return None
 
-        with patch(
-            "src.services.execution.virtual_import.get_module_sync",
-            side_effect=mock_get_module,
+        with (
+            patch(
+                "src.services.execution.virtual_import.get_module_index_sync",
+                return_value={"shared/__init__.py"},
+            ),
+            patch(
+                "src.services.execution.virtual_import.get_module_sync",
+                side_effect=mock_get_module,
+            ),
         ):
             spec = finder.find_spec("shared")
 
@@ -137,9 +150,15 @@ class TestVirtualModuleFinder:
                 return {"content": "# package", "path": "shared/__init__.py", "hash": "def"}
             return None
 
-        with patch(
-            "src.services.execution.virtual_import.get_module_sync",
-            side_effect=mock_get_module,
+        with (
+            patch(
+                "src.services.execution.virtual_import.get_module_index_sync",
+                return_value={"shared.py", "shared/__init__.py"},
+            ),
+            patch(
+                "src.services.execution.virtual_import.get_module_sync",
+                side_effect=mock_get_module,
+            ),
         ):
             spec = finder.find_spec("shared")
 
@@ -222,7 +241,7 @@ class TestVirtualModuleFinder:
         """Test that __init__.py takes precedence over namespace package."""
         finder = VirtualModuleFinder()
 
-        module_index = {"modules/extensions/halopsa.py"}
+        module_index = {"modules/__init__.py", "modules/extensions/halopsa.py"}
 
         def mock_get_module(path: str):
             if path == "modules/__init__.py":
@@ -250,7 +269,7 @@ class TestVirtualModuleFinder:
         """Test that stdlib modules are not looked up in cache."""
         finder = VirtualModuleFinder()
 
-        mock_get_module = pytest.importorskip("unittest.mock").MagicMock(return_value=None)
+        mock_get_module = MagicMock(return_value=None)
         with patch(
             "src.services.execution.virtual_import.get_module_sync",
             mock_get_module,
@@ -263,6 +282,25 @@ class TestVirtualModuleFinder:
 
             # get_module_sync should not have been called
             mock_get_module.assert_not_called()
+
+    def test_find_spec_skips_non_workspace_third_party_modules(self):
+        """Third-party dependencies not in the module index should not hit cache lookup."""
+        finder = VirtualModuleFinder()
+        mock_get_module = MagicMock(return_value=None)
+
+        with (
+            patch(
+                "src.services.execution.virtual_import.get_module_index_sync",
+                return_value={"shared/halopsa.py"},
+            ),
+            patch(
+                "src.services.execution.virtual_import.get_module_sync",
+                mock_get_module,
+            ),
+        ):
+            assert finder.find_spec("httpcore") is None
+
+        mock_get_module.assert_not_called()
 
     def test_find_spec_recursion_guard(self):
         """Test that recursion guard prevents infinite loops."""
@@ -416,7 +454,7 @@ class TestInstallRemoveHook:
 
         assert isinstance(finder, VirtualModuleFinder)
         assert len(sys.meta_path) == initial_count + 1
-        assert sys.meta_path[-1] is finder
+        assert sys.meta_path[0] is finder
 
     def test_install_virtual_import_hook_idempotent(self):
         """Test that installing twice returns same finder."""
@@ -544,9 +582,15 @@ class TestIntegration:
                 }
             return None
 
-        with patch(
-            "src.services.execution.virtual_import.get_module_sync",
-            side_effect=mock_get_module,
+        with (
+            patch(
+                "src.services.execution.virtual_import.get_module_index_sync",
+                return_value={"virtual_test_module.py"},
+            ),
+            patch(
+                "src.services.execution.virtual_import.get_module_sync",
+                side_effect=mock_get_module,
+            ),
         ):
             import virtual_test_module  # type: ignore[import-not-found]
 
@@ -573,9 +617,18 @@ class TestIntegration:
             }
             return modules.get(path)
 
-        with patch(
-            "src.services.execution.virtual_import.get_module_sync",
-            side_effect=mock_get_module,
+        with (
+            patch(
+                "src.services.execution.virtual_import.get_module_index_sync",
+                return_value={
+                    "virtual_test_pkg/__init__.py",
+                    "virtual_test_pkg/submod.py",
+                },
+            ),
+            patch(
+                "src.services.execution.virtual_import.get_module_sync",
+                side_effect=mock_get_module,
+            ),
         ):
             import virtual_test_pkg  # type: ignore[import-not-found]
             from virtual_test_pkg import submod  # type: ignore[import-not-found]
@@ -638,3 +691,56 @@ class TestIntegration:
             assert virtual_test_ns.extensions.__file__ is None
             assert hasattr(virtual_test_ns, "__path__")
             assert hasattr(virtual_test_ns.extensions, "__path__")
+
+    def test_virtual_package_takes_precedence_over_filesystem_module(self, tmp_path):
+        """Workspace packages should not be shadowed by same-named platform modules."""
+        module_name = "virtual_collision_pkg"
+        filesystem_module = tmp_path / f"{module_name}.py"
+        filesystem_module.write_text("ORIGIN = 'filesystem'\n")
+        sys.path.insert(0, str(tmp_path))
+        install_virtual_import_hook()
+
+        module_index = {
+            f"{module_name}/__init__.py",
+            f"{module_name}/submodule.py",
+        }
+
+        def mock_get_module(path: str):
+            modules = {
+                f"{module_name}/__init__.py": {
+                    "content": "ORIGIN = 'virtual_package'",
+                    "path": f"{module_name}/__init__.py",
+                    "hash": "abc",
+                },
+                f"{module_name}/submodule.py": {
+                    "content": "VALUE = 'from_submodule'",
+                    "path": f"{module_name}/submodule.py",
+                    "hash": "def",
+                },
+            }
+            return modules.get(path)
+
+        try:
+            with (
+                patch(
+                    "src.services.execution.virtual_import.get_module_index_sync",
+                    return_value=module_index,
+                ),
+                patch(
+                    "src.services.execution.virtual_import.get_module_sync",
+                    side_effect=mock_get_module,
+                ),
+            ):
+                package = importlib.import_module(module_name)
+                submodule = importlib.import_module(f"{module_name}.submodule")
+
+                assert package.ORIGIN == "virtual_package"
+                assert submodule.VALUE == "from_submodule"
+                assert package.__file__ == f"{module_name}/__init__.py"
+        finally:
+            sys.path.remove(str(tmp_path))
+            for loaded in [
+                module_name,
+                f"{module_name}.submodule",
+            ]:
+                sys.modules.pop(loaded, None)


### PR DESCRIPTION
## Summary
- gate virtual module fetches on the module index so third-party imports fall through without Redis/API/S3 probes
- install the virtual import hook before filesystem finders so workspace packages cannot be shadowed by same-named modules on sys.path
- add regression coverage for non-workspace third-party imports and virtual-package precedence

## Issue linkage
Refs #418. This PR addresses only the two virtual-import edge cases described there:
- non-workspace third-party imports should not probe Bifrost module storage
- Bifrost workspace packages should not be shadowed by same-named filesystem modules

It intentionally does not close #418; the DB-backed platform data / trusted internal API discussion remains open.

## Verification
- ./test.sh tests/unit/services/test_virtual_import.py -q
- ./test.sh tests/unit/services/test_virtual_import.py tests/unit/test_virtual_import_s3_fallback.py tests/unit/test_solution_import_root.py tests/unit/test_solution_module_isolation.py -q
- ./test.sh tests/e2e/platform/test_virtual_import_integration.py -q
- ./test.sh quality api
- ./test.sh unit -q
- ./test.sh tests/e2e/api/test_builtin_events.py::TestBuiltInWorkflowEvents::test_workflow_failure_and_retry_exhausted_events_run_subscribers -q
- ./test.sh all

Note: an initial ./test.sh all attempt exposed a stale local test image with /entrypoint.sh permissions baked incorrectly; rebuilding the worktree test stack fixed the worker container, and the targeted failing e2e plus full backend suite then passed.