### PR TITLE
Enable loose v2 app migration staging

### DIFF
--- a/api/src/repositories/applications.py
+++ b/api/src/repositories/applications.py
@@ -7,6 +7,7 @@ HTTP-handler-only surface. See docs/plans/2026-05-26-org-scoping-consolidation.m
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from datetime import datetime, timezone
 from uuid import UUID
@@ -170,22 +171,6 @@ class ApplicationRepository(OrgScopedRepository[Application]):
         if existing:
             raise ValueError(f"Application with slug '{data.slug}' already exists")
 
-        # standalone_v2 apps render only from a built dist, and the ONLY thing
-        # that builds + serves that dist is a Solution deploy (deploy.py builds
-        # to _apps/{id}/). A bare `apps create` makes a LOOSE (non-solution) app
-        # — solution apps are created by deploy, not here — so a v2 app created
-        # this way could never render. Bark instead of silently making a dead
-        # app. v2 = a Solutions thing: scaffold with `bifrost solution
-        # scaffold-app` and deploy. inline_v1 is the standalone/legacy model.
-        if data.app_model == "standalone_v2":
-            raise ValueError(
-                "standalone_v2 apps live in a Solution (only a Solution deploy "
-                "builds + serves their dist). Create one with "
-                "`bifrost solution scaffold-app <slug>` inside a Solution "
-                "workspace, then `bifrost solution deploy`. To make a legacy "
-                "standalone app here, pass app_model='inline_v1' explicitly."
-            )
-
         application = Application(
             name=data.name,
             slug=data.slug,
@@ -200,8 +185,16 @@ class ApplicationRepository(OrgScopedRepository[Application]):
         self.session.add(application)
         await self.session.flush()
 
-        # Scaffold initial files via FileStorageService
-        await self._scaffold_code_files(application.slug)
+        if data.app_model == "standalone_v2":
+            # Migration staging deliberately creates a loose v2 app first so it
+            # can run against loose backing entities, participate in a slug
+            # swap, and only then be captured by a Solution. Build the already-
+            # authored _repo source into the same _apps/{id}/dist location used
+            # by Solution apps; never replace it with the inline-v1 scaffold.
+            await self._build_loose_v2_dist(application)
+        else:
+            # Legacy inline apps keep the App Builder scaffold behavior.
+            await self._scaffold_code_files(application.slug)
 
         # Add role associations if role_based access
         if data.access_level == "role_based" and data.role_ids:
@@ -218,6 +211,45 @@ class ApplicationRepository(OrgScopedRepository[Application]):
 
         logger.info(f"Created application '{log_safe(data.slug)}' in org {self.org_id} with access_level={log_safe(data.access_level)}")
         return application
+
+    async def _build_loose_v2_dist(self, application: Application) -> None:
+        """Build an authored loose standalone_v2 app from its _repo source."""
+        from src.services.file_storage import FileStorageService
+        from src.services.solutions.app_build import SolutionAppBuilder
+
+        prefix = application.repo_prefix
+        storage = FileStorageService(self.session)
+        entries = await storage.list_files(prefix.rstrip("/"), recursive=True)
+        src_files: dict[str, bytes] = {}
+        for entry in entries:
+            full_path = str(entry.path)
+            if not full_path.startswith(prefix):
+                continue
+            relative_path = full_path[len(prefix):]
+            if not relative_path:
+                continue
+            content, _metadata = await storage.read_file(full_path)
+            src_files[relative_path] = content
+
+        if "package.json" not in src_files or "index.html" not in src_files:
+            raise ValueError(
+                f"standalone_v2 source must already exist under {prefix} "
+                "and include package.json plus index.html; push the app source first"
+            )
+
+        builder = SolutionAppBuilder()
+        try:
+            dist = await asyncio.to_thread(
+                builder.compile_dist,
+                application.id,
+                src_files,
+                application.dependencies or {},
+            )
+            await builder.upload_dist(application.id, dist)
+        except Exception as exc:
+            raise ValueError(
+                f"standalone_v2 build failed for {application.slug}: {exc}"
+            ) from exc
 
     async def update_application(
         self,
@@ -661,4 +693,3 @@ export default function RootLayout() {
         Published snapshots are immutable point-in-time captures.
         """
         raise ValueError("Version rollback is not supported. Use published snapshots instead.")
-

--- a/api/tests/e2e/platform/test_loose_v2_app_e2e.py
+++ b/api/tests/e2e/platform/test_loose_v2_app_e2e.py
@@ -1,0 +1,100 @@
+"""Loose standalone_v2 staging for v1-to-Solution migrations."""
+
+from __future__ import annotations
+
+import json
+import re
+import uuid
+
+import pytest
+
+pytestmark = pytest.mark.e2e
+
+
+def _write(e2e_client, headers, path: str, content: str) -> None:
+    response = e2e_client.put(
+        "/api/files/editor/content",
+        headers=headers,
+        json={"path": path, "content": content, "encoding": "utf-8"},
+    )
+    assert response.status_code in (200, 201), response.text
+
+
+def test_loose_v2_app_builds_serves_and_remains_capture_eligible(
+    e2e_client, platform_admin
+):
+    headers = platform_admin.headers
+    slug = f"loose-v2-{uuid.uuid4().hex[:8]}"
+    prefix = f"apps/{slug}"
+    package = {
+        "name": slug,
+        "private": True,
+        "type": "module",
+        "scripts": {"build": "vite build"},
+        "devDependencies": {"vite": "^8.1.4"},
+    }
+    paths = [
+        f"{prefix}/package.json",
+        f"{prefix}/index.html",
+        f"{prefix}/src/main.js",
+    ]
+    _write(e2e_client, headers, paths[0], json.dumps(package))
+    _write(
+        e2e_client,
+        headers,
+        paths[1],
+        '<!doctype html><div id="root"></div><script type="module" src="/src/main.js"></script>',
+    )
+    _write(
+        e2e_client,
+        headers,
+        paths[2],
+        'document.querySelector("#root").textContent = "loose v2 staged";',
+    )
+
+    created = e2e_client.post(
+        "/api/applications",
+        headers=headers,
+        json={
+            "name": "Loose V2 Staging",
+            "slug": slug,
+            "app_model": "standalone_v2",
+            "organization_id": None,
+        },
+    )
+    assert created.status_code == 201, created.text
+    app = created.json()
+    app_id = app["id"]
+    assert app["app_model"] == "standalone_v2"
+    assert app["organization_id"] is None
+    assert app["is_solution_managed"] is False
+
+    index = e2e_client.get(
+        f"/api/applications/{app_id}/dist/index.html", headers=headers
+    )
+    assert index.status_code == 200, index.text
+    match = re.search(r'<script[^>]+src="([^"]+)"', index.text)
+    assert match is not None
+    asset_path = match.group(1).split(f"/api/applications/{app_id}/dist/")[-1]
+    asset = e2e_client.get(
+        f"/api/applications/{app_id}/dist/{asset_path}", headers=headers
+    )
+    assert asset.status_code == 200, asset.text
+    assert "loose v2 staged" in asset.text
+
+    solution = e2e_client.post(
+        "/api/solutions",
+        headers=headers,
+        json={
+            "slug": f"capture-{slug}",
+            "name": "Loose V2 Capture Target",
+            "organization_id": None,
+        },
+    )
+    assert solution.status_code in (200, 201), solution.text
+    candidates = e2e_client.get(
+        f"/api/solutions/{solution.json()['id']}/capture/candidates",
+        headers=headers,
+    )
+    assert candidates.status_code == 200, candidates.text
+    assert app_id in {candidate["id"] for candidate in candidates.json()["apps"]}

--- a/api/tests/unit/repositories/test_applications_repository.py
+++ b/api/tests/unit/repositories/test_applications_repository.py
@@ -68,17 +68,29 @@ async def test_create_application_takes_slug_advisory_lock_first(db_session, mon
     ), "duplicate-check SELECT not found after the lock"
 
 
-async def test_create_application_barks_on_v2_default(db_session):
-    """A bare `apps create` defaults to standalone_v2, but a loose (non-solution)
-    v2 app can never render (only a Solution deploy builds its dist). So
-    create_application REFUSES v2 with a message pointing at the Solution flow.
-    Solution apps are created by deploy, not this path."""
+async def test_create_application_builds_loose_v2_from_authored_source(
+    db_session, monkeypatch
+):
+    """Loose v2 is the migration staging model: build it, do not v1-scaffold it."""
     repo = ApplicationRepository(db_session, org_id=None, user_id=None, is_superuser=True)
-    with pytest.raises(ValueError, match="Solution"):
-        await repo.create_application(
-            ApplicationCreate(name="V2 loose", slug=f"v2-{uuid.uuid4().hex[:8]}"),
-            created_by="dev@x",
-        )
+    built: list[Application] = []
+
+    async def _fake_build(app: Application) -> None:
+        built.append(app)
+
+    async def _unexpected_scaffold(_slug: str) -> None:
+        raise AssertionError("standalone_v2 must not receive the inline_v1 scaffold")
+
+    monkeypatch.setattr(repo, "_build_loose_v2_dist", _fake_build)
+    monkeypatch.setattr(repo, "_scaffold_code_files", _unexpected_scaffold)
+
+    app = await repo.create_application(
+        ApplicationCreate(name="V2 loose", slug=f"v2-{uuid.uuid4().hex[:8]}"),
+        created_by="dev@x",
+    )
+
+    assert app.app_model == "standalone_v2"
+    assert built == [app]
 
 
 async def test_create_application_default_is_v2():


### PR DESCRIPTION
## What changed

- allow authored loose `standalone_v2` applications to be created for migration staging
- build their existing `_repo/apps/<slug>` source into the normal application dist store
- preserve the legacy scaffold path for `inline_v1` applications
- cover creation, serving, and Solution-capture eligibility end to end

## Why

The supported v1-to-Solution migration sequence needs a temporary loose v2 application so it can run against existing loose tables, be proven in place, participate in a slug swap, and then be captured into a Solution. The repository previously rejected this state even though swap and capture already supported it.

## Validation

- `./test.sh tests/unit/repositories/test_applications_repository.py -v` — 4 passed
- `./test.sh tests/e2e/platform/test_loose_v2_app_e2e.py -v` — 1 passed
- `./test.sh quality api` — 0 errors, all checks passed
- `git diff --check`

Docs freshness reports pre-existing CLI drift in `api/bifrost/cli.py`; this API repository change does not add or change CLI flags.
