### PR TITLE
feat: stream v2 SDK workflows and gate stale SDKs

### DIFF
--- a/.claude/skills/bifrost-build/generated/cli-reference.md
+++ b/.claude/skills/bifrost-build/generated/cli-reference.md
@@ -1728,6 +1728,7 @@ Commands:
   migrate-app   Migrate a v1 inline app dir to a scaffolded standalone_v2...
   pull          Pull captured entities into the local .bifrost/ manifest...
   scaffold-app  Scaffold a standalone_v2 React app (package.json, vite,...
+  sdk           Manage the app's vendored Bifrost SDK.
   start         Run the app's dev server + local workflows (one origin).
   swap-slugs    Atomically exchange two apps' slugs (v1→v2 migration...
 ```
@@ -1928,6 +1929,31 @@ Options:
   --api-url TEXT  Instance URL the app resolves `bifrost` from (default:
                   $BIFROST_API_URL).
   --help          Show this message and exit.
+```
+
+### `solution sdk`
+
+```
+Usage: solution sdk [OPTIONS] COMMAND [ARGS]...
+
+  Manage the app's vendored Bifrost SDK.
+
+Options:
+  --help  Show this message and exit.
+
+Commands:
+  update  Re-vendor the Bifrost SDK into the app (re-download + reinstall).
+```
+
+#### `solution sdk update`
+
+```
+Usage: solution sdk update [OPTIONS] [PATH]
+
+  Re-vendor the Bifrost SDK into the app (re-download + reinstall).
+
+Options:
+  --help  Show this message and exit.
 ```
 
 ### `solution start`

--- a/.claude/skills/bifrost-build/generated/cli-reference.md
+++ b/.claude/skills/bifrost-build/generated/cli-reference.md
@@ -1953,7 +1953,9 @@ Usage: solution sdk update [OPTIONS] [PATH]
   Re-vendor the Bifrost SDK into the app (re-download + reinstall).
 
 Options:
-  --help  Show this message and exit.
+  --app TEXT  standalone_v2 app slug (required when the Solution has multiple
+              apps).
+  --help      Show this message and exit.
 ```
 
 ### `solution start`

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -91,6 +91,7 @@ COPY client/src/lib/app-sdk/provider.tsx \
      client/src/lib/app-sdk/use-table.ts \
      client/src/lib/app-sdk/use-infinite-table.ts \
      client/src/lib/app-sdk/ws-client.ts \
+     client/src/lib/app-sdk/execution-stream.ts \
      client/src/lib/app-sdk/use-workflow.ts \
      client/src/lib/app-sdk/use-workflow-hooks.ts \
      client/src/lib/app-sdk/files.ts \
@@ -98,6 +99,9 @@ COPY client/src/lib/app-sdk/provider.tsx \
      client/src/lib/app-sdk/bifrost-header.tsx \
      /app/src/services/sdk_package/sdk_src/
 COPY client/src/lib/app-sdk/index.v2.ts /app/src/services/sdk_package/sdk_src/index.ts
+# Contract version stamp (read directly by Python, not bundled by esbuild) —
+# see sdk_contract_version() in sdk_package/__init__.py.
+COPY client/src/lib/app-sdk/sdk-contract.json /app/src/services/sdk_package/sdk_src/sdk-contract.json
 
 # Create non-root user
 RUN useradd -m -u 1000 bifrost && \

--- a/api/Dockerfile.dev
+++ b/api/Dockerfile.dev
@@ -91,6 +91,7 @@ COPY client/src/lib/app-sdk/provider.tsx \
      client/src/lib/app-sdk/use-table.ts \
      client/src/lib/app-sdk/use-infinite-table.ts \
      client/src/lib/app-sdk/ws-client.ts \
+     client/src/lib/app-sdk/execution-stream.ts \
      client/src/lib/app-sdk/use-workflow.ts \
      client/src/lib/app-sdk/use-workflow-hooks.ts \
      client/src/lib/app-sdk/files.ts \
@@ -98,6 +99,9 @@ COPY client/src/lib/app-sdk/provider.tsx \
      client/src/lib/app-sdk/bifrost-header.tsx \
      /app/src/services/sdk_package/sdk_src/
 COPY client/src/lib/app-sdk/index.v2.ts /app/src/services/sdk_package/sdk_src/index.ts
+# Contract version stamp (read directly by Python, not bundled by esbuild) —
+# see sdk_contract_version() in sdk_package/__init__.py.
+COPY client/src/lib/app-sdk/sdk-contract.json /app/src/services/sdk_package/sdk_src/sdk-contract.json
 RUN chmod -R a+rX /app/src/services/sdk_package
 
 # Copy entrypoint script

--- a/api/bifrost/commands/solution.py
+++ b/api/bifrost/commands/solution.py
@@ -3002,9 +3002,18 @@ def sdk_group() -> None:
 solution_group.add_command(sdk_group)
 
 
-@sdk_group.command(name="update", help="Re-vendor the Bifrost SDK into the app (re-download + reinstall).")
+@sdk_group.command(
+    name="update",
+    help="Re-vendor the Bifrost SDK into the app (re-download + reinstall).",
+)
 @click.argument("path", type=click.Path(exists=True, file_okay=False), default=".")
-def sdk_update_cmd(path: str) -> None:
+@click.option(
+    "--app",
+    "app_slug",
+    default=None,
+    help="standalone_v2 app slug (required when the Solution has multiple apps).",
+)
+def sdk_update_cmd(path: str, app_slug: str | None) -> None:
     import shutil
 
     from bifrost.solution_dev.app_select import AppSelectionError, select_app
@@ -3024,9 +3033,12 @@ def sdk_update_cmd(path: str) -> None:
     click.echo(f"Using Solution install id: {binding.solution_id}")
 
     try:
-        chosen = select_app(workspace, slug=None)
+        chosen = select_app(workspace, slug=app_slug)
     except AppSelectionError as exc:
-        raise click.ClickException(str(exc))
+        message = str(exc)
+        if app_slug is None and message.startswith("Multiple apps found"):
+            message = f"{message} For SDK updates, pass --app <slug>."
+        raise click.ClickException(message)
 
     async def _fetch_server_fingerprint() -> str | None:
         resp = await client.get("/api/version")

--- a/api/bifrost/commands/solution.py
+++ b/api/bifrost/commands/solution.py
@@ -2326,6 +2326,39 @@ def start_cmd(
                     "— see the npm output above."
                 )
 
+    async def _fetch_server_version() -> tuple[str | None, int | None]:
+        resp = await client.get("/api/version")
+        if resp.status_code != 200:
+            return None, None
+        data = resp.json()
+        fp = data.get("sdk_fingerprint")
+        fp = fp if isinstance(fp, str) else None
+        if fp == "unavailable":
+            # Server's own toolchain failed to compute a fingerprint — no
+            # signal to compare against, treat like an old server.
+            fp = None
+        contract = data.get("sdk_contract_version")
+        contract = contract if isinstance(contract, int) else None
+        return fp, contract
+
+    try:
+        server_fp, server_contract = asyncio.run(_fetch_server_version())
+    except Exception:
+        # The staleness check must never block `start`: network errors, an
+        # old server without this field, bad JSON, or anything else the
+        # server does wrong all degrade to "no warning", not a crash.
+        server_fp, server_contract = None, None
+
+    warning = sdk_staleness_warning(
+        installed_sdk_fingerprint(chosen.app_dir),
+        server_fp,
+        installed_sdk_contract(chosen.app_dir),
+        server_contract,
+    )
+    if warning is not None:
+        message, severity = warning
+        click.secho(message, fg="red" if severity == "breaking" else "yellow")
+
     proxy_origin = (public_url or f"http://127.0.0.1:{port}").rstrip("/")
     vite_env = _vite_child_env(
         dict(os.environ),
@@ -2900,6 +2933,48 @@ def installed_sdk_fingerprint(app_dir: pathlib.Path) -> str | None:
         return None
     fingerprint = stamp.get("fingerprint")
     return fingerprint if isinstance(fingerprint, str) else None
+
+
+def sdk_staleness_warning(
+    installed_fp: str | None,
+    server_fp: str | None,
+    installed_contract: int | None,
+    server_contract: int | None,
+) -> tuple[str, str] | None:  # (message, severity: "warn"|"breaking") or None
+    """Decide whether `solution start` should warn that the locally-installed
+    web SDK is stale relative to the server. Pure/no-network — callers own
+    fetching `server_fp`/`server_contract` from `GET /api/version` and reading
+    `installed_fp`/`installed_contract` via `installed_sdk_fingerprint` /
+    `installed_sdk_contract`.
+
+    Tiered: "no change" is silent, "non-breaking" is gentle (yellow), a
+    contract mismatch is loud (red) since hooks may actually fail.
+    """
+    if server_fp is None:
+        # Old server (predates the staleness gate), fetch failure, or the
+        # server's own toolchain couldn't compute a fingerprint — no signal,
+        # so stay silent rather than nag.
+        return None
+    if installed_fp is not None and installed_fp == server_fp:
+        return None  # nothing changed -> never prompts
+
+    update_hint = "Run: bifrost solution sdk update"
+    if (
+        installed_contract is not None
+        and server_contract is not None
+        and installed_contract != server_contract
+    ):
+        return (
+            f"Web SDK is incompatible with this server (SDK contract "
+            f"v{installed_contract}, server v{server_contract}) — hooks may "
+            f"fail. {update_hint}",
+            "breaking",
+        )
+
+    return (
+        f"Web SDK update available (non-breaking). {update_hint}",
+        "warn",
+    )
 
 
 def installed_sdk_contract(app_dir: pathlib.Path) -> int | None:

--- a/api/bifrost/commands/solution.py
+++ b/api/bifrost/commands/solution.py
@@ -2885,6 +2885,140 @@ def _restore_sdk_dep(app_dir: pathlib.Path, api_url: str, original: str) -> None
         pass  # best-effort: worst case the user re-heals on a later start
 
 
+def installed_sdk_fingerprint(app_dir: pathlib.Path) -> str | None:
+    """Read the ``bifrost.fingerprint`` stamp from the installed SDK's
+    ``package.json``, or ``None`` if it's missing, unreadable, or unstamped
+    (an old SDK predating the staleness gate). Pure/no-network — Task 6
+    reuses this to decide whether the app's SDK needs `sdk update`."""
+    pkg_file = app_dir / "node_modules" / "bifrost" / "package.json"
+    try:
+        pkg = json.loads(pkg_file.read_text(encoding="utf-8-sig"))
+    except (OSError, ValueError):
+        return None
+    stamp = pkg.get("bifrost")
+    if not isinstance(stamp, dict):
+        return None
+    fingerprint = stamp.get("fingerprint")
+    return fingerprint if isinstance(fingerprint, str) else None
+
+
+def installed_sdk_contract(app_dir: pathlib.Path) -> int | None:
+    """Read the ``bifrost.contract`` stamp from the installed SDK's
+    ``package.json``, or ``None`` if missing/unreadable/unstamped. Sibling to
+    ``installed_sdk_fingerprint``; Task 6 reuses this for the CLI/SDK contract
+    version gate."""
+    pkg_file = app_dir / "node_modules" / "bifrost" / "package.json"
+    try:
+        pkg = json.loads(pkg_file.read_text(encoding="utf-8-sig"))
+    except (OSError, ValueError):
+        return None
+    stamp = pkg.get("bifrost")
+    if not isinstance(stamp, dict):
+        return None
+    contract = stamp.get("contract")
+    return contract if isinstance(contract, int) else None
+
+
+@click.group(name="sdk", help="Manage the app's vendored Bifrost SDK.")
+def sdk_group() -> None:
+    pass
+
+
+solution_group.add_command(sdk_group)
+
+
+@sdk_group.command(name="update", help="Re-vendor the Bifrost SDK into the app (re-download + reinstall).")
+@click.argument("path", type=click.Path(exists=True, file_okay=False), default=".")
+def sdk_update_cmd(path: str) -> None:
+    import shutil
+
+    from bifrost.solution_dev.app_select import AppSelectionError, select_app
+
+    workspace = _workspace_from_path_arg(path)
+    if not is_solution_workspace(workspace):
+        raise click.ClickException(
+            f"No {DESCRIPTOR_FILENAME} in {workspace} — not a Solution workspace. "
+            f"Run `bifrost solution init` first."
+        )
+    descriptor = load_descriptor(workspace)
+
+    client = BifrostClient.get_instance(require_auth=True)
+    binding = asyncio.run(
+        _resolve_bound_solution(client, workspace, descriptor, None)
+    )
+    click.echo(f"Using Solution install id: {binding.solution_id}")
+
+    try:
+        chosen = select_app(workspace, slug=None)
+    except AppSelectionError as exc:
+        raise click.ClickException(str(exc))
+
+    async def _fetch_server_fingerprint() -> str | None:
+        resp = await client.get("/api/version")
+        if resp.status_code != 200:
+            click.echo(
+                f"  warning: could not reach /api/version ({resp.status_code}) — "
+                "continuing without server-side verification.",
+                err=True,
+            )
+            return None
+        try:
+            data = resp.json()
+        except ValueError:
+            return None
+        fingerprint = data.get("sdk_fingerprint")
+        return fingerprint if isinstance(fingerprint, str) else None
+
+    server_fingerprint = asyncio.run(_fetch_server_fingerprint())
+    if server_fingerprint is None:
+        click.echo(
+            "  note: this server does not report sdk_fingerprint (predates the "
+            "staleness gate) — updating without verification."
+        )
+    elif server_fingerprint == "unavailable":
+        click.echo(
+            "  note: server could not compute its own SDK fingerprint "
+            "(toolchain failure) — updating without verification."
+        )
+        server_fingerprint = None
+
+    old_fingerprint = installed_sdk_fingerprint(chosen.app_dir)
+
+    if server_fingerprint is not None and old_fingerprint == server_fingerprint:
+        click.echo(f"SDK already up to date ({old_fingerprint})")
+        return
+
+    bifrost_modules = chosen.app_dir / "node_modules" / "bifrost"
+    if bifrost_modules.is_dir():
+        shutil.rmtree(bifrost_modules)
+
+    npm = shutil.which("npm")
+    if npm is None:
+        raise click.ClickException("npm not found on PATH — install Node.js to run this command.")
+
+    dep_spec = f"bifrost@{client.api_url.rstrip('/')}{_SDK_DOWNLOAD_SUFFIX}"
+    click.echo(f"Reinstalling {dep_spec}...")
+    try:
+        subprocess.run([npm, "install", "--force", dep_spec], cwd=chosen.app_dir, check=True)
+    except subprocess.CalledProcessError as exc:
+        raise click.ClickException(
+            f"npm install failed in {chosen.app_dir} (exit {exc.returncode}) "
+            "— see the npm output above."
+        )
+
+    new_fingerprint = installed_sdk_fingerprint(chosen.app_dir)
+
+    if server_fingerprint is not None and new_fingerprint != server_fingerprint:
+        raise click.ClickException(
+            f"SDK still stale after reinstall: was {old_fingerprint!r}, now "
+            f"{new_fingerprint!r}, server wants {server_fingerprint!r}. The npm "
+            "registry/cache may be serving an old tarball — try again or check "
+            "the SDK download endpoint."
+        )
+
+    click.echo(f"SDK updated: {old_fingerprint} -> {new_fingerprint}")
+
+
 def _ensure_port_free(port: int) -> None:
     """Refuse to spawn vite onto a port something already serves.
 

--- a/api/src/routers/version.py
+++ b/api/src/routers/version.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 
 from fastapi import APIRouter
@@ -43,6 +44,8 @@ async def get_version_info() -> VersionResponse:
     return VersionResponse(
         version=get_version(),
         contract_version=get_contract_version(),
-        sdk_fingerprint=get_sdk_fingerprint(),
+        # The cold path shells out to node/esbuild (up to 120s). Keep that
+        # synchronous build off the API event loop, matching /api/sdk/download.
+        sdk_fingerprint=await asyncio.to_thread(get_sdk_fingerprint),
         sdk_contract_version=sdk_contract_version(),
     )

--- a/api/src/routers/version.py
+++ b/api/src/routers/version.py
@@ -1,15 +1,41 @@
+import logging
+
 from fastapi import APIRouter
 from pydantic import BaseModel
 
 from shared.contract_version import get_contract_version
 from shared.version import get_version
+from src.services.sdk_package import sdk_contract_version, sdk_fingerprint
 
 router = APIRouter(prefix="/api/version", tags=["version"])
+
+logger = logging.getLogger(__name__)
 
 
 class VersionResponse(BaseModel):
     version: str
     contract_version: int
+    sdk_fingerprint: str
+    sdk_contract_version: int
+
+
+def get_sdk_fingerprint() -> str:
+    """SDK content fingerprint, degrading to ``"unavailable"`` rather than
+    failing the whole /api/version response.
+
+    ``sdk_fingerprint`` shells out to node/esbuild on first call per version
+    (lru_cached thereafter via ``_built_bundle``); a broken node toolchain in
+    this environment must not take down an otherwise-healthy version
+    endpoint. Broad except is intentional here: any failure of the build
+    subprocess (missing binary, timeout, non-zero exit, ...) should degrade
+    the same way, and the exception is logged so the underlying cause is
+    still visible.
+    """
+    try:
+        return sdk_fingerprint(get_version())
+    except Exception:  # noqa: BLE001 - build-toolchain failure must degrade, not 500 /api/version; logged below
+        logger.exception("failed to compute SDK fingerprint")
+        return "unavailable"
 
 
 @router.get("", response_model=VersionResponse)
@@ -17,4 +43,6 @@ async def get_version_info() -> VersionResponse:
     return VersionResponse(
         version=get_version(),
         contract_version=get_contract_version(),
+        sdk_fingerprint=get_sdk_fingerprint(),
+        sdk_contract_version=sdk_contract_version(),
     )

--- a/api/src/services/sdk_package/__init__.py
+++ b/api/src/services/sdk_package/__init__.py
@@ -15,6 +15,7 @@ the consuming app provides them so React stays a singleton).
 from __future__ import annotations
 
 import functools
+import hashlib
 import io
 import json
 import subprocess
@@ -67,6 +68,48 @@ def _bundle(workdir: Path) -> bytes:
     return out.read_bytes()
 
 
+# Caching is safe: the bundle is a pure function of version + the SDK source
+# baked into the image. maxsize=2 covers a rolling-upgrade window. Shared by
+# build_sdk_tarball and sdk_fingerprint so both agree on the exact bytes and
+# esbuild only runs once per version.
+@functools.lru_cache(maxsize=2)
+def _built_bundle(version: str) -> bytes:
+    """esbuild output for the SDK source baked into this image. Cached: pure
+    function of the source; ``version`` keys the cache for rolling upgrades."""
+    with tempfile.TemporaryDirectory(prefix="bifrost-sdk-build-") as tmp:
+        return _bundle(Path(tmp))
+
+
+def sdk_fingerprint(version: str) -> str:
+    """Content fingerprint of the shipped SDK bundle (sha256, 16 hex chars).
+
+    Pure function of the SDK source: changes exactly when the built SDK
+    changes. This is what ``bifrost solution start`` compares against an
+    app's installed copy — no manual bump anywhere. Raises on a build
+    failure (e.g. broken node toolchain); callers that need a
+    never-fails read (``/api/version``) must catch and degrade — see
+    ``get_sdk_fingerprint`` in ``src.routers.version``. Not caught here:
+    ``_built_bundle`` is lru_cached, and functools does not cache raised
+    exceptions, so a transient failure is retried on the next call rather
+    than permanently poisoning the cache.
+    """
+    return hashlib.sha256(_built_bundle(version)).hexdigest()[:16]
+
+
+@functools.lru_cache(maxsize=1)
+def sdk_contract_version() -> int:
+    """The SDK<->server wire contract version (see ``sdk-contract.json``).
+
+    Bumped only on a DECIDED breaking change to the SDK's wire surface —
+    mirrors the CLI's ``CONTRACT_VERSION`` two-tier model (content
+    fingerprint = automatic, contract version = manual/tripwire-forced).
+    The JSON file is baked into the image alongside the SDK source (see
+    Dockerfile), so this resolves identically in dev and in the built image.
+    """
+    contract = json.loads((_SDK_SRC / "sdk-contract.json").read_text())
+    return contract["version"]
+
+
 # Caching is safe: the tarball is a pure function of version + the SDK source
 # baked into the image. maxsize=2 covers a rolling-upgrade window.
 @functools.lru_cache(maxsize=2)
@@ -75,31 +118,32 @@ def build_sdk_tarball(version: str) -> bytes:
     stamped. Layout: ``package/package.json`` (name ``bifrost``, ESM ``module``
     entry, React peer deps) + ``package/dist/index.mjs`` (the bundle)."""
     pkg_version = _pep440ish(version)
+    bundle = _built_bundle(version)
 
-    with tempfile.TemporaryDirectory(prefix="bifrost-sdk-build-") as tmp:
-        workdir = Path(tmp)
-        bundle = _bundle(workdir)
+    package_json = {
+        "name": "bifrost",
+        "version": pkg_version,
+        "description": "Bifrost web SDK for standalone v2 apps.",
+        "type": "module",
+        "module": "dist/index.mjs",
+        "main": "dist/index.mjs",
+        "exports": {".": {"import": "./dist/index.mjs"}},
+        "peerDependencies": _PEER_DEPS,
+        "bifrost": {
+            "fingerprint": sdk_fingerprint(version),
+            "contract": sdk_contract_version(),
+        },
+    }
 
-        package_json = {
-            "name": "bifrost",
-            "version": pkg_version,
-            "description": "Bifrost web SDK for standalone v2 apps.",
-            "type": "module",
-            "module": "dist/index.mjs",
-            "main": "dist/index.mjs",
-            "exports": {".": {"import": "./dist/index.mjs"}},
-            "peerDependencies": _PEER_DEPS,
-        }
+    buffer = io.BytesIO()
+    with tarfile.open(fileobj=buffer, mode="w:gz") as tar:
+        def _add(name: str, data: bytes) -> None:
+            info = tarfile.TarInfo(name=name)
+            info.size = len(data)
+            tar.addfile(info, fileobj=io.BytesIO(data))
 
-        buffer = io.BytesIO()
-        with tarfile.open(fileobj=buffer, mode="w:gz") as tar:
-            def _add(name: str, data: bytes) -> None:
-                info = tarfile.TarInfo(name=name)
-                info.size = len(data)
-                tar.addfile(info, fileobj=io.BytesIO(data))
+        # npm expects everything under a top-level "package/" dir.
+        _add("package/package.json", json.dumps(package_json, indent=2).encode())
+        _add("package/dist/index.mjs", bundle)
 
-            # npm expects everything under a top-level "package/" dir.
-            _add("package/package.json", json.dumps(package_json, indent=2).encode())
-            _add("package/dist/index.mjs", bundle)
-
-        return buffer.getvalue()
+    return buffer.getvalue()

--- a/api/tests/unit/test_sdk_package.py
+++ b/api/tests/unit/test_sdk_package.py
@@ -28,6 +28,7 @@ _SRC_FILES = [
     "use-table.ts",
     "use-infinite-table.ts",
     "ws-client.ts",
+    "execution-stream.ts",
     "use-workflow.ts",
     "use-workflow-hooks.ts",
     "files.ts",
@@ -54,6 +55,7 @@ def _ensure_sdk_src() -> bool:
     for f in _SRC_FILES:
         shutil.copy(client / f, dst / f)
     shutil.copy(client / "index.v2.ts", dst / "index.ts")
+    shutil.copy(client / "sdk-contract.json", dst / "sdk-contract.json")
     return True
 
 
@@ -65,6 +67,7 @@ def test_build_sdk_tarball_cached_per_version(monkeypatch):
     import src.services.sdk_package as sdkpkg
 
     sdkpkg.build_sdk_tarball.cache_clear()
+    sdkpkg._built_bundle.cache_clear()
     calls: list[Path] = []
 
     def _fake_bundle(workdir: Path) -> bytes:
@@ -78,6 +81,7 @@ def test_build_sdk_tarball_cached_per_version(monkeypatch):
     finally:
         # Don't leak the fake-bundle tarball into other tests via the cache.
         sdkpkg.build_sdk_tarball.cache_clear()
+        sdkpkg._built_bundle.cache_clear()
 
     assert first == second
     assert len(calls) == 1, "builder ran more than once for the same version"

--- a/api/tests/unit/test_sdk_package_fingerprint.py
+++ b/api/tests/unit/test_sdk_package_fingerprint.py
@@ -78,6 +78,26 @@ def test_version_endpoint_reports_sdk_fingerprint_and_contract(monkeypatch):
     assert "sdk_contract_version" in version_router.VersionResponse.model_fields
 
 
+def test_version_endpoint_builds_fingerprint_off_event_loop(monkeypatch):
+    import asyncio
+
+    from src.routers import version as version_router
+
+    calls = []
+
+    async def _fake_to_thread(func, *args):
+        calls.append((func, args))
+        return func(*args)
+
+    monkeypatch.setattr(version_router.asyncio, "to_thread", _fake_to_thread)
+    monkeypatch.setattr(version_router, "get_sdk_fingerprint", lambda: "threaded-fp")
+    monkeypatch.setattr(version_router, "sdk_contract_version", lambda: 1)
+
+    resp = asyncio.run(version_router.get_version_info())
+    assert resp.sdk_fingerprint == "threaded-fp"
+    assert calls == [(version_router.get_sdk_fingerprint, ())]
+
+
 def test_get_sdk_fingerprint_degrades_gracefully_on_build_failure(monkeypatch):
     """A broken node toolchain must not take down /api/version."""
     from src.routers import version as version_router

--- a/api/tests/unit/test_sdk_package_fingerprint.py
+++ b/api/tests/unit/test_sdk_package_fingerprint.py
@@ -1,0 +1,133 @@
+"""The SDK staleness gate hinges on two independent stamps:
+
+- a content fingerprint (sha256 of the built bundle) that changes automatically
+  whenever the shipped SDK source changes -- present both in the tarball's
+  package.json and in GET /api/version.
+- a contract version (sdk-contract.json) that only changes on a DECIDED
+  breaking SDK<->server change -- same two-tier model as the CLI's
+  CONTRACT_VERSION + DTO-fingerprint pair (see api/bifrost/contract_version.py).
+
+Same source -> same fingerprint, stable across calls, and a broken node
+toolchain must degrade gracefully rather than 500 /api/version.
+"""
+
+import io
+import json
+import tarfile
+
+import pytest
+
+
+def test_tarball_package_json_carries_fingerprint():
+    from src.services.sdk_package import build_sdk_tarball, sdk_fingerprint
+
+    data = build_sdk_tarball("v1.2.3")
+    with tarfile.open(fileobj=io.BytesIO(data), mode="r:gz") as tar:
+        pkg = json.load(tar.extractfile("package/package.json"))
+
+    assert pkg["bifrost"]["fingerprint"] == sdk_fingerprint("v1.2.3")
+    assert len(pkg["bifrost"]["fingerprint"]) == 16
+
+
+def test_fingerprint_is_stable_across_calls():
+    from src.services.sdk_package import sdk_fingerprint
+
+    assert sdk_fingerprint("v1.2.3") == sdk_fingerprint("v1.2.3")
+
+
+def test_sdk_contract_version_is_positive_int():
+    from src.services.sdk_package import sdk_contract_version
+
+    version = sdk_contract_version()
+    assert isinstance(version, int)
+    assert version > 0
+
+
+def test_sdk_contract_version_matches_json_file():
+    import json as _json
+    from pathlib import Path
+
+    from src.services.sdk_package import _SDK_SRC, sdk_contract_version
+
+    contract = _json.loads((_SDK_SRC / "sdk-contract.json").read_text())
+    assert sdk_contract_version() == contract["version"]
+
+
+def test_tarball_package_json_carries_contract_version():
+    from src.services.sdk_package import build_sdk_tarball, sdk_contract_version
+
+    data = build_sdk_tarball("v1.2.3")
+    with tarfile.open(fileobj=io.BytesIO(data), mode="r:gz") as tar:
+        pkg = json.load(tar.extractfile("package/package.json"))
+
+    assert pkg["bifrost"]["contract"] == sdk_contract_version()
+
+
+def test_version_endpoint_reports_sdk_fingerprint_and_contract(monkeypatch):
+    import asyncio
+
+    from src.routers import version as version_router
+
+    monkeypatch.setattr(version_router, "get_sdk_fingerprint", lambda: "abcd1234abcd1234")
+    monkeypatch.setattr(version_router, "sdk_contract_version", lambda: 1)
+
+    resp = asyncio.run(version_router.get_version_info())
+    assert resp.sdk_fingerprint == "abcd1234abcd1234"
+    assert resp.sdk_contract_version == 1
+    assert "sdk_fingerprint" in version_router.VersionResponse.model_fields
+    assert "sdk_contract_version" in version_router.VersionResponse.model_fields
+
+
+def test_get_sdk_fingerprint_degrades_gracefully_on_build_failure(monkeypatch):
+    """A broken node toolchain must not take down /api/version."""
+    from src.routers import version as version_router
+
+    def _boom(_version: str) -> str:
+        raise RuntimeError("esbuild exploded")
+
+    monkeypatch.setattr(version_router, "sdk_fingerprint", _boom)
+    assert version_router.get_sdk_fingerprint() == "unavailable"
+
+
+def test_version_endpoint_tolerates_fingerprint_failure(monkeypatch):
+    import asyncio
+
+    from src.routers import version as version_router
+
+    def _boom() -> str:
+        raise RuntimeError("esbuild exploded")
+
+    monkeypatch.setattr(version_router, "get_sdk_fingerprint", _boom)
+    with pytest.raises(RuntimeError):
+        # get_sdk_fingerprint itself is the guarded call site; if the handler
+        # calls it directly (not wrapped again), a raise here is a bug in the
+        # handler -- this test documents that get_sdk_fingerprint is where the
+        # try/except must live, not a second layer in the handler.
+        asyncio.run(version_router.get_version_info())
+
+
+def test_sdk_fingerprint_does_not_cache_failures(monkeypatch):
+    """A transient node hiccup must be retryable on the next call, not
+    permanently cached as a failure."""
+    from src.services.sdk_package import sdk_fingerprint
+
+    import src.services.sdk_package as sdkpkg
+
+    calls = {"n": 0}
+
+    def _flaky(_version: str) -> bytes:
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise RuntimeError("transient failure")
+        return b"//bundle-ok"
+
+    monkeypatch.setattr(sdkpkg, "_built_bundle", _flaky)
+
+    with pytest.raises(RuntimeError):
+        sdk_fingerprint("v9.9.9-fingerprint-cache-test")
+
+    # Second call retries the underlying build rather than replaying a cached
+    # exception.
+    result = sdk_fingerprint("v9.9.9-fingerprint-cache-test")
+    assert isinstance(result, str)
+    assert calls["n"] == 2

--- a/api/tests/unit/test_sdk_package_fingerprint.py
+++ b/api/tests/unit/test_sdk_package_fingerprint.py
@@ -45,7 +45,6 @@ def test_sdk_contract_version_is_positive_int():
 
 def test_sdk_contract_version_matches_json_file():
     import json as _json
-    from pathlib import Path
 
     from src.services.sdk_package import _SDK_SRC, sdk_contract_version
 
@@ -129,8 +128,6 @@ def test_version_endpoint_tolerates_fingerprint_failure(monkeypatch):
 def test_sdk_fingerprint_does_not_cache_failures(monkeypatch):
     """A transient node hiccup must be retryable on the next call, not
     permanently cached as a failure."""
-    from src.services.sdk_package import sdk_fingerprint
-
     import src.services.sdk_package as sdkpkg
 
     calls = {"n": 0}
@@ -144,10 +141,10 @@ def test_sdk_fingerprint_does_not_cache_failures(monkeypatch):
     monkeypatch.setattr(sdkpkg, "_built_bundle", _flaky)
 
     with pytest.raises(RuntimeError):
-        sdk_fingerprint("v9.9.9-fingerprint-cache-test")
+        sdkpkg.sdk_fingerprint("v9.9.9-fingerprint-cache-test")
 
     # Second call retries the underlying build rather than replaying a cached
     # exception.
-    result = sdk_fingerprint("v9.9.9-fingerprint-cache-test")
+    result = sdkpkg.sdk_fingerprint("v9.9.9-fingerprint-cache-test")
     assert isinstance(result, str)
     assert calls["n"] == 2

--- a/api/tests/unit/test_solution_sdk_update.py
+++ b/api/tests/unit/test_solution_sdk_update.py
@@ -31,6 +31,25 @@ def test_installed_sdk_fingerprint_none_when_missing(tmp_path):
     assert installed_sdk_fingerprint(tmp_path) is None
 
 
+def test_installed_sdk_contract_reads_stamp(tmp_path):
+    from bifrost.commands.solution import installed_sdk_contract
+
+    pkg_dir = tmp_path / "node_modules" / "bifrost"
+    pkg_dir.mkdir(parents=True)
+    pkg = {"name": "bifrost", "version": "1.0.0", "bifrost": {"contract": 1}}
+    (pkg_dir / "package.json").write_text(json.dumps(pkg))
+
+    assert installed_sdk_contract(tmp_path) == 1
+
+
+def test_installed_sdk_contract_none_when_missing(tmp_path):
+    from bifrost.commands.solution import installed_sdk_contract
+
+    assert installed_sdk_contract(tmp_path) is None  # no node_modules
+    _write_installed_sdk(tmp_path, "abcd1234abcd1234")  # unstamped for contract
+    assert installed_sdk_contract(tmp_path) is None
+
+
 def _sdk_update_workspace(tmp_path, monkeypatch, *, installed_fingerprint):
     """Bound workspace with a single standalone_v2 app, mirroring
     `_start_workspace` in test_solution_dev_command.py but scoped to what
@@ -117,6 +136,104 @@ def test_sdk_update_reinstalls_and_verifies(tmp_path, monkeypatch):
     assert spawned  # npm WAS invoked
     assert "oldoldoldoldold1" in result.output
     assert "newnewnewnewnew1" in result.output
+
+    # Pin the npm invocation's shape: a regression dropping --force (the
+    # cache-bust) or mangling the dep spec must fail this test.
+    argv = spawned[0]
+    assert argv[0].endswith("npm")  # resolved via shutil.which, so may be a full path
+    assert argv[1:3] == ["install", "--force"]
+    assert "bifrost@http://localhost:8000/api/sdk/download" in argv
+
+
+def _fake_run_reinstalls(app_dir, spawned):
+    import subprocess
+
+    def _fake_run(argv, **kwargs):
+        spawned.append(list(argv))
+        import shutil as _shutil
+        bifrost_dir = app_dir / "node_modules" / "bifrost"
+        if bifrost_dir.exists():
+            _shutil.rmtree(bifrost_dir)
+        _write_installed_sdk(app_dir, "brandnewbrandnew")
+
+    return _fake_run
+
+
+def test_sdk_update_continues_unverified_when_field_missing(tmp_path, monkeypatch):
+    """Server predates sdk_fingerprint (field absent from /api/version) — the
+    command must say so and continue with the reinstall unverified rather
+    than erroring or skipping."""
+    import subprocess
+
+    class _NoFieldVersionResp:
+        status_code = 200
+        text = ""
+
+        def json(self):
+            return {}
+
+    app_dir = _sdk_update_workspace(tmp_path, monkeypatch, installed_fingerprint="oldoldoldoldold1")
+
+    import bifrost.client as client_mod
+
+    class _FakeClient:
+        organization = {"id": "org-1"}
+        user = {"id": "u", "is_superuser": True}
+        api_url = "http://localhost:8000"
+        _access_token = "tok"
+
+        async def get(self, path, **kwargs):
+            assert path == "/api/version"
+            return _NoFieldVersionResp()
+
+    monkeypatch.setattr(client_mod.BifrostClient, "get_instance", staticmethod(lambda **k: _FakeClient()))
+
+    spawned = []
+    monkeypatch.setattr(subprocess, "run", _fake_run_reinstalls(app_dir, spawned))
+
+    result = CliRunner().invoke(solution_group, ["sdk", "update", "."])
+
+    assert result.exit_code == 0, result.output
+    assert spawned  # npm WAS invoked despite no verification available
+    assert "predates" in result.output or "without verification" in result.output
+
+
+def test_sdk_update_continues_unverified_when_unavailable(tmp_path, monkeypatch):
+    """Server reports sdk_fingerprint == "unavailable" (toolchain failure) —
+    the command must say so and continue with the reinstall unverified."""
+    import subprocess
+
+    class _UnavailableVersionResp:
+        status_code = 200
+        text = ""
+
+        def json(self):
+            return {"sdk_fingerprint": "unavailable"}
+
+    app_dir = _sdk_update_workspace(tmp_path, monkeypatch, installed_fingerprint="oldoldoldoldold1")
+
+    import bifrost.client as client_mod
+
+    class _FakeClient:
+        organization = {"id": "org-1"}
+        user = {"id": "u", "is_superuser": True}
+        api_url = "http://localhost:8000"
+        _access_token = "tok"
+
+        async def get(self, path, **kwargs):
+            assert path == "/api/version"
+            return _UnavailableVersionResp()
+
+    monkeypatch.setattr(client_mod.BifrostClient, "get_instance", staticmethod(lambda **k: _FakeClient()))
+
+    spawned = []
+    monkeypatch.setattr(subprocess, "run", _fake_run_reinstalls(app_dir, spawned))
+
+    result = CliRunner().invoke(solution_group, ["sdk", "update", "."])
+
+    assert result.exit_code == 0, result.output
+    assert spawned  # npm WAS invoked despite no verification available
+    assert "toolchain failure" in result.output or "without verification" in result.output
 
 
 def test_sdk_update_fails_loud_when_still_stale(tmp_path, monkeypatch):

--- a/api/tests/unit/test_solution_sdk_update.py
+++ b/api/tests/unit/test_solution_sdk_update.py
@@ -1,0 +1,137 @@
+import json
+from pathlib import Path
+
+import yaml
+from click.testing import CliRunner
+
+from bifrost.commands.solution import solution_group
+
+
+def _write_installed_sdk(app_dir: Path, fingerprint: str | None) -> None:
+    pkg_dir = app_dir / "node_modules" / "bifrost"
+    pkg_dir.mkdir(parents=True)
+    pkg = {"name": "bifrost", "version": "1.0.0"}
+    if fingerprint:
+        pkg["bifrost"] = {"fingerprint": fingerprint}
+    (pkg_dir / "package.json").write_text(json.dumps(pkg))
+
+
+def test_installed_sdk_fingerprint_reads_stamp(tmp_path):
+    from bifrost.commands.solution import installed_sdk_fingerprint
+
+    _write_installed_sdk(tmp_path, "abcd1234abcd1234")
+    assert installed_sdk_fingerprint(tmp_path) == "abcd1234abcd1234"
+
+
+def test_installed_sdk_fingerprint_none_when_missing(tmp_path):
+    from bifrost.commands.solution import installed_sdk_fingerprint
+
+    assert installed_sdk_fingerprint(tmp_path) is None          # no node_modules
+    _write_installed_sdk(tmp_path, None)                        # unstamped (old SDK)
+    assert installed_sdk_fingerprint(tmp_path) is None
+
+
+def _sdk_update_workspace(tmp_path, monkeypatch, *, installed_fingerprint):
+    """Bound workspace with a single standalone_v2 app, mirroring
+    `_start_workspace` in test_solution_dev_command.py but scoped to what
+    `sdk update` needs: no FunctionHost/vite fakes, just client + app dir."""
+    import bifrost.client as client_mod
+
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "bifrost.solution.yaml").write_text("slug: s\nname: S\nscope: org\n")
+    (tmp_path / ".env").write_text(
+        "BIFROST_SOLUTION_ID=11111111-1111-1111-1111-111111111111\n"
+        "BIFROST_SOLUTION_SLUG=s\n"
+        "BIFROST_SOLUTION_ORG_ID=org-1\n"
+        "BIFROST_SOLUTION_SCOPE=org\n"
+    )
+    (tmp_path / ".bifrost").mkdir()
+    (tmp_path / ".bifrost" / "apps.yaml").write_text(
+        yaml.safe_dump({"apps": {
+            "a": {"id": "a", "slug": "dash", "path": "apps/dash", "app_model": "standalone_v2"},
+        }})
+    )
+    app_dir = tmp_path / "apps" / "dash"
+    app_dir.mkdir(parents=True)
+    if installed_fingerprint is not None:
+        _write_installed_sdk(app_dir, installed_fingerprint)
+
+    class _FakeClient:
+        organization = {"id": "org-1"}
+        user = {"id": "u", "is_superuser": True}
+        api_url = "http://localhost:8000"
+        _access_token = "tok"
+
+        async def get(self, path, **kwargs):
+            assert path == "/api/version"
+            return _VersionResp()
+
+    monkeypatch.setattr(client_mod.BifrostClient, "get_instance", staticmethod(lambda **k: _FakeClient()))
+    return app_dir
+
+
+class _VersionResp:
+    status_code = 200
+    text = ""
+
+    def json(self):
+        return {"sdk_fingerprint": "newnewnewnewnew1"}
+
+
+def test_sdk_update_skips_when_current(tmp_path, monkeypatch):
+    import subprocess
+
+    app_dir = _sdk_update_workspace(tmp_path, monkeypatch, installed_fingerprint="newnewnewnewnew1")
+
+    spawned = []
+    monkeypatch.setattr(subprocess, "run", lambda argv, **k: spawned.append(list(argv)))
+
+    result = CliRunner().invoke(solution_group, ["sdk", "update", "."])
+
+    assert result.exit_code == 0, result.output
+    assert "already up to date" in result.output
+    assert spawned == []  # npm NOT invoked
+
+
+def test_sdk_update_reinstalls_and_verifies(tmp_path, monkeypatch):
+    import subprocess
+
+    app_dir = _sdk_update_workspace(tmp_path, monkeypatch, installed_fingerprint="oldoldoldoldold1")
+
+    spawned = []
+
+    def _fake_run(argv, **kwargs):
+        spawned.append(list(argv))
+        # Simulate npm install replacing node_modules/bifrost with the new SDK.
+        import shutil as _shutil
+        bifrost_dir = app_dir / "node_modules" / "bifrost"
+        if bifrost_dir.exists():
+            _shutil.rmtree(bifrost_dir)
+        _write_installed_sdk(app_dir, "newnewnewnewnew1")
+
+    monkeypatch.setattr(subprocess, "run", _fake_run)
+
+    result = CliRunner().invoke(solution_group, ["sdk", "update", "."])
+
+    assert result.exit_code == 0, result.output
+    assert spawned  # npm WAS invoked
+    assert "oldoldoldoldold1" in result.output
+    assert "newnewnewnewnew1" in result.output
+
+
+def test_sdk_update_fails_loud_when_still_stale(tmp_path, monkeypatch):
+    import subprocess
+
+    app_dir = _sdk_update_workspace(tmp_path, monkeypatch, installed_fingerprint="oldoldoldoldold1")
+
+    def _noop_run(argv, **kwargs):
+        # npm install is mocked as a no-op: node_modules/bifrost keeps the old stamp.
+        pass
+
+    monkeypatch.setattr(subprocess, "run", _noop_run)
+
+    result = CliRunner().invoke(solution_group, ["sdk", "update", "."])
+
+    assert result.exit_code == 1
+    assert "oldoldoldoldold1" in result.output
+    assert "newnewnewnewnew1" in result.output

--- a/api/tests/unit/test_solution_sdk_update.py
+++ b/api/tests/unit/test_solution_sdk_update.py
@@ -50,7 +50,13 @@ def test_installed_sdk_contract_none_when_missing(tmp_path):
     assert installed_sdk_contract(tmp_path) is None
 
 
-def _sdk_update_workspace(tmp_path, monkeypatch, *, installed_fingerprint):
+def _sdk_update_workspace(
+    tmp_path,
+    monkeypatch,
+    *,
+    installed_fingerprint,
+    app_slugs=("dash",),
+):
     """Bound workspace with a single standalone_v2 app, mirroring
     `_start_workspace` in test_solution_dev_command.py but scoped to what
     `sdk update` needs: no FunctionHost/vite fakes, just client + app dir."""
@@ -65,13 +71,21 @@ def _sdk_update_workspace(tmp_path, monkeypatch, *, installed_fingerprint):
         "BIFROST_SOLUTION_SCOPE=org\n"
     )
     (tmp_path / ".bifrost").mkdir()
+    apps = {
+        f"app-{index}": {
+            "id": f"app-{index}",
+            "slug": slug,
+            "path": f"apps/{slug}",
+            "app_model": "standalone_v2",
+        }
+        for index, slug in enumerate(app_slugs)
+    }
     (tmp_path / ".bifrost" / "apps.yaml").write_text(
-        yaml.safe_dump({"apps": {
-            "a": {"id": "a", "slug": "dash", "path": "apps/dash", "app_model": "standalone_v2"},
-        }})
+        yaml.safe_dump({"apps": apps})
     )
-    app_dir = tmp_path / "apps" / "dash"
-    app_dir.mkdir(parents=True)
+    for slug in app_slugs:
+        (tmp_path / "apps" / slug).mkdir(parents=True)
+    app_dir = tmp_path / "apps" / app_slugs[0]
     if installed_fingerprint is not None:
         _write_installed_sdk(app_dir, installed_fingerprint)
 
@@ -143,6 +157,49 @@ def test_sdk_update_reinstalls_and_verifies(tmp_path, monkeypatch):
     assert argv[0].endswith("npm")  # resolved via shutil.which, so may be a full path
     assert argv[1:3] == ["install", "--force"]
     assert "bifrost@http://localhost:8000/api/sdk/download" in argv
+
+
+def test_sdk_update_selects_app_in_multi_app_solution(tmp_path, monkeypatch):
+    import subprocess
+
+    _sdk_update_workspace(
+        tmp_path,
+        monkeypatch,
+        installed_fingerprint="oldoldoldoldold1",
+        app_slugs=("dash", "reports"),
+    )
+    reports_dir = tmp_path / "apps" / "reports"
+    _write_installed_sdk(reports_dir, "oldoldoldoldold1")
+    spawned = []
+
+    def _fake_run(argv, **kwargs):
+        spawned.append((list(argv), kwargs["cwd"]))
+        _write_installed_sdk(reports_dir, "newnewnewnewnew1")
+
+    monkeypatch.setattr(subprocess, "run", _fake_run)
+
+    result = CliRunner().invoke(
+        solution_group,
+        ["sdk", "update", ".", "--app", "reports"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert spawned[0][1] == reports_dir
+    assert "newnewnewnewnew1" in result.output
+
+
+def test_sdk_update_multi_app_error_names_selector(tmp_path, monkeypatch):
+    _sdk_update_workspace(
+        tmp_path,
+        monkeypatch,
+        installed_fingerprint="oldoldoldoldold1",
+        app_slugs=("dash", "reports"),
+    )
+
+    result = CliRunner().invoke(solution_group, ["sdk", "update", "."])
+
+    assert result.exit_code == 1
+    assert "--app <slug>" in result.output
 
 
 def _fake_run_reinstalls(app_dir, spawned):

--- a/api/tests/unit/test_solution_sdk_update.py
+++ b/api/tests/unit/test_solution_sdk_update.py
@@ -114,7 +114,7 @@ class _VersionResp:
 def test_sdk_update_skips_when_current(tmp_path, monkeypatch):
     import subprocess
 
-    app_dir = _sdk_update_workspace(tmp_path, monkeypatch, installed_fingerprint="newnewnewnewnew1")
+    _sdk_update_workspace(tmp_path, monkeypatch, installed_fingerprint="newnewnewnewnew1")
 
     spawned = []
     monkeypatch.setattr(subprocess, "run", lambda argv, **k: spawned.append(list(argv)))
@@ -203,8 +203,6 @@ def test_sdk_update_multi_app_error_names_selector(tmp_path, monkeypatch):
 
 
 def _fake_run_reinstalls(app_dir, spawned):
-    import subprocess
-
     def _fake_run(argv, **kwargs):
         spawned.append(list(argv))
         import shutil as _shutil
@@ -229,7 +227,11 @@ def test_sdk_update_continues_unverified_when_field_missing(tmp_path, monkeypatc
         def json(self):
             return {}
 
-    app_dir = _sdk_update_workspace(tmp_path, monkeypatch, installed_fingerprint="oldoldoldoldold1")
+    app_dir = _sdk_update_workspace(
+        tmp_path,
+        monkeypatch,
+        installed_fingerprint="oldoldoldoldold1",
+    )
 
     import bifrost.client as client_mod
 
@@ -296,7 +298,7 @@ def test_sdk_update_continues_unverified_when_unavailable(tmp_path, monkeypatch)
 def test_sdk_update_fails_loud_when_still_stale(tmp_path, monkeypatch):
     import subprocess
 
-    app_dir = _sdk_update_workspace(tmp_path, monkeypatch, installed_fingerprint="oldoldoldoldold1")
+    _sdk_update_workspace(tmp_path, monkeypatch, installed_fingerprint="oldoldoldoldold1")
 
     def _noop_run(argv, **kwargs):
         # npm install is mocked as a no-op: node_modules/bifrost keeps the old stamp.

--- a/api/tests/unit/test_solution_start_sdk_warning.py
+++ b/api/tests/unit/test_solution_start_sdk_warning.py
@@ -1,0 +1,186 @@
+"""`bifrost solution start` must warn when the locally-installed web SDK is
+stale relative to the server, without ever blocking startup on the check.
+
+Rules (see sdk_staleness_warning docstring / task-6 brief):
+- server_fp None (old server / fetch failure / "unavailable") -> silent.
+- fingerprints equal -> silent (nothing changed -> never prompts).
+- contracts both present and DIFFERENT -> loud "breaking" (red).
+- fingerprints differ, contracts equal/missing -> gentle "warn" (yellow).
+- installed_fp None (unstamped old SDK) with server_fp present -> "warn".
+"""
+import json
+
+import yaml
+from click.testing import CliRunner
+
+from bifrost.commands.solution import sdk_staleness_warning, solution_group
+
+
+class TestSdkStalenessWarningHelper:
+    def test_server_fp_none_is_silent(self):
+        assert sdk_staleness_warning("abc", None, 1, 1) is None
+
+    def test_equal_fingerprints_is_silent(self):
+        assert sdk_staleness_warning("abc", "abc", 1, 1) is None
+        # Nothing changed -> never prompts, even if contract fields differ oddly.
+        assert sdk_staleness_warning("abc", "abc", None, None) is None
+
+    def test_differing_contracts_is_breaking(self):
+        result = sdk_staleness_warning("abc", "def", 1, 2)
+        assert result is not None
+        message, severity = result
+        assert severity == "breaking"
+        assert "SDK contract v1" in message
+        assert "server v2" in message
+        assert "bifrost solution sdk update" in message
+        assert "incompatible" in message
+
+    def test_differing_fingerprints_same_contract_is_warn(self):
+        result = sdk_staleness_warning("abc", "def", 1, 1)
+        assert result is not None
+        message, severity = result
+        assert severity == "warn"
+        assert "update available" in message.lower()
+        assert "bifrost solution sdk update" in message
+
+    def test_differing_fingerprints_missing_contract_is_warn(self):
+        result = sdk_staleness_warning("abc", "def", None, 1)
+        assert result is not None
+        message, severity = result
+        assert severity == "warn"
+
+        result = sdk_staleness_warning("abc", "def", 1, None)
+        assert result is not None
+        _, severity = result
+        assert severity == "warn"
+
+    def test_unstamped_installed_sdk_with_server_fp_is_warn(self):
+        result = sdk_staleness_warning(None, "def", None, 1)
+        assert result is not None
+        message, severity = result
+        assert severity == "warn"
+        assert "bifrost solution sdk update" in message
+
+
+def _start_workspace(tmp_path, monkeypatch):
+    """Minimal bound-workspace fixture mirroring test_solution_dev_command.py's
+    `_start_workspace` helper: fakes the network/host layer so `start` can run
+    all the way through in a CliRunner invocation."""
+    import shutil
+    import subprocess
+
+    import bifrost.client as client_mod
+    from bifrost.solution_dev import function_host
+
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "bifrost.solution.yaml").write_text("slug: s\nname: S\nscope: org\n")
+    (tmp_path / ".env").write_text(
+        "BIFROST_SOLUTION_ID=11111111-1111-1111-1111-111111111111\n"
+        "BIFROST_SOLUTION_SLUG=s\n"
+        "BIFROST_SOLUTION_ORG_ID=org-1\n"
+        "BIFROST_SOLUTION_SCOPE=org\n"
+    )
+    (tmp_path / ".bifrost").mkdir()
+    (tmp_path / ".bifrost" / "apps.yaml").write_text(
+        yaml.safe_dump({"apps": {
+            "a": {"id": "a", "slug": "dash", "path": "apps/dash", "app_model": "standalone_v2"},
+        }})
+    )
+    app_dir = tmp_path / "apps" / "dash"
+    app_dir.mkdir(parents=True)
+
+    class _FakeClient:
+        organization = {"id": "org-1"}
+        user = {"id": "u", "is_superuser": True}
+        api_url = "http://localhost:8000"
+        _access_token = "tok"
+
+    fake_client = _FakeClient()
+    monkeypatch.setattr(client_mod.BifrostClient, "get_instance", staticmethod(lambda **k: fake_client))
+    monkeypatch.setattr(function_host, "set_dev_execution_context", lambda **k: None)
+
+    class _FakeHost:
+        def __init__(self, workspace):
+            pass
+
+        def reload(self):
+            pass
+
+        def refs(self):
+            return []
+
+        def failures(self):
+            return {}
+
+    monkeypatch.setattr(function_host, "FunctionHost", _FakeHost)
+    monkeypatch.setattr(shutil, "which", lambda name: "/usr/bin/npm" if name == "npm" else None)
+    monkeypatch.setattr(subprocess, "run", lambda argv, **k: None)
+
+    class _FakeProc:
+        pid = 4242
+
+    monkeypatch.setattr(subprocess, "Popen", lambda argv, **k: _FakeProc())
+
+    served = {}
+
+    async def _fake_serve(*args, **kwargs):
+        served["called"] = True
+        return None
+
+    monkeypatch.setattr("bifrost.commands.solution._serve", _fake_serve)
+    monkeypatch.setattr("bifrost.commands.solution._ensure_port_free", lambda port: None)
+    monkeypatch.setattr("bifrost.commands.solution._wait_for_vite", lambda proc, port: None)
+    monkeypatch.setattr("bifrost.commands.solution._terminate_process_group", lambda proc: None)
+
+    return app_dir, served, fake_client
+
+
+class TestStartWiresInStalenessWarning:
+    def test_start_prints_warning_and_still_boots(self, tmp_path, monkeypatch):
+        app_dir, served, fake_client = _start_workspace(tmp_path, monkeypatch)
+
+        # Installed SDK is stamped and stale relative to the server.
+        node_modules_bifrost = app_dir / "node_modules" / "bifrost"
+        node_modules_bifrost.mkdir(parents=True)
+        (node_modules_bifrost / "package.json").write_text(json.dumps({
+            "bifrost": {"fingerprint": "old-fp", "contract": 1},
+        }))
+
+        class _VersionResp:
+            status_code = 200
+
+            def json(self):
+                return {"sdk_fingerprint": "new-fp", "sdk_contract_version": 1}
+
+        async def _fake_get(path, **kwargs):
+            assert path == "/api/version"
+            return _VersionResp()
+
+        fake_client.get = _fake_get
+
+        result = CliRunner().invoke(solution_group, ["start"])
+        assert result.exit_code == 0, result.output
+        assert "Web SDK update available" in result.output
+        assert "bifrost solution sdk update" in result.output
+        # Startup still proceeded to the serve step.
+        assert served.get("called") is True
+
+    def test_start_swallows_version_fetch_failure_silently(self, tmp_path, monkeypatch):
+        app_dir, served, fake_client = _start_workspace(tmp_path, monkeypatch)
+
+        node_modules_bifrost = app_dir / "node_modules" / "bifrost"
+        node_modules_bifrost.mkdir(parents=True)
+        (node_modules_bifrost / "package.json").write_text(json.dumps({
+            "bifrost": {"fingerprint": "old-fp", "contract": 1},
+        }))
+
+        async def _fake_get(path, **kwargs):
+            raise RuntimeError("network is down")
+
+        fake_client.get = _fake_get
+
+        result = CliRunner().invoke(solution_group, ["start"])
+        assert result.exit_code == 0, result.output
+        assert "Web SDK" not in result.output
+        assert "sdk update" not in result.output
+        assert served.get("called") is True

--- a/client/src/lib/app-sdk/execution-stream.test.ts
+++ b/client/src/lib/app-sdk/execution-stream.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { subscribeToExecution } from "./execution-stream";
+
+class MockWebSocket {
+  static instances: MockWebSocket[] = [];
+  url: string;
+  sent: string[] = [];
+  listeners: Record<string, ((e: any) => void)[]> = {};
+  constructor(url: string) {
+    this.url = url;
+    MockWebSocket.instances.push(this);
+  }
+  addEventListener(type: string, cb: (e: any) => void) {
+    (this.listeners[type] ??= []).push(cb);
+  }
+  send(data: string) {
+    this.sent.push(data);
+  }
+  close() {
+    this.emit("close", { code: 1000 });
+  }
+  emit(type: string, e: any) {
+    (this.listeners[type] ?? []).forEach((cb) => cb(e));
+  }
+}
+
+beforeEach(() => {
+  MockWebSocket.instances = [];
+  vi.stubGlobal("WebSocket", MockWebSocket);
+});
+afterEach(() => vi.unstubAllGlobals());
+
+describe("subscribeToExecution", () => {
+  it("subscribes to the execution channel on open", () => {
+    subscribeToExecution("abc-123", () => {});
+    const ws = MockWebSocket.instances[0];
+    ws.emit("open", {});
+    expect(JSON.parse(ws.sent[0])).toEqual({
+      type: "subscribe",
+      channels: [{ name: "execution:abc-123" }],
+    });
+  });
+
+  it("maps execution_update frames to status events with terminal detection", () => {
+    const events: any[] = [];
+    subscribeToExecution("abc-123", (e) => events.push(e));
+    const ws = MockWebSocket.instances[0];
+    ws.emit("open", {});
+    ws.emit("message", {
+      data: JSON.stringify({
+        type: "execution_update",
+        executionId: "abc-123",
+        status: "Running",
+      }),
+    });
+    ws.emit("message", {
+      data: JSON.stringify({
+        type: "execution_update",
+        executionId: "abc-123",
+        status: "Success",
+        duration_ms: 42,
+      }),
+    });
+    expect(events).toEqual([
+      { type: "status", status: "Running", isTerminal: false },
+      { type: "status", status: "Success", isTerminal: true },
+    ]);
+  });
+
+  it("maps execution_log frames to log events", () => {
+    const events: any[] = [];
+    subscribeToExecution("abc-123", (e) => events.push(e));
+    const ws = MockWebSocket.instances[0];
+    ws.emit("open", {});
+    ws.emit("message", {
+      data: JSON.stringify({
+        type: "execution_log",
+        executionId: "abc-123",
+        level: "info",
+        message: "hi",
+        timestamp: "t",
+        sequence: 3,
+      }),
+    });
+    expect(events[0]).toEqual({
+      type: "log",
+      log: { level: "info", message: "hi", timestamp: "t", sequence: 3 },
+    });
+  });
+
+  it("fires onSocketDown on error and on unexpected close, but not on unsubscribe", () => {
+    const down = vi.fn();
+    const unsub = subscribeToExecution("abc-123", () => {}, down);
+    const ws = MockWebSocket.instances[0];
+    ws.emit("error", {});
+    expect(down).toHaveBeenCalledTimes(1);
+    unsub(); // client-initiated close must NOT fire onSocketDown again
+    expect(down).toHaveBeenCalledTimes(1);
+  });
+
+  it("dedupes onSocketDown when error is followed by close", () => {
+    const down = vi.fn();
+    subscribeToExecution("abc-123", () => {}, down);
+    const ws = MockWebSocket.instances[0];
+    ws.emit("error", {});
+    ws.emit("close", { code: 1000 });
+    expect(down).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores unparseable frames", () => {
+    const events: any[] = [];
+    subscribeToExecution("abc-123", (e) => events.push(e));
+    const ws = MockWebSocket.instances[0];
+    ws.emit("message", { data: "not json" });
+    expect(events).toEqual([]);
+  });
+});

--- a/client/src/lib/app-sdk/execution-stream.test.ts
+++ b/client/src/lib/app-sdk/execution-stream.test.ts
@@ -91,6 +91,41 @@ describe("subscribeToExecution", () => {
     });
   });
 
+  it("emits ready only after the server acknowledges the execution subscription", () => {
+    const events: ExecutionStreamEvent[] = [];
+    subscribeToExecution("abc-123", (e) => events.push(e));
+    const ws = MockWebSocket.instances[0];
+    ws.emit("open", {});
+    expect(events).toEqual([]);
+    ws.emit("message", {
+      data: JSON.stringify({ type: "subscribed", channel: "execution:abc-123" }),
+    });
+    expect(events).toEqual([{ type: "ready" }]);
+  });
+
+  it("falls back when the server rejects or revokes the subscription", () => {
+    const rejected = vi.fn();
+    subscribeToExecution("abc-123", () => {}, rejected);
+    MockWebSocket.instances[0].emit("message", {
+      data: JSON.stringify({
+        type: "error",
+        channel: "execution:abc-123",
+        message: "Access denied",
+      }),
+    });
+    expect(rejected).toHaveBeenCalledTimes(1);
+
+    const revoked = vi.fn();
+    subscribeToExecution("def-456", () => {}, revoked);
+    MockWebSocket.instances[1].emit("message", {
+      data: JSON.stringify({
+        type: "subscription_revoked",
+        channel: "execution:def-456",
+      }),
+    });
+    expect(revoked).toHaveBeenCalledTimes(1);
+  });
+
   it("fires onSocketDown on error and on unexpected close, but not on unsubscribe", () => {
     const down = vi.fn();
     const unsub = subscribeToExecution("abc-123", () => {}, down);

--- a/client/src/lib/app-sdk/execution-stream.test.ts
+++ b/client/src/lib/app-sdk/execution-stream.test.ts
@@ -1,16 +1,19 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 import { subscribeToExecution } from "./execution-stream";
+import type { ExecutionStreamEvent } from "./execution-stream";
+
+type MockEvent = { data?: string; code?: number };
 
 class MockWebSocket {
   static instances: MockWebSocket[] = [];
   url: string;
   sent: string[] = [];
-  listeners: Record<string, ((e: any) => void)[]> = {};
+  listeners: Record<string, ((e: MockEvent) => void)[]> = {};
   constructor(url: string) {
     this.url = url;
     MockWebSocket.instances.push(this);
   }
-  addEventListener(type: string, cb: (e: any) => void) {
+  addEventListener(type: string, cb: (e: MockEvent) => void) {
     (this.listeners[type] ??= []).push(cb);
   }
   send(data: string) {
@@ -19,7 +22,7 @@ class MockWebSocket {
   close() {
     this.emit("close", { code: 1000 });
   }
-  emit(type: string, e: any) {
+  emit(type: string, e: MockEvent) {
     (this.listeners[type] ?? []).forEach((cb) => cb(e));
   }
 }
@@ -42,7 +45,7 @@ describe("subscribeToExecution", () => {
   });
 
   it("maps execution_update frames to status events with terminal detection", () => {
-    const events: any[] = [];
+    const events: ExecutionStreamEvent[] = [];
     subscribeToExecution("abc-123", (e) => events.push(e));
     const ws = MockWebSocket.instances[0];
     ws.emit("open", {});
@@ -68,7 +71,7 @@ describe("subscribeToExecution", () => {
   });
 
   it("maps execution_log frames to log events", () => {
-    const events: any[] = [];
+    const events: ExecutionStreamEvent[] = [];
     subscribeToExecution("abc-123", (e) => events.push(e));
     const ws = MockWebSocket.instances[0];
     ws.emit("open", {});
@@ -108,7 +111,7 @@ describe("subscribeToExecution", () => {
   });
 
   it("ignores unparseable frames", () => {
-    const events: any[] = [];
+    const events: ExecutionStreamEvent[] = [];
     subscribeToExecution("abc-123", (e) => events.push(e));
     const ws = MockWebSocket.instances[0];
     ws.emit("message", { data: "not json" });

--- a/client/src/lib/app-sdk/execution-stream.ts
+++ b/client/src/lib/app-sdk/execution-stream.ts
@@ -1,0 +1,91 @@
+/**
+ * Live subscription to one execution's status + log stream over the SDK
+ * websocket. Mirrors `subscribeToTable` in ws-client.ts: one socket per
+ * subscription, auth via buildWsUrl() (token query param under a provider
+ * transport, cookies same-origin).
+ *
+ * Terminal `execution_update` frames carry status + duration_ms but NOT the
+ * result (large results are not rebroadcast; see #483) — the caller fetches
+ * `/api/executions/{id}` when isTerminal fires.
+ */
+import { buildWsUrl } from "./ws-client";
+
+const TERMINAL_STATUSES = new Set([
+  "Success",
+  "Failed",
+  "CompletedWithErrors",
+  "Timeout",
+  "Cancelled",
+]);
+
+export interface ExecutionStreamEvent {
+  type: "status" | "log";
+  status?: string;
+  isTerminal?: boolean;
+  log?: { level: string; message: string; timestamp: string; sequence?: number };
+}
+
+export function subscribeToExecution(
+  executionId: string,
+  onEvent: (evt: ExecutionStreamEvent) => void,
+  onSocketDown?: () => void,
+): () => void {
+  const ws = new WebSocket(buildWsUrl());
+  let closedByClient = false;
+  let downFired = false;
+
+  ws.addEventListener("open", () => {
+    ws.send(
+      JSON.stringify({
+        type: "subscribe",
+        channels: [{ name: `execution:${executionId}` }],
+      }),
+    );
+  });
+
+  ws.addEventListener("message", (e) => {
+    try {
+      const msg = JSON.parse(e.data);
+      if (msg.type === "execution_update" && msg.executionId === executionId) {
+        onEvent({
+          type: "status",
+          status: msg.status,
+          isTerminal: TERMINAL_STATUSES.has(msg.status),
+        });
+      } else if (msg.type === "execution_log" && msg.executionId === executionId) {
+        onEvent({
+          type: "log",
+          log: {
+            level: msg.level,
+            message: msg.message,
+            timestamp: msg.timestamp,
+            sequence: msg.sequence,
+          },
+        });
+      }
+    } catch {
+      // ignore unparseable frames — same policy as subscribeToTable
+    }
+  });
+
+  ws.addEventListener("error", () => {
+    console.warn("[bifrost-sdk] execution stream socket error");
+    if (!closedByClient && !downFired) {
+      downFired = true;
+      onSocketDown?.();
+    }
+  });
+
+  ws.addEventListener("close", (e) => {
+    if (!closedByClient && !downFired) {
+      downFired = true;
+      console.warn("[bifrost-sdk] execution stream closed", e.code);
+      onSocketDown?.();
+    }
+  });
+
+  return () => {
+    closedByClient = true;
+    ws.close();
+  };
+}

--- a/client/src/lib/app-sdk/execution-stream.ts
+++ b/client/src/lib/app-sdk/execution-stream.ts
@@ -19,7 +19,7 @@ const TERMINAL_STATUSES = new Set([
 ]);
 
 export interface ExecutionStreamEvent {
-  type: "status" | "log";
+  type: "ready" | "status" | "log";
   status?: string;
   isTerminal?: boolean;
   log?: { level: string; message: string; timestamp: string; sequence?: number };
@@ -31,14 +31,22 @@ export function subscribeToExecution(
   onSocketDown?: () => void,
 ): () => void {
   const ws = new WebSocket(buildWsUrl());
+  const channel = `execution:${executionId}`;
   let closedByClient = false;
   let downFired = false;
+
+  const fireSocketDown = () => {
+    if (!closedByClient && !downFired) {
+      downFired = true;
+      onSocketDown?.();
+    }
+  };
 
   ws.addEventListener("open", () => {
     ws.send(
       JSON.stringify({
         type: "subscribe",
-        channels: [{ name: `execution:${executionId}` }],
+        channels: [{ name: channel }],
       }),
     );
   });
@@ -46,7 +54,19 @@ export function subscribeToExecution(
   ws.addEventListener("message", (e) => {
     try {
       const msg = JSON.parse(e.data);
-      if (msg.type === "execution_update" && msg.executionId === executionId) {
+      if (msg.type === "subscribed" && msg.channel === channel) {
+        // The server adds the socket to the channel before acknowledging it.
+        // A result check at this point closes the gap between the initial GET
+        // and the live subscription becoming authoritative.
+        onEvent({ type: "ready" });
+      } else if (
+        (msg.type === "error" && (msg.channel === undefined || msg.channel === channel)) ||
+        (msg.type === "subscription_revoked" && msg.channel === channel)
+      ) {
+        console.warn("[bifrost-sdk] execution stream subscription unavailable");
+        fireSocketDown();
+        ws.close();
+      } else if (msg.type === "execution_update" && msg.executionId === executionId) {
         onEvent({
           type: "status",
           status: msg.status,
@@ -70,17 +90,13 @@ export function subscribeToExecution(
 
   ws.addEventListener("error", () => {
     console.warn("[bifrost-sdk] execution stream socket error");
-    if (!closedByClient && !downFired) {
-      downFired = true;
-      onSocketDown?.();
-    }
+    fireSocketDown();
   });
 
   ws.addEventListener("close", (e) => {
     if (!closedByClient && !downFired) {
-      downFired = true;
       console.warn("[bifrost-sdk] execution stream closed", e.code);
-      onSocketDown?.();
+      fireSocketDown();
     }
   });
 

--- a/client/src/lib/app-sdk/sdk-contract.json
+++ b/client/src/lib/app-sdk/sdk-contract.json
@@ -1,0 +1,6 @@
+{
+  "version": 1,
+  "history": {
+    "1": "Baseline. v2 SDKs built before the streaming workflow transport (this PR) POSTed /api/workflows/execute and read the result straight off the response. The new transport starts the run the same way, then subscribes to a websocket for live status/log frames and fetches GET /api/executions/{id} for the terminal result -- but a pre-streaming SDK's synchronous POST/response flow still works unmodified against the new server (the server still returns a usable response, and old SDKs never subscribed to the socket in the first place). Additive, not breaking. No contract bump."
+  }
+}

--- a/client/src/lib/app-sdk/sdk-contract.test.ts
+++ b/client/src/lib/app-sdk/sdk-contract.test.ts
@@ -38,7 +38,7 @@ function fnv1aHex(input: string): string {
   return (hash >>> 0).toString(16).padStart(8, "0");
 }
 
-const SNAPSHOT_HASH = "bcffced8";
+const SNAPSHOT_HASH = "5dc39567";
 
 describe("SDK wire-surface tripwire", () => {
   it("matches the committed snapshot hash", () => {

--- a/client/src/lib/app-sdk/sdk-contract.test.ts
+++ b/client/src/lib/app-sdk/sdk-contract.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Tripwire: the SDK's wire-facing surface (wire-surface.ts) is snapshot-hashed
+ * so any change to it forces a conscious decision, mirroring the CLI's
+ * DTO-fingerprint tripwire (api/tests/unit/test_contract_version.py).
+ *
+ * On mismatch: refresh SNAPSHOT_HASH below if the change is non-breaking
+ * (e.g. a new optional field/endpoint an old SDK simply never called);
+ * bump sdk-contract.json's "version" (with a history entry explaining why)
+ * if it's breaking.
+ */
+import { describe, expect, it } from "vitest";
+
+import contract from "./sdk-contract.json";
+import { wireSurface } from "./wire-surface";
+
+// Simple, dependency-free stable hash (FNV-1a) over the sorted-key JSON
+// serialization of wireSurface. Not cryptographic — just needs to change
+// whenever the object's shape changes.
+function stableStringify(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map(stableStringify).join(",")}]`;
+  }
+  if (value !== null && typeof value === "object") {
+    const keys = Object.keys(value as Record<string, unknown>).sort();
+    return `{${keys
+      .map((k) => `${JSON.stringify(k)}:${stableStringify((value as Record<string, unknown>)[k])}`)
+      .join(",")}}`;
+  }
+  return JSON.stringify(value);
+}
+
+function fnv1aHex(input: string): string {
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < input.length; i += 1) {
+    hash ^= input.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return (hash >>> 0).toString(16).padStart(8, "0");
+}
+
+const SNAPSHOT_HASH = "bcffced8";
+
+describe("SDK wire-surface tripwire", () => {
+  it("matches the committed snapshot hash", () => {
+    const hash = fnv1aHex(stableStringify(wireSurface));
+    expect(
+      hash,
+      `wire-surface.ts hash changed (${hash} !== ${SNAPSHOT_HASH}). ` +
+        "Refresh SNAPSHOT_HASH in sdk-contract.test.ts if this is a non-breaking " +
+        "change; bump sdk-contract.json's \"version\" (with a history entry) if " +
+        "it's a breaking change to the SDK<->server wire contract.",
+    ).toBe(SNAPSHOT_HASH);
+  });
+
+  it("sdk-contract.json has a positive integer version", () => {
+    expect(typeof contract.version).toBe("number");
+    expect(Number.isInteger(contract.version)).toBe(true);
+    expect(contract.version).toBeGreaterThan(0);
+  });
+});

