### PR TITLE
fix(cli): clear folder credentials on logout

### DIFF
--- a/.claude/skills/bifrost-build/SKILL.md
+++ b/.claude/skills/bifrost-build/SKILL.md
@@ -11,12 +11,33 @@ Build Bifrost artifacts — apps, workflows, forms, agents, tables, and files. T
 
 ```bash
 echo "SDK: $BIFROST_SDK_INSTALLED | Login: $BIFROST_LOGGED_IN | MCP: $BIFROST_MCP_CONFIGURED"
-echo "Source: $BIFROST_HAS_SOURCE | Path: $BIFROST_SOURCE_PATH | URL: $BIFROST_DEV_URL"
+echo "Source: $BIFROST_HAS_SOURCE | Path: $BIFROST_SOURCE_PATH"
+command -v bifrost >/dev/null && bifrost auth default
 ```
 
-**If SDK or Login is false/empty:** Direct user to run `/bifrost:setup` first.
+**If the SDK is false/empty or the CLI is not authenticated:** Direct the user
+to run `/bifrost:setup` first.
 
-**If `BIFROST_DEV_URL` is empty:** Ask the user: "I don't see `BIFROST_DEV_URL` set — what URL should I use for previews and platform links?" Never invent a `*.gobifrost.com` / `*.musick.gg` / etc. host.
+## Connection model
+
+Bifrost can store credentials for multiple instance URLs. The nearest `.env`
+in the current folder or a parent binds that workspace to one connection; a
+folder without a binding uses the user's saved default.
+
+`bifrost auth default` is read-only. Its `Default connection` line shows the
+saved fallback, while `Current connection` shows what commands from this
+folder will use. Before discovery or mutation, confirm the current connection
+is the intended instance. If it is wrong, run from the intended workspace or
+neutral folder. Do not change the saved default merely to work with a debug
+stack; the debug skill creates a dedicated folder binding.
+
+Most entity commands do not accept `--url`; the folder binding is their
+connection selector. Never repoint a bound folder by overriding only
+`BIFROST_API_URL`, because folder-loaded tokens may belong to its original URL.
+
+`BIFROST_DEV_URL` is only a base for preview and platform links. It does not
+select or prove the authenticated CLI connection. If it is empty and a link is
+needed, ask the user for the base URL. Never invent a host.
 
 ## Step 1: Detect Workspace Mode
 

--- a/.claude/skills/bifrost-debug/SKILL.md
+++ b/.claude/skills/bifrost-debug/SKILL.md
@@ -52,37 +52,43 @@ The user picks the mode by setting (or not setting) `NETBIRD_SETUP_KEY` in `~/.c
 
 4. **Point at logs if they ask.** `./debug.sh logs <service>` — services include `api`, `client`, `worker`, `scheduler`, `postgres`, `rabbitmq`, `redis`, `minio`.
 
-## Auto-connect the CLI in this folder
+## Connect the CLI
 
-After `./debug.sh up`, wire the per-folder CLI to target this stack. Tokens for multiple instances coexist in the OS keychain, keyed by URL — the user's prod token (if any) is not affected.
+Bifrost can keep credentials for several instances. A folder's nearest `.env`
+selects the connection for commands run there; otherwise the CLI uses the
+user's saved default. Debug should use its own folder binding and must not
+change that saved default.
 
-1. Run the standard browser login against the debug URL:
-
-   ```bash
-   bifrost login --url <URL_FROM_DEBUG_STATUS>
-   ```
-
-   This opens the device-code page, the user accepts, and the token lands in the keychain (or the JSON fallback on headless Linux). On success, `bifrost login` also writes `BIFROST_API_URL=<URL>` to `.env` in the current directory and adds `.env` to `.gitignore` if it isn't already.
-
-2. Tell the user: *"Stack up at <URL>. CLI in this folder is now connected — token is in your keychain alongside any other instances you've logged into."*
-
-On `./debug.sh down`, run:
+After the stack is up, create one scratch directory for this worktree. Never
+run debug CLI commands from bare `/tmp`.
 
 ```bash
