### PR TITLE
Add bifrost update command

### DIFF
--- a/api/bifrost/cli.py
+++ b/api/bifrost/cli.py
@@ -19,7 +19,9 @@ import json
 import logging
 import os
 import pathlib
+import shlex
 import shutil
+import subprocess
 import sys
 import textwrap
 import time
@@ -635,19 +637,24 @@ def main(args: list[str] | None = None) -> int:
         print(f"bifrost {__version__}")
         return 0
 
+    command = args[0].lower()
     help_requested = any(a in ("-h", "--help") for a in args)
     if args[0].lower() == "help" or args[0] in ("-h", "--help"):
         print_help()
         return 0
 
-    if not help_requested:
+    # An incompatible CLI must still be able to replace itself. Running the
+    # compatibility gate before `update` would block the recovery command in
+    # exactly the state where it is needed most.
+    if not help_requested and command != "update":
         _check_cli_version()
 
     try:
-        command = args[0].lower()
-
         if command == "login":
             return handle_login(args[1:])
+
+        if command == "update":
+            return handle_update(args[1:])
 
         if command == "logout":
             return handle_logout(args[1:])
@@ -727,6 +734,7 @@ Commands:
   migrate-imports  Rewrite "bifrost" imports into user/lucide/router imports
   skill       Install / update / remove agent skills (.claude/skills + .agents/skills)
   login       Authenticate (browser device-code by default; password-grant with --email/--password)
+  update      Update this CLI from the selected Bifrost instance
   logout      Clear stored credentials for one URL
   auth        Inspect stored credentials (auth list)
   help        Show this help message
@@ -804,10 +812,126 @@ Examples:
   bifrost migrate-imports apps/my-app --yes
   bifrost login
   bifrost login --url https://app.gobifrost.com
