### PR TITLE
Fix coordinated auth refresh for Solution dev sessions

### DIFF
--- a/api/bifrost/client.py
+++ b/api/bifrost/client.py
@@ -184,8 +184,8 @@ async def _acquire_refresh_lock(lock: threading.Lock) -> None:
     except asyncio.CancelledError:
         # to_thread keeps running after cancellation. Wait until it owns the lock,
         # release it, then preserve cancellation for the request task.
-        await acquire_task
-        lock.release()
+        if await acquire_task:
+            lock.release()
         raise
 
 # Auto-load .env file if present (for local development).

--- a/api/bifrost/client.py
+++ b/api/bifrost/client.py
@@ -24,6 +24,7 @@ from .credentials import (
     clear_credentials,
     get_credentials,
     is_token_expired,
+    replace_env_credentials,
     resolve_current_connection,
     save_credentials,
 )
@@ -32,6 +33,22 @@ logger = logging.getLogger(__name__)
 
 # Global client injection for platform mode
 _injected_client: Optional["BifrostClient"] = None
+
+
+class BifrostAPIError(httpx.HTTPStatusError):
+    """An authenticated Bifrost API request returned a non-success status."""
+
+
+class BifrostAuthenticationError(BifrostAPIError):
+    """The active Bifrost session could not authenticate the request."""
+
+
+class BifrostAuthorizationError(BifrostAPIError):
+    """The active Bifrost identity may not perform the request."""
+
+
+class BifrostDependencyError(BifrostAPIError):
+    """A declared Bifrost dependency is unavailable."""
 
 # Retry config for transient 5xx — see workstream E of issue #171.
 # SDK is machine-to-machine, so the retry budget is more generous than
@@ -110,19 +127,66 @@ def raise_for_status_with_detail(response: httpx.Response) -> None:
         # Response wasn't JSON or didn't have dict-like .get — fall back to raise_for_status
         logger.debug(f"could not extract error detail from response body: {e}")
 
+    error_type: type[BifrostAPIError]
+    if response.status_code == 401:
+        error_type = BifrostAuthenticationError
+    elif response.status_code == 403:
+        error_type = BifrostAuthorizationError
+    elif response.status_code == 424:
+        error_type = BifrostDependencyError
+    else:
+        error_type = BifrostAPIError
+    message = f"{response.status_code} {response.reason_phrase}"
     if detail:
-        raise httpx.HTTPStatusError(
-            message=f"{response.status_code} {response.reason_phrase}: {detail}",
-            request=response.request,
-            response=response,
-        )
-
-    response.raise_for_status()
+        message += f": {detail}"
+    raise error_type(message=message, request=response.request, response=response)
 
 # Thread-local storage for per-thread singleton instances
 # This is needed because thread workers create new event loops via asyncio.run(),
 # and httpx.AsyncClient is bound to the event loop that created it.
 _thread_local = threading.local()
+
+
+class _ConnectionRefreshCoordinator:
+    """Loop-agnostic single-flight state for one normalized API URL."""
+
+    def __init__(self) -> None:
+        self.lock = threading.Lock()
+        self.latest_access_token: str | None = None
+        self.latest_refresh_token: str | None = None
+
+
+_refresh_coordinators: dict[str, _ConnectionRefreshCoordinator] = {}
+_refresh_coordinators_lock = threading.Lock()
+
+
+def _refresh_coordinator(api_url: str) -> _ConnectionRefreshCoordinator:
+    normalized = api_url.rstrip("/")
+    with _refresh_coordinators_lock:
+        coordinator = _refresh_coordinators.get(normalized)
+        if coordinator is None:
+            coordinator = _ConnectionRefreshCoordinator()
+            _refresh_coordinators[normalized] = coordinator
+        return coordinator
+
+
+def _reset_refresh_coordinators_for_tests() -> None:
+    """Clear process refresh state so credential tests remain isolated."""
+    with _refresh_coordinators_lock:
+        _refresh_coordinators.clear()
+
+
+async def _acquire_refresh_lock(lock: threading.Lock) -> None:
+    """Acquire a thread lock without leaking it when the waiter is cancelled."""
+    acquire_task = asyncio.create_task(asyncio.to_thread(lock.acquire))
+    try:
+        await asyncio.shield(acquire_task)
+    except asyncio.CancelledError:
+        # to_thread keeps running after cancellation. Wait until it owns the lock,
+        # release it, then preserve cancellation for the request task.
+        await acquire_task
+        lock.release()
+        raise
 
 # Auto-load .env file if present (for local development).
 # Walk upward from cwd, not from this file. With pipx-installed CLIs, __file__
@@ -136,7 +200,89 @@ except ImportError:
     pass  # dotenv not installed, rely on environment variables
 
 
