### PR TITLE
Fix large workflow result latency + execution history pagination

### DIFF
--- a/api/bifrost/executions.py
+++ b/api/bifrost/executions.py
@@ -42,7 +42,10 @@ class executions:
             limit: Maximum number of results (default: 50, max: 1000)
 
         Returns:
-            list[WorkflowExecution]: List of execution objects with attributes:
+            list[WorkflowExecution]: List of execution SUMMARIES. Summaries
+            carry metadata only — ``input_data``, ``result``, ``logs``, and
+            ``variables`` are always None here; call ``executions.get(id)``
+            for a specific execution's payload. Summary attributes:
                 - execution_id: str - Unique execution ID
                 - workflow_name: str - Name of the workflow
                 - org_id: str | None - Organization ID
@@ -50,14 +53,10 @@ class executions:
                 - executed_by: str - User ID who executed
                 - executed_by_name: str - Display name of user
                 - status: str - Current status
-                - input_data: dict - Input parameters
-                - result: Any - Execution result
                 - result_type: str | None - How to render result
                 - error_message: str | None - Error if failed
                 - duration_ms: int | None - Execution duration
                 - started_at, completed_at: datetime | None
-                - logs: list[dict] | None - Execution logs
-                - variables: dict | None - Runtime variables
                 - session_id: str | None - CLI session ID
                 - peak_memory_bytes, cpu_total_seconds: Resource metrics
 

--- a/api/bifrost/models.py
+++ b/api/bifrost/models.py
@@ -106,7 +106,12 @@ class ExecutionLog(BaseModel):
 
 
 class WorkflowExecution(BaseModel):
-    """Workflow execution record."""
+    """Workflow execution record.
+
+    List responses are summaries: the server omits input_data, result, logs,
+    and variables entirely, so those default to None there. Fetch a single
+    execution (``executions.get``) for the full payload.
+    """
 
     execution_id: str
     workflow_name: str
@@ -115,15 +120,15 @@ class WorkflowExecution(BaseModel):
     executed_by: str | None
     executed_by_name: str | None
     status: str
-    input_data: dict | None
-    result: Any
+    input_data: dict | None = None
+    result: Any = None
     result_type: str | None
     error_message: str | None
     duration_ms: int | None
     started_at: datetime | None
     completed_at: datetime | None
-    logs: list[dict] | None
-    variables: dict | None
+    logs: list[dict] | None = None
+    variables: dict | None = None
     session_id: str | None
     peak_memory_bytes: int | None
     process_rss_bytes: int | None

--- a/api/src/jobs/consumers/workflow_execution.py
+++ b/api/src/jobs/consumers/workflow_execution.py
@@ -226,11 +226,27 @@ class WorkflowExecutionConsumer(BaseConsumer):
 
             await session.commit()
 
-        # Pub/sub — no DB connection held
+        # Wake sync callers as soon as their result and buffered SDK writes are
+        # durably committed.  Everything below is terminal-event fan-out or
+        # cleanup and must not add latency to the request/response path.
+        if is_sync:
+            await self._redis_client.push_result(
+                execution_id=execution_id,
+                status=status.value,
+                result=workflow_result,
+                error=result.get("error"),
+                error_type=result.get("error_type"),
+                duration_ms=duration_ms,
+            )
+
+        # Pub/sub — no DB connection held.  The result is already persisted and
+        # execution clients fetch it from the result endpoint, so publishing it
+        # again needlessly serializes and transports large payloads through
+        # Redis and WebSocket connections.
         await publish_execution_update(
             execution_id,
             status.value,
-            {"result": workflow_result, "durationMs": duration_ms},
+            {"duration_ms": duration_ms},
         )
 
         completed_at = datetime.now(timezone.utc)
@@ -253,16 +269,6 @@ class WorkflowExecutionConsumer(BaseConsumer):
             logger.warning(f"Failed to cleanup cache for {execution_id[:8]}...: {e}")
 
         await self._redis_client.delete_pending_execution(execution_id)
-
-        if is_sync:
-            await self._redis_client.push_result(
-                execution_id=execution_id,
-                status=status.value,
-                result=workflow_result,
-                error=result.get("error"),
-                error_type=result.get("error_type"),
-                duration_ms=duration_ms,
-            )
 
         logger.info(
             f"Execution result processed: {execution_id[:8]}... status={status.value}",

--- a/api/src/models/contracts/executions.py
+++ b/api/src/models/contracts/executions.py
@@ -67,8 +67,13 @@ class AIUsageTotalsSimple(BaseModel):
     call_count: int = 0
 
 
-class WorkflowExecution(BaseModel):
-    """Workflow execution entity"""
+class ExecutionSummary(BaseModel):
+    """Execution metadata without payloads — what list views return.
+
+    Deliberately omits input_data/result/logs/variables/execution_context so
+    list responses never select or serialize multi-megabyte payloads. Fetch a
+    single execution for those.
+    """
     execution_id: str
     workflow_name: str
     workflow_id: str | None = None  # FK to workflows table (null for inline scripts/legacy)
@@ -79,16 +84,12 @@ class WorkflowExecution(BaseModel):
     executed_by_name: str  # Display name of user who executed
     executed_by_email: str | None = None  # Email of user who executed
     status: ExecutionStatus
-    input_data: dict[str, Any]
-    result: dict[str, Any] | list[Any] | str | None = Field(default=None)  # Can be dict/list (JSON) or str (HTML/text)
     result_type: str | None = None  # How to render result (json, html, text)
     error_message: str | None = None
     duration_ms: int | None = None
     started_at: datetime | None = None  # May be None if not started yet
     completed_at: datetime | None = None
     scheduled_at: datetime | None = None  # For Scheduled rows, when the row is due to promote
-    logs: list[dict[str, Any]] | None = None  # Structured logger output (replaces old ExecutionLog format)
-    variables: dict[str, Any] | None = None  # Runtime variables captured from execution scope
     # CLI session tracking
     session_id: str | None = None  # CLI session ID if executed from local runner
     # Resource metrics (admin only, null for non-admins)
@@ -100,6 +101,14 @@ class WorkflowExecution(BaseModel):
     # ROI economics (admin only)
     time_saved: int = 0  # Minutes saved
     value: float = 0  # Value generated
+
+
+class WorkflowExecution(ExecutionSummary):
+    """Workflow execution entity — summary fields plus full payloads."""
+    input_data: dict[str, Any]
+    result: dict[str, Any] | list[Any] | str | None = Field(default=None)  # Can be dict/list (JSON) or str (HTML/text)
+    logs: list[dict[str, Any]] | None = None  # Structured logger output (replaces old ExecutionLog format)
+    variables: dict[str, Any] | None = None  # Runtime variables captured from execution scope
     # AI usage tracking
     ai_usage: list[AIUsagePublicSimple] | None = None
     ai_totals: AIUsageTotalsSimple | None = None
@@ -190,7 +199,7 @@ class WorkflowExecutionResponse(BaseModel):
 
 class ExecutionsListResponse(BaseModel):
     """Response model for listing workflow executions with pagination"""
-    executions: list[WorkflowExecution] = Field(..., description="List of workflow executions")
+    executions: list[ExecutionSummary] = Field(..., description="List of workflow execution summaries (no input/result payloads — fetch a single execution for those)")
     continuation_token: str | None = Field(default=None, description="Continuation token for next page (opaque, base64-encoded). Presence of token indicates more results available.")
 
 

--- a/api/src/routers/executions.py
+++ b/api/src/routers/executions.py
@@ -4,6 +4,8 @@ Executions Router
 Provides access to workflow execution history with filtering capabilities.
 """
 
+import base64
+import json
 import logging
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal
@@ -11,7 +13,7 @@ from typing import Any
 from uuid import UUID
 
 from fastapi import APIRouter, HTTPException, Query, status
-from sqlalchemy import select, and_, desc, func
+from sqlalchemy import select, and_, desc, func, or_
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import defer, selectinload
 
@@ -50,6 +52,43 @@ router = APIRouter(prefix="/api/executions", tags=["Executions"])
 
 
 # =============================================================================
+# History pagination cursor
+# =============================================================================
+#
+# History pagination is keyset-based: the continuation token names the last
+# row the client saw — (started_at, id) — and the next page is "rows strictly
+# older than that". An offset token ("give me rows 26–50") re-serves the
+# previous page's tail whenever new executions land between page loads, which
+# on a busy instance is every pagination: users stepping into the past see
+# today's rows (and a "Today" day header) at the top of every page.
+
+
+def _encode_history_cursor(started_at: datetime | None, row_id: UUID) -> str:
+    """Encode the last-served row's position as an opaque token."""
+    payload = {
+        "v": 1,
+        "s": started_at.isoformat() if started_at else None,
+        "i": str(row_id),
+    }
+    return base64.urlsafe_b64encode(json.dumps(payload).encode()).decode()
+
+
+def _decode_history_cursor(token: str) -> tuple[datetime | None, UUID] | None:
+    """Decode a keyset cursor; None for legacy offsets or malformed tokens."""
+    try:
+        payload = json.loads(base64.urlsafe_b64decode(token.encode()))
+        if not isinstance(payload, dict) or payload.get("v") != 1:
+            return None
+        raw_started = payload.get("s")
+        started_at = datetime.fromisoformat(raw_started) if raw_started else None
+        return started_at, UUID(payload["i"])
+    except (ValueError, KeyError, TypeError, json.JSONDecodeError):
+        # Not a keyset cursor (legacy numeric offset, or garbage) — the caller
+        # falls back to legacy offset parsing / first page.
+        return None
+
+
+# =============================================================================
 # Repository
 # =============================================================================
 
@@ -72,8 +111,14 @@ class ExecutionRepository:
         exclude_local: bool = True,
         limit: int = 25,
         offset: int = 0,
+        cursor: tuple[datetime | None, UUID] | None = None,
     ) -> tuple[list[ExecutionSummary], str | None]:
-        """List executions with filtering."""
+        """List executions with filtering.
+
+        `cursor` is the keyset position (last row's started_at + id); `offset`
+        is only honored for legacy numeric tokens still in flight from before
+        the keyset change. New continuation tokens are always keyset.
+        """
         query = select(ExecutionModel).options(
             selectinload(ExecutionModel.organization),
             selectinload(ExecutionModel.executed_by_user),
@@ -131,11 +176,50 @@ class ExecutionRepository:
         if exclude_local:
             query = query.where(ExecutionModel.is_local_execution == False)  # noqa: E712
 
-        # Order by newest first
-        query = query.order_by(desc(ExecutionModel.started_at))
+        # Order newest first with an id tiebreaker so the order is total:
+        # never-started rows (Scheduled/Pending, NULL started_at) sort first
+        # deterministically instead of "arbitrarily on the server" per page.
+        query = query.order_by(
+            desc(ExecutionModel.started_at).nulls_first(),
+            desc(ExecutionModel.id),
+        )
 
-        # Pagination
-        query = query.offset(offset).limit(limit + 1)  # +1 to check for more
+        # Pagination: keyset when the caller has a cursor, legacy offset
+        # otherwise (first page, or an old numeric token still in flight).
+        if cursor is not None:
+            cursor_started, cursor_id = cursor
+            if cursor_started is None:
+                # Last row served was in the leading NULL block: continue
+                # through older NULL rows, then everything started.
+                query = query.where(
+                    or_(
+                        and_(
+                            ExecutionModel.started_at.is_(None),
+                            ExecutionModel.id < cursor_id,
+                        ),
+                        ExecutionModel.started_at.is_not(None),
+                    )
+                )
+            else:
+                # Strictly older than the cursor row. Excludes the NULL block
+                # (already served on page one) — new Scheduled rows don't
+                # inject themselves into the middle of a pagination either.
+                query = query.where(
+                    and_(
+                        ExecutionModel.started_at.is_not(None),
+                        or_(
+                            ExecutionModel.started_at < cursor_started,
+                            and_(
+                                ExecutionModel.started_at == cursor_started,
+                                ExecutionModel.id < cursor_id,
+                            ),
+                        ),
+                    )
+                )
+        elif offset:
+            query = query.offset(offset)
+
+        query = query.limit(limit + 1)  # +1 to check for more
 
         result = await self.db.execute(query)
         executions = list(result.scalars().all())
@@ -145,10 +229,11 @@ class ExecutionRepository:
         if has_more:
             executions = executions[:limit]
 
-        # Generate continuation token
+        # Continuation token: keyset position of the last row served.
         next_token = None
-        if has_more:
-            next_token = str(offset + limit)
+        if has_more and executions:
+            last = executions[-1]
+            next_token = _encode_history_cursor(last.started_at, last.id)
 
         return [ExecutionRepository._to_summary(e) for e in executions], next_token
 
@@ -619,14 +704,18 @@ async def list_executions(
 
     repo = ExecutionRepository(ctx.db)
 
-    # Parse continuation token as offset
+    # Parse continuation token: keyset cursor, with legacy numeric-offset
+    # fallback for tokens minted before the keyset change.
     offset = 0
+    cursor = None
     if continuationToken:
-        try:
-            offset = int(continuationToken)
-        except ValueError as e:
-            # Malformed continuation token — start from beginning
-            logger.debug(f"invalid continuationToken {log_safe(continuationToken)!r}, starting from offset 0: {log_safe(e)}")
+        cursor = _decode_history_cursor(continuationToken)
+        if cursor is None:
+            try:
+                offset = int(continuationToken)
+            except ValueError as e:
+                # Malformed continuation token — start from beginning
+                logger.debug(f"invalid continuationToken {log_safe(continuationToken)!r}, starting from offset 0: {log_safe(e)}")
 
     # Parse workflowId to UUID if provided
     parsed_workflow_id = UUID(workflowId) if workflowId else None
@@ -642,6 +731,7 @@ async def list_executions(
         exclude_local=excludeLocal,
         limit=limit,
         offset=offset,
+        cursor=cursor,
     )
 
     return ExecutionsListResponse(

--- a/api/src/routers/executions.py
+++ b/api/src/routers/executions.py
@@ -27,6 +27,7 @@ from src.models import (
 from src.models.contracts.executions import (
     AIUsagePublicSimple,
     AIUsageTotalsSimple,
+    ExecutionSummary,
     LogsListResponse,
     LogListEntry,
 )
@@ -71,7 +72,7 @@ class ExecutionRepository:
         exclude_local: bool = True,
         limit: int = 25,
         offset: int = 0,
-    ) -> tuple[list[WorkflowExecution], str | None]:
+    ) -> tuple[list[ExecutionSummary], str | None]:
         """List executions with filtering."""
         query = select(ExecutionModel).options(
             selectinload(ExecutionModel.organization),
@@ -149,9 +150,7 @@ class ExecutionRepository:
         if has_more:
             next_token = str(offset + limit)
 
-        return [
-            self._to_pydantic(e, user, include_payload=False) for e in executions
-        ], next_token
+        return [ExecutionRepository._to_summary(e) for e in executions], next_token
 
     async def get_execution(
         self,
@@ -490,12 +489,45 @@ class ExecutionRepository:
 
         return self._to_pydantic(execution, user), None
 
+    @staticmethod
+    def _org_name(execution: ExecutionModel) -> str | None:
+        """Display name for the execution's effective scope."""
+        if execution.organization_id:
+            if hasattr(execution, 'organization') and execution.organization is not None:
+                return execution.organization.name
+            return None  # Will be populated by caller if needed
+        return "Global"  # No org_id means global scope
+
+    @staticmethod
+    def _to_summary(execution: ExecutionModel) -> ExecutionSummary:
+        """Convert SQLAlchemy model to the payload-free list model.
+
+        Must only touch columns the list query loads — the payload columns
+        (parameters/result/variables/execution_context) are deferred with
+        raiseload=True so History never selects or serializes them.
+        """
+        return ExecutionSummary(
+            execution_id=str(execution.id),
+            workflow_name=execution.workflow_name,
+            workflow_id=str(execution.workflow_id) if execution.workflow_id else None,
+            org_id=str(execution.organization_id) if execution.organization_id else None,
+            org_name=ExecutionRepository._org_name(execution),
+            form_id=str(execution.form_id) if execution.form_id else None,
+            executed_by=str(execution.executed_by),
+            executed_by_name=execution.executed_by_name or str(execution.executed_by),
+            executed_by_email=execution.executed_by_user.email if hasattr(execution, 'executed_by_user') and execution.executed_by_user else None,
+            status=ExecutionStatus(execution.status),
+            result_type=execution.result_type,
+            error_message=execution.error_message,
+            duration_ms=execution.duration_ms,
+            started_at=execution.started_at,
+            completed_at=execution.completed_at,
+            scheduled_at=execution.scheduled_at,
+            session_id=str(execution.session_id) if execution.session_id else None,
+        )
+
     def _to_pydantic(
-        self,
-        execution: ExecutionModel,
-        user: UserPrincipal | None = None,
-        *,
-        include_payload: bool = True,
+        self, execution: ExecutionModel, user: UserPrincipal | None = None
     ) -> WorkflowExecution:
         """Convert SQLAlchemy model to Pydantic model.
 
@@ -506,35 +538,22 @@ class ExecutionRepository:
             execution: The SQLAlchemy execution model
             user: Optional user for permission checks. If provided, admin-only
                   fields (variables) are gated based on is_superuser.
-            include_payload: Include input, result, variables, and execution
-                context. List views disable this so multi-megabyte results are
-                neither selected from PostgreSQL nor serialized into history.
         """
         is_admin = user.is_superuser if user else False
-        # Determine org_name: use organization relationship if loaded, otherwise None for global
-        org_name: str | None = None
-        if execution.organization_id:
-            # Try to get name from loaded relationship, fall back to "Unknown" if not loaded
-            if hasattr(execution, 'organization') and execution.organization is not None:
-                org_name = execution.organization.name
-            else:
-                org_name = None  # Will be populated by caller if needed
-        else:
-            org_name = "Global"  # No org_id means global scope
 
         return WorkflowExecution(
             execution_id=str(execution.id),
             workflow_name=execution.workflow_name,
             workflow_id=str(execution.workflow_id) if execution.workflow_id else None,
             org_id=str(execution.organization_id) if execution.organization_id else None,
-            org_name=org_name,
+            org_name=self._org_name(execution),
             form_id=str(execution.form_id) if execution.form_id else None,
             executed_by=str(execution.executed_by),
             executed_by_name=execution.executed_by_name or str(execution.executed_by),
             executed_by_email=execution.executed_by_user.email if hasattr(execution, 'executed_by_user') and execution.executed_by_user else None,
             status=ExecutionStatus(execution.status),
-            input_data=(execution.parameters or {}) if include_payload else {},
-            result=execution.result if include_payload else None,
+            input_data=execution.parameters or {},
+            result=execution.result,
             result_type=execution.result_type,
             error_message=execution.error_message,
             duration_ms=execution.duration_ms,
@@ -542,14 +561,8 @@ class ExecutionRepository:
             completed_at=execution.completed_at,
             scheduled_at=execution.scheduled_at,
             logs=None,  # Fetched separately via /logs endpoint
-            variables=(
-                execution.variables if is_admin and include_payload else None
-            ),
-            execution_context=(
-                execution.execution_context
-                if is_admin and include_payload
-                else None
-            ),
+            variables=execution.variables if is_admin else None,
+            execution_context=execution.execution_context if is_admin else None,
             session_id=str(execution.session_id) if execution.session_id else None,
         )
 

--- a/api/src/routers/executions.py
+++ b/api/src/routers/executions.py
@@ -13,7 +13,7 @@ from uuid import UUID
 from fastapi import APIRouter, HTTPException, Query, status
 from sqlalchemy import select, and_, desc, func
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import selectinload
+from sqlalchemy.orm import defer, selectinload
 
 # Import existing Pydantic models for API compatibility
 from src.models import (
@@ -73,7 +73,14 @@ class ExecutionRepository:
         offset: int = 0,
     ) -> tuple[list[WorkflowExecution], str | None]:
         """List executions with filtering."""
-        query = select(ExecutionModel).options(selectinload(ExecutionModel.organization), selectinload(ExecutionModel.executed_by_user))
+        query = select(ExecutionModel).options(
+            selectinload(ExecutionModel.organization),
+            selectinload(ExecutionModel.executed_by_user),
+            defer(ExecutionModel.parameters, raiseload=True),
+            defer(ExecutionModel.result, raiseload=True),
+            defer(ExecutionModel.variables, raiseload=True),
+            defer(ExecutionModel.execution_context, raiseload=True),
+        )
 
         # Organization scoping
         if org_id:
@@ -142,7 +149,9 @@ class ExecutionRepository:
         if has_more:
             next_token = str(offset + limit)
 
-        return [self._to_pydantic(e, user) for e in executions], next_token
+        return [
+            self._to_pydantic(e, user, include_payload=False) for e in executions
+        ], next_token
 
     async def get_execution(
         self,
@@ -482,7 +491,11 @@ class ExecutionRepository:
         return self._to_pydantic(execution, user), None
 
     def _to_pydantic(
-        self, execution: ExecutionModel, user: UserPrincipal | None = None
+        self,
+        execution: ExecutionModel,
+        user: UserPrincipal | None = None,
+        *,
+        include_payload: bool = True,
     ) -> WorkflowExecution:
         """Convert SQLAlchemy model to Pydantic model.
 
@@ -493,6 +506,9 @@ class ExecutionRepository:
             execution: The SQLAlchemy execution model
             user: Optional user for permission checks. If provided, admin-only
                   fields (variables) are gated based on is_superuser.
+            include_payload: Include input, result, variables, and execution
+                context. List views disable this so multi-megabyte results are
+                neither selected from PostgreSQL nor serialized into history.
         """
         is_admin = user.is_superuser if user else False
         # Determine org_name: use organization relationship if loaded, otherwise None for global
@@ -517,8 +533,8 @@ class ExecutionRepository:
             executed_by_name=execution.executed_by_name or str(execution.executed_by),
             executed_by_email=execution.executed_by_user.email if hasattr(execution, 'executed_by_user') and execution.executed_by_user else None,
             status=ExecutionStatus(execution.status),
-            input_data=execution.parameters or {},
-            result=execution.result,
+            input_data=(execution.parameters or {}) if include_payload else {},
+            result=execution.result if include_payload else None,
             result_type=execution.result_type,
             error_message=execution.error_message,
             duration_ms=execution.duration_ms,
@@ -526,8 +542,14 @@ class ExecutionRepository:
             completed_at=execution.completed_at,
             scheduled_at=execution.scheduled_at,
             logs=None,  # Fetched separately via /logs endpoint
-            variables=execution.variables if is_admin else None,
-            execution_context=execution.execution_context if is_admin else None,
+            variables=(
+                execution.variables if is_admin and include_payload else None
+            ),
+            execution_context=(
+                execution.execution_context
+                if is_admin and include_payload
+                else None
+            ),
             session_id=str(execution.session_id) if execution.session_id else None,
         )
 

--- a/api/src/services/execution/template_process.py
+++ b/api/src/services/execution/template_process.py
@@ -231,6 +231,18 @@ def _template_main(
     del os.environ["BIFROST_SECRET_KEY"]
     logger.info("SECRET_KEY scrubbed: settings cache primed with inert sentinel, env var removed")
 
+    # Preload the platform execution runtime after credential scrubbing. Every
+    # execution runs in a fresh one-shot fork; leaving this import to the child
+    # makes each request pay the full SDK + engine import cost before the engine
+    # duration timer even starts. Forked children inherit these modules through
+    # copy-on-write, so the pod pays that cost once while workflow code itself
+    # remains freshly loaded per execution.
+    import bifrost.credentials  # noqa: F401
+    import src.models.enums  # noqa: F401
+    import src.sdk.context  # noqa: F401
+    import src.services.execution.engine  # noqa: F401
+    import src.services.execution.worker  # noqa: F401
+
     logger.info("Template process ready — all dependencies loaded")
     pipe.send({"status": "ready", "pid": os.getpid()})
 

--- a/api/tests/e2e/platform/test_fork_pool.py
+++ b/api/tests/e2e/platform/test_fork_pool.py
@@ -220,8 +220,12 @@ class TestForkBasedExecution:
             if execution["execution_id"] == data["execution_id"]
         ]
         assert len(matching) == 1
-        assert matching[0]["result"] is None
-        assert matching[0]["input_data"] == {}
+        # List items are summaries: payload fields are omitted entirely, not
+        # returned as null/{} (which would read as "this run had no result").
+        assert "result" not in matching[0]
+        assert "input_data" not in matching[0]
+        assert "variables" not in matching[0]
+        assert "execution_context" not in matching[0]
 
     def test_concurrent_executions(self, e2e_client, platform_admin, concurrent_workflow):
         """Multiple concurrent executions should complete without interference."""

--- a/api/tests/e2e/platform/test_fork_pool.py
+++ b/api/tests/e2e/platform/test_fork_pool.py
@@ -49,6 +49,28 @@ async def e2e_fork_timeout(sleep_seconds: int = 60) -> dict:
     return {"status": "completed"}
 '''
 
+LARGE_FLAT_RESULT_WORKFLOW = '''
+"""Production-shaped flat result regression for issue #480."""
+from bifrost import workflow
+
+@workflow(name="e2e_large_flat_result", execution_mode="async")
+async def e2e_large_flat_result(row_count: int = 5395) -> list[dict[str, str]]:
+    """Return the scrubbed production row shape without customer values."""
+    return [
+        {
+            "Attendees": "x",
+            "Cost": "x" * 5,
+            "Cost Formatted": "x" * 6,
+            "Duration": "x" * 3,
+            "End Date": "x" * 19,
+            "Start Date": "x" * 19,
+            "Subject": "x" * 24,
+            "Total Hours": "xx",
+        }
+        for _ in range(row_count)
+    ]
+'''
+
 
 @pytest.fixture(scope="module")
 def simple_workflow(e2e_client, platform_admin):
@@ -104,6 +126,23 @@ def timeout_workflow(e2e_client, platform_admin):
     )
 
 
+@pytest.fixture(scope="module")
+def large_flat_result_workflow(e2e_client, platform_admin):
+    """Create the sanitized 5,395-row production-shape reproduction."""
+    result = write_and_register(
+        e2e_client,
+        platform_admin.headers,
+        "e2e_large_flat_result.py",
+        LARGE_FLAT_RESULT_WORKFLOW,
+        "e2e_large_flat_result",
+    )
+    yield result
+    e2e_client.delete(
+        "/api/files/editor?path=e2e_large_flat_result.py",
+        headers=platform_admin.headers,
+    )
+
+
 @pytest.mark.e2e
 class TestForkBasedExecution:
     """Test that workflows execute correctly with fork-based pool."""
@@ -136,6 +175,53 @@ class TestForkBasedExecution:
         assert data["status"] == "Success"
         result = data.get("result", {})
         assert result.get("value") == 999
+
+    def test_large_flat_result_returns_without_polluting_history_payload(
+        self,
+        e2e_client,
+        platform_admin,
+        large_flat_result_workflow,
+    ):
+        """Sync callers get all rows while history remains summary-only."""
+        data = execute_workflow_sync(
+            e2e_client,
+            platform_admin.headers,
+            large_flat_result_workflow["id"],
+            {"row_count": 5395},
+            max_wait=30.0,
+            request_sync=True,
+            request_timeout=30.0,
+        )
+
+        assert data["status"] == "Success", f"Unexpected status: {data}"
+        rows = data["result"]
+        assert len(rows) == 5395
+        assert set(rows[0]) == {
+            "Attendees",
+            "Cost",
+            "Cost Formatted",
+            "Duration",
+            "End Date",
+            "Start Date",
+            "Subject",
+            "Total Hours",
+        }
+
+        history_response = e2e_client.get(
+            "/api/executions",
+            headers=platform_admin.headers,
+            params={"workflowId": large_flat_result_workflow["id"], "limit": 10},
+        )
+        assert history_response.status_code == 200
+        executions = history_response.json()["executions"]
+        matching = [
+            execution
+            for execution in executions
+            if execution["execution_id"] == data["execution_id"]
+        ]
+        assert len(matching) == 1
+        assert matching[0]["result"] is None
+        assert matching[0]["input_data"] == {}
 
     def test_concurrent_executions(self, e2e_client, platform_admin, concurrent_workflow):
         """Multiple concurrent executions should complete without interference."""

--- a/api/tests/unit/jobs/consumers/test_workflow_execution_session.py
+++ b/api/tests/unit/jobs/consumers/test_workflow_execution_session.py
@@ -97,3 +97,116 @@ class TestConsumerStartupOrder:
             f"Pool must start before RabbitMQ consumer; got {call_order}"
         )
         assert consumer._pool_started is True
+
+
+class TestSuccessfulExecutionCompletionOrder:
+    """Sync callers should not wait for non-critical completion fan-out."""
+
+    @pytest.mark.asyncio
+    async def test_sync_result_is_pushed_before_terminal_fan_out(self):
+        """Wake the requester after the durable commit, before UI/cache work.
+
+        Large workflow results make every extra serialization on this path
+        requester-visible.  The terminal WebSocket event is only a status
+        notification; clients fetch the persisted result through the result
+        endpoint, so rebroadcasting the full payload is both redundant and
+        expensive.
+        """
+        from src.jobs.consumers.workflow_execution import WorkflowExecutionConsumer
+
+        call_order: list[str] = []
+        session = AsyncMock()
+        session.commit.side_effect = lambda: call_order.append("commit")
+        session_factory = MagicMock()
+        session_factory.return_value.__aenter__ = AsyncMock(return_value=session)
+        session_factory.return_value.__aexit__ = AsyncMock(return_value=None)
+
+        with patch.object(WorkflowExecutionConsumer, "__init__", lambda self: None):
+            consumer = WorkflowExecutionConsumer()
+            consumer._redis_client = AsyncMock()
+            consumer._redis_client.get_pending_execution.return_value = {
+                "workflow_id": "00000000-0000-0000-0000-000000000001",
+                "workflow_name": "large_result_workflow",
+                "org_id": "00000000-0000-0000-0000-000000000002",
+                "user_id": "00000000-0000-0000-0000-000000000003",
+                "user_name": "Test User",
+                "sync": True,
+            }
+            consumer._redis_client.push_result.side_effect = (
+                lambda **_kwargs: call_order.append("push_result")
+            )
+            consumer._redis_client.delete_pending_execution.side_effect = (
+                lambda _execution_id: call_order.append("delete_pending")
+            )
+
+            publish_execution = AsyncMock(
+                side_effect=lambda *_args, **_kwargs: call_order.append(
+                    "publish_execution"
+                )
+            )
+            publish_history = AsyncMock(
+                side_effect=lambda **_kwargs: call_order.append("publish_history")
+            )
+            cleanup_cache = AsyncMock(
+                side_effect=lambda _execution_id: call_order.append("cleanup_cache")
+            )
+
+            with (
+                patch(
+                    "src.core.database.get_session_factory",
+                    return_value=session_factory,
+                ),
+                patch(
+                    "src.repositories.executions.update_execution",
+                    new_callable=AsyncMock,
+                ),
+                patch(
+                    "src.services.events.processor.update_delivery_from_execution",
+                    new_callable=AsyncMock,
+                ),
+                patch(
+                    "bifrost._sync.flush_pending_changes",
+                    new_callable=AsyncMock,
+                    return_value=0,
+                ),
+                patch(
+                    "bifrost._logging.flush_logs_to_postgres",
+                    new_callable=AsyncMock,
+                    return_value=0,
+                ),
+                patch(
+                    "src.core.metrics.update_daily_metrics",
+                    new_callable=AsyncMock,
+                ),
+                patch(
+                    "src.core.metrics.update_workflow_roi_daily",
+                    new_callable=AsyncMock,
+                ),
+                patch(
+                    "src.jobs.consumers.workflow_execution.publish_execution_update",
+                    publish_execution,
+                ),
+                patch(
+                    "src.jobs.consumers.workflow_execution.publish_history_update",
+                    publish_history,
+                ),
+                patch("src.core.cache.cleanup_execution_cache", cleanup_cache),
+            ):
+                await consumer._process_success(
+                    "00000000-0000-0000-0000-000000000004",
+                    {
+                        "success": True,
+                        "status": "Success",
+                        "result": {"rows": [{"value": "x" * 1000}]},
+                        "duration_ms": 123,
+                    },
+                )
+
+        assert call_order[:2] == ["commit", "push_result"]
+        assert call_order.index("push_result") < call_order.index("publish_execution")
+        assert call_order.index("push_result") < call_order.index("publish_history")
+        assert call_order.index("push_result") < call_order.index("cleanup_cache")
+        assert call_order.index("push_result") < call_order.index("delete_pending")
+
+        terminal_data = publish_execution.await_args.args[2]
+        assert terminal_data == {"duration_ms": 123}

--- a/api/tests/unit/routers/test_executions_list_payload.py
+++ b/api/tests/unit/routers/test_executions_list_payload.py
@@ -1,0 +1,39 @@
+"""Regression tests for lightweight execution-history responses."""
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from uuid import uuid4
+
+
+def test_execution_summary_does_not_access_large_payload_fields() -> None:
+    """History serialization must work with result/input columns unloaded."""
+    from src.routers.executions import ExecutionRepository
+
+    execution = SimpleNamespace(
+        id=uuid4(),
+        workflow_name="large_result_workflow",
+        workflow_id=uuid4(),
+        organization_id=None,
+        organization=None,
+        form_id=None,
+        executed_by=uuid4(),
+        executed_by_name="Test User",
+        executed_by_user=None,
+        status="Success",
+        result_type="json",
+        error_message=None,
+        duration_ms=118,
+        started_at=datetime.now(timezone.utc),
+        completed_at=datetime.now(timezone.utc),
+        scheduled_at=None,
+        session_id=None,
+    )
+
+    summary = ExecutionRepository._to_pydantic(  # type: ignore[arg-type]
+        SimpleNamespace(), execution, include_payload=False
+    )
+
+    assert summary.input_data == {}
+    assert summary.result is None
+    assert summary.variables is None
+    assert summary.execution_context is None

--- a/api/tests/unit/routers/test_executions_list_payload.py
+++ b/api/tests/unit/routers/test_executions_list_payload.py
@@ -5,11 +5,8 @@ from types import SimpleNamespace
 from uuid import uuid4
 
 
-def test_execution_summary_does_not_access_large_payload_fields() -> None:
-    """History serialization must work with result/input columns unloaded."""
-    from src.routers.executions import ExecutionRepository
-
-    execution = SimpleNamespace(
+def _summary_row() -> SimpleNamespace:
+    return SimpleNamespace(
         id=uuid4(),
         workflow_name="large_result_workflow",
         workflow_id=uuid4(),
@@ -29,11 +26,38 @@ def test_execution_summary_does_not_access_large_payload_fields() -> None:
         session_id=None,
     )
 
-    summary = ExecutionRepository._to_pydantic(  # type: ignore[arg-type]
-        SimpleNamespace(), execution, include_payload=False
-    )
 
-    assert summary.input_data == {}
-    assert summary.result is None
-    assert summary.variables is None
-    assert summary.execution_context is None
+def test_summary_does_not_access_large_payload_fields() -> None:
+    """History serialization must work with result/input columns unloaded."""
+    from src.routers.executions import ExecutionRepository
+
+    summary = ExecutionRepository._to_summary(_summary_row())  # type: ignore[arg-type]
+
+    assert summary.duration_ms == 118
+    assert summary.result_type == "json"
+
+
+def test_summary_omits_payload_fields_entirely() -> None:
+    """List items must not carry payload keys at all — absent, not null.
+
+    Returning `result: null` / `input_data: {}` reads as "this execution had
+    no result", which is a lie for large executions. Omission makes the
+    summary-vs-detail split explicit for SDK and API consumers.
+    """
+    from src.models.contracts.executions import ExecutionSummary
+    from src.routers.executions import ExecutionRepository
+
+    summary = ExecutionRepository._to_summary(_summary_row())  # type: ignore[arg-type]
+
+    assert isinstance(summary, ExecutionSummary)
+    payload = summary.model_dump()
+    for field in ("input_data", "result", "variables", "execution_context", "logs"):
+        assert field not in payload
+
+
+def test_full_model_still_carries_payload_fields() -> None:
+    """The single-execution model keeps the payload contract intact."""
+    from src.models.contracts.executions import WorkflowExecution
+
+    fields = set(WorkflowExecution.model_fields)
+    assert {"input_data", "result", "variables", "execution_context", "logs"} <= fields

--- a/api/tests/unit/routers/test_executions_pagination.py
+++ b/api/tests/unit/routers/test_executions_pagination.py
@@ -1,0 +1,55 @@
+"""Keyset-cursor tests for the execution history endpoint.
+
+History pagination must be keyset-based ("rows older than the last one I
+saw"), not offset-based: on a busy instance new executions land constantly,
+and an offset token re-serves the previous page's tail — users paginating
+into the past see today's rows (and a "Today" header) on every page.
+"""
+
+from datetime import datetime, timezone
+from uuid import uuid4
+
+
+def test_cursor_round_trips_started_row() -> None:
+    from src.routers.executions import (
+        _decode_history_cursor,
+        _encode_history_cursor,
+    )
+
+    started = datetime(2026, 7, 10, 12, 30, 45, 123456, tzinfo=timezone.utc)
+    row_id = uuid4()
+
+    token = _encode_history_cursor(started, row_id)
+    decoded = _decode_history_cursor(token)
+
+    assert decoded == (started, row_id)
+
+
+def test_cursor_round_trips_null_started_row() -> None:
+    """Scheduled/Pending rows have no started_at; the cursor must carry that."""
+    from src.routers.executions import (
+        _decode_history_cursor,
+        _encode_history_cursor,
+    )
+
+    row_id = uuid4()
+    token = _encode_history_cursor(None, row_id)
+
+    assert _decode_history_cursor(token) == (None, row_id)
+
+
+def test_cursor_is_opaque_not_a_bare_offset() -> None:
+    """A numeric token is the legacy offset format, not a keyset cursor."""
+    from src.routers.executions import _encode_history_cursor
+
+    token = _encode_history_cursor(None, uuid4())
+    assert not token.isdigit()
+
+
+def test_decode_rejects_garbage_and_legacy_offsets() -> None:
+    """Legacy numeric offsets and junk must decode to None (caller falls back)."""
+    from src.routers.executions import _decode_history_cursor
+
+    assert _decode_history_cursor("25") is None
+    assert _decode_history_cursor("not-a-token") is None
+    assert _decode_history_cursor("") is None

--- a/client/src/components/execution/ExecutionMetadataBar.test.tsx
+++ b/client/src/components/execution/ExecutionMetadataBar.test.tsx
@@ -90,6 +90,22 @@ describe("ExecutionMetadataBar — duration formatting", () => {
 		);
 		expect(screen.getByText(expected)).toBeInTheDocument();
 	});
+
+	it("distinguishes total elapsed time from workflow execution time", () => {
+		renderWithProviders(
+			<ExecutionMetadataBar
+				workflowName="x"
+				status="Success"
+				durationMs={118}
+				totalDurationMs={20_000}
+			/>,
+		);
+
+		expect(screen.getByText("Total")).toBeInTheDocument();
+		expect(screen.getByText("20.0s")).toBeInTheDocument();
+		expect(screen.getByText("Workflow")).toBeInTheDocument();
+		expect(screen.getByText("118ms")).toBeInTheDocument();
+	});
 });
 
 describe("ExecutionMetadataBar — provided metadata", () => {

--- a/client/src/components/execution/ExecutionMetadataBar.tsx
+++ b/client/src/components/execution/ExecutionMetadataBar.tsx
@@ -15,6 +15,7 @@ interface ExecutionMetadataBarProps {
 	orgName?: string | null;
 	startedAt?: string | null;
 	durationMs?: number | null;
+	totalDurationMs?: number | null;
 	queuePosition?: number;
 	waitReason?: string;
 	availableMemoryMb?: number;
@@ -36,6 +37,7 @@ export function ExecutionMetadataBar({
 	orgName,
 	startedAt,
 	durationMs,
+	totalDurationMs,
 	queuePosition,
 	waitReason,
 	availableMemoryMb,
@@ -73,10 +75,24 @@ export function ExecutionMetadataBar({
 					<Clock className="h-3 w-3" />
 					{startedAt ? formatRelativeTime(startedAt) : "Not started"}
 				</span>
-				<span className="flex items-center gap-1">
+				{totalDurationMs != null && (
+					<span
+						className="flex items-center gap-1"
+						title="Total platform time from worker start through persisted completion"
+					>
+						<Timer className="h-3 w-3" />
+						<span>Total</span>
+						<span>{formatDuration(totalDurationMs)}</span>
+					</span>
+				)}
+				<span
+					className="flex items-center gap-1"
+					title="Time spent executing workflow code"
+				>
 					<Timer className="h-3 w-3" />
+					<span>Workflow</span>
 					{durationMs != null
-						? formatDuration(durationMs)
+						? <span>{formatDuration(durationMs)}</span>
 						: "In progress..."}
 				</span>
 			</div>

--- a/client/src/components/execution/PrettyInputDisplay.test.tsx
+++ b/client/src/components/execution/PrettyInputDisplay.test.tsx
@@ -210,6 +210,35 @@ describe("PrettyInputDisplay — mini table for uniform object arrays", () => {
 		expect(screen.queryByRole("table")).not.toBeInTheDocument();
 		expect(screen.getByText(/"nested"/)).toBeInTheDocument();
 	});
+
+	it("previews a production-sized flat result without rendering every row", () => {
+		const rows = Array.from({ length: 5395 }, (_, index) => ({
+			Subject: `row-${index}`,
+			Duration: "1",
+		}));
+
+		renderWithProviders(<PrettyInputDisplay inputData={{ rows }} />);
+
+		expect(screen.getByRole("table")).toBeInTheDocument();
+		expect(
+			screen.getByText("Showing first 50 of 5,395 rows"),
+		).toBeInTheDocument();
+		expect(screen.getByText("row-49")).toBeInTheDocument();
+		expect(screen.queryByText("row-50")).not.toBeInTheDocument();
+	});
+});
+
+describe("PrettyInputDisplay — large scalar values", () => {
+	it("truncates multi-megabyte strings in the DOM", () => {
+		const largeHtml = `<table>${"x".repeat(3_225_167)}</table>`;
+
+		renderWithProviders(
+			<PrettyInputDisplay inputData={{ table_html: largeHtml }} />,
+		);
+
+		expect(screen.getByText(/3,225,182 characters total/)).toBeInTheDocument();
+		expect(screen.queryByText(largeHtml)).not.toBeInTheDocument();
+	});
 });
 
 describe("PrettyInputDisplay — top-level arrays", () => {

--- a/client/src/components/execution/PrettyInputDisplay.tsx
+++ b/client/src/components/execution/PrettyInputDisplay.tsx
@@ -7,7 +7,10 @@ import { oneDark } from "react-syntax-highlighter/dist/esm/styles/prism";
 import { VariablesTreeView } from "@/components/ui/variables-tree-view";
 import { toast } from "sonner";
 import { cn } from "@/lib/utils";
-import { classify, tableColumns } from "./prettyShape";
+import { classify, tableColumns, MAX_TABLE_ROWS } from "./prettyShape";
+
+const MAX_SCALAR_DISPLAY_CHARS = 1000;
+const MAX_HIGHLIGHTED_JSON_CHARS = 25_000;
 
 interface PrettyInputDisplayProps {
 	inputData: Record<string, unknown> | unknown[];
@@ -73,6 +76,13 @@ function formatScalar(value: unknown): { display: string; badge?: string } {
 	}
 
 	if (typeof value === "string") {
+		if (value.length > MAX_SCALAR_DISPLAY_CHARS) {
+			return {
+				display: `${value.slice(0, MAX_SCALAR_DISPLAY_CHARS)}…`,
+				badge: `${value.length.toLocaleString()} characters total`,
+			};
+		}
+
 		// Check if it's a URL
 		try {
 			new URL(value);
@@ -116,6 +126,23 @@ function badgeFor(value: unknown): string | undefined {
 
 /** Syntax-highlighted JSON block — the ladder's last resort. */
 function JsonBlock({ value }: { value: unknown }) {
+	const json = JSON.stringify(value, null, 2);
+	if (json.length > MAX_HIGHLIGHTED_JSON_CHARS) {
+		return (
+			<div className="mt-1 space-y-1.5">
+				<p className="text-xs text-muted-foreground">
+					Showing the first {MAX_HIGHLIGHTED_JSON_CHARS.toLocaleString()} of{" "}
+					{json.length.toLocaleString()} JSON characters. Copy retains the full
+					value.
+				</p>
+				<pre className="max-h-64 max-w-full overflow-auto rounded-md bg-slate-950 p-3 font-mono text-xs text-slate-100">
+					{json.slice(0, MAX_HIGHLIGHTED_JSON_CHARS)}
+					{"\n…"}
+				</pre>
+			</div>
+		);
+	}
+
 	return (
 		<SyntaxHighlighter
 			language="json"
@@ -129,7 +156,7 @@ function JsonBlock({ value }: { value: unknown }) {
 				overflow: "auto",
 			}}
 		>
-			{JSON.stringify(value, null, 2)}
+			{json}
 		</SyntaxHighlighter>
 	);
 }
@@ -144,14 +171,22 @@ function MiniTable({
 }) {
 	const columns = tableColumns(items);
 	if (columns === null) return <JsonBlock value={items} />;
+	const previewItems = items.slice(0, MAX_TABLE_ROWS);
 
 	return (
-		<div
-			className={cn(
-				"overflow-x-auto rounded-md ring-1 ring-foreground/5",
-				className,
+		<div className="space-y-1.5">
+			{items.length > previewItems.length && (
+				<p className="text-xs text-muted-foreground">
+					Showing first {previewItems.length.toLocaleString()} of{" "}
+					{items.length.toLocaleString()} rows
+				</p>
 			)}
-		>
+			<div
+				className={cn(
+					"overflow-x-auto rounded-md ring-1 ring-foreground/5",
+					className,
+				)}
+			>
 			<table className="w-full text-sm">
 				<thead>
 					<tr className="bg-muted">
@@ -166,7 +201,7 @@ function MiniTable({
 					</tr>
 				</thead>
 				<tbody className="divide-y divide-border/60">
-					{items.map((item, i) => (
+					{previewItems.map((item, i) => (
 						<tr key={i}>
 							{columns.map((col) => {
 								const cell = item[col];
@@ -189,6 +224,7 @@ function MiniTable({
 					))}
 				</tbody>
 			</table>
+			</div>
 		</div>
 	);
 }

--- a/client/src/components/execution/prettyShape.test.ts
+++ b/client/src/components/execution/prettyShape.test.ts
@@ -184,11 +184,11 @@ describe("classify — object tables", () => {
 		).toBe("object-table");
 	});
 
-	it("falls back to json beyond the row cap", () => {
+	it("keeps large flat arrays table-shaped so the renderer can preview them", () => {
 		const make = (n: number) =>
 			Array.from({ length: n }, (_, i) => ({ label: `r${i}`, value: i }));
 		expect(classify(make(MAX_TABLE_ROWS))).toBe("object-table");
-		expect(classify(make(MAX_TABLE_ROWS + 1))).toBe("json");
+		expect(classify(make(5395))).toBe("object-table");
 	});
 
 	it("falls back to json beyond the column cap", () => {

--- a/client/src/components/execution/prettyShape.ts
+++ b/client/src/components/execution/prettyShape.ts
@@ -24,7 +24,7 @@ export type PrettyShape =
 export const MAX_OBJECT_DEPTH = 3;
 /** Objects with more keys than this fall back to JSON. */
 export const MAX_OBJECT_KEYS = 20;
-/** Arrays with more rows than this are too big for a mini table. */
+/** Maximum rows inspected and rendered for a table preview. */
 export const MAX_TABLE_ROWS = 50;
 /** Tables with more columns than this fall back to JSON. */
 export const MAX_TABLE_COLUMNS = 8;
@@ -52,18 +52,21 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
  * Derive the column set for an array that should render as a mini table.
  *
  * Returns the columns in first-seen key order, or null when the array is not
- * table-shaped: any non-object item, any non-scalar cell, an empty/oversized
- * array, too many columns, or a column present on fewer than
- * TABLE_KEY_COVERAGE of the rows (ragged shapes).
+ * table-shaped: any sampled non-object item, any sampled non-scalar cell, an
+ * empty array, too many columns, or a column present on fewer than
+ * TABLE_KEY_COVERAGE of the sampled rows (ragged shapes). Large arrays are
+ * deliberately sampled so they remain eligible for a bounded table preview
+ * instead of falling into the expensive syntax-highlighted JSON fallback.
  */
 export function tableColumns(value: unknown): string[] | null {
 	if (!Array.isArray(value)) return null;
-	if (value.length === 0 || value.length > MAX_TABLE_ROWS) return null;
+	if (value.length === 0) return null;
+	const sampledRows = value.slice(0, MAX_TABLE_ROWS);
 
 	const columns: string[] = [];
 	const counts = new Map<string, number>();
 
-	for (const item of value) {
+	for (const item of sampledRows) {
 		if (!isPlainObject(item)) return null;
 		const keys = Object.keys(item);
 		if (keys.length === 0) return null;
@@ -79,7 +82,7 @@ export function tableColumns(value: unknown): string[] | null {
 	}
 
 	for (const key of columns) {
-		if ((counts.get(key) ?? 0) / value.length < TABLE_KEY_COVERAGE) {
+		if ((counts.get(key) ?? 0) / sampledRows.length < TABLE_KEY_COVERAGE) {
 			return null;
 		}
 	}

--- a/client/src/lib/v1.d.ts
+++ b/client/src/lib/v1.d.ts
@@ -14398,15 +14398,76 @@ export interface components {
          */
         ExecutionStatus: "Scheduled" | "Pending" | "Running" | "Success" | "Failed" | "Timeout" | "Stuck" | "CompletedWithErrors" | "Cancelling" | "Cancelled";
         /**
+         * ExecutionSummary
+         * @description Execution metadata without payloads — what list views return.
+         *
+         *     Deliberately omits input_data/result/logs/variables/execution_context so
+         *     list responses never select or serialize multi-megabyte payloads. Fetch a
+         *     single execution for those.
+         */
+        ExecutionSummary: {
+            /** Execution Id */
+            execution_id: string;
+            /** Workflow Name */
+            workflow_name: string;
+            /** Workflow Id */
+            workflow_id?: string | null;
+            /** Org Id */
+            org_id?: string | null;
+            /** Org Name */
+            org_name?: string | null;
+            /** Form Id */
+            form_id?: string | null;
+            /** Executed By */
+            executed_by: string;
+            /** Executed By Name */
+            executed_by_name: string;
+            /** Executed By Email */
+            executed_by_email?: string | null;
+            status: components["schemas"]["ExecutionStatus"];
+            /** Result Type */
+            result_type?: string | null;
+            /** Error Message */
+            error_message?: string | null;
+            /** Duration Ms */
+            duration_ms?: number | null;
+            /** Started At */
+            started_at?: string | null;
+            /** Completed At */
+            completed_at?: string | null;
+            /** Scheduled At */
+            scheduled_at?: string | null;
+            /** Session Id */
+            session_id?: string | null;
+            /** Peak Memory Bytes */
+            peak_memory_bytes?: number | null;
+            /** Process Rss Bytes */
+            process_rss_bytes?: number | null;
+            /** Cpu Total Seconds */
+            cpu_total_seconds?: number | null;
+            /** Execution Model */
+            execution_model?: string | null;
+            /**
+             * Time Saved
+             * @default 0
+             */
+            time_saved: number;
+            /**
+             * Value
+             * @default 0
+             */
+            value: number;
+        };
+        /**
          * ExecutionsListResponse
          * @description Response model for listing workflow executions with pagination
          */
         ExecutionsListResponse: {
             /**
              * Executions
-             * @description List of workflow executions
+             * @description List of workflow execution summaries (no input/result payloads — fetch a single execution for those)
              */
-            executions: components["schemas"]["WorkflowExecution"][];
+            executions: components["schemas"]["ExecutionSummary"][];
             /**
              * Continuation Token
              * @description Continuation token for next page (opaque, base64-encoded). Presence of token indicates more results available.
@@ -23315,7 +23376,7 @@ export interface components {
         };
         /**
          * WorkflowExecution
-         * @description Workflow execution entity
+         * @description Workflow execution entity — summary fields plus full payloads.
          */
         WorkflowExecution: {
             /** Execution Id */
@@ -23337,14 +23398,6 @@ export interface components {
             /** Executed By Email */
             executed_by_email?: string | null;
             status: components["schemas"]["ExecutionStatus"];
-            /** Input Data */
-            input_data: {
-                [key: string]: unknown;
-            };
-            /** Result */
-            result?: {
-                [key: string]: unknown;
-            } | unknown[] | string | null;
             /** Result Type */
             result_type?: string | null;
             /** Error Message */
@@ -23357,14 +23410,6 @@ export interface components {
             completed_at?: string | null;
             /** Scheduled At */
             scheduled_at?: string | null;
-            /** Logs */
-            logs?: {
-                [key: string]: unknown;
-            }[] | null;
-            /** Variables */
-            variables?: {
-                [key: string]: unknown;
-            } | null;
             /** Session Id */
             session_id?: string | null;
             /** Peak Memory Bytes */
@@ -23385,6 +23430,22 @@ export interface components {
              * @default 0
              */
             value: number;
+            /** Input Data */
+            input_data: {
+                [key: string]: unknown;
+            };
+            /** Result */
+            result?: {
+                [key: string]: unknown;
+            } | unknown[] | string | null;
+            /** Logs */
+            logs?: {
+                [key: string]: unknown;
+            }[] | null;
+            /** Variables */
+            variables?: {
+                [key: string]: unknown;
+            } | null;
             /** Ai Usage */
             ai_usage?: components["schemas"]["AIUsagePublicSimple"][] | null;
             ai_totals?: components["schemas"]["AIUsageTotalsSimple"] | null;

--- a/client/src/pages/ExecutionDetails.tsx
+++ b/client/src/pages/ExecutionDetails.tsx
@@ -47,6 +47,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { createPortal } from "react-dom";
 import { useEffect, useState, useCallback, useMemo } from "react";
 import { copyToClipboard } from "@/lib/clipboard";
+import { parseBackendDate } from "@/lib/utils";
 import type { StreamingLog } from "@/stores/executionStreamStore";
 
 type ExecutionStatus =
@@ -216,6 +217,19 @@ export function ExecutionDetails({
 		executionStatus === "CompletedWithErrors" ||
 		executionStatus === "Timeout" ||
 		executionStatus === "Cancelled";
+	const totalDurationMs = (() => {
+		if (!execution?.started_at || !execution.completed_at) return null;
+		const startedAt = parseBackendDate(execution.started_at).getTime();
+		const completedAt = parseBackendDate(execution.completed_at).getTime();
+		if (
+			Number.isNaN(startedAt) ||
+			Number.isNaN(completedAt) ||
+			completedAt < startedAt
+		) {
+			return null;
+		}
+		return completedAt - startedAt;
+	})();
 
 	// Data now comes from single API call - create adapter variables for compatibility
 	const resultData = execution
@@ -578,6 +592,7 @@ export function ExecutionDetails({
 						orgName={execution.org_name}
 						startedAt={execution.started_at}
 						durationMs={execution.duration_ms}
+						totalDurationMs={totalDurationMs}
 						queuePosition={streamState?.queuePosition}
 						waitReason={streamState?.waitReason}
 						availableMemoryMb={streamState?.availableMemoryMb}


### PR DESCRIPTION
Fixes #480

## Summary

Three related fixes to the execution result path and History surface, all measured live on a debug stack (identical machine/payloads, A/B against pre-fix code):

| Scenario | Before | After |
|---|---|---|
| Trivial workflow, sync execute | 1.6–2.9s | ~0.4s |
| 4.9 MB result, sync execute | ~2.9s (25.5s prod baseline) | ~1.4s |
| History list (50 rows, large results present) | 1.2s / 50.7 MB | ~25ms / ~10 KB |

### 1. Result latency (`e19e675`)
- Sync callers wake immediately after the result commits, before pub/sub fan-out and cleanup.
- The websocket completion event no longer carries the result payload (clients refetch over HTTP); key fixed `durationMs` → `duration_ms`, which also repairs the previously-broken live duration display.
- The fork template preloads the SDK + engine once at worker start; forks inherit via copy-on-write instead of re-importing per execution (this was the "Pending for seconds" on trivial workflows). User workspace modules/requirements handling is untouched — still loaded fresh per fork.
- Execution Details shows Total (started→completed) vs Workflow (engine) durations; large input/result rendering is bounded (50-row table preview, 25k-char JSON cap).

### 2. List payload omission (`f70c68d`) — ⚠️ release-notes item
List responses (`GET /api/executions`) previously returned `input_data: {}` / `result: null` placeholders; the payload columns are now deferred (`raiseload=True`) and **omitted entirely** via a new `ExecutionSummary` model. **Breaking:** API/SDK consumers reading `input_data`/`result` off LIST items must fetch the single execution instead (`executions.get(id)`). Not covered by the CLI contract fingerprint (tripwire green); no CLI command or known workspace code consumes these fields from lists. SDK docstrings updated.

### 3. Keyset History pagination (`24d6f15`)
The continuation token was a bare offset, so new executions landing between page loads re-served the previous page's tail — on a busy instance every "Next" click showed today's rows (and a "Today" header) again. The token is now a keyset cursor (last row's `started_at` + `id`) with a deterministic `NULLS FIRST, id DESC` ordering; legacy numeric tokens still work. Verified live: 15 executions injected mid-pagination → zero duplicate rows (previously 8).

## Testing
- Full unit suite: 5262 passed (fresh DB via ./test.sh unit)
- Client: vitest full suite (2 known load-flaky page tests pass in isolation), tsc clean, lint clean (1 pre-existing warning), ruff clean
- New tests: consumer session-ordering, list-payload omission, keyset cursor round-trip/legacy fallback, e2e large-flat-result regression (production-shaped 5,395-row payload)
- Live-driven: SDK sync path benchmarked at prod scale; web UI large-execution click verified by hand

🤖 Generated with [Claude Code](https://claude.com/claude-code)