+  bifrost update
+  bifrost update --url https://app.gobifrost.com
   bifrost logout
 
 For more information, visit: https://docs.gobifrost.com
 """.strip())
+
+
+def _update_install_command(download_url: str) -> list[str]:
+    """Return the installer command for the environment running this CLI."""
+    pipx_metadata = pathlib.Path(sys.prefix) / "pipx_metadata.json"
+    if pipx_metadata.is_file():
+        pipx = shutil.which("pipx")
+        if not pipx:
+            raise RuntimeError(
+                "This CLI is managed by pipx, but the pipx command is not on PATH."
+            )
+        return [pipx, "install", "--force", download_url]
+    return [
+        sys.executable,
+        "-m",
+        "pip",
+        "install",
+        "--upgrade",
+        download_url,
+    ]
+
+
+def _format_update_command(command: list[str]) -> str:
+    """Format an argv list for a copyable platform-appropriate error message."""
+    if os.name == "nt":
+        return subprocess.list2cmdline(command)
+    return shlex.join(command)
+
+
+def handle_update(args: list[str]) -> int:
+    """Handle ``bifrost update`` by reinstalling from a Bifrost instance."""
+    api_url: str | None = None
+
+    i = 0
+    while i < len(args):
+        arg = args[i]
+        if arg in ("--url", "-u"):
+            if i + 1 >= len(args):
+                print("Error: --url requires a value", file=sys.stderr)
+                return 1
+            api_url = args[i + 1]
+            i += 2
+        elif arg in ("--help", "-h"):
+            print("""
+Usage: bifrost update [options]
+
+Update this CLI from the selected Bifrost instance. If --url is omitted,
+the current connection is resolved from BIFROST_API_URL, the selected default,
+or the only stored connection. If several connections exist with no default,
+an interactive terminal prompts you to choose one.
+
+Options:
+  --url, -u URL   Bifrost instance to update from
+  --help, -h      Show this help message
+
+Examples:
+  bifrost update
+  bifrost update --url https://app.gobifrost.com
+""".strip())
+            return 0
+        else:
+            print(f"Unknown option: {arg}", file=sys.stderr)
+            return 1
+
+    resolved_url, _source = credentials.resolve_current_connection(
+        api_url,
+        prompt_for_default=True,
+    )
+    if not resolved_url:
+        print(
+            "Error: no Bifrost connection selected. Pass --url, run "
+            "`bifrost auth use <url>`, or log in first.",
+            file=sys.stderr,
+        )
+        return 1
+
+    resolved_url = resolved_url.rstrip("/")
+    download_url = f"{resolved_url}/api/cli/download"
+    try:
+        command = _update_install_command(download_url)
+    except RuntimeError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        print(
+            f"Install pipx, then run: pipx install --force {download_url}",
+            file=sys.stderr,
+        )
+        return 1
+
+    from bifrost import __version__
+
+    print(f"Updating Bifrost CLI {__version__} from {resolved_url}...")
+    try:
+        result = subprocess.run(command, check=False)
+    except OSError as exc:
+        print(f"Error: could not start the installer: {exc}", file=sys.stderr)
+        print(
+            f"Run manually: {_format_update_command(command)}",
+            file=sys.stderr,
+        )
+        return 1
+
+    if result.returncode != 0:
+        print(
+            f"Error: CLI update failed with exit code {result.returncode}.",
+            file=sys.stderr,
+        )
+        print(
+            f"Run manually: {_format_update_command(command)}",
+            file=sys.stderr,
+        )
+        return result.returncode or 1
+
+    print("Bifrost CLI updated successfully. Run `bifrost --version` to verify.")
+    return 0
 
 
 def handle_login(args: list[str]) -> int:

--- a/api/tests/unit/cli/test_cli_update.py
+++ b/api/tests/unit/cli/test_cli_update.py
@@ -1,0 +1,184 @@
+"""Tests for the self-update CLI command."""
+
+from __future__ import annotations
+
+import pathlib
+import subprocess
+from unittest.mock import patch
+
+import pytest
+
+from bifrost import cli
+
+
+def test_update_help_does_not_resolve_or_install(capsys: pytest.CaptureFixture[str]) -> None:
+    with patch("bifrost.credentials.resolve_current_connection") as resolve, patch(
+        "subprocess.run"
+    ) as run:
+        rc = cli.handle_update(["--help"])
+
+    assert rc == 0
+    assert "Usage: bifrost update" in capsys.readouterr().out
+    resolve.assert_not_called()
+    run.assert_not_called()
+
+
+def test_update_requires_url_value(capsys: pytest.CaptureFixture[str]) -> None:
+    assert cli.handle_update(["--url"]) == 1
+    assert "--url requires a value" in capsys.readouterr().err
+
+
+def test_update_rejects_unknown_option(capsys: pytest.CaptureFixture[str]) -> None:
+    assert cli.handle_update(["--wat"]) == 1
+    assert "Unknown option: --wat" in capsys.readouterr().err
+
+
+def test_update_resolves_current_connection_and_normalizes_url(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(cli, "_update_install_command", lambda url: ["installer", url])
+    completed = subprocess.CompletedProcess(["installer"], 0)
+
+    with patch(
+        "bifrost.credentials.resolve_current_connection",
+        return_value=("https://bifrost.example.com/", "default"),
+    ) as resolve, patch("subprocess.run", return_value=completed) as run:
+        rc = cli.handle_update([])
+
+    assert rc == 0
+    resolve.assert_called_once_with(None, prompt_for_default=True)
+    run.assert_called_once_with(
+        ["installer", "https://bifrost.example.com/api/cli/download"],
+        check=False,
+    )
+
+
+def test_update_url_override_wins() -> None:
+    completed = subprocess.CompletedProcess(["installer"], 0)
+    with patch(
+        "bifrost.credentials.resolve_current_connection",
+        return_value=("https://override.example.com", "argument"),
+    ) as resolve, patch(
+        "bifrost.cli._update_install_command", return_value=["installer"]
+    ), patch("subprocess.run", return_value=completed):
+        rc = cli.handle_update(["--url", "https://override.example.com/"])
+
+    assert rc == 0
+    resolve.assert_called_once_with(
+        "https://override.example.com/",
+        prompt_for_default=True,
+    )
+
+
+def test_update_errors_without_connection(capsys: pytest.CaptureFixture[str]) -> None:
+    with patch(
+        "bifrost.credentials.resolve_current_connection",
+        return_value=(None, None),
+    ), patch("subprocess.run") as run:
+        rc = cli.handle_update([])
+
+    assert rc == 1
+    assert "no Bifrost connection selected" in capsys.readouterr().err
+    run.assert_not_called()
+
+
+def test_update_uses_pipx_for_pipx_managed_install(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: pathlib.Path,
+) -> None:
+    (tmp_path / "pipx_metadata.json").write_text("{}")
+    monkeypatch.setattr(cli.sys, "prefix", str(tmp_path))
+    monkeypatch.setattr(cli.shutil, "which", lambda name: "/usr/bin/pipx")
+
+    assert cli._update_install_command("https://example.com/api/cli/download") == [
+        "/usr/bin/pipx",
+        "install",
+        "--force",
+        "https://example.com/api/cli/download",
+    ]
+
+
+def test_update_uses_current_python_outside_pipx(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: pathlib.Path,
+) -> None:
+    monkeypatch.setattr(cli.sys, "prefix", str(tmp_path))
+    monkeypatch.setattr(cli.sys, "executable", "/venv/bin/python")
+
+    assert cli._update_install_command("https://example.com/api/cli/download") == [
+        "/venv/bin/python",
+        "-m",
+        "pip",
+        "install",
+        "--upgrade",
+        "https://example.com/api/cli/download",
+    ]
+
+
+def test_update_reports_missing_pipx(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: pathlib.Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    (tmp_path / "pipx_metadata.json").write_text("{}")
+    monkeypatch.setattr(cli.sys, "prefix", str(tmp_path))
+    monkeypatch.setattr(cli.shutil, "which", lambda name: None)
+
+    with patch(
+        "bifrost.credentials.resolve_current_connection",
+        return_value=("https://example.com", "default"),
+    ):
+        rc = cli.handle_update([])
+
+    assert rc == 1
+    assert "managed by pipx" in capsys.readouterr().err
+
+
+def test_update_propagates_installer_failure(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    completed = subprocess.CompletedProcess(["installer"], 7)
+    with patch(
+        "bifrost.credentials.resolve_current_connection",
+        return_value=("https://example.com", "default"),
+    ), patch(
+        "bifrost.cli._update_install_command", return_value=["installer", "package"]
+    ), patch("subprocess.run", return_value=completed):
+        rc = cli.handle_update([])
+
+    assert rc == 7
+    stderr = capsys.readouterr().err
+    assert "exit code 7" in stderr
+    assert "installer package" in stderr
+
+
+def test_update_reports_installer_launch_failure(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    with patch(
+        "bifrost.credentials.resolve_current_connection",
+        return_value=("https://example.com", "default"),
+    ), patch(
+        "bifrost.cli._update_install_command", return_value=["installer", "package"]
+    ), patch("subprocess.run", side_effect=OSError("not found")):
+        rc = cli.handle_update([])
+
+    assert rc == 1
+    stderr = capsys.readouterr().err
+    assert "could not start the installer" in stderr
+    assert "installer package" in stderr
+
+
+def test_main_dispatches_update_without_version_gate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        cli,
+        "_check_cli_version",
+        lambda: pytest.fail("update must bypass the compatibility gate"),
+    )
+    called: list[list[str]] = []
+    monkeypatch.setattr(cli, "handle_update", lambda args: called.append(args) or 0)
+
+    assert cli.main(["update", "--url", "https://example.com"]) == 0
+    assert called == [["--url", "https://example.com"]]

--- a/api/tests/unit/test_cli_surface_smoke.py
+++ b/api/tests/unit/test_cli_surface_smoke.py
@@ -36,6 +36,7 @@ TOP_LEVEL_COMMANDS = {
     "migrate-imports",
     "skill",
     "login",
+    "update",
     "logout",
     "auth",
     "help",


### PR DESCRIPTION
## What changed

- add `bifrost update` with optional `--url` targeting
- reuse the existing connection resolution order, including selected defaults and interactive selection
- update pipx-managed installs through pipx and other installs through their current Python environment
- let the update command bypass the CLI compatibility gate so an incompatible CLI can recover
- surface installer failures with a copyable manual command

## Why

Updating the CLI currently requires users to copy the instance-specific `/api/cli/download` install command. This adds a safe shortcut tied to the active Bifrost connection while preserving pipx metadata when applicable.

## User impact

Users can now run `bifrost update` for the active/default instance or `bifrost update --url <instance>` to target a specific server.

## Validation

- focused CLI suite: 126 passed
- full backend suite: 6,956 passed, 55 pre-existing environment-dependent skips
- API quality checks: pyright 0 errors; ruff passed
- disposable standard-venv self-update smoke test passed
- disposable pipx-managed self-update smoke test passed