-bifrost logout --url <URL>
+mkdir -p /tmp/bifrost-cli-<worktree-name>
+cd /tmp/bifrost-cli-<worktree-name>
+touch .env
+python3 -m venv .venv
+./.venv/bin/pip install --quiet --upgrade pip
+./.venv/bin/pip install --quiet "<URL_FROM_DEBUG_STATUS>/api/cli/download"
+./.venv/bin/bifrost login --url <URL_FROM_DEBUG_STATUS> \
+  --email dev@gobifrost.com --password password
 ```
 
-That removes the keychain entry and prompts to remove the matching `BIFROST_API_URL` line from `.env`.
+The empty `.env` created before the first CLI call prevents an unrelated
+parent `.env` from being loaded. Login then writes this debug stack's URL and
+tokens into that scratch `.env`. Run all later debug-instance CLI commands
+from the same scratch directory with `./.venv/bin/bifrost ...`.
 
-### When to use password-grant instead
+Run `./debug.sh` commands from the worktree, never from the scratch directory.
+If the connection is ever unclear, `bifrost auth default` is a read-only check:
+the `Current connection` line is what commands in that folder will use.
 
-If the user wants tokens that *don't* persist anywhere — POC folders, throwaway sessions — use the password-grant path:
+When explicitly tearing down the stack, clear its folder binding before or
+after `./debug.sh down`:
 
 ```bash
-bifrost login --url <URL> --email dev@gobifrost.com --password password
+cd /tmp/bifrost-cli-<worktree-name>
+./.venv/bin/bifrost logout --url <URL_FROM_DEBUG_STATUS> --yes
 ```
-
-This prints three `BIFROST_*` lines to stdout and writes nothing to disk. The caller can `eval` them or pipe them into `.env`. Only works on instances with `BIFROST_MFA_ENABLED=false`. Do not suggest this as the default — it exists for the "leave no trace" use case.
 
 ## Lifecycle: who tears down what
 

--- a/.claude/skills/bifrost-setup/SKILL.md
+++ b/.claude/skills/bifrost-setup/SKILL.md
@@ -18,6 +18,17 @@ Before running any commands, introduce the setup process to the user:
 >
 > Let me check your current setup status...
 
+## Connection model
+
+Bifrost stores credentials separately for each instance URL, so several
+connections can coexist on one computer. A folder's nearest `.env` binds CLI
+commands in that workspace to one of those connections. Without a folder
+binding, the CLI uses the user's saved default.
+
+`bifrost auth default` only reports these values; it changes nothing. Only
+`bifrost auth use <url>` changes the saved default, so never run it unless the
+user explicitly asks to change their default connection.
+
 ## Check Current State
 
 Run this command to check environment (set by SessionStart hook):
@@ -25,13 +36,17 @@ Run this command to check environment (set by SessionStart hook):
 ```bash
 echo "SDK: $BIFROST_SDK_INSTALLED | Login: $BIFROST_LOGGED_IN | MCP: $BIFROST_MCP_CONFIGURED"
 echo "Python: $BIFROST_PYTHON_CMD ($BIFROST_PYTHON_VERSION) | Pip: $BIFROST_PIP_CMD | OS: $BIFROST_OS"
+command -v bifrost >/dev/null && bifrost auth default
 ```
+
+The environment flags are hints. When the CLI is installed, the read-only
+`bifrost auth default` output is the source of truth for the current folder.
 
 ## Resume Logic
 
 Based on the environment state:
 
-1. **All true** -> Setup complete! Inform user they're ready to use `/bifrost:build`
+1. **All true and current connection is intended** -> Setup complete! Inform user they're ready to use `/bifrost:build`
 2. **SDK installed + logged in, MCP not configured** -> SDK-first development is ready! MCP is optional — the CLI (`bifrost api`, `bifrost watch`) handles most operations. MCP is only needed for creating forms/apps/agents and knowledge search. Ask if they want to configure it.
 3. **SDK not installed** -> Go to SDK Installation
 4. **SDK installed but not logged in** -> Go to Login
@@ -98,11 +113,15 @@ winget or python.org, then use `py -3.11` explicitly. Do not use plain
 
 ### Get Bifrost URL
 
-**If `$BIFROST_DEV_URL` is set:** Use that URL (already detected from credentials).
+If `bifrost auth default` already shows the intended current connection, reuse
+that URL and do not log in again.
 
 **Otherwise:** Ask the user: "What is your Bifrost instance URL? (e.g., https://yourcompany.gobifrost.com)"
 
 Do NOT suggest placeholder URLs - every Bifrost instance has a unique URL provided by the user's organization.
+
+`BIFROST_DEV_URL` is for preview and platform links. Do not use it as evidence
+of the authenticated CLI connection.
 
 ### Install SDK
 
@@ -128,14 +147,26 @@ If `bifrost` is not on PATH yet, open a new PowerShell window or run it from
 
 ## Login
 
+Run login from the project folder the user wants connected:
+
 ```bash
 bifrost login --url {url}
