### PR TITLE
Fix local Solution workflows with streaming web SDK

### DIFF
--- a/api/bifrost/solution_dev/proxy.py
+++ b/api/bifrost/solution_dev/proxy.py
@@ -599,6 +599,25 @@ def _is_uuid(ref: str) -> bool:
 _SCOPE_BODY_FIELDS = ("solution_id", "form_id", "app_id")
 
 
+def _local_execution_response(*, result: Any = None, error: str | None = None) -> web.Response:
+    """Return a terminal execution shape for an in-process local workflow.
+
+    Local runs have no durable execution row to stream or poll. The canonical
+    terminal status lets the current SDK settle inline; the additive fields
+    remain compatible with pre-streaming SDKs, which read ``result``/``error``
+    directly from this same 200 response.
+    """
+    payload: dict[str, Any] = {
+        "execution_id": f"solution-start-{_uuid.uuid4()}",
+        "is_transient": True,
+    }
+    if error is None:
+        payload.update({"status": "Success", "result": result})
+    else:
+        payload.update({"status": "Failed", "error": error})
+    return web.json_response(payload)
+
+
 async def _execute_handler(request: web.Request) -> web.Response:
     cfg: DevProxyConfig = request.app[_CFG]
     host = request.app[_HOST]
@@ -635,7 +654,7 @@ async def _execute_handler(request: web.Request) -> web.Response:
     try:
         local_ref = host.resolve(ref)
     except LocalWorkflowError as exc:
-        return web.json_response({"error": str(exc)})
+        return _local_execution_response(error=str(exc))
 
     if local_ref is not None:
         if _is_uuid(ref) and ref not in request.app[_WARNED_UUID_REFS]:
@@ -655,20 +674,22 @@ async def _execute_handler(request: web.Request) -> web.Response:
             import traceback
 
             tb = traceback.format_exc()
-            return web.json_response({"error": f"{type(exc).__name__}: {exc}\n\n{tb}"})
-        return web.json_response({"status": "completed", "result": result})
+            return _local_execution_response(
+                error=f"{type(exc).__name__}: {exc}\n\n{tb}"
+            )
+        return _local_execution_response(result=result)
 
     if not cfg.global_repo_access:
         known = ", ".join(host.refs()) or "(none discovered)"
-        return web.json_response({
-            "error": (
+        return _local_execution_response(
+            error=(
                 f"Workflow '{ref}' not found in this Solution workspace. "
                 f"Local refs: {known}. This Solution does not set "
                 "global_repo_access: true in bifrost.solution.yaml, so "
                 "`bifrost solution start` will not ask the platform to "
                 "resolve it."
             )
-        })
+        )
 
     # Shared _repo/ fallback, stripped of every install-scope signal.
     fallback_body = {k: v for k, v in body.items() if k not in _SCOPE_BODY_FIELDS}

--- a/api/tests/unit/test_solution_dev_proxy.py
+++ b/api/tests/unit/test_solution_dev_proxy.py
@@ -205,10 +205,28 @@ async def test_local_path_ref_runs_in_function_host():
     dev_runner = await _serve(build_dev_app(cfg, host, vite_url="http://127.0.0.1:1"), dev_port)
     try:
         async with httpx.AsyncClient() as c:
-            r = await c.post(f"http://127.0.0.1:{dev_port}/api/workflows/execute",
-                             json={"workflow_id": "functions/hello.py::main", "input_data": {"x": 1}, "app_id": "A"})
-        assert r.status_code == 200
-        assert r.json()["result"] == {"ran_local": "functions/hello.py::main", "params": {"x": 1}}
+            responses = [
+                await c.post(
+                    f"http://127.0.0.1:{dev_port}/api/workflows/execute",
+                    json={
+                        "workflow_id": "functions/hello.py::main",
+                        "input_data": {"x": 1},
+                        "app_id": "A",
+                        **({"sync": True} if legacy else {}),
+                    },
+                )
+                for legacy in (False, True)
+            ]
+        for response in responses:
+            assert response.status_code == 200
+            body = response.json()
+            assert body["execution_id"].startswith("solution-start-")
+            assert body["is_transient"] is True
+            assert body["status"] == "Success"
+            assert body["result"] == {
+                "ran_local": "functions/hello.py::main",
+                "params": {"x": 1},
+            }
         assert host.last_call == ("functions/hello.py::main", {"x": 1})
         assert "execute_body" not in record  # never hit upstream
     finally:
@@ -224,10 +242,12 @@ class _RaisingHost:
         raise ValueError("boom in the workflow")
 
 
-async def test_local_error_returns_200_with_error_field():
+async def test_local_error_returns_inline_terminal_failure():
     # A local workflow exception must surface the real error to the SDK, which
     # reads `body.error` on a 200 (deployed contract); a non-200 would only show
-    # statusText. So the proxy returns 200 + {"error": "...boom..."}.
+    # statusText. The response is terminal so the streaming SDK does not poll
+    # an execution that exists only inside this process. A pre-streaming SDK
+    # still rejects the unchanged `error` field.
     up_port, dev_port = _free_port(), _free_port()
     up_runner = await _serve(_make_upstream({}), up_port)
     cfg = DevProxyConfig(upstream_url=f"http://127.0.0.1:{up_port}", token="t", app_id="A", org_id="O")
@@ -237,7 +257,11 @@ async def test_local_error_returns_200_with_error_field():
             r = await c.post(f"http://127.0.0.1:{dev_port}/api/workflows/execute",
                              json={"workflow_id": "functions/boom.py::main", "input_data": {}})
         assert r.status_code == 200
-        err = r.json()["error"]
+        body = r.json()
+        assert body["execution_id"].startswith("solution-start-")
+        assert body["is_transient"] is True
+        assert body["status"] == "Failed"
+        err = body["error"]
         assert "boom in the workflow" in err
         assert "ValueError" in err  # includes the exception type + traceback
     finally:
@@ -299,7 +323,11 @@ async def test_resolution_errors_surface_as_200_error_body():
                     json={"workflow_id": "Dup", "input_data": {}},
                 )
             assert r.status_code == 200
-            assert needle in r.json()["error"]
+            body = r.json()
+            assert body["execution_id"].startswith("solution-start-")
+            assert body["is_transient"] is True
+            assert body["status"] == "Failed"
+            assert needle in body["error"]
             assert "execute_body" not in record  # even with global access: no proxy
         finally:
             await dev_runner.cleanup()
@@ -325,6 +353,9 @@ async def test_unknown_ref_without_global_access_errors_locally():
             )
         assert r.status_code == 200
         body = r.json()
+        assert body["execution_id"].startswith("solution-start-")
+        assert body["is_transient"] is True
+        assert body["status"] == "Failed"
         assert "not found" in body["error"]
         assert "functions/hello.py::main" in body["error"]  # lists known refs
         assert "global_repo_access" in body["error"]


### PR DESCRIPTION
## Summary

- return contract-valid inline terminal responses for workflows run in-process by `bifrost solution start`
- preserve the pre-streaming SDK's synchronous `result`/`error` behavior, including its legacy `sync: true` request
- prevent the streaming SDK from subscribing to or polling `/api/executions/undefined`

## Verification

- `./test.sh tests/unit/test_solution_dev_proxy.py -q` — 21 passed
- `./test.sh unit` — 5294 passed, 3 skipped, 19 deselected
- `./test.sh quality api` — pyright and ruff passed
- live-drove the migrated Halo Dispatch Portal through the patched CLI proxy: three reloads, local workflows completed, full live Halo schedule rendered, no `/api/executions/undefined`

Fixes #488