--- a/client/src/lib/app-sdk/use-workflow-hooks.test.tsx
+++ b/client/src/lib/app-sdk/use-workflow-hooks.test.tsx
@@ -1,8 +1,13 @@
 import { render, screen, waitFor } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi, afterEach } from "vitest";
 
 import { BifrostProvider } from "./provider";
 import { useWorkflowMutation, useWorkflowQuery } from "./use-workflow-hooks";
+import * as useWorkflowModule from "./use-workflow";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 function fakeFetchReturning(result: unknown, record?: (body: unknown) => void) {
   return (async (_input: RequestInfo | URL, init?: RequestInit) => {
@@ -15,6 +20,48 @@ function fakeFetchReturning(result: unknown, record?: (body: unknown) => void) {
 }
 
 describe("useWorkflowQuery (auto-running, React-Query-shaped)", () => {
+  it("exposes logs, status, and executionId from the underlying useWorkflow", async () => {
+    const mockLogs = [
+      { level: "info", message: "Started", timestamp: "2026-07-14T00:00:00Z", sequence: 1 },
+      { level: "debug", message: "Processing", timestamp: "2026-07-14T00:00:01Z", sequence: 2 },
+    ];
+    const mockStatus = "Running";
+    const mockExecutionId = "exec-123";
+
+    vi.spyOn(useWorkflowModule, "useWorkflow").mockReturnValue({
+      data: { result: "test-result" },
+      loading: false,
+      error: null,
+      run: vi.fn(async () => ({ result: "test-result" })),
+      logs: mockLogs,
+      status: mockStatus,
+      executionId: mockExecutionId,
+    });
+
+    function View() {
+      const { logs, status, executionId } = useWorkflowQuery<{ result: string }>("wf::test");
+      return (
+        <div>
+          <span data-testid="logs">{logs.length}</span>
+          <span data-testid="status">{status}</span>
+          <span data-testid="executionId">{executionId}</span>
+        </div>
+      );
+    }
+
+    render(
+      <BifrostProvider baseUrl="https://dev.example" token="t" fetchImpl={fakeFetchReturning({})}>
+        <View />
+      </BifrostProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("logs").textContent).toBe("2");
+      expect(screen.getByTestId("status").textContent).toBe("Running");
+      expect(screen.getByTestId("executionId").textContent).toBe("exec-123");
+    });
+  });
+
   it("auto-runs on mount and exposes data + refresh", async () => {
     let runs = 0;
     const fetchImpl = (async () => {
@@ -94,6 +141,47 @@ function QueryWithParams() {
 }
 
 describe("useWorkflowMutation (imperative, React-Query-shaped)", () => {
+  it("exposes logs, status, and executionId from the underlying useWorkflow", async () => {
+    const mockLogs = [
+      { level: "info", message: "Mutation started", timestamp: "2026-07-14T00:00:00Z", sequence: 1 },
+    ];
+    const mockStatus = "Success";
+    const mockExecutionId = "exec-456";
+
+    vi.spyOn(useWorkflowModule, "useWorkflow").mockReturnValue({
+      data: { done: true },
+      loading: false,
+      error: null,
+      run: vi.fn(async () => ({ done: true })),
+      logs: mockLogs,
+      status: mockStatus,
+      executionId: mockExecutionId,
+    });
+
+    function View() {
+      const { logs, status, executionId } = useWorkflowMutation<{ done: boolean }>("wf::test");
+      return (
+        <div>
+          <span data-testid="logs">{logs.length}</span>
+          <span data-testid="status">{status}</span>
+          <span data-testid="executionId">{executionId}</span>
+        </div>
+      );
+    }
+
+    render(
+      <BifrostProvider baseUrl="https://dev.example" token="t" fetchImpl={fakeFetchReturning({})}>
+        <View />
+      </BifrostProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("logs").textContent).toBe("1");
+      expect(screen.getByTestId("status").textContent).toBe("Success");
+      expect(screen.getByTestId("executionId").textContent).toBe("exec-456");
+    });
+  });
+
   it("does NOT auto-run; mutate() triggers and returns the result", async () => {
     let runs = 0;
     const fetchImpl = (async () => {

--- a/client/src/lib/app-sdk/use-workflow-hooks.ts
+++ b/client/src/lib/app-sdk/use-workflow-hooks.ts
@@ -19,7 +19,7 @@
  */
 import { useCallback, useEffect } from "react";
 
-import { useWorkflow, type UseWorkflowState } from "./use-workflow";
+import { useWorkflow, type UseWorkflowState, type WorkflowLogEntry } from "./use-workflow";
 
 export interface UseWorkflowQueryState<T> {
   /** Last successful result, or null before the first run completes. */
@@ -30,6 +30,12 @@ export interface UseWorkflowQueryState<T> {
   error: Error | null;
   /** Re-run the query (e.g. a refresh button). Resolves to the new result. */
   refresh: (input?: Record<string, unknown>) => Promise<T>;
+  /** Live log stream for the latest run. Reset to `[]` at the start of each run. */
+  logs: WorkflowLogEntry[];
+  /** Latest run's status (e.g. "Pending", "Running", "Success"), or null before the first run. */
+  status: string | null;
+  /** Latest run's execution id, or null before the first run. */
+  executionId: string | null;
 }
 
 export interface UseWorkflowMutationState<T> {
@@ -41,6 +47,12 @@ export interface UseWorkflowMutationState<T> {
   loading: boolean;
   /** Last error, or null. */
   error: Error | null;
+  /** Live log stream for the latest mutate. Reset to `[]` at the start of each mutate. */
+  logs: WorkflowLogEntry[];
+  /** Latest mutate's status (e.g. "Pending", "Running", "Success"), or null before the first mutate. */
+  status: string | null;
+  /** Latest mutate's execution id, or null before the first mutate. */
+  executionId: string | null;
 }
 
 /**
@@ -52,7 +64,7 @@ export function useWorkflowQuery<T = unknown>(
   workflowRef: string,
   params?: Record<string, unknown>,
 ): UseWorkflowQueryState<T> {
-  const { data, loading, error, run }: UseWorkflowState<T> = useWorkflow<T>(workflowRef);
+  const { data, loading, error, run, logs, status, executionId }: UseWorkflowState<T> = useWorkflow<T>(workflowRef);
 
   // Serialize params for a stable effect dep without re-running on every render
   // (a fresh object literal each render would otherwise loop). JSON is enough —
@@ -80,7 +92,7 @@ export function useWorkflowQuery<T = unknown>(
     [run, paramsKey],
   );
 
-  return { data, loading, error, refresh };
+  return { data, loading, error, refresh, logs, status, executionId };
 }
 
 /**
@@ -90,6 +102,6 @@ export function useWorkflowQuery<T = unknown>(
 export function useWorkflowMutation<T = unknown>(
   workflowRef: string,
 ): UseWorkflowMutationState<T> {
-  const { data, loading, error, run }: UseWorkflowState<T> = useWorkflow<T>(workflowRef);
-  return { mutate: run, data, loading, error };
+  const { data, loading, error, run, logs, status, executionId }: UseWorkflowState<T> = useWorkflow<T>(workflowRef);
+  return { mutate: run, data, loading, error, logs, status, executionId };
 }

--- a/client/src/lib/app-sdk/use-workflow.test.tsx
+++ b/client/src/lib/app-sdk/use-workflow.test.tsx
@@ -354,6 +354,32 @@ describe("useWorkflow", () => {
     expect(subscribeToExecution).not.toHaveBeenCalled();
   });
 
+  it.each(["Timeout", "Cancelled"])(
+    "rejects an inline %s terminal response instead of resolving undefined",
+    async (terminalStatus) => {
+      const fakeFetch = (async () =>
+        new Response(
+          JSON.stringify({ execution_id: "e-terminal", status: terminalStatus, result: null }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        )) as typeof fetch;
+
+      const onResult = vi.fn();
+      const rejections: Error[] = [];
+      render(
+        <BifrostProvider baseUrl="https://dev.example" token="tok-x" fetchImpl={fakeFetch}>
+          <StreamRunner onResult={onResult} onError={(e) => rejections.push(e)} />
+        </BifrostProvider>,
+      );
+      screen.getByText("go").click();
+
+      await waitFor(() => expect(rejections).toHaveLength(1));
+      expect(onResult).not.toHaveBeenCalled();
+      expect(rejections[0].message).toContain(terminalStatus);
+      expect(screen.getByTestId("status").textContent).toBe(terminalStatus);
+      expect(subscribeToExecution).not.toHaveBeenCalled();
+    },
+  );
+
   it("settles from the immediate check when the run finished before the socket", async () => {
     (subscribeToExecution as Mock).mockImplementation(() => vi.fn());
 
@@ -374,6 +400,156 @@ describe("useWorkflow", () => {
     screen.getByText("go").click();
 
     await waitFor(() => expect(onResult).toHaveBeenCalledWith({ fast: true }));
+  });
+
+  it("re-checks on subscription acknowledgement so a pre-ack terminal event is not lost", async () => {
+    let streamCb: (evt: unknown) => void = () => {};
+    (subscribeToExecution as Mock).mockImplementation(
+      (_id: string, cb: (evt: unknown) => void) => {
+        streamCb = cb;
+        return vi.fn();
+      },
+    );
+
+    let getCount = 0;
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (isExecute(url)) {
+        return new Response(JSON.stringify({ execution_id: "e-ack", status: "Pending" }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      if (isGetExecution(url, "e-ack")) {
+        getCount += 1;
+        return new Response(
+          JSON.stringify(
+            getCount === 1
+              ? { status: "Running" }
+              : { status: "Success", result: { ackRecovered: true } },
+          ),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }
+      throw new Error(`unhandled fetch: ${url}`);
+    });
+
+    const onResult = vi.fn();
+    render(
+      <BifrostProvider
+        baseUrl="https://dev.example"
+        token="tok-x"
+        fetchImpl={fetchMock as unknown as typeof fetch}
+      >
+        <StreamRunner onResult={onResult} />
+      </BifrostProvider>,
+    );
+    screen.getByText("go").click();
+    await waitFor(() => expect(getCount).toBe(1));
+
+    // The workflow completed after the first GET but before the websocket
+    // subscription was installed, so no terminal frame reached the client.
+    act(() => streamCb({ type: "ready" }));
+
+    await waitFor(() => expect(onResult).toHaveBeenCalledWith({ ackRecovered: true }));
+    expect(getCount).toBe(2);
+  });
+
+  it("ignores an older nonterminal GET that returns after a concurrent terminal check", async () => {
+    let streamCb: (evt: unknown) => void = () => {};
+    (subscribeToExecution as Mock).mockImplementation(
+      (_id: string, cb: (evt: unknown) => void) => {
+        streamCb = cb;
+        return vi.fn();
+      },
+    );
+
+    let resolveInitialGet: ((response: Response) => void) | undefined;
+    let getCount = 0;
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (isExecute(url)) {
+        return new Response(JSON.stringify({ execution_id: "e-reordered", status: "Pending" }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      if (isGetExecution(url, "e-reordered")) {
+        getCount += 1;
+        if (getCount === 1) {
+          return new Promise<Response>((resolve) => {
+            resolveInitialGet = resolve;
+          });
+        }
+        return new Response(
+          JSON.stringify({ status: "Success", result: { reordered: true } }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }
+      throw new Error(`unhandled fetch: ${url}`);
+    });
+
+    const onResult = vi.fn();
+    render(
+      <BifrostProvider
+        baseUrl="https://dev.example"
+        token="tok-x"
+        fetchImpl={fetchMock as unknown as typeof fetch}
+      >
+        <StreamRunner onResult={onResult} />
+      </BifrostProvider>,
+    );
+    screen.getByText("go").click();
+    await waitFor(() => expect(resolveInitialGet).toBeDefined());
+
+    act(() => streamCb({ type: "ready" }));
+    await waitFor(() => expect(onResult).toHaveBeenCalledWith({ reordered: true }));
+    expect(screen.getByTestId("status").textContent).toBe("Success");
+
+    await act(async () => {
+      resolveInitialGet!(
+        new Response(JSON.stringify({ status: "Running" }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      );
+      await Promise.resolve();
+    });
+
+    expect(screen.getByTestId("status").textContent).toBe("Success");
+  });
+
+  it("rejects a permanent execution-fetch failure instead of polling forever", async () => {
+    (subscribeToExecution as Mock).mockImplementation(() => vi.fn());
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (isExecute(url)) {
+        return new Response(JSON.stringify({ execution_id: "e-forbidden", status: "Pending" }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      if (isGetExecution(url, "e-forbidden")) {
+        return new Response("forbidden", { status: 403, statusText: "Forbidden" });
+      }
+      throw new Error(`unhandled fetch: ${url}`);
+    });
+
+    const rejections: Error[] = [];
+    render(
+      <BifrostProvider
+        baseUrl="https://dev.example"
+        token="tok-x"
+        fetchImpl={fetchMock as unknown as typeof fetch}
+      >
+        <StreamRunner onResult={() => {}} onError={(e) => rejections.push(e)} />
+      </BifrostProvider>,
+    );
+    screen.getByText("go").click();
+
+    await waitFor(() => expect(rejections).toHaveLength(1));
+    expect(rejections[0].message).toBe("failed to fetch execution: 403 Forbidden");
+    expect(screen.getByTestId("state").textContent).toBe("error");
   });
 
   it("falls back to polling when the socket drops", async () => {

--- a/client/src/lib/app-sdk/use-workflow.test.tsx
+++ b/client/src/lib/app-sdk/use-workflow.test.tsx
@@ -489,4 +489,75 @@ describe("useWorkflow", () => {
     await waitFor(() => expect(rejections).toHaveLength(1));
     expect(rejections[0].message).toBe("boom");
   });
+
+  it("arms the poll fallback when the post-terminal-event fetch fails transiently", async () => {
+    vi.useFakeTimers();
+    let streamCb: (evt: unknown) => void = () => {};
+    (subscribeToExecution as Mock).mockImplementation((_id: string, cb: (evt: unknown) => void) => {
+      streamCb = cb;
+      return vi.fn();
+    });
+
+    let getCount = 0;
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (isExecute(url)) {
+        return new Response(JSON.stringify({ execution_id: "e6", status: "Pending" }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      if (isGetExecution(url, "e6")) {
+        getCount += 1;
+        // 1st GET: immediate post-subscribe check (Running).
+        // 2nd GET: fired by the terminal ws event — fails transiently.
+        // 3rd GET: fired by the poll fallback — returns the terminal result.
+        if (getCount === 1) {
+          return new Response(JSON.stringify({ status: "Running" }), {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          });
+        }
+        if (getCount === 2) {
+          throw new Error("network error");
+        }
+        return new Response(
+          JSON.stringify({ status: "Success", result: { recovered: true } }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }
+      throw new Error(`unhandled fetch: ${url}`);
+    });
+
+    const onResult = vi.fn();
+    render(
+      <BifrostProvider
+        baseUrl="https://dev.example"
+        token="tok-x"
+        fetchImpl={fetchMock as unknown as typeof fetch}
+      >
+        <StreamRunner onResult={onResult} />
+      </BifrostProvider>,
+    );
+    await act(async () => {
+      screen.getByText("go").click();
+    });
+
+    await vi.waitFor(() => expect(subscribeToExecution).toHaveBeenCalled());
+    await vi.waitFor(() => expect(screen.getByTestId("execId").textContent).toBe("e6"));
+
+    await act(async () => {
+      streamCb({ type: "status", status: "Success", isTerminal: true });
+      // let the failing fetch's rejection settle
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000);
+    });
+
+    expect(onResult).toHaveBeenCalledWith({ recovered: true });
+    vi.useRealTimers();
+  });
 });

--- a/client/src/lib/app-sdk/use-workflow.test.tsx
+++ b/client/src/lib/app-sdk/use-workflow.test.tsx
@@ -1,8 +1,16 @@
-import { render, screen, waitFor } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { act, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi, type Mock } from "vitest";
 
 import { BifrostProvider } from "./provider";
 import { useWorkflow } from "./use-workflow";
+
+vi.mock("./execution-stream", () => ({ subscribeToExecution: vi.fn() }));
+
+import { subscribeToExecution } from "./execution-stream";
+
+beforeEach(() => {
+  (subscribeToExecution as Mock).mockReset();
+});
 
 function Runner({ onResult }: { onResult: (r: unknown) => void }) {
   const { run, loading, error } = useWorkflow<{ ok: boolean }>("my-wf");
@@ -14,8 +22,33 @@ function Runner({ onResult }: { onResult: (r: unknown) => void }) {
   );
 }
 
+/** Build a fetch mock that answers a fixed sequence of {url, response} pairs by URL match. */
+function makeFetchMock(
+  handlers: { match: (url: string, init?: RequestInit) => boolean; respond: () => unknown }[],
+) {
+  const calls: { url: string; init?: RequestInit }[] = [];
+  const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(input);
+    calls.push({ url, init });
+    const handler = handlers.find((h) => h.match(url, init));
+    if (!handler) throw new Error(`unhandled fetch: ${url}`);
+    return new Response(JSON.stringify(handler.respond()), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  });
+  return { fetchMock, calls };
+}
+
+function isExecute(url: string) {
+  return url.endsWith("/api/workflows/execute");
+}
+function isGetExecution(url: string, id: string) {
+  return url.endsWith(`/api/executions/${id}`);
+}
+
 describe("useWorkflow", () => {
-  it("POSTs /api/workflows/execute through the provider's authed fetch", async () => {
+  it("POSTs /api/workflows/execute (no sync key) through the provider's authed fetch", async () => {
     const calls: { url: string; body: unknown; auth: string | null }[] = [];
     const fakeFetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
       const headers = new Headers(init?.headers);
@@ -24,7 +57,7 @@ describe("useWorkflow", () => {
         body: init?.body ? JSON.parse(String(init.body)) : null,
         auth: headers.get("Authorization"),
       });
-      return new Response(JSON.stringify({ status: "Success", result: { ok: true } }), {
+      return new Response(JSON.stringify({ execution_id: "e0", status: "Success", result: { ok: true } }), {
         status: 200,
         headers: { "content-type": "application/json" },
       });
@@ -41,14 +74,15 @@ describe("useWorkflow", () => {
     await waitFor(() => expect(onResult).toHaveBeenCalledWith({ ok: true }));
     expect(calls[0].url).toBe("https://dev.example/api/workflows/execute");
     expect(calls[0].auth).toBe("Bearer tok-x");
-    expect(calls[0].body).toEqual({ workflow_id: "my-wf", input_data: { a: 1 }, sync: true });
+    expect(calls[0].body).toEqual({ workflow_id: "my-wf", input_data: { a: 1 } });
+    expect("sync" in (calls[0].body as Record<string, unknown>)).toBe(false);
   });
 
   it("sends app_id so a path ref resolves to this install's workflow (Codex #8 P1)", async () => {
     const calls: { body: Record<string, unknown> }[] = [];
     const fakeFetch = (async (_input: RequestInfo | URL, init?: RequestInit) => {
       calls.push({ body: init?.body ? JSON.parse(String(init.body)) : {} });
-      return new Response(JSON.stringify({ status: "Success", result: { ok: true } }), {
+      return new Response(JSON.stringify({ execution_id: "e0", status: "Success", result: { ok: true } }), {
         status: 200,
         headers: { "content-type": "application/json" },
       });
@@ -73,7 +107,7 @@ describe("useWorkflow", () => {
     const calls: { body: Record<string, unknown> }[] = [];
     const fakeFetch = (async (_input: RequestInfo | URL, init?: RequestInit) => {
       calls.push({ body: init?.body ? JSON.parse(String(init.body)) : {} });
-      return new Response(JSON.stringify({ status: "Success", result: { ok: true } }), {
+      return new Response(JSON.stringify({ execution_id: "e0", status: "Success", result: { ok: true } }), {
         status: 200,
         headers: { "content-type": "application/json" },
       });
@@ -93,7 +127,7 @@ describe("useWorkflow", () => {
     // "Failed" is the real wire value — ExecutionStatus is PascalCase.
     const fakeFetch = (async () =>
       new Response(
-        JSON.stringify({ status: "Failed", error: null, result: null }),
+        JSON.stringify({ execution_id: "e0", status: "Failed", error: null, result: null }),
         { status: 200, headers: { "content-type": "application/json" } },
       )) as typeof fetch;
 
@@ -168,18 +202,18 @@ describe("useWorkflow", () => {
     screen.getByText("runB").click();
     await waitFor(() => expect(resolvers.size).toBe(2));
 
-    const ok = (result: string) =>
-      new Response(JSON.stringify({ status: "Success", result }), {
+    const ok = (result: string, id: string) =>
+      new Response(JSON.stringify({ execution_id: id, status: "Success", result }), {
         status: 200,
         headers: { "content-type": "application/json" },
       });
 
     // Newer run B settles first…
-    resolvers.get("B")!(ok("B-result"));
+    resolvers.get("B")!(ok("B-result", "eb"));
     await waitFor(() => expect(screen.getByTestId("data").textContent).toBe("B-result"));
 
     // …then the stale run A settles. It must not clobber B's result.
-    resolvers.get("A")!(ok("A-result"));
+    resolvers.get("A")!(ok("A-result", "ea"));
     // flush the resolved promise chain through React
     await waitFor(() => expect(screen.getByTestId("loading").textContent).toBe("false"));
     expect(screen.getByTestId("data").textContent).toBe("B-result");
@@ -187,7 +221,7 @@ describe("useWorkflow", () => {
 
   it("surfaces a workflow-level error", async () => {
     const fakeFetch = (async () =>
-      new Response(JSON.stringify({ status: "Failed", error: "boom" }), {
+      new Response(JSON.stringify({ execution_id: "e0", status: "Failed", error: "boom" }), {
         status: 200,
         headers: { "content-type": "application/json" },
       })) as typeof fetch;
@@ -199,5 +233,260 @@ describe("useWorkflow", () => {
     );
     screen.getByText("go").click();
     await waitFor(() => expect(screen.getByTestId("state").textContent).toBe("error"));
+  });
+
+  function StreamRunner({
+    onResult,
+    onError,
+  }: {
+    onResult: (r: unknown) => void;
+    onError?: (e: Error) => void;
+  }) {
+    const { run, loading, error, data, logs, status, executionId } = useWorkflow<{ ok: number }>(
+      "my-wf",
+    );
+    return (
+      <div>
+        <button onClick={() => run({}).then(onResult).catch((e: Error) => onError?.(e))}>go</button>
+        <span data-testid="state">{loading ? "loading" : error ? "error" : "idle"}</span>
+        <span data-testid="data">{data === null ? "null" : JSON.stringify(data)}</span>
+        <span data-testid="status">{status ?? "null"}</span>
+        <span data-testid="execId">{executionId ?? "null"}</span>
+        <span data-testid="logs">{logs.map((l) => l.message).join(",")}</span>
+      </div>
+    );
+  }
+
+  it("executes async (no sync flag) and resolves with the fetched result on terminal event", async () => {
+    let streamCb: (evt: unknown) => void = () => {};
+    (subscribeToExecution as Mock).mockImplementation((_id: string, cb: (evt: unknown) => void) => {
+      streamCb = cb;
+      return vi.fn();
+    });
+
+    const { fetchMock } = makeFetchMock([
+      { match: isExecute, respond: () => ({ execution_id: "e1", status: "Pending" }) },
+      {
+        match: (url) => isGetExecution(url, "e1"),
+        respond: () => ({ status: "Running" }),
+      },
+    ]);
+
+    render(
+      <BifrostProvider baseUrl="https://dev.example" token="tok-x" fetchImpl={fetchMock as unknown as typeof fetch}>
+        <StreamRunner onResult={() => {}} />
+      </BifrostProvider>,
+    );
+
+    screen.getByText("go").click();
+
+    await waitFor(() =>
+      expect(subscribeToExecution).toHaveBeenCalledWith("e1", expect.any(Function), expect.any(Function)),
+    );
+    await waitFor(() => expect(screen.getByTestId("execId").textContent).toBe("e1"));
+
+    // Now change the GET handler to return the terminal result for the
+    // second GET (post-terminal-event fetch).
+    fetchMock.mockImplementation(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (isGetExecution(url, "e1")) {
+        return new Response(JSON.stringify({ status: "Success", result: { ok: 1 } }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      throw new Error(`unhandled fetch: ${url}`);
+    });
+
+    act(() => {
+      streamCb({ type: "status", status: "Success", isTerminal: true });
+    });
+
+    await waitFor(() => expect(screen.getByTestId("data").textContent).toBe(JSON.stringify({ ok: 1 })));
+  });
+
+  it("streams logs into state", async () => {
+    let streamCb: (evt: unknown) => void = () => {};
+    (subscribeToExecution as Mock).mockImplementation((_id: string, cb: (evt: unknown) => void) => {
+      streamCb = cb;
+      return vi.fn();
+    });
+
+    const { fetchMock } = makeFetchMock([
+      { match: isExecute, respond: () => ({ execution_id: "e1", status: "Pending" }) },
+      { match: (url) => isGetExecution(url, "e1"), respond: () => ({ status: "Running" }) },
+    ]);
+
+    render(
+      <BifrostProvider baseUrl="https://dev.example" token="tok-x" fetchImpl={fetchMock as unknown as typeof fetch}>
+        <StreamRunner onResult={() => {}} />
+      </BifrostProvider>,
+    );
+    screen.getByText("go").click();
+    await waitFor(() => expect(subscribeToExecution).toHaveBeenCalled());
+
+    act(() => {
+      streamCb({ type: "log", log: { level: "info", message: "step 1", timestamp: "t1" } });
+    });
+    act(() => {
+      streamCb({ type: "log", log: { level: "info", message: "step 2", timestamp: "t2" } });
+    });
+
+    await waitFor(() => expect(screen.getByTestId("logs").textContent).toBe("step 1,step 2"));
+  });
+
+  it("keeps the transient short-circuit (never touches the websocket)", async () => {
+    const fakeFetch = (async () =>
+      new Response(
+        JSON.stringify({ execution_id: "e2", is_transient: true, status: "Success", result: { x: 2 } }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      )) as typeof fetch;
+
+    const onResult = vi.fn();
+    render(
+      <BifrostProvider baseUrl="https://dev.example" token="tok-x" fetchImpl={fakeFetch}>
+        <StreamRunner onResult={onResult} />
+      </BifrostProvider>,
+    );
+    screen.getByText("go").click();
+
+    await waitFor(() => expect(onResult).toHaveBeenCalledWith({ x: 2 }));
+    expect(subscribeToExecution).not.toHaveBeenCalled();
+  });
+
+  it("settles from the immediate check when the run finished before the socket", async () => {
+    (subscribeToExecution as Mock).mockImplementation(() => vi.fn());
+
+    const { fetchMock } = makeFetchMock([
+      { match: isExecute, respond: () => ({ execution_id: "e3", status: "Pending" }) },
+      {
+        match: (url) => isGetExecution(url, "e3"),
+        respond: () => ({ status: "Success", result: { fast: true } }),
+      },
+    ]);
+
+    const onResult = vi.fn();
+    render(
+      <BifrostProvider baseUrl="https://dev.example" token="tok-x" fetchImpl={fetchMock as unknown as typeof fetch}>
+        <StreamRunner onResult={onResult} />
+      </BifrostProvider>,
+    );
+    screen.getByText("go").click();
+
+    await waitFor(() => expect(onResult).toHaveBeenCalledWith({ fast: true }));
+  });
+
+  it("falls back to polling when the socket drops", async () => {
+    vi.useFakeTimers();
+    let onSocketDown: (() => void) | undefined;
+    (subscribeToExecution as Mock).mockImplementation(
+      (_id: string, _cb: (evt: unknown) => void, down?: () => void) => {
+        onSocketDown = down;
+        return vi.fn();
+      },
+    );
+
+    let pollCount = 0;
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (isExecute(url)) {
+        return new Response(JSON.stringify({ execution_id: "e4", status: "Pending" }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      if (isGetExecution(url, "e4")) {
+        pollCount += 1;
+        // First call is the immediate post-subscribe check (Running).
+        // Subsequent calls are polls; the 2nd poll onward returns Success.
+        const status = pollCount <= 2 ? "Running" : "Success";
+        const body =
+          status === "Success"
+            ? { status: "Success", result: { polled: true } }
+            : { status: "Running" };
+        return new Response(JSON.stringify(body), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      throw new Error(`unhandled fetch: ${url}`);
+    });
+
+    const onResult = vi.fn();
+    render(
+      <BifrostProvider
+        baseUrl="https://dev.example"
+        token="tok-x"
+        fetchImpl={fetchMock as unknown as typeof fetch}
+      >
+        <StreamRunner onResult={onResult} />
+      </BifrostProvider>,
+    );
+    await act(async () => {
+      screen.getByText("go").click();
+    });
+
+    await vi.waitFor(() => expect(onSocketDown).toBeDefined());
+    act(() => {
+      onSocketDown!();
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000);
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000);
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000);
+    });
+
+    expect(onResult).toHaveBeenCalledWith({ polled: true });
+    vi.useRealTimers();
+  });
+
+  it("rejects with error_message on Failed terminal", async () => {
+    let streamCb: (evt: unknown) => void = () => {};
+    (subscribeToExecution as Mock).mockImplementation((_id: string, cb: (evt: unknown) => void) => {
+      streamCb = cb;
+      return vi.fn();
+    });
+
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (isExecute(url)) {
+        return new Response(JSON.stringify({ execution_id: "e5", status: "Pending" }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      if (isGetExecution(url, "e5")) {
+        return new Response(JSON.stringify({ status: "Failed", error_message: "boom" }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      throw new Error(`unhandled fetch: ${url}`);
+    });
+
+    const rejections: Error[] = [];
+    render(
+      <BifrostProvider
+        baseUrl="https://dev.example"
+        token="tok-x"
+        fetchImpl={fetchMock as unknown as typeof fetch}
+      >
+        <StreamRunner onResult={() => {}} onError={(e) => rejections.push(e)} />
+      </BifrostProvider>,
+    );
+    screen.getByText("go").click();
+    await waitFor(() => expect(subscribeToExecution).toHaveBeenCalled());
+
+    act(() => {
+      streamCb({ type: "status", status: "Failed", isTerminal: true });
+    });
+
+    await waitFor(() => expect(rejections).toHaveLength(1));
+    expect(rejections[0].message).toBe("boom");
   });
 });

--- a/client/src/lib/app-sdk/use-workflow.ts
+++ b/client/src/lib/app-sdk/use-workflow.ts
@@ -10,14 +10,38 @@
  *
  * Two shapes, matching the v1 surface:
  *   - `useWorkflow(workflowRef)` → a query-style result you trigger with `run()`.
- *   - `run(input)` POSTs `/api/workflows/execute` with `sync: true` and returns
- *     the workflow `result`.
+ *   - `run(input)` POSTs `/api/workflows/execute` (no `sync` flag — the server
+ *     always starts the run asynchronously and returns `{ execution_id, status }`
+ *     immediately).
+ *
+ * Streaming transport: after starting the run, `run()` subscribes to the
+ * execution over the SDK websocket (`subscribeToExecution`) for live `status`
+ * and `log` events. Terminal websocket frames do NOT carry the result (see
+ * execution-stream.ts) — on `isTerminal`, `run()` unsubscribes and fetches
+ * `GET /api/executions/{id}` once to get the actual `result`/`error_message`.
+ * A fast run can finish before the socket even opens, so `run()` also does one
+ * immediate `GET` right after subscribing. If the socket goes down
+ * (`onSocketDown`), `run()` degrades to polling that same GET every 2s until
+ * terminal — no client-side deadline; the server enforces the workflow's own
+ * timeout and will eventually flip the execution terminal.
+ *
+ * Two exceptions bypass the stream entirely and settle inline from the POST
+ * response: `is_transient` runs (data-provider-style executions) and runs
+ * that are already terminal by the time the POST responds.
  */
 import { useCallback, useRef, useState } from "react";
 
 import type { components } from "@/lib/v1";
 
+import { subscribeToExecution, type ExecutionStreamEvent } from "./execution-stream";
 import { useBifrostContext } from "./provider";
+
+export interface WorkflowLogEntry {
+  level: string;
+  message: string;
+  timestamp: string;
+  sequence?: number;
+}
 
 export interface UseWorkflowState<T> {
   /** Last successful result, or null before the first run. */
@@ -28,12 +52,28 @@ export interface UseWorkflowState<T> {
   error: Error | null;
   /** Execute the workflow with `input_data`; resolves to the result. */
   run: (input?: Record<string, unknown>) => Promise<T>;
+  /** Live log stream for the latest run. Reset to `[]` at the start of each run. */
+  logs: WorkflowLogEntry[];
+  /** Latest run's status (e.g. "Pending", "Running", "Success"), or null before the first run. */
+  status: string | null;
+  /** Latest run's execution id, or null before the first run. */
+  executionId: string | null;
 }
 
 // The generated contract type: `status` is the PascalCase `ExecutionStatus`
 // literal union ("Success" | "Failed" | ...), so the compiler enforces the
 // exact wire casing in the failed-status check below.
 type ExecuteResponse = components["schemas"]["WorkflowExecutionResponse"];
+
+const TERMINAL_STATUSES = new Set([
+  "Success",
+  "Failed",
+  "CompletedWithErrors",
+  "Timeout",
+  "Cancelled",
+]);
+
+const POLL_INTERVAL_MS = 2000;
 
 /**
  * Run a Bifrost workflow by UUID, portable `path::function` ref, or workflow
@@ -49,6 +89,9 @@ export function useWorkflow<T = unknown>(workflowRef: string): UseWorkflowState<
   const [data, setData] = useState<T | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<Error | null>(null);
+  const [logs, setLogs] = useState<WorkflowLogEntry[]>([]);
+  const [status, setStatus] = useState<string | null>(null);
+  const [executionId, setExecutionId] = useState<string | null>(null);
   // Monotonic run counter: overlapping runs each capture their own seq, and
   // only the LATEST run (seq === seqRef.current) may write hook state. A slow
   // stale run can't overwrite a newer run's data or flip `loading` while the
@@ -61,6 +104,29 @@ export function useWorkflow<T = unknown>(workflowRef: string): UseWorkflowState<
       const seq = ++seqRef.current;
       setLoading(true);
       setError(null);
+      setLogs([]);
+      setStatus("Pending");
+
+      const settleFromExecution = (exec: {
+        status?: string;
+        result?: unknown;
+        error_message?: string | null;
+      }): T => {
+        if (exec.status === "Success" || exec.status === "CompletedWithErrors") {
+          return exec.result as T;
+        }
+        throw new Error(exec.error_message ?? `Workflow ${exec.status ?? "failed"}`);
+      };
+      const fetchExecution = async (id: string) => {
+        const r = await authedFetch(`/api/executions/${id}`);
+        if (!r.ok) throw new Error(`failed to fetch execution: ${r.status}`);
+        return (await r.json()) as {
+          status?: string;
+          result?: unknown;
+          error_message?: string | null;
+        };
+      };
+
       try {
         const resp = await authedFetch("/api/workflows/execute", {
           method: "POST",
@@ -68,7 +134,6 @@ export function useWorkflow<T = unknown>(workflowRef: string): UseWorkflowState<
           body: JSON.stringify({
             workflow_id: workflowRef,
             input_data: input,
-            sync: true,
             // Scope a path::function ref to THIS install's own workflow (so it
             // can't resolve a sibling install's workflow sharing the path).
             ...(appId ? { app_id: appId } : {}),
@@ -77,15 +142,74 @@ export function useWorkflow<T = unknown>(workflowRef: string): UseWorkflowState<
         if (!resp.ok) {
           throw new Error(`workflow execution failed: ${resp.status} ${resp.statusText}`);
         }
-        const body = (await resp.json()) as ExecuteResponse;
-        // A failed run can come back with `error: null` — status is the
-        // authoritative signal, the message is best-effort.
-        if (body.error || body.status === "Failed") {
-          throw new Error(
-            body.error ?? `Workflow failed (status: ${body.status})`,
-          );
+        const body = (await resp.json()) as ExecuteResponse & { is_transient?: boolean };
+        const execId = body.execution_id;
+        if (seq === seqRef.current && execId) setExecutionId(execId);
+
+        // Transient (data-provider-style) and already-terminal responses
+        // settle inline — never touch the websocket.
+        if (body.is_transient || TERMINAL_STATUSES.has(body.status)) {
+          if (body.error || body.status === "Failed") {
+            throw new Error(body.error ?? `Workflow failed (status: ${body.status})`);
+          }
+          const result = body.result as T;
+          if (seq === seqRef.current) {
+            setData(result);
+            setStatus(body.status);
+          }
+          return result;
         }
-        const result = body.result as T;
+
+        const result = await new Promise<T>((resolve, reject) => {
+          let settled = false;
+          let pollTimer: ReturnType<typeof setInterval> | null = null;
+          let unsubscribe: () => void = () => {};
+          const settle = (fn: () => void) => {
+            if (settled) return;
+            settled = true;
+            if (pollTimer) clearInterval(pollTimer);
+            unsubscribe();
+            fn();
+          };
+          const checkOnce = async () => {
+            try {
+              const exec = await fetchExecution(execId);
+              if (seq === seqRef.current && exec.status) setStatus(exec.status);
+              if (exec.status && TERMINAL_STATUSES.has(exec.status)) {
+                settle(() => {
+                  try {
+                    resolve(settleFromExecution(exec));
+                  } catch (e) {
+                    reject(e);
+                  }
+                });
+              }
+            } catch {
+              // Transient fetch failure — the stream/poll keeps driving; a
+              // persistent failure surfaces on the next terminal fetch attempt.
+            }
+          };
+          unsubscribe = subscribeToExecution(
+            execId,
+            (evt: ExecutionStreamEvent) => {
+              if (evt.type === "log" && evt.log && seq === seqRef.current) {
+                const log = evt.log;
+                setLogs((prev) => [...prev, log]);
+              }
+              if (evt.type === "status") {
+                if (seq === seqRef.current && evt.status) setStatus(evt.status);
+                if (evt.isTerminal) void checkOnce();
+              }
+            },
+            () => {
+              // Socket died — degrade to polling. No deadline: the server
+              // enforces the workflow's own timeout and will flip it terminal.
+              if (!settled && !pollTimer) pollTimer = setInterval(checkOnce, POLL_INTERVAL_MS);
+            },
+          );
+          void checkOnce(); // fast runs can finish before the socket opens
+        });
+
         if (seq === seqRef.current) setData(result);
         return result;
       } catch (e) {
@@ -99,5 +223,5 @@ export function useWorkflow<T = unknown>(workflowRef: string): UseWorkflowState<
     [authedFetch, workflowRef, appId],
   );
 
-  return { data, loading, error, run };
+  return { data, loading, error, run, logs, status, executionId };
 }

--- a/client/src/lib/app-sdk/use-workflow.ts
+++ b/client/src/lib/app-sdk/use-workflow.ts
@@ -75,6 +75,19 @@ const TERMINAL_STATUSES = new Set([
 
 const POLL_INTERVAL_MS = 2000;
 
+class ExecutionFetchError extends Error {
+  readonly retryable: boolean;
+
+  constructor(status: number, statusText: string) {
+    super(`failed to fetch execution: ${status}${statusText ? ` ${statusText}` : ""}`);
+    this.name = "ExecutionFetchError";
+    // A just-created execution can briefly 404, and transient overload/server
+    // failures can recover. Other 4xx responses (notably an expired/forbidden
+    // token) will not improve by polling forever.
+    this.retryable = status === 404 || status === 408 || status === 429 || status >= 500;
+  }
+}
+
 /**
  * Run a Bifrost workflow by UUID, portable `path::function` ref, or workflow
  * name from a v2 app. All three resolve identically: the server scopes the
@@ -106,6 +119,7 @@ export function useWorkflow<T = unknown>(workflowRef: string): UseWorkflowState<
       setError(null);
       setLogs([]);
       setStatus("Pending");
+      setExecutionId(null);
 
       const settleFromExecution = (exec: {
         status?: string;
@@ -115,11 +129,13 @@ export function useWorkflow<T = unknown>(workflowRef: string): UseWorkflowState<
         if (exec.status === "Success" || exec.status === "CompletedWithErrors") {
           return exec.result as T;
         }
-        throw new Error(exec.error_message ?? `Workflow ${exec.status ?? "failed"}`);
+        throw new Error(
+          exec.error_message ?? `Workflow failed (status: ${exec.status ?? "unknown"})`,
+        );
       };
       const fetchExecution = async (id: string) => {
         const r = await authedFetch(`/api/executions/${id}`);
-        if (!r.ok) throw new Error(`failed to fetch execution: ${r.status}`);
+        if (!r.ok) throw new ExecutionFetchError(r.status, r.statusText);
         return (await r.json()) as {
           status?: string;
           result?: unknown;
@@ -149,14 +165,13 @@ export function useWorkflow<T = unknown>(workflowRef: string): UseWorkflowState<
         // Transient (data-provider-style) and already-terminal responses
         // settle inline — never touch the websocket.
         if (body.is_transient || TERMINAL_STATUSES.has(body.status)) {
-          if (body.error || body.status === "Failed") {
-            throw new Error(body.error ?? `Workflow failed (status: ${body.status})`);
-          }
-          const result = body.result as T;
-          if (seq === seqRef.current) {
-            setData(result);
-            setStatus(body.status);
-          }
+          if (seq === seqRef.current) setStatus(body.status);
+          const result = settleFromExecution({
+            status: body.status,
+            result: body.result,
+            error_message: body.error,
+          });
+          if (seq === seqRef.current) setData(result);
           return result;
         }
 
@@ -177,8 +192,13 @@ export function useWorkflow<T = unknown>(workflowRef: string): UseWorkflowState<
             fn();
           };
           const checkOnce = async () => {
+            if (settled) return;
             try {
               const exec = await fetchExecution(execId);
+              // Another concurrent check (ready ack, terminal frame, or poll)
+              // may have settled while this request was in flight. Never let
+              // its older snapshot regress terminal state after resolution.
+              if (settled) return;
               if (seq === seqRef.current && exec.status) setStatus(exec.status);
               if (exec.status && TERMINAL_STATUSES.has(exec.status)) {
                 settle(() => {
@@ -189,9 +209,13 @@ export function useWorkflow<T = unknown>(workflowRef: string): UseWorkflowState<
                   }
                 });
               }
-            } catch {
+            } catch (fetchError) {
+              if (settled) return;
+              if (fetchError instanceof ExecutionFetchError && !fetchError.retryable) {
+                settle(() => reject(fetchError));
+                return;
+              }
               // Transient fetch failure — the stream/poll keeps driving; a
-              // persistent failure surfaces on the next terminal fetch attempt.
               // If this was the post-terminal-event fetch, there's no further
               // status frame coming and the socket may stay open (so
               // onSocketDown never fires) — arm the poll fallback so the run
@@ -204,6 +228,12 @@ export function useWorkflow<T = unknown>(workflowRef: string): UseWorkflowState<
           unsubscribe = subscribeToExecution(
             execId,
             (evt: ExecutionStreamEvent) => {
+              if (evt.type === "ready") {
+                // The server has installed the subscription. Re-check now so a
+                // terminal transition between the initial GET and this ack
+                // cannot be lost forever.
+                void checkOnce();
+              }
               if (evt.type === "log" && evt.log && seq === seqRef.current) {
                 const log = evt.log;
                 setLogs((prev) => [...prev, log]);

--- a/client/src/lib/app-sdk/use-workflow.ts
+++ b/client/src/lib/app-sdk/use-workflow.ts
@@ -164,6 +164,11 @@ export function useWorkflow<T = unknown>(workflowRef: string): UseWorkflowState<
           let settled = false;
           let pollTimer: ReturnType<typeof setInterval> | null = null;
           let unsubscribe: () => void = () => {};
+          // Set once a terminal ws frame has been seen. There's no client
+          // deadline, so if the one post-terminal fetch fails transiently we
+          // must not just give up — arm the poll fallback so the run still
+          // settles instead of hanging forever.
+          let sawTerminal = false;
           const settle = (fn: () => void) => {
             if (settled) return;
             settled = true;
@@ -187,6 +192,13 @@ export function useWorkflow<T = unknown>(workflowRef: string): UseWorkflowState<
             } catch {
               // Transient fetch failure — the stream/poll keeps driving; a
               // persistent failure surfaces on the next terminal fetch attempt.
+              // If this was the post-terminal-event fetch, there's no further
+              // status frame coming and the socket may stay open (so
+              // onSocketDown never fires) — arm the poll fallback so the run
+              // still settles instead of hanging forever.
+              if (sawTerminal && !settled && !pollTimer) {
+                pollTimer = setInterval(checkOnce, POLL_INTERVAL_MS);
+              }
             }
           };
           unsubscribe = subscribeToExecution(
@@ -198,7 +210,10 @@ export function useWorkflow<T = unknown>(workflowRef: string): UseWorkflowState<
               }
               if (evt.type === "status") {
                 if (seq === seqRef.current && evt.status) setStatus(evt.status);
-                if (evt.isTerminal) void checkOnce();
+                if (evt.isTerminal) {
+                  sawTerminal = true;
+                  void checkOnce();
+                }
               }
             },
             () => {

--- a/client/src/lib/app-sdk/use-workflow.ts
+++ b/client/src/lib/app-sdk/use-workflow.ts
@@ -215,12 +215,12 @@ export function useWorkflow<T = unknown>(workflowRef: string): UseWorkflowState<
                 settle(() => reject(fetchError));
                 return;
               }
-              // Transient fetch failure — the stream/poll keeps driving; a
+              // Transient fetch failure — the stream/poll keeps driving.
               // If this was the post-terminal-event fetch, there's no further
               // status frame coming and the socket may stay open (so
               // onSocketDown never fires) — arm the poll fallback so the run
               // still settles instead of hanging forever.
-              if (sawTerminal && !settled && !pollTimer) {
+              if (sawTerminal && !pollTimer) {
                 pollTimer = setInterval(checkOnce, POLL_INTERVAL_MS);
               }
             }

--- a/client/src/lib/app-sdk/wire-surface.ts
+++ b/client/src/lib/app-sdk/wire-surface.ts
@@ -92,6 +92,10 @@ export const wireSurface = {
       type: "subscribe",
       channels: ["name", "filter", "scope"],
     },
+    subscribedFrame: {
+      type: "subscribed",
+      fields: ["channel"],
+    },
     // Inbound frames read by tables.ts (via ws-client.ts subscribeToTable).
     tableChangeFrame: {
       type: "document_change",

--- a/client/src/lib/app-sdk/wire-surface.ts
+++ b/client/src/lib/app-sdk/wire-surface.ts
@@ -1,0 +1,124 @@
+/**
+ * The v2 SDK's server-facing wire surface, as an explicit data structure so
+ * `sdk-contract.test.ts` can snapshot-hash it. This is NOT executed against
+ * the server — it's a manually-maintained inventory of every HTTP endpoint,
+ * request-body key, and websocket frame field the SDK reads/writes, derived
+ * by reading use-workflow.ts, execution-stream.ts, tables.ts, files.ts,
+ * ws-client.ts, and transport.ts.
+ *
+ * When this object's hash changes (see sdk-contract.test.ts), the SDK's wire
+ * surface changed. Refresh the snapshot if the change is non-breaking (e.g. a
+ * new optional field); bump sdk-contract.json's version if it's breaking
+ * (e.g. a field renamed/removed, or a response shape an old SDK depends on
+ * changed incompatibly).
+ */
+
+export const wireSurface = {
+  http: {
+    // use-workflow.ts: useWorkflow().run()
+    "POST /api/workflows/execute": {
+      requestBody: ["workflow_id", "input_data", "app_id"],
+      responseFields: [
+        "execution_id",
+        "status",
+        "result",
+        "error",
+        "is_transient",
+      ],
+    },
+    // use-workflow.ts: post-terminal-event result fetch + poll fallback
+    "GET /api/executions/{id}": {
+      responseFields: ["status", "result", "error_message"],
+    },
+    // tables.ts
+    "GET /api/tables/{table}/documents/{id}": {},
+    "POST /api/tables/{table}/documents": {
+      requestBody: ["data", "upsert"],
+    },
+    "POST /api/tables/{table}/documents/batch": {
+      requestBody: ["documents", "upsert"],
+    },
+    "PATCH /api/tables/{table}/documents/{id}": {
+      requestBody: ["data"],
+    },
+    "DELETE /api/tables/{table}/documents/{id}": {},
+    "POST /api/tables/{table}/documents/batch-delete": {
+      requestBody: ["ids"],
+    },
+    "POST /api/tables/{table}/documents/query": {
+      requestBody: [], // full DocumentQuery, passed through
+    },
+    "GET /api/tables/{table}/documents/count": {},
+    // files.ts
+    "POST /api/files/read": {
+      requestBody: ["path", "location", "mode", "scope", "binary"],
+    },
+    "POST /api/files/write": {
+      requestBody: ["path", "content", "location", "mode", "scope", "binary"],
+    },
+    "POST /api/files/delete": {
+      requestBody: ["path", "location", "mode", "scope"],
+    },
+    "POST /api/files/list": {
+      requestBody: [
+        "directory",
+        "location",
+        "mode",
+        "scope",
+        "include_metadata",
+      ],
+    },
+    "POST /api/files/exists": {
+      requestBody: ["path", "location", "mode", "scope"],
+    },
+    "POST /api/files/signed-url": {
+      requestBody: ["path", "method", "content_type", "location", "scope"],
+    },
+    "POST /api/files/signed-urls": {
+      requestBody: ["requests"],
+    },
+    "POST /api/files/complete-upload": {
+      requestBody: ["path", "content_type", "size_bytes", "location", "scope"],
+    },
+  },
+  websocket: {
+    // ws-client.ts / execution-stream.ts: /ws/connect, token via query param
+    // when a provider transport is installed (cookie auth same-origin).
+    connectPath: "/ws/connect",
+    authQueryParam: "token",
+    // Outbound subscribe frame (shared shape across table/file/execution
+    // subscriptions).
+    subscribeFrame: {
+      type: "subscribe",
+      channels: ["name", "filter", "scope"],
+    },
+    // Inbound frames read by tables.ts (via ws-client.ts subscribeToTable).
+    tableChangeFrame: {
+      type: "document_change",
+      fields: ["table_id", "action", "row", "row_id", "channel"],
+    },
+    fileChangeFrame: {
+      type: "file_change",
+      fields: ["path", "action", "channel"],
+    },
+    // Inbound frames read by execution-stream.ts subscribeToExecution.
+    // Terminal frames carry status but NOT the result (see #483) — the
+    // caller does a follow-up GET /api/executions/{id}.
+    executionUpdateFrame: {
+      type: "execution_update",
+      fields: ["executionId", "status"],
+    },
+    executionLogFrame: {
+      type: "execution_log",
+      fields: ["executionId", "level", "message", "timestamp", "sequence"],
+    },
+    subscriptionRevokedFrame: {
+      type: "subscription_revoked",
+      fields: ["channel"],
+    },
+    errorFrame: {
+      type: "error",
+      fields: ["channel", "message"],
+    },
+  },
+} as const;

--- a/docs/superpowers/plans/2026-07-14-v2-sdk-streaming-and-version-gate.md
+++ b/docs/superpowers/plans/2026-07-14-v2-sdk-streaming-and-version-gate.md
@@ -1,0 +1,673 @@
+# v2 SDK Streaming Transport + Version Gate Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give the v2 web SDK's workflow hooks the v1 streaming engine (async execute + websocket + result fetch) so long-running workflows don't 504, and add a zero-maintenance SDK staleness gate (`bifrost solution sdk update` + a warning in `bifrost solution start`).
+
+**Architecture:** The v2 SDK (`client/src/lib/app-sdk/`) keeps its public hook API (`useWorkflow`, `useWorkflowQuery`, `useWorkflowMutation`) but swaps the transport under `useWorkflow.run()`: POST `/api/workflows/execute` **without** `sync:true` → subscribe to the `execution:{id}` websocket channel (server support already exists, see `api/src/routers/websocket.py:795`) → stream logs/status → on terminal event, GET `/api/executions/{id}` and resolve with its `result`. The staleness gate reuses the existing tarball builder (`api/src/services/sdk_package/__init__.py`): stamp a sha256 content fingerprint of the built bundle into the tarball's `package.json`, report the current fingerprint in `GET /api/version`, compare in the CLI.
+
+**Tech Stack:** TypeScript/React (vitest), Python/FastAPI/click (pytest), esbuild-built SDK tarball.
+
+**GitHub issue:** #484. **Branch/worktree:** `.worktrees/484-v2-sdk-streaming-version-gate`, based off `origin/main` AFTER PR #483 merges (this work depends on #483's websocket message shape: terminal `execution_update` events carry `duration_ms` but NOT the result).
+
+## Global Constraints
+
+- Public hook APIs must not change shape in a breaking way: `useWorkflow(ref) → { data, loading, error, run }` may GAIN fields (`logs`, `status`, `executionId`) but existing fields keep their exact types.
+- The transient short-circuit in `use-workflow.ts` (server returns `is_transient` + inline result for data providers) MUST be preserved — those never hit the websocket.
+- No artificial client-side timeout on workflow runs. The server enforces the workflow's own `timeout_seconds`. (The old 5-minute ceiling was the bug.)
+- Terminal statuses everywhere: `Success`, `Failed`, `CompletedWithErrors`, `Timeout`, `Cancelled`.
+- The fingerprint must be a pure function of the built SDK bundle — no manual version bump anywhere. Human-readable `version` stays as-is (instance version, `_pep440ish`).
+- `bifrost solution start` warning must NEVER block or exit — warn and continue.
+- Python: `datetime.now(timezone.utc)` convention; every `except X: pass` needs an inline why-comment (CodeQL).
+- CLI command surface changes require regenerating skill appendices: `python api/scripts/skill-truth/generate.py` and running `./test.sh tests/unit/test_cli_surface_smoke.py tests/unit/test_skill_appendix_fresh.py`.
+- Run tests via `./test.sh <path>` (backend, needs `./test.sh stack up` once) and `cd client && npx vitest run <path>` (frontend).
+
+---
+
+### Task 1: `execution-stream.ts` — websocket subscription for one execution
+
+**Files:**
+- Create: `client/src/lib/app-sdk/execution-stream.ts`
+- Test: `client/src/lib/app-sdk/execution-stream.test.ts`
+
+**Interfaces:**
+- Consumes: `buildWsUrl()` from `./ws-client` (already exported? — it IS exported: `export function buildWsUrl()`).
+- Produces (Task 2 relies on these exact signatures):
+
+```typescript
+export interface ExecutionStreamEvent {
+  type: "status" | "log";
+  status?: string;            // on "status": Pending/Running/Success/Failed/...
+  isTerminal?: boolean;       // on "status"
+  log?: { level: string; message: string; timestamp: string; sequence?: number };
+}
+export function subscribeToExecution(
+  executionId: string,
+  onEvent: (evt: ExecutionStreamEvent) => void,
+  onSocketDown?: () => void,  // fired on error/unexpected close — caller falls back to polling
+): () => void                 // unsubscribe
+```
+
+The server sends frames on channel `execution:{id}` shaped (see `api/src/core/pubsub.py`):
+- `{"type": "execution_update", "executionId": "<id>", "status": "Success", "duration_ms": 123}` — NO result field (post-#483).
+- `{"type": "execution_log", "executionId": "<id>", "level": "info", "message": "...", "timestamp": "...", "sequence": 1}`
+
+- [ ] **Step 1: Write the failing test.** Follow the existing `ws-client.test.ts` mock-WebSocket pattern (read it first; it stubs `global.WebSocket`). Test cases:
+
+```typescript
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { subscribeToExecution } from "./execution-stream";
+
+class MockWebSocket {
+  static instances: MockWebSocket[] = [];
+  url: string;
+  sent: string[] = [];
+  listeners: Record<string, ((e: any) => void)[]> = {};
+  constructor(url: string) { this.url = url; MockWebSocket.instances.push(this); }
+  addEventListener(type: string, cb: (e: any) => void) { (this.listeners[type] ??= []).push(cb); }
+  send(data: string) { this.sent.push(data); }
+  close() { this.emit("close", { code: 1000 }); }
+  emit(type: string, e: any) { (this.listeners[type] ?? []).forEach((cb) => cb(e)); }
+}
+
+beforeEach(() => { MockWebSocket.instances = []; vi.stubGlobal("WebSocket", MockWebSocket); });
+afterEach(() => vi.unstubAllGlobals());
+
+describe("subscribeToExecution", () => {
+  it("subscribes to the execution channel on open", () => {
+    subscribeToExecution("abc-123", () => {});
+    const ws = MockWebSocket.instances[0];
+    ws.emit("open", {});
+    expect(JSON.parse(ws.sent[0])).toEqual({
+      type: "subscribe",
+      channels: [{ name: "execution:abc-123" }],
+    });
+  });
+
+  it("maps execution_update frames to status events with terminal detection", () => {
+    const events: any[] = [];
+    subscribeToExecution("abc-123", (e) => events.push(e));
+    const ws = MockWebSocket.instances[0];
+    ws.emit("open", {});
+    ws.emit("message", { data: JSON.stringify({ type: "execution_update", executionId: "abc-123", status: "Running" }) });
+    ws.emit("message", { data: JSON.stringify({ type: "execution_update", executionId: "abc-123", status: "Success", duration_ms: 42 }) });
+    expect(events).toEqual([
+      { type: "status", status: "Running", isTerminal: false },
+      { type: "status", status: "Success", isTerminal: true },
+    ]);
+  });
+
+  it("maps execution_log frames to log events", () => {
+    const events: any[] = [];
+    subscribeToExecution("abc-123", (e) => events.push(e));
+    const ws = MockWebSocket.instances[0];
+    ws.emit("open", {});
+    ws.emit("message", { data: JSON.stringify({ type: "execution_log", executionId: "abc-123", level: "info", message: "hi", timestamp: "t", sequence: 3 }) });
+    expect(events[0]).toEqual({ type: "log", log: { level: "info", message: "hi", timestamp: "t", sequence: 3 } });
+  });
+
+  it("fires onSocketDown on error and on unexpected close, but not on unsubscribe", () => {
+    const down = vi.fn();
+    const unsub = subscribeToExecution("abc-123", () => {}, down);
+    const ws = MockWebSocket.instances[0];
+    ws.emit("error", {});
+    expect(down).toHaveBeenCalledTimes(1);
+    unsub(); // client-initiated close must NOT fire onSocketDown again
+    expect(down).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores unparseable frames", () => {
+    const events: any[] = [];
+    subscribeToExecution("abc-123", (e) => events.push(e));
+    const ws = MockWebSocket.instances[0];
+    ws.emit("message", { data: "not json" });
+    expect(events).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure.** `cd client && npx vitest run src/lib/app-sdk/execution-stream.test.ts` — expect FAIL (module not found).
+
+- [ ] **Step 3: Implement** `client/src/lib/app-sdk/execution-stream.ts`:
+
+```typescript
+/**
+ * Live subscription to one execution's status + log stream over the SDK
+ * websocket. Mirrors `subscribeToTable` in ws-client.ts: one socket per
+ * subscription, auth via buildWsUrl() (token query param under a provider
+ * transport, cookies same-origin).
+ *
+ * Terminal `execution_update` frames carry status + duration_ms but NOT the
+ * result (large results are not rebroadcast; see #483) — the caller fetches
+ * `/api/executions/{id}` when isTerminal fires.
+ */
+import { buildWsUrl } from "./ws-client";
+
+const TERMINAL_STATUSES = new Set([
+  "Success",
+  "Failed",
+  "CompletedWithErrors",
+  "Timeout",
+  "Cancelled",
+]);
+
+export interface ExecutionStreamEvent {
+  type: "status" | "log";
+  status?: string;
+  isTerminal?: boolean;
+  log?: { level: string; message: string; timestamp: string; sequence?: number };
+}
+
+export function subscribeToExecution(
+  executionId: string,
+  onEvent: (evt: ExecutionStreamEvent) => void,
+  onSocketDown?: () => void,
+): () => void {
+  const ws = new WebSocket(buildWsUrl());
+  let closedByClient = false;
+  ws.addEventListener("open", () => {
+    ws.send(
+      JSON.stringify({
+        type: "subscribe",
+        channels: [{ name: `execution:${executionId}` }],
+      }),
+    );
+  });
+  ws.addEventListener("message", (e) => {
+    try {
+      const msg = JSON.parse(e.data);
+      if (msg.type === "execution_update" && msg.executionId === executionId) {
+        onEvent({
+          type: "status",
+          status: msg.status,
+          isTerminal: TERMINAL_STATUSES.has(msg.status),
+        });
+      } else if (msg.type === "execution_log" && msg.executionId === executionId) {
+        onEvent({
+          type: "log",
+          log: {
+            level: msg.level,
+            message: msg.message,
+            timestamp: msg.timestamp,
+            sequence: msg.sequence,
+          },
+        });
+      }
+    } catch {
+      // ignore unparseable frames — same policy as subscribeToTable
+    }
+  });
+  ws.addEventListener("error", () => {
+    console.warn("[bifrost-sdk] execution stream socket error");
+    if (!closedByClient) onSocketDown?.();
+  });
+  ws.addEventListener("close", (e) => {
+    if (!closedByClient) {
+      console.warn("[bifrost-sdk] execution stream closed", e.code);
+      onSocketDown?.();
+    }
+  });
+  return () => {
+    closedByClient = true;
+    ws.close();
+  };
+}
+```
+
+NOTE the error+close double-fire: a socket error is typically followed by a close. Guard in the CALLER (Task 2 uses a `fellBack` flag) OR dedupe here — implement dedupe here: add `let downFired = false;` and in both handlers `if (!closedByClient && !downFired) { downFired = true; onSocketDown?.(); }`. The test in Step 1 (`error then unsubscribe → 1 call`) plus an added case (`error then close → still 1 call`) pin this.
+
+- [ ] **Step 4: Run to verify pass.** Same command — expect all PASS.
+
+- [ ] **Step 5: Commit.** `git add client/src/lib/app-sdk/execution-stream.{ts,test.ts} && git commit -m "feat(sdk): execution status/log stream subscription"`
+
+---
+
+### Task 2: `use-workflow.ts` — swap sync-hold for streaming transport
+
+**Files:**
+- Modify: `client/src/lib/app-sdk/use-workflow.ts`
+- Test: `client/src/lib/app-sdk/use-workflow.test.tsx` (extend existing)
+
+**Interfaces:**
+- Consumes: `subscribeToExecution`, `ExecutionStreamEvent` (Task 1); `useBifrostContext()` → `{ authedFetch, appId }` (existing).
+- Produces (Task 3 passes these through):
+
+```typescript
+export interface WorkflowLogEntry { level: string; message: string; timestamp: string; sequence?: number }
+export interface UseWorkflowState<T> {
+  data: T | null;
+  loading: boolean;
+  error: Error | null;
+  run: (input?: Record<string, unknown>) => Promise<T>;
+  logs: WorkflowLogEntry[];        // NEW — live log stream for the latest run
+  status: string | null;           // NEW — latest run's status
+  executionId: string | null;      // NEW — latest run's id
+}
+```
+
+**Execution flow of the new `run()` (the current one is at `use-workflow.ts:59-104`, sends `sync: true`):**
+1. POST `/api/workflows/execute` body `{ workflow_id, input_data, app_id? }` — **no `sync` key**.
+2. Response body: `{ execution_id, status, result?, error?, is_transient? }`. If `is_transient` OR the returned `status` is already terminal → resolve/reject inline exactly like today (data providers + races). On `Failed`-family status throw `Error(body.error ?? ...)`.
+3. Otherwise: subscribe via `subscribeToExecution(execution_id, ...)`.
+4. Immediately after subscribing, GET `/api/executions/{execution_id}` once — fast workflows can finish before the socket opens; if terminal, settle now (unsubscribe first).
+5. On stream `status` events: update `status` state. On `log` events: append to `logs` state (only if this run is still the latest, seq-guard).
+6. On `isTerminal`: unsubscribe, GET `/api/executions/{execution_id}`, resolve with `.result` on `Success`/`CompletedWithErrors`, otherwise reject with `.error_message`.
+7. `onSocketDown`: switch to polling GET `/api/executions/{execution_id}` every 2000ms until terminal (clear interval on settle). No overall deadline.
+8. All hook-state writes stay behind the existing `seq === seqRef.current` guard; every run resets `logs` to `[]` and `status` to `"Pending"`.
+
+- [ ] **Step 1: Write the failing tests.** Read `use-workflow.test.tsx` first and keep its harness (it wraps hooks in `<BifrostProvider>` with a mocked fetch). Mock `subscribeToExecution` with `vi.mock("./execution-stream", ...)`. New/changed cases:
+
+```typescript
+// Sketch of the new cases — adapt to the file's existing render/act helpers.
+import { subscribeToExecution } from "./execution-stream";
+vi.mock("./execution-stream", () => ({ subscribeToExecution: vi.fn() }));
+
+it("executes async (no sync flag) and resolves with the fetched result on terminal event", async () => {
+  // fetch mock: POST /api/workflows/execute → { execution_id: "e1", status: "Pending" }
+  //             GET /api/executions/e1 (immediate check) → { status: "Running" }
+  //             GET /api/executions/e1 (after terminal)  → { status: "Success", result: { ok: 1 } }
+  let streamCb: any;
+  (subscribeToExecution as Mock).mockImplementation((_id, cb) => { streamCb = cb; return vi.fn(); });
+  const { result } = renderUseWorkflow("wf.py::main");
+  let p: Promise<unknown>;
+  act(() => { p = result.current.run({}); });
+  await waitFor(() => expect(subscribeToExecution).toHaveBeenCalledWith("e1", expect.any(Function), expect.any(Function)));
+  act(() => streamCb({ type: "status", status: "Success", isTerminal: true }));
+  await expect(p!).resolves.toEqual({ ok: 1 });
+  expect(result.current.data).toEqual({ ok: 1 });
+  // assert the execute POST body had NO sync key:
+  const executeBody = JSON.parse(fetchMock.mock.calls[0][1].body);
+  expect("sync" in executeBody).toBe(false);
+});
+
+it("streams logs into state", async () => { /* emit {type:"log"} events; expect result.current.logs to accumulate */ });
+
+it("keeps the transient short-circuit", async () => {
+  // POST → { execution_id: "e2", is_transient: true, status: "Success", result: { x: 2 } }
+  // run() resolves { x: 2 } and subscribeToExecution is NEVER called.
+});
+
+it("settles from the immediate check when the run finished before the socket", async () => {
+  // immediate GET returns { status: "Success", result: { fast: true } } → resolve without any stream event.
+});
+
+it("falls back to polling when the socket drops", async () => {
+  vi.useFakeTimers();
+  // capture onSocketDown (3rd arg), invoke it; GET returns Running, then Success with result.
+  // advance 2000ms per poll; expect resolution.
+});
+
+it("rejects with error_message on Failed terminal", async () => { /* terminal event → GET returns { status: "Failed", error_message: "boom" } → run() rejects "boom" */ });
+```
+
+- [ ] **Step 2: Run to verify the new cases fail.** `npx vitest run src/lib/app-sdk/use-workflow.test.tsx` — new cases FAIL; pre-existing sync-transport cases will also fail once implementation changes (update them in step 3 to the new transport shape — the ones asserting `sync: true` in the POST body get inverted).
+
+- [ ] **Step 3: Implement the new `run()`** in `use-workflow.ts` per the flow above. Concrete skeleton (preserve the module's existing doc comment style and the `seqRef` guard):
+
+```typescript
+const TERMINAL = new Set(["Success", "Failed", "CompletedWithErrors", "Timeout", "Cancelled"]);
+
+const run = useCallback(
+  async (input: Record<string, unknown> = {}): Promise<T> => {
+    const seq = ++seqRef.current;
+    setLoading(true);
+    setError(null);
+    if (seq === seqRef.current) { setLogs([]); setStatus("Pending"); }
+
+    const settleFromExecution = (exec: any): T => {
+      if (exec.status === "Success" || exec.status === "CompletedWithErrors") {
+        return exec.result as T;
+      }
+      throw new Error(exec.error_message ?? `Workflow ${exec.status}`);
+    };
+    const fetchExecution = async (id: string) => {
+      const r = await authedFetch(`/api/executions/${id}`);
+      if (!r.ok) throw new Error(`failed to fetch execution: ${r.status}`);
+      return r.json();
+    };
+
+    try {
+      const resp = await authedFetch("/api/workflows/execute", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          workflow_id: workflowRef,
+          input_data: input,
+          ...(appId ? { app_id: appId } : {}),
+        }),
+      });
+      if (!resp.ok) throw new Error(`workflow execution failed: ${resp.status} ${resp.statusText}`);
+      const body = (await resp.json()) as ExecuteResponse;
+      const execId = body.execution_id;
+      if (seq === seqRef.current && execId) setExecutionId(execId);
+
+      // Transient (data providers) and already-terminal responses settle inline.
+      if (body.is_transient || TERMINAL.has(body.status)) {
+        if (body.error || body.status === "Failed") {
+          throw new Error(body.error ?? `Workflow failed (status: ${body.status})`);
+        }
+        const result = body.result as T;
+        if (seq === seqRef.current) { setData(result); setStatus(body.status); }
+        return result;
+      }
+
+      const result = await new Promise<T>((resolve, reject) => {
+        let settled = false;
+        let pollTimer: ReturnType<typeof setInterval> | null = null;
+        let unsubscribe: () => void = () => {};
+        const settle = (fn: () => void) => {
+          if (settled) return;
+          settled = true;
+          if (pollTimer) clearInterval(pollTimer);
+          unsubscribe();
+          fn();
+        };
+        const checkOnce = async () => {
+          try {
+            const exec = await fetchExecution(execId);
+            if (seq === seqRef.current && exec.status) setStatus(exec.status);
+            if (TERMINAL.has(exec.status)) {
+              settle(() => { try { resolve(settleFromExecution(exec)); } catch (e) { reject(e); } });
+            }
+          } catch {
+            // transient fetch failure — the stream/poll keeps driving; a
+            // persistent failure surfaces on the next terminal fetch attempt
+          }
+        };
+        unsubscribe = subscribeToExecution(
+          execId,
+          (evt) => {
+            if (evt.type === "log" && evt.log && seq === seqRef.current) {
+              setLogs((prev) => [...prev, evt.log!]);
+            }
+            if (evt.type === "status") {
+              if (seq === seqRef.current && evt.status) setStatus(evt.status);
+              if (evt.isTerminal) void checkOnce();
+            }
+          },
+          () => {
+            // Socket died — degrade to polling. No deadline: the server
+            // enforces the workflow's own timeout and will flip it terminal.
+            if (!settled && !pollTimer) pollTimer = setInterval(checkOnce, 2000);
+          },
+        );
+        void checkOnce(); // fast runs can finish before the socket opens
+      });
+
+      if (seq === seqRef.current) setData(result);
+      return result;
+    } catch (e) {
+      const err = e instanceof Error ? e : new Error(String(e));
+      if (seq === seqRef.current) setError(err);
+      throw err;
+    } finally {
+      if (seq === seqRef.current) setLoading(false);
+    }
+  },
+  [authedFetch, workflowRef, appId],
+);
+```
+
+Add the three new state hooks (`logs`, `status`, `executionId`) and return them. Update the module doc comment: it currently documents the sync transport; describe the streaming transport and that terminal ws frames don't carry results.
+
+- [ ] **Step 4: Run the full file.** `npx vitest run src/lib/app-sdk/use-workflow.test.tsx` — all PASS.
+
+- [ ] **Step 5: Typecheck + neighboring tests.** `npx tsc --noEmit && npx vitest run src/lib/app-sdk/` — all PASS.
+
+- [ ] **Step 6: Commit.** `git commit -am "feat(sdk): streaming workflow transport — async execute + ws + result fetch"`
+
+---
+
+### Task 3: `use-workflow-hooks.ts` — pass through logs/status/executionId
+
+**Files:**
+- Modify: `client/src/lib/app-sdk/use-workflow-hooks.ts`
+- Test: `client/src/lib/app-sdk/use-workflow-hooks.test.tsx` (extend)
+
+**Interfaces:**
+- Consumes: `UseWorkflowState<T>` from Task 2 (now has `logs`, `status`, `executionId`).
+- Produces: `UseWorkflowQueryState<T>` and `UseWorkflowMutationState<T>` each gain `logs: WorkflowLogEntry[]`, `status: string | null`, `executionId: string | null` — same names, straight pass-through.
+
+- [ ] **Step 1: Write failing tests** asserting `useWorkflowQuery` and `useWorkflowMutation` expose `logs`/`status`/`executionId` from the underlying `useWorkflow` (mock `./use-workflow` and return a canned state; assert pass-through).
+- [ ] **Step 2: Verify fail**, **Step 3: implement** (add the three fields to both interfaces and both return objects), **Step 4: verify pass** (`npx vitest run src/lib/app-sdk/use-workflow-hooks.test.tsx`), **Step 5: commit** `git commit -am "feat(sdk): expose logs/status/executionId on query+mutation hooks"`.
+
+---
+
+### Task 4: SDK content fingerprint — tarball stamp + `/api/version`
+
+**Files:**
+- Modify: `api/src/services/sdk_package/__init__.py`
+- Modify: `api/src/routers/version.py`
+- Test: `api/tests/unit/test_sdk_package_fingerprint.py` (create)
+
+**Interfaces:**
+- Produces (Tasks 5+6 rely on these):
+  - `sdk_fingerprint(version: str) -> str` — sha256 hex (first 16 chars) of the built bundle bytes; exported from `src.services.sdk_package`.
+  - `sdk_contract_version() -> int` — reads `client/src/lib/app-sdk/sdk-contract.json` (new file, see below); exported from `src.services.sdk_package`.
+  - Tarball `package/package.json` gains `"bifrost": {"fingerprint": "<16-hex>", "contract": <int>}`.
+  - `GET /api/version` response gains `sdk_fingerprint: str` and `sdk_contract_version: int` (existing fields `version`, `contract_version` unchanged).
+
+**Two-tier staleness model (mirrors the CLI's `CONTRACT_VERSION` + DTO-fingerprint pair):**
+- `sdk-contract.json` — `{"version": 1}` plus a comment-style `"history"` map documenting each bump, exactly like the header comments in `api/bifrost/contract_version.py`. Bumped ONLY on breaking SDK↔server changes (the streaming transport in this very PR is bump #1: an SDK built before it expects `result` in terminal ws frames... actually pre-existing v2 SDKs used sync HTTP and still work — decide at implementation time whether this PR is a bump; document the decision in the history map either way).
+- The content fingerprint changes on EVERY shipped SDK change (automatic); the contract version changes only on decided breaking changes (manual, tripwire-forced).
+- Vitest tripwire (`client/src/lib/app-sdk/sdk-contract.test.ts`): snapshot-hash the SDK's wire-facing surface — the endpoints it calls, the request bodies it sends, the ws frame fields it reads (maintain these as an explicit exported const in a `wire-surface.ts` or extract from the modules). When the surface hash changes, the test fails with instructions: "refresh the snapshot if non-breaking, bump sdk-contract.json version if breaking" — the same forced-decision mechanism as `api/tests/unit/test_contract_version.py`.
+
+Current builder (read it first): `build_sdk_tarball(version)` at `api/src/services/sdk_package/__init__.py:73` — lru_cached, bundles via `_bundle(workdir)`, writes `package_json` dict. The fingerprint is sha256 of the bundle bytes — a pure function of the SDK source baked into the image, so it changes exactly when the shipped SDK changes and never needs a manual bump.
+
+- [ ] **Step 1: Write failing tests:**
+
+```python
+"""The SDK staleness gate hinges on the tarball fingerprint being a stable,
+content-addressed stamp: same source -> same fingerprint, present both in the
+tarball's package.json and in GET /api/version."""
+
+import io
+import json
+import tarfile
+
+
+def test_tarball_package_json_carries_fingerprint():
+    from src.services.sdk_package import build_sdk_tarball, sdk_fingerprint
+
+    data = build_sdk_tarball("v1.2.3")
+    with tarfile.open(fileobj=io.BytesIO(data), mode="r:gz") as tar:
+        pkg = json.load(tar.extractfile("package/package.json"))
+
+    assert pkg["bifrost"]["fingerprint"] == sdk_fingerprint("v1.2.3")
+    assert len(pkg["bifrost"]["fingerprint"]) == 16
+
+
+def test_fingerprint_is_stable_across_calls():
+    from src.services.sdk_package import sdk_fingerprint
+
+    assert sdk_fingerprint("v1.2.3") == sdk_fingerprint("v1.2.3")
+
+
+def test_version_endpoint_reports_sdk_fingerprint(monkeypatch):
+    from src.routers import version as version_router
+
+    monkeypatch.setattr(version_router, "get_sdk_fingerprint", lambda: "abcd1234abcd1234")
+    resp = version_router.VersionResponse  # shape check via model fields
+    assert "sdk_fingerprint" in resp.model_fields
+```
+
+(Adapt the endpoint test to the router's actual structure after reading `api/src/routers/version.py` — it's ~20 lines; if the handler is a plain function, call it directly and assert the field.)
+
+- [ ] **Step 2: Verify fail.** `./test.sh tests/unit/test_sdk_package_fingerprint.py` — FAIL (no `sdk_fingerprint`).
+
+- [ ] **Step 3: Implement.** In `sdk_package/__init__.py`: extract the bundle build so fingerprint and tarball share it:
+
+```python
+import hashlib
+
+
+@functools.lru_cache(maxsize=2)
+def _built_bundle(version: str) -> bytes:
+    """esbuild output for the SDK source baked into this image. Cached: pure
+    function of the source; `version` keys the cache for rolling upgrades."""
+    with tempfile.TemporaryDirectory(prefix="bifrost-sdk-build-") as tmp:
+        return _bundle(Path(tmp))
+
+
+def sdk_fingerprint(version: str) -> str:
+    """Content fingerprint of the shipped SDK bundle (sha256, 16 hex chars).
+
+    Pure function of the SDK source: changes exactly when the built SDK
+    changes. This is what `bifrost solution start` compares against an app's
+    installed copy — no manual bump anywhere.
+    """
+    return hashlib.sha256(_built_bundle(version)).hexdigest()[:16]
+```
+
+Refactor `build_sdk_tarball` to call `_built_bundle(version)` instead of `_bundle` directly (keep its own lru_cache), and add to `package_json`:
+
+```python
+            "bifrost": {"fingerprint": sdk_fingerprint(version)},
+```
+
+In `api/src/routers/version.py`: add `sdk_fingerprint: str` to `VersionResponse` and populate it. The instance version passed to the SDK builder elsewhere comes from the same source the version endpoint reports — read how `cli.py:2744` calls `build_sdk_tarball` and use the identical version source so the fingerprints agree:
+
+```python
+from src.services.sdk_package import sdk_fingerprint
+# in the handler:
+    sdk_fingerprint=sdk_fingerprint(<same version value used at the /api/sdk/download call site>),
+```
+
+NOTE: `sdk_fingerprint` shells out to node/esbuild on first call — acceptable (lru_cached, and /api/version is not hot), but wrap in try/except returning `"unavailable"` on failure so a broken node toolchain can't take down the version endpoint; log the exception.
+
+- [ ] **Step 4: Verify pass.** `./test.sh tests/unit/test_sdk_package_fingerprint.py` — PASS. Also run the existing SDK package tests: `./test.sh tests/unit/test_sdk_*.py`.
+- [ ] **Step 5: Commit.** `git commit -am "feat(api): content fingerprint on SDK tarball + /api/version"`
+
+---
+
+### Task 5: `bifrost solution sdk update` — re-vendor the SDK into a v2 app
+
+**Files:**
+- Modify: `api/bifrost/commands/solution.py`
+- Test: `api/tests/unit/test_solution_sdk_update.py` (create)
+
+**Interfaces:**
+- Consumes: server `GET /api/version` → `sdk_fingerprint` (Task 4); existing helpers in `solution.py`: `_SDK_DOWNLOAD_SUFFIX = "/api/sdk/download"` (line ~2822), `_heal_sdk_dep(app_dir, api_url)` (line ~2825), the `solution_group` click group (line 72), and however existing commands resolve the bound instance + app dir (read `solution start`'s resolution: `chosen.app_dir`, `client.api_url` around line 2293).
+- Produces:
+  - CLI: `bifrost solution sdk update [PATH]` — click sub-GROUP `sdk` under `solution_group` with an `update` command, so future sdk-related commands nest cleanly.
+  - Pure helper (unit-testable, no network): `installed_sdk_fingerprint(app_dir: Path) -> str | None` — reads `<app_dir>/node_modules/bifrost/package.json`, returns `["bifrost"]["fingerprint"]`, `None` if missing/unreadable.
+
+Behavior of `update`:
+1. Resolve the app dir + bound instance exactly like `solution start` does (reuse its resolution helpers — do NOT reimplement).
+2. GET `/api/version`; read `sdk_fingerprint`. If the server predates the field, say so and continue (update still works — it just can't verify).
+3. Compare with `installed_sdk_fingerprint(app_dir)`. If equal, print "SDK already up to date (<fp>)" and exit 0.
+4. Refresh: delete `<app_dir>/node_modules/bifrost` and the npm cache entry for the tarball URL is busted by installing with `--no-cache`? npm has no `--no-cache` install flag — the reliable sequence is `npm cache clean --force --silent` scoped is NOT possible, so instead: `rm -rf node_modules/bifrost` then `npm install bifrost@<api_url>/api/sdk/download --no-save=false`. npm treats a URL dep with the same URL as cached — bust it by running `npm install --force bifrost@<url>`. Use `--force` and verify afterwards by re-reading `installed_sdk_fingerprint` and comparing to the server's; if they still differ, exit 1 with a loud error naming both fingerprints.
+5. Print the old → new fingerprint on success.
+
+- [ ] **Step 1: Write failing unit tests** (follow `api/tests/unit/test_solution_dev_command.py`'s patterns — CliRunner + tmp_path app dirs + mocked HTTP):
+
+```python
+import json
+from pathlib import Path
+
+
+def _write_installed_sdk(app_dir: Path, fingerprint: str | None) -> None:
+    pkg_dir = app_dir / "node_modules" / "bifrost"
+    pkg_dir.mkdir(parents=True)
+    pkg = {"name": "bifrost", "version": "1.0.0"}
+    if fingerprint:
+        pkg["bifrost"] = {"fingerprint": fingerprint}
+    (pkg_dir / "package.json").write_text(json.dumps(pkg))
+
+
+def test_installed_sdk_fingerprint_reads_stamp(tmp_path):
+    from bifrost.commands.solution import installed_sdk_fingerprint
+
+    _write_installed_sdk(tmp_path, "abcd1234abcd1234")
+    assert installed_sdk_fingerprint(tmp_path) == "abcd1234abcd1234"
+
+
+def test_installed_sdk_fingerprint_none_when_missing(tmp_path):
+    from bifrost.commands.solution import installed_sdk_fingerprint
+
+    assert installed_sdk_fingerprint(tmp_path) is None          # no node_modules
+    _write_installed_sdk(tmp_path, None)                        # unstamped (old SDK)
+    assert installed_sdk_fingerprint(tmp_path) is None
+
+
+def test_sdk_update_skips_when_current(tmp_path, ...):
+    # mock server /api/version -> {"sdk_fingerprint": "abcd1234abcd1234"}
+    # installed fingerprint identical -> command exits 0, npm NOT invoked
+    ...
+
+
+def test_sdk_update_reinstalls_and_verifies(tmp_path, ...):
+    # installed "old", server "new"; mock subprocess npm install; after install,
+    # re-stamp the fake node_modules with "new" -> exits 0, prints old -> new
+    ...
+
+
+def test_sdk_update_fails_loud_when_still_stale(tmp_path, ...):
+    # npm install mocked as no-op; fingerprints still differ -> exit code 1
+    ...
+```
+
+Fill the `...` fixtures by copying the client/instance mocking approach used in `test_solution_dev_command.py` (read it; it has established fixtures for a bound workspace + fake API client).
+
+- [ ] **Step 2: Verify fail.** `./test.sh tests/unit/test_solution_sdk_update.py`
+- [ ] **Step 3: Implement** the `sdk` group + `update` command + `installed_sdk_fingerprint` in `api/bifrost/commands/solution.py`, reusing `solution start`'s app-dir/binding resolution and `_SDK_DOWNLOAD_SUFFIX`. Subprocess calls follow the file's existing npm-invocation style (it already runs npm for `solution start`).
+- [ ] **Step 4: Verify pass**, plus the CLI surface tripwires: `./test.sh tests/unit/test_solution_sdk_update.py tests/unit/test_cli_surface_smoke.py tests/unit/test_skill_appendix_fresh.py`. If the appendix test fails: `python api/scripts/skill-truth/generate.py`, commit the regenerated files.
+- [ ] **Step 5: Commit.** `git commit -am "feat(cli): bifrost solution sdk update"`
+
+---
+
+### Task 6: staleness warning in `bifrost solution start`
+
+**Files:**
+- Modify: `api/bifrost/commands/solution.py` (the `start` command path, near `_heal_sdk_dep` usage at line ~2293)
+- Test: `api/tests/unit/test_solution_start_sdk_warning.py` (create)
+
+**Interfaces:**
+- Consumes: `installed_sdk_fingerprint(app_dir)` and `installed_sdk_contract(app_dir)` (Task 5 — the latter reads `["bifrost"]["contract"]`, `None` if absent), server `sdk_fingerprint` + `sdk_contract_version` via `GET /api/version` (Task 4).
+- Produces: a pure helper returning the warning text or None — the `start` flow calls it and `click.secho`s the result (yellow for update-available, red for breaking):
+
+```python
+def sdk_staleness_warning(
+    installed_fp: str | None,
+    server_fp: str | None,
+    installed_contract: int | None,
+    server_contract: int | None,
+) -> tuple[str, str] | None:  # (message, severity: "warn"|"breaking") or None
+```
+
+Rules (tiered — "no change" is silent, "non-breaking" is gentle, "breaking" is loud):
+- `server_fp is None` (old server / fetch failed) → None (no warning, no noise).
+- Fingerprints equal → None. **Nothing changed → never prompts.**
+- Contract versions both present and DIFFERENT → `("Web SDK is incompatible with this server (SDK contract v<a>, server v<b>) — hooks may fail. Run: bifrost solution sdk update", "breaking")`.
+- Fingerprints differ, contracts equal (or either contract missing) → `("Web SDK update available (non-breaking). Run: bifrost solution sdk update", "warn")`.
+- `installed_fp is None` (unstamped old SDK) with `server_fp` present → the non-breaking "update available" message (can't tell more without a stamp).
+- The warning must never raise and never block startup — wrap the version fetch in try/except (with a why-comment) and treat failure as `server_fp=None`.
+
+- [ ] **Step 1: Write failing tests** for the four rule branches of `sdk_staleness_warning`, plus one CliRunner test asserting `solution start` prints the warning text (mock the version fetch + installed stamp) and STILL proceeds to boot (assert the next startup step is reached — follow how `test_solution_start_env.py` fakes the start sequence).
+- [ ] **Step 2: Verify fail.** `./test.sh tests/unit/test_solution_start_sdk_warning.py`
+- [ ] **Step 3: Implement** the helper + wire into `start` right after the SDK dep heal/install step (so the freshly-installed copy is what gets compared).
+- [ ] **Step 4: Verify pass**, plus re-run `./test.sh tests/unit/test_solution_dev_command.py tests/unit/test_solution_start_env.py` (nearest neighbors).
+- [ ] **Step 5: Commit.** `git commit -am "feat(cli): warn on stale web SDK in solution start"`
+
+---
+
+### Task 7: full verification + live drive (NOT subagent-delegable — run in the main session)
+
+**Files:** none (verification only)
+
+- [ ] Full local gates: `./test.sh unit`, `cd client && npx tsc --noEmit && npm run lint && npx vitest run`, `ruff check api/src api/bifrost`, pyright on touched files.
+- [ ] Boot the worktree debug stack (`bifrost-debug` skill), scaffold or reuse a v2 solution app bound to it, and drive as a real user:
+  - Short workflow (<5s): result appears, logs streamed live into the hook state.
+  - Long workflow (`time.sleep(360)`, 6 min — PAST the old 5-minute nginx ceiling): no 504, run resolves. This is the headline fix; do not skip it.
+  - Kill the API's websocket mid-run (restart api container): poll fallback resolves the run.
+  - Stale-SDK flow: install SDK, bump SDK source (touch a comment in `client/src/lib/app-sdk/index.v2.ts` inside the stack), restart api, `bifrost solution start` → warning prints; `bifrost solution sdk update` → refreshes; warning gone.
+- [ ] `python api/scripts/skill-truth/generate.py` if not already run; `bash scripts/sync-codex-skills.sh` if any skill files changed.
+- [ ] Commit any stragglers; push; open PR with `Fixes #484`.
+
+---
+
+## Self-Review Notes
+
+- Spec coverage: streaming transport (Tasks 1–3), fingerprint + version endpoint (Task 4), update command (Task 5), start warning (Task 6), debug-stack drive incl. >5-min run (Task 7). ✔
+- Type consistency: `ExecutionStreamEvent`/`subscribeToExecution` (T1) consumed verbatim in T2; `UseWorkflowState` additions (T2) passed through in T3; `sdk_fingerprint`/`installed_sdk_fingerprint` names consistent across T4–T6. ✔
+- Known unknowns called out inline rather than hidden: exact `version.py` handler shape (Task 4 step 1), `test_solution_dev_command.py` fixture reuse (Task 5 step 1), npm cache-bust behavior (Task 5 — verified-by-fingerprint regardless of npm's caching mood). Implementers must READ the named files before coding.

--- a/plugins/bifrost/skills/bifrost-build/generated/cli-reference.md
+++ b/plugins/bifrost/skills/bifrost-build/generated/cli-reference.md
@@ -1728,6 +1728,7 @@ Commands:
   migrate-app   Migrate a v1 inline app dir to a scaffolded standalone_v2...
   pull          Pull captured entities into the local .bifrost/ manifest...
   scaffold-app  Scaffold a standalone_v2 React app (package.json, vite,...
+  sdk           Manage the app's vendored Bifrost SDK.
   start         Run the app's dev server + local workflows (one origin).
   swap-slugs    Atomically exchange two apps' slugs (v1→v2 migration...
 ```
@@ -1928,6 +1929,31 @@ Options:
   --api-url TEXT  Instance URL the app resolves `bifrost` from (default:
                   $BIFROST_API_URL).
   --help          Show this message and exit.
+```
+
+### `solution sdk`
+
+```
+Usage: solution sdk [OPTIONS] COMMAND [ARGS]...
+
+  Manage the app's vendored Bifrost SDK.
+
+Options:
+  --help  Show this message and exit.
+
+Commands:
+  update  Re-vendor the Bifrost SDK into the app (re-download + reinstall).
+```
+
+#### `solution sdk update`
+
+```
+Usage: solution sdk update [OPTIONS] [PATH]
+
+  Re-vendor the Bifrost SDK into the app (re-download + reinstall).
+
+Options:
+  --help  Show this message and exit.
 ```
 
 ### `solution start`

--- a/plugins/bifrost/skills/bifrost-build/generated/cli-reference.md
+++ b/plugins/bifrost/skills/bifrost-build/generated/cli-reference.md
@@ -1953,7 +1953,9 @@ Usage: solution sdk update [OPTIONS] [PATH]
   Re-vendor the Bifrost SDK into the app (re-download + reinstall).
 
 Options:
-  --help  Show this message and exit.
+  --app TEXT  standalone_v2 app slug (required when the Solution has multiple
+              apps).
+  --help      Show this message and exit.
 ```
 
 ### `solution start`


### PR DESCRIPTION
## Summary

- switch the standalone v2 web SDK workflow hooks from the synchronous HTTP wait to async execute + live websocket status/log streaming + terminal result fetch
- fall back to polling when the execution socket closes, is rejected, or is revoked, without imposing a client-side deadline
- stamp SDK tarballs with a content fingerprint and contract version, expose both from `/api/version`, and add `bifrost solution sdk update` plus non-blocking `solution start` staleness warnings
- support targeted SDK refreshes in multi-app Solutions with `bifrost solution sdk update --app <slug>`
- add SDK wire-contract and CLI/generated-reference tripwires

## Verification

- `./test.sh unit` — 5,294 passed, 3 skipped, 19 deselected
- `npx vitest run src/lib/app-sdk/` — 14 files, 166 tests passed
- `npx tsc --noEmit` — passed
- `npm run lint` — 0 errors (one pre-existing React Compiler warning)
- `ruff check api/src api/bifrost` — passed
- focused SDK fingerprint/update/start regressions — 29 passed
- generated skill appendix and public/Codex mirrors refreshed; CLI surface tripwires passed in the full unit suite

## Live debug-stack drive

- short workflow exposed its first live log at 139 ms and resolved successfully at 2.469 s with all three logs
- workflow containing exact `time.sleep(360)` resolved successfully at 360.973 s with no 504, past the former five-minute proxy ceiling
- restarting the actual API container mid-run closed the websocket with code 1012; polling survived five temporary 502s during recovery and the run still resolved successfully with all 15 logs retained
- a deliberately stale SDK fingerprint produced the update warning; `bifrost solution sdk update` refreshed the fingerprint and the next `solution start` was warning-free

Final whole-branch re-review found no Critical or Important issues.

Fixes #484