+bifrost auth default
 ```
 
 This opens a browser for authentication. On Windows, credentials are stored in
 Windows Credential Manager when keyring is available, with
 `%APPDATA%\Bifrost\credentials.json` as the fallback. On Linux/macOS, keyring is
-used when available with `~/.bifrost/credentials.json` as the fallback.
+used when available with `~/.bifrost/credentials.json` as the fallback. Login
+also writes the URL to the current folder's `.env`, binding that folder to the
+connection. Tokens for other instance URLs remain available.
+
+For the repository's local debug stack, use the `bifrost-debug` skill instead;
+it knows the default `dev@gobifrost.com` / `password` credentials and creates a
+dedicated scratch-folder binding without changing the saved default.
+
+To disconnect a specific instance, use `bifrost logout --url {url}`. It clears
+that URL's stored credentials and offers to remove a matching folder binding.
 
 ## MCP Configuration
 

--- a/.codex/skills/bifrost-debug/SKILL.md
+++ b/.codex/skills/bifrost-debug/SKILL.md
@@ -52,37 +52,43 @@ The user picks the mode by setting (or not setting) `NETBIRD_SETUP_KEY` in `~/.c
 
 4. **Point at logs if they ask.** `./debug.sh logs <service>` — services include `api`, `client`, `worker`, `scheduler`, `postgres`, `rabbitmq`, `redis`, `minio`.
 
-## Auto-connect the CLI in this folder
+## Connect the CLI
 
-After `./debug.sh up`, wire the per-folder CLI to target this stack. Tokens for multiple instances coexist in the OS keychain, keyed by URL — the user's prod token (if any) is not affected.
+Bifrost can keep credentials for several instances. A folder's nearest `.env`
+selects the connection for commands run there; otherwise the CLI uses the
+user's saved default. Debug should use its own folder binding and must not
+change that saved default.
 
-1. Run the standard browser login against the debug URL:
-
-   ```bash
-   bifrost login --url <URL_FROM_DEBUG_STATUS>
-   ```
-
-   This opens the device-code page, the user accepts, and the token lands in the keychain (or the JSON fallback on headless Linux). On success, `bifrost login` also writes `BIFROST_API_URL=<URL>` to `.env` in the current directory and adds `.env` to `.gitignore` if it isn't already.
-
-2. Tell the user: *"Stack up at <URL>. CLI in this folder is now connected — token is in your keychain alongside any other instances you've logged into."*
-
-On `./debug.sh down`, run:
+After the stack is up, create one scratch directory for this worktree. Never
+run debug CLI commands from bare `/tmp`.
 
 ```bash
-bifrost logout --url <URL>
+mkdir -p /tmp/bifrost-cli-<worktree-name>
+cd /tmp/bifrost-cli-<worktree-name>
+touch .env
+python3 -m venv .venv
+./.venv/bin/pip install --quiet --upgrade pip
+./.venv/bin/pip install --quiet "<URL_FROM_DEBUG_STATUS>/api/cli/download"
+./.venv/bin/bifrost login --url <URL_FROM_DEBUG_STATUS> \
+  --email dev@gobifrost.com --password password
 ```
 
-That removes the keychain entry and prompts to remove the matching `BIFROST_API_URL` line from `.env`.
+The empty `.env` created before the first CLI call prevents an unrelated
+parent `.env` from being loaded. Login then writes this debug stack's URL and
+tokens into that scratch `.env`. Run all later debug-instance CLI commands
+from the same scratch directory with `./.venv/bin/bifrost ...`.
 
-### When to use password-grant instead
+Run `./debug.sh` commands from the worktree, never from the scratch directory.
+If the connection is ever unclear, `bifrost auth default` is a read-only check:
+the `Current connection` line is what commands in that folder will use.
 