-async def refresh_tokens() -> bool:
+async def refresh_connection_access_token(
+    api_url: str,
+    observed_access_token: str | None,
+) -> str | None:
+    """Return the authoritative access token for one stale credential generation.
+
+    Concurrent callers for the same connection are serialized with a threading
+    lock so the coordinator works across threads and event loops. After waiting,
+    a caller re-reads stored credentials and reuses a token already installed by
+    another caller instead of rotating the same refresh token twice.
+    """
+    normalized_url = api_url.rstrip("/")
+    coordinator = _refresh_coordinator(normalized_url)
+    await _acquire_refresh_lock(coordinator.lock)
+    try:
+        creds = get_credentials(normalized_url)
+        if not creds:
+            return None
+
+        stored_access_token = str(creds["access_token"])
+        stored_refresh_token = str(creds["refresh_token"])
+        env_url = os.environ.get("BIFROST_API_URL", "").rstrip("/")
+        env_backed = (
+            env_url == normalized_url
+            and bool(os.environ.get("BIFROST_ACCESS_TOKEN"))
+            and bool(os.environ.get("BIFROST_REFRESH_TOKEN"))
+        )
+
+        if coordinator.latest_access_token is not None:
+            if observed_access_token != coordinator.latest_access_token:
+                return coordinator.latest_access_token
+            if not env_backed and stored_access_token != coordinator.latest_access_token:
+                coordinator.latest_access_token = stored_access_token
+                coordinator.latest_refresh_token = stored_refresh_token
+                return stored_access_token
+        elif observed_access_token is not None and stored_access_token != observed_access_token:
+            coordinator.latest_access_token = stored_access_token
+            coordinator.latest_refresh_token = stored_refresh_token
+            return stored_access_token
+
+        refresh_token = coordinator.latest_refresh_token or stored_refresh_token
+
+        async with httpx.AsyncClient(base_url=normalized_url, timeout=30.0) as client:
+            response = await client.post(
+                "/auth/refresh",
+                json={"refresh_token": refresh_token},
+            )
+        if response.status_code != 200:
+            return None
+
+        data = response.json()
+        access_token = str(data["access_token"])
+        expires_at = datetime.now(timezone.utc) + timedelta(
+            seconds=data.get("expires_in", 1800)
+        )
+        new_refresh_token = str(data["refresh_token"])
+        replaced_env = replace_env_credentials(
+            normalized_url,
+            stored_access_token,
+            refresh_token,
+            access_token,
+            new_refresh_token,
+        )
+        if not replaced_env:
+            save_credentials(
+                api_url=normalized_url,
+                access_token=access_token,
+                refresh_token=new_refresh_token,
+                expires_at=expires_at.isoformat(),
+            )
+        coordinator.latest_access_token = access_token
+        coordinator.latest_refresh_token = new_refresh_token
+        return access_token
+    except Exception:
+        return None
+    finally:
+        coordinator.lock.release()
+
+
+async def refresh_tokens(
+    api_url: str | None = None,
+    observed_access_token: str | None = None,
+) -> bool:
     """
     Refresh access token using refresh token.
 
@@ -146,54 +292,48 @@ async def refresh_tokens() -> bool:
     Returns:
         True if refresh successful, False otherwise
     """
-    creds = get_credentials()
+    creds = get_credentials(api_url)
     if not creds:
         return False
+    observed = observed_access_token or str(creds["access_token"])
+    token = await refresh_connection_access_token(str(creds["api_url"]), observed)
+    return token is not None
 
-    api_url = creds["api_url"]
-    refresh_token = creds["refresh_token"]
 
-    try:
-        async with httpx.AsyncClient(base_url=api_url, timeout=30.0) as client:
-            response = await client.post(
-                "/auth/refresh",
-                json={"refresh_token": refresh_token}
-            )
-
-            if response.status_code != 200:
-                return False
-
-            data = response.json()
-
-            # Calculate expiry time (30 minutes from now)
-            expires_at = datetime.now(timezone.utc) + timedelta(seconds=data.get("expires_in", 1800))
-
-            # Save new credentials
-            save_credentials(
-                api_url=api_url,
-                access_token=data["access_token"],
-                refresh_token=data["refresh_token"],
-                expires_at=expires_at.isoformat(),
-            )
-
-            return True
-    except Exception:
+def _refresh_tokens_sync(
+    api_url: str | None = None,
+    observed_access_token: str | None = None,
+) -> bool:
+    creds = get_credentials(api_url)
+    if not creds:
         return False
+    token = _refresh_connection_access_token_sync(
+        str(creds["api_url"]),
+        observed_access_token or str(creds["access_token"]),
+    )
+    return token is not None
 
 
-def _refresh_tokens_sync() -> bool:
+def _refresh_connection_access_token_sync(
+    api_url: str,
+    observed_access_token: str,
+) -> str | None:
     try:
         asyncio.get_running_loop()
     except RuntimeError:
-        return asyncio.run(refresh_tokens())
+        return asyncio.run(
+            refresh_connection_access_token(api_url, observed_access_token)
+        )
 
-    result: bool | None = None
+    result: str | None = None
     error: Exception | None = None
 
     def _run() -> None:
         nonlocal result, error
         try:
-            result = asyncio.run(refresh_tokens())
+            result = asyncio.run(
+                refresh_connection_access_token(api_url, observed_access_token)
+            )
         except Exception as exc:
             error = exc
 
@@ -203,7 +343,7 @@ def _refresh_tokens_sync() -> bool:
 
     if error is not None:
         raise error
-    return bool(result)
+    return result
 
 
 async def login_flow(api_url: str | None = None, auto_open: bool = True) -> bool:
@@ -442,8 +582,13 @@ class BifrostClient:
             # Check if token needs refresh
             if creds and is_token_expired():
                 # Try to refresh
-                if _refresh_tokens_sync():
-                    creds = get_credentials()  # Reload fresh credentials
+                access_token = _refresh_connection_access_token_sync(
+                    creds["api_url"], creds["access_token"]
+                )
+                if access_token is not None:
+                    # Use the coordinator result directly so startup and
+                    # request-time refresh share the same token generation.
+                    creds = {**creds, "access_token": access_token}
                 else:
                     creds = None  # Refresh failed, need to re-login
 
@@ -499,7 +644,7 @@ class BifrostClient:
     def _fetch_context_sync(self) -> dict[str, Any]:
         """Fetch development context synchronously."""
         if self._context is None:
-            response = self._sync_http.get("/api/sdk/context")
+            response = self.get_sync("/api/sdk/context")
             raise_for_status_with_detail(response)
             self._context = response.json()
         return self._context or {}
@@ -507,8 +652,7 @@ class BifrostClient:
     async def _fetch_context(self) -> dict[str, Any]:
         """Fetch development context."""
         if self._context is None:
-            http = self._get_async_client()
-            response = await http.get("/api/sdk/context")
+            response = await self.get("/api/sdk/context")
             raise_for_status_with_detail(response)
             self._context = response.json()
         return self._context or {}
@@ -533,18 +677,58 @@ class BifrostClient:
         """Get default workflow parameters."""
         return self.context.get("default_parameters", {})
 
-    async def _refresh_and_update(self) -> bool:
-        """Refresh tokens and update this client's auth headers."""
-        if await refresh_tokens():
-            creds = get_credentials()
-            if creds:
-                self._access_token = creds["access_token"]
-                # Force new async client on next request (with new token)
-                self._http = None
-                # Update sync client headers too
-                self._sync_http.headers["Authorization"] = f"Bearer {self._access_token}"
-                return True
-        return False
+    def install_access_token(self, access_token: str) -> None:
+        """Install one access token across every transport owned by this client."""
+        if access_token == self._access_token:
+            return
+        self._access_token = access_token
+        # Force a new async client on the next request. An in-flight request may
+        # still finish on the old client, but its retry resolves a fresh one.
+        self._http = None
+        self._http_loop = None
+        self._sync_http.headers["Authorization"] = f"Bearer {access_token}"
+
+    async def refresh_access_token(
+        self, observed_access_token: str | None = None
+    ) -> str | None:
+        """Refresh or adopt the token replacing the one used by a failed request."""
+        observed = observed_access_token or self._access_token
+        token = await refresh_connection_access_token(self.api_url, observed)
+        if token is not None:
+            self.install_access_token(token)
+        return token
+
+    async def _refresh_and_update(
+        self, observed_access_token: str | None = None
+    ) -> bool:
+        """Backward-compatible boolean wrapper used by CLI request loops."""
+        return await self.refresh_access_token(observed_access_token) is not None
+
+    def _refresh_and_update_sync(
+        self, observed_access_token: str | None = None
+    ) -> bool:
+        """Synchronous counterpart used by context and legacy SDK requests."""
+        observed = observed_access_token or self._access_token
+        token = _refresh_connection_access_token_sync(self.api_url, observed)
+        if token is None:
+            return False
+        self.install_access_token(token)
+        return True
+
+    def _request_with_refresh_sync(
+        self, method: str, path: str, **kwargs
+    ) -> httpx.Response:
+        """Make a synchronous request, refreshing on 401 and retrying once."""
+        def _send() -> httpx.Response:
+            observed_access_token = self._access_token
+            response = self._sync_http.request(method.upper(), path, **kwargs)
+            if response.status_code == 401 and self._refresh_and_update_sync(
+                observed_access_token
+            ):
+                response = self._sync_http.request(method.upper(), path, **kwargs)
+            return response
+
+        return _send_sync_with_5xx_retry(method, _send)
 
     async def _request_with_refresh(self, method: str, path: str, **kwargs) -> httpx.Response:
         """Make an HTTP request, refreshing token on 401 and retrying once.
@@ -556,9 +740,10 @@ class BifrostClient:
         """
         async def _send() -> httpx.Response:
             http = self._get_async_client()
+            observed_access_token = self._access_token
             response = await getattr(http, method)(path, **kwargs)
             if response.status_code == 401:
-                if await self._refresh_and_update():
+                if await self._refresh_and_update(observed_access_token):
                     http = self._get_async_client()
                     response = await getattr(http, method)(path, **kwargs)
             return response
@@ -600,9 +785,10 @@ class BifrostClient:
         """
         async def _send() -> httpx.Response:
             http = self._get_async_client()
+            observed_access_token = self._access_token
             response = await http.request(method.upper(), path, **kwargs)
             if response.status_code == 401:
-                if await self._refresh_and_update():
+                if await self._refresh_and_update(observed_access_token):
                     http = self._get_async_client()
                     response = await http.request(method.upper(), path, **kwargs)
             return response
@@ -626,11 +812,11 @@ class BifrostClient:
         Wrapped with :func:`_send_sync_with_5xx_retry` so transient 502/503/504
         from rolling API deploys are retried.
         """
-        return _send_sync_with_5xx_retry("GET", lambda: self._sync_http.get(path, **kwargs))
+        return self._request_with_refresh_sync("GET", path, **kwargs)
 
     def post_sync(self, path: str, **kwargs) -> httpx.Response:
         """Make synchronous POST request."""
-        return self._sync_http.post(path, **kwargs)
+        return self._request_with_refresh_sync("POST", path, **kwargs)
 
     async def close(self):
         """Close HTTP clients."""

--- a/api/bifrost/commands/solution.py
+++ b/api/bifrost/commands/solution.py
@@ -32,8 +32,7 @@ from typing import Any
 import click
 import yaml
 
