### PR TITLE
fix: isolate Solution context from credential bootstrap

### DIFF
--- a/api/bifrost/credentials.py
+++ b/api/bifrost/credentials.py
@@ -278,7 +278,7 @@ def _select_persistent_backend() -> Backend:
         # when the backend is nominally available but the OS service isn't.
         keyring.get_password(KEYRING_SERVICE, "__probe__")
         return KeyringBackend(_keyring=keyring)
-    except (keyring.errors.NoKeyringError, keyring.errors.KeyringError, Exception) as e:
+    except Exception as e:  # noqa: BLE001 - any unusable OS backend falls back to JSON
         _keyring_fallback_reason = type(e).__name__
         return JsonBackend()
 

--- a/api/src/services/execution/simple_worker.py
+++ b/api/src/services/execution/simple_worker.py
@@ -364,10 +364,9 @@ async def _execute_async(execution_id: str, worker_id: str) -> dict[str, Any]:
     # _clear_workspace_modules keys off the active install (get_solution_context);
     # if it ran with no context (as the template_process fork path did), a prior
     # install's same-name module could survive the hash check and shadow this
-    # install's file, breaking multi-install isolation (Codex #9). _run_execution
-    # re-applies the same context for the run itself; setting it here is the
-    # idempotent prerequisite for a correctly-scoped eviction.
-    from src.core.module_cache_sync import set_solution_context
+    # install's file, breaking multi-install isolation (Codex #9). This context is
+    # temporary: _run_execution activates it again after credential bootstrap.
+    from src.core.module_cache_sync import clear_solution_context, set_solution_context
 
     _exec_solution_id = context.get("solution_id")
     if _exec_solution_id:
@@ -375,7 +374,12 @@ async def _execute_async(execution_id: str, worker_id: str) -> dict[str, Any]:
             _exec_solution_id,
             global_repo_access=bool(context.get("solution_global_repo_access", False)),
         )
-    _clear_workspace_modules()
+    try:
+        _clear_workspace_modules()
+    finally:
+        # Credential backend imports must run without Solution namespace probing;
+        # otherwise their own API credential lookup can recursively import them.
+        clear_solution_context()
 
     # 2. Run the execution using existing worker logic
     # This reuses the shared _run_execution() from worker.py

--- a/api/tests/unit/test_credentials.py
+++ b/api/tests/unit/test_credentials.py
@@ -348,6 +348,26 @@ class TestBackendSelection:
         assert "keyring" in captured.err.lower()
         assert "fallback" in captured.err.lower() or "falling back" in captured.err.lower()
 
+    def test_partial_keyring_module_falls_back_to_json(self, monkeypatch):
+        """A cached keyring.errors module may not be attached to its parent."""
+        from bifrost.credentials import JsonBackend, _select_persistent_backend
+
+        creds_mod._reset_persistent_backend_for_tests()
+        import keyring
+        import keyring.errors
+
+        errors_module = keyring.errors
+
+        def fake_get_password(_service, _username):
+            raise errors_module.NoKeyringError("no backend")
+
+        monkeypatch.setattr(keyring, "get_password", fake_get_password)
+        monkeypatch.delattr(keyring, "errors")
+
+        backend = _select_persistent_backend()
+
+        assert isinstance(backend, JsonBackend)
+
     def test_keyring_import_error_falls_back_to_json(self, monkeypatch):
         from bifrost.credentials import JsonBackend, _select_persistent_backend
         creds_mod._reset_persistent_backend_for_tests()

--- a/api/tests/unit/test_solution_module_isolation.py
+++ b/api/tests/unit/test_solution_module_isolation.py
@@ -116,12 +116,16 @@ async def test_execute_async_sets_solution_context_before_clearing_modules(monke
     def _fake_clear():
         calls.append(("clear_modules", None))
 
+    def _fake_clear_ctx():
+        calls.append(("clear_context", None))
+
     async def _fake_run(_eid, _ctx):
         calls.append(("run", None))
         return {"status": "Success", "result": {}, "metrics": {}}
 
     monkeypatch.setattr(sw, "_read_context_from_redis", _fake_read_context)
     monkeypatch.setattr(mcs, "set_solution_context", _fake_set_ctx)
+    monkeypatch.setattr(mcs, "clear_solution_context", _fake_clear_ctx)
     monkeypatch.setattr(sw, "_clear_workspace_modules", _fake_clear)
     monkeypatch.setattr(sw, "_get_pss_bytes", lambda: 0)
     # _run_execution is imported inside the function from worker; patch there.
@@ -134,6 +138,9 @@ async def test_execute_async_sets_solution_context_before_clearing_modules(monke
     assert order.index("set_context") < order.index("clear_modules"), (
         f"context must be set before clearing modules; got {order}"
     )
-    assert order.index("clear_modules") < order.index("run")
+    assert order.index("clear_modules") < order.index("clear_context")
+    assert order.index("clear_context") < order.index("run"), (
+        f"eviction-only context must be clear before credential bootstrap; got {order}"
+    )
     # The context activated is THIS execution's install.
     assert ("set_context", sid) in calls


### PR DESCRIPTION
Fixes #485

## Incident

Production Solution executions fail before workflow code runs with:

```text
AttributeError: module 'keyring' has no attribute 'errors'
```

This reproduces on fresh worker pods. A rolling worker restart did not mitigate it, while non-Solution executions continued through credential bootstrap normally.

## Root cause

The simple worker temporarily activates the Solution import context to evict modules from the previous install, but left that context active while `_run_execution` initialized CLI credentials. On a worker where `keyring` had not already been imported, the virtual Solution finder probed the API for `keyring` submodules. That API call recursively requested credentials while the outer `keyring` import was incomplete, leaving the parent package without its `errors` attribute.

Local/debug stacks commonly masked this because a cold requirements-cache fetch initialized credentials before any Solution context was active.

## Fix

- Clear the temporary Solution context immediately after install-scoped module eviction; `_run_execution` restores it after credential bootstrap.
- Catch the credential probe exception directly instead of evaluating attributes on a potentially partial `keyring` module.
- Add regressions for partial `keyring` initialization and Solution context lifecycle ordering.

## Verification

- Production-equivalent debug repro with a fresh child, warm requirements cache, and minimal config-secret Solution: succeeds after the fix (`secret_present: true`), where the same setup failed before workflow entry.
- Targeted virtual-import/credential/isolation suites: 84 passed.
- Full backend unit suite: 5,265 passed, 3 skipped.
- API quality: Pyright 0 errors; Ruff clean.

Generated with Codex.