-If the user wants tokens that *don't* persist anywhere — POC folders, throwaway sessions — use the password-grant path:
+When explicitly tearing down the stack, clear its folder binding before or
+after `./debug.sh down`:
 
 ```bash
-bifrost login --url <URL> --email dev@gobifrost.com --password password
+cd /tmp/bifrost-cli-<worktree-name>
+./.venv/bin/bifrost logout --url <URL_FROM_DEBUG_STATUS> --yes
 ```
-
-This prints three `BIFROST_*` lines to stdout and writes nothing to disk. The caller can `eval` them or pipe them into `.env`. Only works on instances with `BIFROST_MFA_ENABLED=false`. Do not suggest this as the default — it exists for the "leave no trace" use case.
 
 ## Lifecycle: who tears down what
 

--- a/api/bifrost/cli.py
+++ b/api/bifrost/cli.py
@@ -494,7 +494,8 @@ def logout_flow(api_url: str | None = None) -> tuple[bool, str | None]:
 
     Args:
         api_url: URL to log out from. If None, resolves the same way
-            get_credentials() does (env var, then first stored URL).
+            get_credentials() does (folder/env binding, saved default, then
+            the sole stored connection).
 
     Returns:
         (cleared, url) — cleared is True if a record was removed; url is
@@ -581,29 +582,45 @@ def _write_env_url(api_url: str) -> None:
             pass
 
 
-def _remove_env_url_line(api_url: str) -> bool:
-    """
-    Remove a `BIFROST_API_URL=<api_url>` line from CWD's .env, if present.
+def _line_assigns_env_var(line: str, key: str) -> bool:
+    stripped = line.lstrip()
+    return stripped.startswith(f"{key}=") or stripped.startswith(f"export {key}=")
 
-    Returns True if a line was removed.
+
+def _remove_env_connection(api_url: str) -> bool:
+    """
+    Remove a matching folder-local Bifrost connection from CWD's .env.
+
+    The URL is the binding key. Only when it matches ``api_url`` do we remove
+    the URL plus any password-grant access and refresh tokens from that file.
+    Browser login writes only the URL, while password-grant login writes all
+    three values.
+
+    Returns True if a matching connection was removed.
     """
     env_path = pathlib.Path.cwd() / ".env"
     lines = _read_env_file(env_path)
     if not lines:
         return False
     target = api_url.rstrip("/")
-    kept: list[str] = []
-    removed = False
-    for line in lines:
-        stripped = line.lstrip()
-        if stripped.startswith("BIFROST_API_URL=") or stripped.startswith("export BIFROST_API_URL="):
-            value = line.split("=", 1)[1].strip().strip('"').strip("'").rstrip("/")
-            if value == target:
-                removed = True
-                continue
-        kept.append(line)
-    if not removed:
+    has_matching_url = any(
+        _line_assigns_env_var(line, "BIFROST_API_URL")
+        and line.split("=", 1)[1].strip().strip('"').strip("'").rstrip("/") == target
+        for line in lines
+    )
+    if not has_matching_url:
         return False
+
+    connection_keys = {
+        "BIFROST_API_URL",
+        "BIFROST_ACCESS_TOKEN",
+        "BIFROST_REFRESH_TOKEN",
+    }
+    kept = [
+        line
+        for line in lines
+        if not any(_line_assigns_env_var(line, key) for key in connection_keys)
+    ]
     if all(not line.strip() for line in kept):
         env_path.unlink()
     else:
@@ -1095,15 +1112,18 @@ Usage: bifrost logout [options]
 Clear stored credentials for one Bifrost URL.
 
 If --url is omitted, logs out from the URL resolved by the same rules as
-`bifrost api ...` (BIFROST_API_URL env var, then the first stored URL).
+`bifrost api ...` (folder/env binding, saved default, then the sole stored
+connection).
 
-After clearing the keychain entry, if the current directory's .env contains
-a BIFROST_API_URL line for that URL, you'll be prompted to remove it.
+After clearing persistent credentials, if the current directory's .env is
+bound to that URL, you'll be prompted to remove the complete folder binding.
+For browser login this is the URL; for password login it also includes the
+folder-local access and refresh tokens.
 
 Options:
   --url, -u URL   Specific URL to log out from
   --yes, -y       Auto-confirm the .env removal prompt
-  --no-prompt     Skip the .env prompt entirely (leaves it as-is)
+  --no-prompt     Skip the .env prompt entirely (leaves the folder binding as-is)
   --help, -h      Show this help message
 
 Examples:
@@ -1119,14 +1139,14 @@ Examples:
     if not cleared or target_url is None:
         return 0
 
-    # Prompt to remove the matching .env line, if present
+    # Prompt to remove the matching folder-local connection, if present.
     if no_prompt:
         return 0
     env_path = pathlib.Path.cwd() / ".env"
     if not env_path.exists():
         return 0
     has_match = any(
-        line.lstrip().startswith(("BIFROST_API_URL=", "export BIFROST_API_URL="))
+        _line_assigns_env_var(line, "BIFROST_API_URL")
         and line.split("=", 1)[1].strip().strip('"').strip("'").rstrip("/") == target_url.rstrip("/")
         for line in _read_env_file(env_path)
     )
@@ -1137,12 +1157,14 @@ Examples:
         confirm = "y"
     else:
         try:
-            confirm = input(f"Remove BIFROST_API_URL={target_url} from {env_path}? [y/N] ").strip().lower()
+            confirm = input(
+                f"Remove Bifrost connection for {target_url} from {env_path}? [y/N] "
+            ).strip().lower()
         except EOFError:
             confirm = "n"
     if confirm in ("y", "yes"):
-        if _remove_env_url_line(target_url):
-            print(f"Removed BIFROST_API_URL line from {env_path}")
+        if _remove_env_connection(target_url):
+            print(f"Removed Bifrost connection for {target_url} from {env_path}")
     return 0
 
 

--- a/api/bifrost/credentials.py
+++ b/api/bifrost/credentials.py
@@ -612,10 +612,10 @@ def clear_credentials(api_url: str | None = None) -> None:
     """
     Remove a single URL's credentials from the persistent backend.
 