-from bifrost.client import BifrostClient, refresh_tokens
-from bifrost.credentials import get_credentials
+from bifrost.client import BifrostClient
 from bifrost.org_target import org_option, resolve_org_target
 from bifrost.solution_binding import (
     SolutionBindingError,
@@ -2207,16 +2206,6 @@ def _vite_child_env(
     return env
 
 
-async def _refresh_solution_start_access_token(api_url: str) -> str | None:
-    if not await refresh_tokens():
-        return None
-    creds = get_credentials(api_url.rstrip("/"))
-    if not creds:
-        return None
-    token = creds.get("access_token")
-    return str(token) if token else None
-
-
 @solution_group.command(name="start", help="Run the app's dev server + local workflows (one origin).")
 @click.argument("app_slug", required=False)
 @click.option("--solution", "solution_ref", default=None, help="Install id or unique slug.")
@@ -3005,9 +2994,7 @@ def _terminate_process_group(proc: "subprocess.Popen") -> None:
         _signal_group(signal.SIGKILL)
 
 
-def _dev_proxy_config(
-    client, chosen, org_info, solution_id, global_repo_access, refresh_token=None
-):
+def _dev_proxy_config(client, chosen, org_info, solution_id, global_repo_access):
     from bifrost.solution_dev.proxy import DevProxyConfig
 
     return DevProxyConfig(
@@ -3017,7 +3004,7 @@ def _dev_proxy_config(
         org_id=(org_info or {}).get("id"),
         solution_id=solution_id,
         global_repo_access=global_repo_access,
-        refresh_token=refresh_token,
+        refresh_token=client.refresh_access_token,
     )
 
 
@@ -3039,11 +3026,8 @@ async def _serve(
     from bifrost.solution_dev.proxy import build_dev_app
     from bifrost.solution_dev.reload import start_function_watch
 
-    async def refresh_token() -> str | None:
-        return await _refresh_solution_start_access_token(client.api_url)
-
     cfg = _dev_proxy_config(
-        client, chosen, org_info, solution_id, global_repo_access, refresh_token
+        client, chosen, org_info, solution_id, global_repo_access
     )
     app = build_dev_app(cfg, host, vite_url=f"http://127.0.0.1:{vite_port}")
     runner = web.AppRunner(app)

--- a/api/bifrost/credentials.py
+++ b/api/bifrost/credentials.py
@@ -548,6 +548,66 @@ def save_credentials(
     get_persistent_backend().save(creds)
 
 
+def replace_env_credentials(
+    api_url: str,
+    observed_access_token: str,
+    observed_refresh_token: str,
+    access_token: str,
+    refresh_token: str,
+) -> bool:
+    """Replace one rotating credential generation sourced from environment.
+
+    Password-grant development sessions are loaded from a workspace ``.env``.
+    Their backend is intentionally isolated from the persistent keychain/store,
+    but a read-only environment snapshot cannot survive refresh-token rotation.
+    Update the current process and, when the same generation came from the
+    nearest ``.env``, update that file so the next CLI process can continue it.
+
+    Returns ``True`` only when the observed generation is the active env source.
+    """
+    normalized_url = api_url.rstrip("/")
+    current = EnvBackend().get(normalized_url)
+    if (
+        current is None
+        or current.access_token != observed_access_token
+        or current.refresh_token != observed_refresh_token
+    ):
+        return False
+
+    try:
+        from dotenv import dotenv_values, find_dotenv, set_key
+
+        env_path = find_dotenv(usecwd=True)
+        if env_path:
+            values = dotenv_values(env_path)
+            file_url = str(values.get("BIFROST_API_URL") or "").rstrip("/")
+            if (
+                file_url == normalized_url
+                and values.get("BIFROST_ACCESS_TOKEN") == observed_access_token
+                and values.get("BIFROST_REFRESH_TOKEN") == observed_refresh_token
+            ):
+                set_key(
+                    env_path,
+                    "BIFROST_ACCESS_TOKEN",
+                    access_token,
+                    quote_mode="never",
+                )
+                set_key(
+                    env_path,
+                    "BIFROST_REFRESH_TOKEN",
+                    refresh_token,
+                    quote_mode="never",
+                )
+    except OSError:
+        # The running process can still continue even if its source file became
+        # unwritable after login.
+        pass
+
+    os.environ["BIFROST_ACCESS_TOKEN"] = access_token
+    os.environ["BIFROST_REFRESH_TOKEN"] = refresh_token
+    return True
+
+
 def clear_credentials(api_url: str | None = None) -> None:
     """
     Remove a single URL's credentials from the persistent backend.

--- a/api/bifrost/integrations.py
+++ b/api/bifrost/integrations.py
@@ -8,14 +8,9 @@ All methods are async and must be awaited.
 
 from __future__ import annotations
 
-import logging
-
-from .client import get_client
+from .client import get_client, raise_for_status_with_detail
 from .models import IntegrationData, IntegrationMappingResponse
 from ._context import resolve_scope, _execution_context
-
-logger = logging.getLogger(__name__)
-
 
 def _current_context():
     """Return the active ExecutionContext, or None if not in a workflow execution."""
@@ -122,9 +117,8 @@ class integrations:
                     if val:
                         register_secret(str(val))
             return data
-        else:
-            logger.warning(f"Integrations API call failed: {response.status_code}")
-            return None
+        raise_for_status_with_detail(response)
+        raise AssertionError("unreachable")
 
     @staticmethod
     async def list_mappings(
@@ -177,9 +171,8 @@ class integrations:
             items = json_result.get("items", [])
             # Convert to IntegrationMappingResponse models
             return [IntegrationMappingResponse.model_validate(item) for item in items]
-        else:
-            logger.warning(f"Integrations API call failed: {response.status_code}")
-            return None
+        raise_for_status_with_detail(response)
+        raise AssertionError("unreachable")
 
     @staticmethod
     async def get_mapping(
@@ -229,9 +222,8 @@ class integrations:
             if result is None:
                 return None
             return IntegrationMappingResponse.model_validate(result)
-        else:
-            logger.warning(f"Integrations get_mapping API call failed: {response.status_code}")
-            return None
+        raise_for_status_with_detail(response)
+        raise AssertionError("unreachable")
 
     @staticmethod
     async def upsert_mapping(
@@ -320,6 +312,5 @@ class integrations:
 
         if response.status_code == 200:
             return response.json().get("deleted", False)
-        else:
-            logger.warning(f"Integrations delete_mapping API call failed: {response.status_code}")
-            return False
+        raise_for_status_with_detail(response)
+        raise AssertionError("unreachable")

--- a/api/bifrost/solution_dev/proxy.py
+++ b/api/bifrost/solution_dev/proxy.py
@@ -107,7 +107,7 @@ class DevProxyConfig:
     # workflow ref that misses locally may fall back to the platform's shared
     # _repo/ content at all. Mirrors the module-loader semantics (§3.5).
     global_repo_access: bool = False
-    refresh_token: Callable[[], Awaitable[str | None]] | None = None
+    refresh_token: Callable[[str], Awaitable[str | None]] | None = None
     auth_expired: bool = False
     branding: dict[str, Any] | None = None
     branding_loaded: bool = False
@@ -170,12 +170,12 @@ def _passthrough_headers(resp, default_content_type: str) -> dict[str, str]:
     return headers
 
 
-async def _refresh_cli_token(cfg: DevProxyConfig) -> bool:
+async def _refresh_cli_token(cfg: DevProxyConfig, observed_access_token: str) -> bool:
     if cfg.refresh_token is None:
         cfg.auth_expired = True
         return False
     try:
-        token = await cfg.refresh_token()
+        token = await cfg.refresh_token(observed_access_token)
     except Exception:
         token = None
     if not token:
@@ -209,10 +209,11 @@ async def _authed_upstream_request(
             headers = {k: v for k, v in headers.items() if k.lower() not in drop_headers}
         return headers
 
+    observed_access_token = cfg.token
     resp = await http.request(method, url, headers=_headers(), **kwargs)
     if resp.status_code != 401:
         return resp
-    if not await _refresh_cli_token(cfg):
+    if not await _refresh_cli_token(cfg, observed_access_token):
         return None
     retry = await http.request(method, url, headers=_headers(), **kwargs)
     if retry.status_code == 401:

--- a/api/tests/unit/sdk/test_sdk_integrations.py
+++ b/api/tests/unit/sdk/test_sdk_integrations.py
@@ -1,13 +1,67 @@
-"""
-Unit tests for Bifrost Integrations SDK module.
+"""HTTP error-contract tests for the Bifrost integrations SDK."""
 
-Note: The integrations SDK no longer has a dual-mode architecture.
-Most unit tests have been removed as the SDK now operates through HTTP API only.
+from unittest.mock import AsyncMock, patch
 
-See test_sdk_platform_mode.py for platform integration tests.
-"""
+import httpx
+import pytest
+
+from bifrost.client import BifrostAPIError, BifrostAuthenticationError
+from bifrost.integrations import integrations
 
 
+def _response(status_code: int, detail: str = "safe failure") -> httpx.Response:
+    return httpx.Response(
+        status_code,
+        json={"detail": detail, "access_token": "must-not-appear"},
+        request=httpx.Request("POST", "https://api.example/api/sdk/integrations/get"),
+    )
 
 
-# All tests removed - integrations SDK behavior is tested through integration tests
+@pytest.mark.asyncio
+async def test_get_returns_none_only_for_successful_null_response() -> None:
+    client = AsyncMock()
+    client.post.return_value = httpx.Response(
+        200,
+        content=b"null",
+        headers={"content-type": "application/json"},
+        request=httpx.Request("POST", "https://api.example/api/sdk/integrations/get"),
+    )
+
+    with patch("bifrost.integrations.get_client", return_value=client):
+        assert await integrations.get("Missing") is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status_code", [403, 424, 500, 503])
+async def test_get_preserves_non_auth_api_failures(status_code: int) -> None:
+    client = AsyncMock()
+    client.post.return_value = _response(status_code)
+
+    with patch("bifrost.integrations.get_client", return_value=client):
+        with pytest.raises(BifrostAPIError) as exc_info:
+            await integrations.get("HaloPSA")
+
+    assert exc_info.value.response.status_code == status_code
+    assert "safe failure" in str(exc_info.value)
+    assert "must-not-appear" not in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_get_surfaces_unauthorized_as_authentication_error() -> None:
+    client = AsyncMock()
+    client.post.return_value = _response(401, "CLI session expired")
+
+    with patch("bifrost.integrations.get_client", return_value=client):
+        with pytest.raises(BifrostAuthenticationError, match="CLI session expired"):
+            await integrations.get("HaloPSA")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("method_name", ["list_mappings", "get_mapping"])
+async def test_mapping_reads_preserve_api_failures(method_name: str) -> None:
+    client = AsyncMock()
+    client.post.return_value = _response(503)
+
+    with patch("bifrost.integrations.get_client", return_value=client):
+        with pytest.raises(BifrostAPIError):
+            await getattr(integrations, method_name)("HaloPSA")

--- a/api/tests/unit/test_bifrost_client_credentials.py
+++ b/api/tests/unit/test_bifrost_client_credentials.py
@@ -168,7 +168,7 @@ async def test_cancelled_refresh_lock_waiter_does_not_leak_lock() -> None:
     lock.release()
 
     with pytest.raises(asyncio.CancelledError):
-        await waiter
+        await asyncio.wait_for(waiter, timeout=1)
     assert lock.acquire(blocking=False) is True
     lock.release()
 

--- a/api/tests/unit/test_bifrost_client_credentials.py
+++ b/api/tests/unit/test_bifrost_client_credentials.py
@@ -1,6 +1,7 @@
 """Tests for BifrostClient credential resolution and refresh coordination."""
 
 import asyncio
+import threading
 from datetime import datetime, timedelta, timezone
 
 import httpx
@@ -152,6 +153,24 @@ async def test_concurrent_refreshes_for_same_stale_token_are_coalesced(
     assert first == second == "fresh-access-token"
     assert refresh_calls == 1
     assert isolated_credentials.get_credentials(api_url)["access_token"] == "fresh-access-token"
+
+
+@pytest.mark.asyncio
+async def test_cancelled_refresh_lock_waiter_does_not_leak_lock() -> None:
+    from bifrost import client as client_mod
+
+    lock = threading.Lock()
+    lock.acquire()
+    waiter = asyncio.create_task(client_mod._acquire_refresh_lock(lock))
+    await asyncio.sleep(0)
+
+    waiter.cancel()
+    lock.release()
+
+    with pytest.raises(asyncio.CancelledError):
+        await waiter
+    assert lock.acquire(blocking=False) is True
+    lock.release()
 
 
 @pytest.mark.asyncio

--- a/api/tests/unit/test_bifrost_client_credentials.py
+++ b/api/tests/unit/test_bifrost_client_credentials.py
@@ -1,7 +1,9 @@
-"""Tests for BifrostClient credential resolution edge cases."""
+"""Tests for BifrostClient credential resolution and refresh coordination."""
 
+import asyncio
 from datetime import datetime, timedelta, timezone
 
+import httpx
 import pytest
 
 
@@ -12,6 +14,7 @@ def isolated_credentials(tmp_path, monkeypatch):
 
     if hasattr(client_mod._thread_local, "bifrost_client"):
         delattr(client_mod._thread_local, "bifrost_client")
+    client_mod._reset_refresh_coordinators_for_tests()
     monkeypatch.setattr(
         creds_mod,
         "get_credentials_path",
@@ -26,6 +29,7 @@ def isolated_credentials(tmp_path, monkeypatch):
     yield creds_mod
     if hasattr(client_mod._thread_local, "bifrost_client"):
         delattr(client_mod._thread_local, "bifrost_client")
+    client_mod._reset_refresh_coordinators_for_tests()
     creds_mod._reset_persistent_backend_for_tests()
 
 
@@ -43,13 +47,15 @@ def test_get_instance_does_not_report_default_ambiguity_when_env_selects_url(
     )
     monkeypatch.setenv("BIFROST_API_URL", "https://second.example.com")
 
-    async def refresh_fails() -> bool:
-        return False
+    async def refresh_fails(*_args) -> None:
+        return None
 
     async def login_fails(*_args, **_kwargs) -> bool:
         return False
 
-    monkeypatch.setattr(client_mod, "refresh_tokens", refresh_fails)
+    monkeypatch.setattr(
+        client_mod, "refresh_connection_access_token", refresh_fails
+    )
     monkeypatch.setattr(client_mod, "login_flow", login_fails)
 
     with pytest.raises(RuntimeError, match="Not logged in"):
@@ -70,8 +76,10 @@ async def test_get_instance_refreshes_expired_credentials_inside_running_loop(
 
     refreshed = False
 
-    async def refresh_succeeds() -> bool:
+    async def refresh_succeeds(api_url, observed_access_token) -> str:
         nonlocal refreshed
+        assert api_url == "https://api.example.com"
+        assert observed_access_token == "expired-access-token"
         refreshed = True
         isolated_credentials.save_credentials(
             "https://api.example.com",
@@ -79,12 +87,232 @@ async def test_get_instance_refreshes_expired_credentials_inside_running_loop(
             "fresh-refresh-token",
             fresh_at,
         )
-        return True
+        return "fresh-access-token"
 
-    monkeypatch.setattr(client_mod, "refresh_tokens", refresh_succeeds)
+    monkeypatch.setattr(
+        client_mod, "refresh_connection_access_token", refresh_succeeds
+    )
 
     client = client_mod.BifrostClient.get_instance(require_auth=True)
 
     assert refreshed is True
     assert client.api_url == "https://api.example.com"
     assert client._access_token == "fresh-access-token"
+
+
+@pytest.mark.asyncio
+async def test_concurrent_refreshes_for_same_stale_token_are_coalesced(
+    isolated_credentials, monkeypatch
+) -> None:
+    from bifrost import client as client_mod
+
+    api_url = "https://api.example.com"
+    isolated_credentials.save_credentials(
+        api_url,
+        "stale-access-token",
+        "rotating-refresh-token",
+        (datetime.now(timezone.utc) - timedelta(minutes=5)).isoformat(),
+    )
+    refresh_calls = 0
+
+    class FakeAsyncClient:
+        def __init__(self, *, base_url, timeout):
+            assert base_url == api_url
+            assert timeout == 30.0
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return None
+
+        async def post(self, path, *, json):
+            nonlocal refresh_calls
+            assert path == "/auth/refresh"
+            assert json == {"refresh_token": "rotating-refresh-token"}
+            refresh_calls += 1
+            await asyncio.sleep(0.01)
+            return httpx.Response(
+                200,
+                json={
+                    "access_token": "fresh-access-token",
+                    "refresh_token": "fresh-refresh-token",
+                    "expires_in": 1800,
+                },
+                request=httpx.Request("POST", f"{api_url}/auth/refresh"),
+            )
+
+    monkeypatch.setattr(client_mod.httpx, "AsyncClient", FakeAsyncClient)
+
+    first, second = await asyncio.gather(
+        client_mod.refresh_connection_access_token(api_url, "stale-access-token"),
+        client_mod.refresh_connection_access_token(api_url, "stale-access-token"),
+    )
+
+    assert first == second == "fresh-access-token"
+    assert refresh_calls == 1
+    assert isolated_credentials.get_credentials(api_url)["access_token"] == "fresh-access-token"
+
+
+@pytest.mark.asyncio
+async def test_refresh_reuses_credentials_replaced_by_another_caller(
+    isolated_credentials, monkeypatch
+) -> None:
+    from bifrost import client as client_mod
+
+    api_url = "https://api.example.com"
+    isolated_credentials.save_credentials(
+        api_url,
+        "fresh-access-token",
+        "fresh-refresh-token",
+        (datetime.now(timezone.utc) + timedelta(minutes=30)).isoformat(),
+    )
+
+    class UnexpectedAsyncClient:
+        def __init__(self, **_kwargs):
+            raise AssertionError("credentials were already refreshed; no network call expected")
+
+    monkeypatch.setattr(client_mod.httpx, "AsyncClient", UnexpectedAsyncClient)
+
+    token = await client_mod.refresh_connection_access_token(
+        api_url, "stale-access-token"
+    )
+
+    assert token == "fresh-access-token"
+
+
+@pytest.mark.asyncio
+async def test_env_credentials_survive_multiple_rotating_refreshes(
+    isolated_credentials, monkeypatch, tmp_path
+) -> None:
+    from bifrost import client as client_mod
+
+    api_url = "https://api.example.com"
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("BIFROST_API_URL", api_url)
+    monkeypatch.setenv("BIFROST_ACCESS_TOKEN", "access-0")
+    monkeypatch.setenv("BIFROST_REFRESH_TOKEN", "refresh-0")
+    (tmp_path / ".env").write_text(
+        "BIFROST_API_URL=https://api.example.com\n"
+        "BIFROST_ACCESS_TOKEN=access-0\n"
+        "BIFROST_REFRESH_TOKEN=refresh-0\n"
+    )
+    refresh_tokens_seen: list[str] = []
+
+    class FakeAsyncClient:
+        def __init__(self, *, base_url, timeout):
+            assert base_url == api_url
+            assert timeout == 30.0
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return None
+
+        async def post(self, path, *, json):
+            assert path == "/auth/refresh"
+            refresh_tokens_seen.append(json["refresh_token"])
+            generation = len(refresh_tokens_seen)
+            return httpx.Response(
+                200,
+                json={
+                    "access_token": f"access-{generation}",
+                    "refresh_token": f"refresh-{generation}",
+                    "expires_in": 1800,
+                },
+                request=httpx.Request("POST", f"{api_url}/auth/refresh"),
+            )
+
+    monkeypatch.setattr(client_mod.httpx, "AsyncClient", FakeAsyncClient)
+
+    first = await client_mod.refresh_connection_access_token(api_url, "access-0")
+    second = await client_mod.refresh_connection_access_token(api_url, "access-1")
+
+    assert first == "access-1"
+    assert second == "access-2"
+    assert refresh_tokens_seen == ["refresh-0", "refresh-1"]
+    assert isolated_credentials.get_persistent_backend().get(api_url) is None
+    assert isolated_credentials.get_credentials(api_url)["access_token"] == "access-2"
+    assert isolated_credentials.get_credentials(api_url)["refresh_token"] == "refresh-2"
+    env_text = (tmp_path / ".env").read_text()
+    assert "BIFROST_ACCESS_TOKEN=access-2" in env_text
+    assert "BIFROST_REFRESH_TOKEN=refresh-2" in env_text
+
+
+@pytest.mark.asyncio
+async def test_client_token_update_is_shared_with_async_and_sync_transports(
+    isolated_credentials, monkeypatch
+) -> None:
+    from bifrost import client as client_mod
+
+    client = client_mod.BifrostClient(
+        "https://api.example.com", "stale-access-token"
+    )
+    async_http = client._get_async_client()
+
+    async def refresh_connection(api_url, observed_access_token):
+        assert api_url == "https://api.example.com"
+        assert observed_access_token == "stale-access-token"
+        return "fresh-access-token"
+
+    monkeypatch.setattr(
+        client_mod, "refresh_connection_access_token", refresh_connection
+    )
+
+    token = await client.refresh_access_token("stale-access-token")
+
+    assert token == "fresh-access-token"
+    assert client._access_token == "fresh-access-token"
+    assert client._sync_http.headers["Authorization"] == "Bearer fresh-access-token"
+    assert client._http is None
+    assert async_http.headers["Authorization"] == "Bearer stale-access-token"
+    await async_http.aclose()
+    client._sync_http.close()
+
+
+def test_sync_context_refreshes_expired_token_and_retries(
+    isolated_credentials, monkeypatch
+) -> None:
+    from bifrost import client as client_mod
+
+    seen_authorization: list[str | None] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        authorization = request.headers.get("Authorization")
+        seen_authorization.append(authorization)
+        if authorization == "Bearer stale-access-token":
+            return httpx.Response(401, request=request)
+        return httpx.Response(
+            200,
+            json={"organization": {"id": "org-1"}},
+            request=request,
+        )
+
+    client = client_mod.BifrostClient(
+        "https://api.example.com", "stale-access-token"
+    )
+    client._sync_http.close()
+    client._sync_http = httpx.Client(
+        base_url=client.api_url,
+        headers={"Authorization": "Bearer stale-access-token"},
+        transport=httpx.MockTransport(handler),
+    )
+
+    def refresh_connection(api_url, observed_access_token):
+        assert api_url == "https://api.example.com"
+        assert observed_access_token == "stale-access-token"
+        return "fresh-access-token"
+
+    monkeypatch.setattr(
+        client_mod, "_refresh_connection_access_token_sync", refresh_connection
+    )
+
+    try:
+        assert client.organization == {"id": "org-1"}
+        assert seen_authorization == [
+            "Bearer stale-access-token",
+            "Bearer fresh-access-token",
+        ]
+    finally:
+        client._sync_http.close()

--- a/api/tests/unit/test_solution_dev_command.py
+++ b/api/tests/unit/test_solution_dev_command.py
@@ -701,6 +701,9 @@ def test_dev_proxy_config_threads_descriptor_global_repo_access():
         api_url = "http://127.0.0.1:8000/"
         _access_token = "tok"
 
+        async def refresh_access_token(self, observed_access_token):
+            return observed_access_token
+
     class _Chosen:
         app_id = "app-uuid"
 
@@ -711,6 +714,7 @@ def test_dev_proxy_config_threads_descriptor_global_repo_access():
     assert cfg.upstream_url == "http://127.0.0.1:8000"
     assert cfg.solution_id == "install-1"
     assert cfg.org_id == "org-1"
+    assert cfg.refresh_token is not None
 
     cfg = _dev_proxy_config(_Client(), _Chosen(), None, "install-1", False)
     assert cfg.global_repo_access is False

--- a/api/tests/unit/test_solution_dev_proxy.py
+++ b/api/tests/unit/test_solution_dev_proxy.py
@@ -469,8 +469,8 @@ async def test_api_proxy_refreshes_cli_token_once_after_401():
     up_runner = await _serve(_make_auth_refresh_upstream(record), up_port)
     host = _StubHost(set())
 
-    async def refresh_token():
-        record["refresh_called"] = True
+    async def refresh_token(observed_token):
+        record["refresh_called"] = observed_token
         return "fresh-token"
 
     cfg = DevProxyConfig(
@@ -486,7 +486,7 @@ async def test_api_proxy_refreshes_cli_token_once_after_401():
             r = await c.get(f"http://127.0.0.1:{dev_port}/api/auth/me")
         assert r.status_code == 200
         assert r.json()["email"] == "dev@gobifrost.com"
-        assert record["refresh_called"] is True
+        assert record["refresh_called"] == "stale-token"
         assert record["auth_headers"] == ["Bearer stale-token", "Bearer fresh-token"]
     finally:
         await dev_runner.cleanup()
@@ -499,8 +499,8 @@ async def test_api_proxy_returns_dev_auth_expired_json_when_refresh_fails():
     up_runner = await _serve(_make_auth_refresh_upstream(record), up_port)
     host = _StubHost(set())
 
-    async def refresh_token():
-        record["refresh_called"] = True
+    async def refresh_token(observed_token):
+        record["refresh_called"] = observed_token
         return None
 
     cfg = DevProxyConfig(
@@ -520,7 +520,7 @@ async def test_api_proxy_returns_dev_auth_expired_json_when_refresh_fails():
             "error": "bifrost_dev_auth_expired",
             "detail": "Your CLI token has expired. Restart `bifrost solution start`.",
         }
-        assert record["refresh_called"] is True
+        assert record["refresh_called"] == "stale-token"
         assert record["auth_headers"] == ["Bearer stale-token"]
     finally:
         await dev_runner.cleanup()
@@ -544,7 +544,7 @@ async def test_vite_proxy_serves_branded_auth_expired_page_after_api_auth_failur
     vite_runner = await _serve(vite, vite_port)
     host = _StubHost(set())
 
-    async def refresh_token():
+    async def refresh_token(_observed_token):
         return None
 
     cfg = DevProxyConfig(

--- a/api/tests/unit/test_solution_start_env.py
+++ b/api/tests/unit/test_solution_start_env.py
@@ -83,37 +83,31 @@ def test_vite_child_env_omits_org_var_for_global_installs():
     assert "VITE_BIFROST_ORG_ID" not in env
 
 
-async def test_solution_start_token_refresher_returns_new_token_for_same_api(monkeypatch):
-    state = {"refreshed": False}
+async def test_solution_proxy_uses_active_client_refresh_authority():
+    class Client:
+        api_url = "http://api.example"
+        _access_token = "stale-token"
 
-    async def _refresh_tokens():
-        state["refreshed"] = True
-        return True
+        def __init__(self):
+            self.observed = None
 
-    def _get_credentials(api_url=None):
-        assert api_url == "http://api.example"
-        return {"access_token": "fresh-token"}
+        async def refresh_access_token(self, observed_access_token):
+            self.observed = observed_access_token
+            self._access_token = "fresh-token"
+            return self._access_token
 
-    monkeypatch.setattr(solution_cmd, "refresh_tokens", _refresh_tokens)
-    monkeypatch.setattr(solution_cmd, "get_credentials", _get_credentials)
-
-    token = await solution_cmd._refresh_solution_start_access_token("http://api.example")
-
-    assert state["refreshed"] is True
-    assert token == "fresh-token"
-
-
-async def test_solution_start_token_refresher_returns_none_when_refresh_fails(monkeypatch):
-    async def _refresh_tokens():
-        return False
-
-    monkeypatch.setattr(solution_cmd, "refresh_tokens", _refresh_tokens)
-    monkeypatch.setattr(
-        solution_cmd,
-        "get_credentials",
-        lambda api_url=None: {"access_token": "should-not-be-used"},
+    client = Client()
+    chosen = type("Chosen", (), {"app_id": "app-id"})()
+    cfg = solution_cmd._dev_proxy_config(
+        client,
+        chosen,
+        {"id": "org-id"},
+        "solution-id",
+        False,
     )
 
-    token = await solution_cmd._refresh_solution_start_access_token("http://api.example")
+    assert cfg.refresh_token is not None
+    token = await cfg.refresh_token("stale-token")
 
-    assert token is None
+    assert client.observed == "stale-token"
+    assert token == client._access_token == "fresh-token"


### PR DESCRIPTION
Closes #472

## Summary
- centralize CLI refresh ownership per API connection and coalesce concurrent proxy and local SDK refreshes
- keep access and rotating refresh-token generations synchronized across async, sync, environment-backed, and subsequent CLI processes
- route Solution dev proxy refresh through the active BifrostClient
- preserve typed authentication, authorization, dependency, and API failures instead of collapsing integration errors into not-found
- cover synchronous context lookup, concurrent refresh, rotating .env credentials, proxy retries, and integration error semantics

## Verification
- ./test.sh quality api
- ./test.sh all: 6943 passed, 55 skipped
- live isolated Halo Dispatch Portal deploy with one-minute access tokens
- two consecutive expiry waves, each with three proxied /api/auth/me calls and three local workflow calls: all succeeded and each wave produced exactly one /auth/refresh
- fresh CLI process then refreshed from the rotated workspace .env and completed another full Solution deploy