-    No-arg behavior uses the same resolution as get_credentials(): env var,
-    then first URL in store. So a `bifrost logout` after a `bifrost login`
-    targets the same record `get_credentials()` would have returned, even
-    when multiple URLs are present.
+    No-arg behavior uses the same resolution as get_credentials(): an explicit
+    environment/folder binding, the saved default, or the sole stored URL. So
+    a `bifrost logout` targets the same connection `get_credentials()` would
+    have returned.
     """
     target = _resolve_url(api_url)
     if target is None:

--- a/api/tests/unit/test_cli_login_ephemeral.py
+++ b/api/tests/unit/test_cli_login_ephemeral.py
@@ -267,7 +267,7 @@ class TestLogoutClearsKeychainAndPromptsEnv:
         assert creds_mod.get_credentials("https://prod.example.com") is None
         assert creds_mod.get_credentials("http://localhost:38421") is not None
 
-    def test_logout_yes_removes_matching_env_line(self, monkeypatch, tmp_path):
+    def test_logout_yes_removes_matching_browser_env_binding(self, monkeypatch, tmp_path):
         from bifrost import credentials as creds_mod
         monkeypatch.setattr(
             creds_mod,
@@ -295,6 +295,74 @@ class TestLogoutClearsKeychainAndPromptsEnv:
         env_text = (tmp_path / ".env").read_text()
         assert "OTHER_VAR=keep-me" in env_text
         assert "BIFROST_API_URL=" not in env_text
+
+    def test_logout_yes_removes_complete_password_grant_binding(
+        self, monkeypatch, tmp_path,
+    ):
+        from bifrost import credentials as creds_mod
+
+        monkeypatch.setattr(
+            creds_mod,
+            "get_credentials_path",
+            lambda: tmp_path / "credentials.json",
+        )
+        monkeypatch.setattr(creds_mod, "_select_persistent_backend", creds_mod.JsonBackend)
+        creds_mod._reset_persistent_backend_for_tests()
+        monkeypatch.setenv("BIFROST_API_URL", "http://localhost:38421")
+        monkeypatch.setenv("BIFROST_ACCESS_TOKEN", "debug-at")
+        monkeypatch.setenv("BIFROST_REFRESH_TOKEN", "debug-rt")
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / ".env").write_text(
+            "OTHER_VAR=keep-me\n"
+            "BIFROST_API_URL=http://localhost:38421\n"
+            "BIFROST_ACCESS_TOKEN=debug-at\n"
+            "BIFROST_REFRESH_TOKEN=debug-rt\n"
+        )
+
+        rc = cli.handle_logout([
+            "--url", "http://localhost:38421",
+            "--yes",
+        ])
+
+        assert rc == 0
+        assert (tmp_path / ".env").read_text() == "OTHER_VAR=keep-me\n"
+
+    def test_logout_does_not_remove_different_folder_binding(
+        self, monkeypatch, tmp_path,
+    ):
+        from bifrost import credentials as creds_mod
+
+        monkeypatch.setattr(
+            creds_mod,
+            "get_credentials_path",
+            lambda: tmp_path / "credentials.json",
+        )
+        monkeypatch.setattr(creds_mod, "_select_persistent_backend", creds_mod.JsonBackend)
+        creds_mod._reset_persistent_backend_for_tests()
+        monkeypatch.delenv("BIFROST_API_URL", raising=False)
+        monkeypatch.delenv("BIFROST_ACCESS_TOKEN", raising=False)
+        monkeypatch.delenv("BIFROST_REFRESH_TOKEN", raising=False)
+        monkeypatch.chdir(tmp_path)
+        creds_mod.save_credentials(
+            "https://prod.example.com",
+            "prod-at",
+            "prod-rt",
+            "2099-01-01T00:00:00+00:00",
+        )
+        binding = (
+            "BIFROST_API_URL=http://localhost:38421\n"
+            "BIFROST_ACCESS_TOKEN=debug-at\n"
+            "BIFROST_REFRESH_TOKEN=debug-rt\n"
+        )
+        (tmp_path / ".env").write_text(binding)
+
+        rc = cli.handle_logout([
+            "--url", "https://prod.example.com",
+            "--yes",
+        ])
+
+        assert rc == 0
+        assert (tmp_path / ".env").read_text() == binding
 
     def test_logout_no_prompt_leaves_env_alone(self, monkeypatch, tmp_path):
         from bifrost import credentials as creds_mod

--- a/plugins/bifrost/skills/bifrost-build/SKILL.md
+++ b/plugins/bifrost/skills/bifrost-build/SKILL.md
@@ -11,12 +11,33 @@ Build Bifrost artifacts — apps, workflows, forms, agents, tables, and files. T
 
 ```bash
 echo "SDK: $BIFROST_SDK_INSTALLED | Login: $BIFROST_LOGGED_IN | MCP: $BIFROST_MCP_CONFIGURED"
-echo "Source: $BIFROST_HAS_SOURCE | Path: $BIFROST_SOURCE_PATH | URL: $BIFROST_DEV_URL"
+echo "Source: $BIFROST_HAS_SOURCE | Path: $BIFROST_SOURCE_PATH"
+command -v bifrost >/dev/null && bifrost auth default
 ```
 
-**If SDK or Login is false/empty:** Direct user to run `/bifrost:setup` first.
+**If the SDK is false/empty or the CLI is not authenticated:** Direct the user
+to run `/bifrost:setup` first.
 
-**If `BIFROST_DEV_URL` is empty:** Ask the user: "I don't see `BIFROST_DEV_URL` set — what URL should I use for previews and platform links?" Never invent a `*.gobifrost.com` / `*.musick.gg` / etc. host.
+## Connection model
+
+Bifrost can store credentials for multiple instance URLs. The nearest `.env`
+in the current folder or a parent binds that workspace to one connection; a
+folder without a binding uses the user's saved default.
+
+`bifrost auth default` is read-only. Its `Default connection` line shows the
+saved fallback, while `Current connection` shows what commands from this
+folder will use. Before discovery or mutation, confirm the current connection
+is the intended instance. If it is wrong, run from the intended workspace or
+neutral folder. Do not change the saved default merely to work with a debug
+stack; the debug skill creates a dedicated folder binding.
+
+Most entity commands do not accept `--url`; the folder binding is their
+connection selector. Never repoint a bound folder by overriding only
+`BIFROST_API_URL`, because folder-loaded tokens may belong to its original URL.
+
+`BIFROST_DEV_URL` is only a base for preview and platform links. It does not
+select or prove the authenticated CLI connection. If it is empty and a link is
+needed, ask the user for the base URL. Never invent a host.
 
 ## Step 1: Detect Workspace Mode
 

--- a/plugins/bifrost/skills/bifrost-setup/SKILL.md
+++ b/plugins/bifrost/skills/bifrost-setup/SKILL.md
@@ -18,6 +18,17 @@ Before running any commands, introduce the setup process to the user:
 >
 > Let me check your current setup status...
 
+## Connection model
+
+Bifrost stores credentials separately for each instance URL, so several
+connections can coexist on one computer. A folder's nearest `.env` binds CLI
+commands in that workspace to one of those connections. Without a folder
+binding, the CLI uses the user's saved default.
+
+`bifrost auth default` only reports these values; it changes nothing. Only
+`bifrost auth use <url>` changes the saved default, so never run it unless the
+user explicitly asks to change their default connection.
+
 ## Check Current State
 
 Run this command to check environment (set by SessionStart hook):
@@ -25,13 +36,17 @@ Run this command to check environment (set by SessionStart hook):
 ```bash
 echo "SDK: $BIFROST_SDK_INSTALLED | Login: $BIFROST_LOGGED_IN | MCP: $BIFROST_MCP_CONFIGURED"
 echo "Python: $BIFROST_PYTHON_CMD ($BIFROST_PYTHON_VERSION) | Pip: $BIFROST_PIP_CMD | OS: $BIFROST_OS"
+command -v bifrost >/dev/null && bifrost auth default
 ```
+
+The environment flags are hints. When the CLI is installed, the read-only
+`bifrost auth default` output is the source of truth for the current folder.
 
 ## Resume Logic
 
 Based on the environment state:
 
-1. **All true** -> Setup complete! Inform user they're ready to use `/bifrost:build`
+1. **All true and current connection is intended** -> Setup complete! Inform user they're ready to use `/bifrost:build`
 2. **SDK installed + logged in, MCP not configured** -> SDK-first development is ready! MCP is optional — the CLI (`bifrost api`, `bifrost watch`) handles most operations. MCP is only needed for creating forms/apps/agents and knowledge search. Ask if they want to configure it.
 3. **SDK not installed** -> Go to SDK Installation
 4. **SDK installed but not logged in** -> Go to Login
@@ -98,11 +113,15 @@ winget or python.org, then use `py -3.11` explicitly. Do not use plain
 
 ### Get Bifrost URL
 
-**If `$BIFROST_DEV_URL` is set:** Use that URL (already detected from credentials).
+If `bifrost auth default` already shows the intended current connection, reuse
+that URL and do not log in again.
 
 **Otherwise:** Ask the user: "What is your Bifrost instance URL? (e.g., https://yourcompany.gobifrost.com)"
 
 Do NOT suggest placeholder URLs - every Bifrost instance has a unique URL provided by the user's organization.
+
+`BIFROST_DEV_URL` is for preview and platform links. Do not use it as evidence
+of the authenticated CLI connection.
 
 ### Install SDK
 
@@ -128,14 +147,26 @@ If `bifrost` is not on PATH yet, open a new PowerShell window or run it from
 
 ## Login
 
+Run login from the project folder the user wants connected:
+
 ```bash
 bifrost login --url {url}
+bifrost auth default
 ```
 
 This opens a browser for authentication. On Windows, credentials are stored in
 Windows Credential Manager when keyring is available, with
 `%APPDATA%\Bifrost\credentials.json` as the fallback. On Linux/macOS, keyring is
-used when available with `~/.bifrost/credentials.json` as the fallback.
+used when available with `~/.bifrost/credentials.json` as the fallback. Login
+also writes the URL to the current folder's `.env`, binding that folder to the
+connection. Tokens for other instance URLs remain available.
+
+For the repository's local debug stack, use the `bifrost-debug` skill instead;
+it knows the default `dev@gobifrost.com` / `password` credentials and creates a
+dedicated scratch-folder binding without changing the saved default.
+
+To disconnect a specific instance, use `bifrost logout --url {url}`. It clears
+that URL's stored credentials and offers to remove a matching folder binding.
 
 ## MCP Configuration
 


### PR DESCRIPTION
## Summary

- clear matching folder-local password-grant tokens during logout
- simplify debug, build, and setup guidance around folder-bound connections
- isolate debug CLI use in a dedicated scratch directory without changing the saved default

## Verification

- `./test.sh all` — 6,958 passed, 55 skipped
- `./test.sh tests/unit/test_cli_login_ephemeral.py tests/unit/test_cli_surface_smoke.py tests/unit/test_skill_appendix_fresh.py tests/unit/test_codex_mirror_sync.py -v` — 135 passed, 2 environment-dependent mirror skips
- `./test.sh quality api`
- canonical and generated skill mirrors compared exactly

Fixes #481