### PR TITLE
docs(skills): harden Solution lifecycle guidance

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "bifrost",
   "description": "Bifrost — MSP automation platform. Skills for building workflows, forms, agents, apps, tables, and files with the Bifrost SDK + CLI. Includes :build (create and debug artifacts), :setup (install CLI, authenticate, configure MCP), and :copilot-cowork-package (package Bifrost agents as Microsoft 365 Copilot Cowork plugins), :migrate (move a legacy v1 inline app + its backing entities into an installable v2 Solution).",
-  "version": "1.1.0",
+  "version": "1.1.1-dev.6",
   "author": {
     "name": "Jack Musick",
     "url": "https://github.com/gobifrost/bifrost"

--- a/.claude/skills/bifrost-build/SKILL.md
+++ b/.claude/skills/bifrost-build/SKILL.md
@@ -31,6 +31,12 @@ is the intended instance. If it is wrong, run from the intended workspace or
 neutral folder. Do not change the saved default merely to work with a debug
 stack; the debug skill creates a dedicated folder binding.
 
+A Codex sandbox may be unable to read the host OS keyring and can therefore
+make an existing login look absent. Before invoking setup or login, rerun the
+same read-only `bifrost auth default` probe with host access from the exact
+workspace you intend to use. If that host probe succeeds, reuse it; never log
+in again merely to work around a sandbox-only credential failure.
+
 Most entity commands do not accept `--url`; the folder binding is their
 connection selector. Never repoint a bound folder by overriding only
 `BIFROST_API_URL`, because folder-loaded tokens may belong to its original URL.

--- a/.claude/skills/bifrost-build/references/solutions.md
+++ b/.claude/skills/bifrost-build/references/solutions.md
@@ -29,6 +29,30 @@ Scaffolds a `standalone_v2` React app under `apps/my-app/`. Config files sit at 
 
 To migrate a v1 inline app to standalone_v2, use `bifrost solution migrate-app <source-slug> <v2-slug>` — it ports source + rewrites imports + prints a judgment checklist.
 
+### Logos have two independent scopes
+
+Port both when a Solution app has a brand icon:
+
+```yaml
+# bifrost.solution.yaml — path relative to the Solution root
+logo: apps/my-app/public/logo.svg
+```
+
+```yaml
+# .bifrost/apps.yaml — path relative to that app's `path`
+apps:
+  <app-manifest-id>:
+    path: apps/my-app
+    logo: public/logo.svg
+```
+
+The descriptor logo is the Solution-catalog icon served by
+`GET /api/solutions/{solution_id}/logo`. The app-manifest logo is the
+`BifrostHeader` icon served by `GET /api/applications/{app_id}/logo`.
+Deploy owns and full-replaces both, so setting only one leaves the other UI
+surface blank. Keep the image tracked inside the workspace and verify both
+live records after deploy.
+
 ### 3. Write workflows in `functions/`
 
 Python workflows live in `functions/` (e.g. `functions/hello.py`). Reference them by portable `path::function` strings, never by UUID or bare name:
@@ -71,6 +95,15 @@ bifrost solution start
 Runs the app's Vite dev server and local workflow functions behind one origin — no deploy required. Hot reload works for both app code and workflow code. `start` requires the workspace's `.env` Solution binding, or an explicit `--solution <id-or-slug>` override; install scope comes from that binding, not `--org`.
 
 Open the origin the command prints (the **proxy** port; `--port` sets it, default 3000). Vite itself binds to **`--port + 1`** behind the proxy — drive the app at the proxy port the command prints, not the Vite port.
+
+After any CLI, server, or web-SDK execution-transport change, drive an actual
+bound app through this origin; a scaffold or mocked unit test is not enough.
+For a local workflow, verify the terminal `POST /api/workflows/execute`
+response contains a non-empty `execution_id`, terminal `status`,
+`is_transient: true`, and the appropriate legacy inline `result` or `error`.
+The app must settle that response inline without opening a websocket or
+polling `GET /api/executions/{execution_id}`. Keep those inline fields when
+adding transport metadata because pre-streaming SDKs consume them directly.
 
 ### 5. Deploy
 

--- a/.claude/skills/bifrost-build/references/sources.yaml
+++ b/.claude/skills/bifrost-build/references/sources.yaml
@@ -64,7 +64,7 @@ references:
       - api/src/models/contracts/solutions.py
       - api/src/services/solution_files.py
       - api/src/services/solutions/*.py
-    verified_at_sha: 236d0f4753b4b14cfc05c42dccbe9db26b411a77
+    verified_at_sha: 44fed5904f8b36b2f8ace25c17e144a8fb89dc87
 
   - file: references/tables.md
     source_globs:

--- a/.claude/skills/bifrost-migrate/SKILL.md
+++ b/.claude/skills/bifrost-migrate/SKILL.md
@@ -147,6 +147,9 @@ renders UNSTYLED. Verify with `vite build` (step 8) AND a screenshot, not just a
   toggle and recolors its own chrome. If the app has hardcoded light colors, omit `supportsTheme`.
 - **BifrostHeader**: keep it in `App.tsx` for the familiar chrome (back-to-Bifrost, user menu).
 - **basename**: the scaffold sets `basename` from the boot; v2 apps mount at `/apps/{slug}`.
+- **brand icon**: port the tracked image in both scopes. Set the Solution-root-relative `logo:` in
+  `bifrost.solution.yaml` for the catalog card, and set the app-relative `logo:` under the app's
+  `.bifrost/apps.yaml` entry for `BifrostHeader`. See the Build skill's `references/solutions.md`.
 
 ### 7. Rename workflows to the org convention (ref-safe)
 
@@ -226,6 +229,8 @@ A's Solution would orphan B's reference across the scope boundary. Report it; le
 - The v2 app builds + runs under `bifrost solution start`, every page works.
 - Capture `--dry-run` shows no dangling refs after rename (refs rewritten).
 - The live slug now serves the v2 app (`bifrost api GET /api/applications/<old-slug>` → the v2 row).
+- Both the Solution catalog record and application record carry the migrated logo when the v1 app
+  had one; verify the two logo scopes separately after deploy.
 - Backing entities are solution-owned (`bifrost api GET /api/solutions/<id>/entities`).
 - A shared-entity report exists for anything irreducibly shared.
 

--- a/.claude/skills/bifrost-setup/SKILL.md
+++ b/.claude/skills/bifrost-setup/SKILL.md
@@ -41,6 +41,10 @@ command -v bifrost >/dev/null && bifrost auth default
 
 The environment flags are hints. When the CLI is installed, the read-only
 `bifrost auth default` output is the source of truth for the current folder.
+If a Codex sandbox reports no credentials, rerun that command with host access
+from the exact intended workspace before entering the Login flow. Sandboxing
+can hide the OS keyring; a successful host probe means the user is already
+logged in and the existing connection must be reused.
 
 ## Resume Logic
 
@@ -144,6 +148,39 @@ bifrost help
 
 If `bifrost` is not on PATH yet, open a new PowerShell window or run it from
 `%USERPROFILE%\.local\bin\bifrost.exe`.
+
+## Update an Existing Installation
+
+Treat these as three independent update planes. Updating one does not update
+the others; update the CLI first because it supplies the SDK-update command.
+
+1. **CLI from the intended Bifrost instance:**
+   ```bash
+   pipx install --force {url}/api/cli/download
+   bifrost --version
+   ```
+   On native Windows, use
+   `py -3.11 -m pipx install --force {url}/api/cli/download`.
+2. **Vendored web SDK in each Solution workspace:**
+   ```bash
+   cd /path/to/solution
+   bifrost solution sdk update
+   ```
+   Review and commit the changed vendored SDK files, then rerun
+   `bifrost solution start` and confirm any stale-SDK warning is gone.
+3. **Installed Codex plugin:**
+   ```bash
+   codex plugin marketplace upgrade bifrost
+   codex plugin list
+   ```
+   If the installed version remains stale, refresh its cached content:
+   ```bash
+   codex plugin remove bifrost@bifrost
+   codex plugin add bifrost@bifrost
+   codex plugin list
+   ```
+   Start a new Codex task (or restart Codex) afterward; the current task keeps
+   the skill text it loaded at startup.
 
 ## Login
 

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "bifrost",
-  "version": "1.1.0",
+  "version": "1.1.1-dev.6",
   "description": "Bifrost — MSP automation platform. Skills for building workflows, forms, agents, apps, tables, and files with the Bifrost SDK + CLI, setting up local Bifrost development, and packaging Bifrost agents as Microsoft 365 Copilot Cowork plugins, :migrate (move a legacy v1 inline app + its backing entities into an installable v2 Solution).",
   "author": {
     "name": "Jack Musick",

--- a/plugins/bifrost/.codex-plugin/plugin.json
+++ b/plugins/bifrost/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "bifrost",
-  "version": "1.1.0",
+  "version": "1.1.1-dev.6",
   "description": "Bifrost — MSP automation platform. Skills for building workflows, forms, agents, apps, tables, and files with the Bifrost SDK + CLI, setting up local Bifrost development, and packaging Bifrost agents as Microsoft 365 Copilot Cowork plugins, :migrate (move a legacy v1 inline app + its backing entities into an installable v2 Solution).",
   "author": {
     "name": "Jack Musick",

--- a/plugins/bifrost/skills/bifrost-build/SKILL.md
+++ b/plugins/bifrost/skills/bifrost-build/SKILL.md
@@ -31,6 +31,12 @@ is the intended instance. If it is wrong, run from the intended workspace or
 neutral folder. Do not change the saved default merely to work with a debug
 stack; the debug skill creates a dedicated folder binding.
 
+A Codex sandbox may be unable to read the host OS keyring and can therefore
+make an existing login look absent. Before invoking setup or login, rerun the
+same read-only `bifrost auth default` probe with host access from the exact
+workspace you intend to use. If that host probe succeeds, reuse it; never log
+in again merely to work around a sandbox-only credential failure.
+
 Most entity commands do not accept `--url`; the folder binding is their
 connection selector. Never repoint a bound folder by overriding only
 `BIFROST_API_URL`, because folder-loaded tokens may belong to its original URL.

--- a/plugins/bifrost/skills/bifrost-build/references/solutions.md
+++ b/plugins/bifrost/skills/bifrost-build/references/solutions.md
@@ -29,6 +29,30 @@ Scaffolds a `standalone_v2` React app under `apps/my-app/`. Config files sit at 
 
 To migrate a v1 inline app to standalone_v2, use `bifrost solution migrate-app <source-slug> <v2-slug>` — it ports source + rewrites imports + prints a judgment checklist.
 
+### Logos have two independent scopes
+
+Port both when a Solution app has a brand icon:
+
+```yaml
+# bifrost.solution.yaml — path relative to the Solution root
+logo: apps/my-app/public/logo.svg
+```
+
+```yaml
+# .bifrost/apps.yaml — path relative to that app's `path`
+apps:
+  <app-manifest-id>:
+    path: apps/my-app
+    logo: public/logo.svg
+```
+
+The descriptor logo is the Solution-catalog icon served by
+`GET /api/solutions/{solution_id}/logo`. The app-manifest logo is the
+`BifrostHeader` icon served by `GET /api/applications/{app_id}/logo`.
+Deploy owns and full-replaces both, so setting only one leaves the other UI
+surface blank. Keep the image tracked inside the workspace and verify both
+live records after deploy.
+
 ### 3. Write workflows in `functions/`
 
 Python workflows live in `functions/` (e.g. `functions/hello.py`). Reference them by portable `path::function` strings, never by UUID or bare name:
@@ -71,6 +95,15 @@ bifrost solution start
 Runs the app's Vite dev server and local workflow functions behind one origin — no deploy required. Hot reload works for both app code and workflow code. `start` requires the workspace's `.env` Solution binding, or an explicit `--solution <id-or-slug>` override; install scope comes from that binding, not `--org`.
 
 Open the origin the command prints (the **proxy** port; `--port` sets it, default 3000). Vite itself binds to **`--port + 1`** behind the proxy — drive the app at the proxy port the command prints, not the Vite port.
+
+After any CLI, server, or web-SDK execution-transport change, drive an actual
+bound app through this origin; a scaffold or mocked unit test is not enough.
+For a local workflow, verify the terminal `POST /api/workflows/execute`
+response contains a non-empty `execution_id`, terminal `status`,
+`is_transient: true`, and the appropriate legacy inline `result` or `error`.
+The app must settle that response inline without opening a websocket or
+polling `GET /api/executions/{execution_id}`. Keep those inline fields when
+adding transport metadata because pre-streaming SDKs consume them directly.
 
 ### 5. Deploy
 

--- a/plugins/bifrost/skills/bifrost-build/references/sources.yaml
+++ b/plugins/bifrost/skills/bifrost-build/references/sources.yaml
@@ -64,7 +64,7 @@ references:
       - api/src/models/contracts/solutions.py
       - api/src/services/solution_files.py
       - api/src/services/solutions/*.py
-    verified_at_sha: 236d0f4753b4b14cfc05c42dccbe9db26b411a77
+    verified_at_sha: 44fed5904f8b36b2f8ace25c17e144a8fb89dc87
 
   - file: references/tables.md
     source_globs:

--- a/plugins/bifrost/skills/bifrost-migrate/SKILL.md
+++ b/plugins/bifrost/skills/bifrost-migrate/SKILL.md
@@ -147,6 +147,9 @@ renders UNSTYLED. Verify with `vite build` (step 8) AND a screenshot, not just a
   toggle and recolors its own chrome. If the app has hardcoded light colors, omit `supportsTheme`.
 - **BifrostHeader**: keep it in `App.tsx` for the familiar chrome (back-to-Bifrost, user menu).
 - **basename**: the scaffold sets `basename` from the boot; v2 apps mount at `/apps/{slug}`.
+- **brand icon**: port the tracked image in both scopes. Set the Solution-root-relative `logo:` in
+  `bifrost.solution.yaml` for the catalog card, and set the app-relative `logo:` under the app's
+  `.bifrost/apps.yaml` entry for `BifrostHeader`. See the Build skill's `references/solutions.md`.
 
 ### 7. Rename workflows to the org convention (ref-safe)
 
@@ -226,6 +229,8 @@ A's Solution would orphan B's reference across the scope boundary. Report it; le
 - The v2 app builds + runs under `bifrost solution start`, every page works.
 - Capture `--dry-run` shows no dangling refs after rename (refs rewritten).
 - The live slug now serves the v2 app (`bifrost api GET /api/applications/<old-slug>` → the v2 row).
+- Both the Solution catalog record and application record carry the migrated logo when the v1 app
+  had one; verify the two logo scopes separately after deploy.
 - Backing entities are solution-owned (`bifrost api GET /api/solutions/<id>/entities`).
 - A shared-entity report exists for anything irreducibly shared.
 

--- a/plugins/bifrost/skills/bifrost-setup/SKILL.md
+++ b/plugins/bifrost/skills/bifrost-setup/SKILL.md
@@ -41,6 +41,10 @@ command -v bifrost >/dev/null && bifrost auth default
 
 The environment flags are hints. When the CLI is installed, the read-only
 `bifrost auth default` output is the source of truth for the current folder.
+If a Codex sandbox reports no credentials, rerun that command with host access
+from the exact intended workspace before entering the Login flow. Sandboxing
+can hide the OS keyring; a successful host probe means the user is already
+logged in and the existing connection must be reused.
 
 ## Resume Logic
 
@@ -144,6 +148,39 @@ bifrost help
 
 If `bifrost` is not on PATH yet, open a new PowerShell window or run it from
 `%USERPROFILE%\.local\bin\bifrost.exe`.
+
+## Update an Existing Installation
+
+Treat these as three independent update planes. Updating one does not update
+the others; update the CLI first because it supplies the SDK-update command.
+
+1. **CLI from the intended Bifrost instance:**
+   ```bash
+   pipx install --force {url}/api/cli/download
+   bifrost --version
+   ```
+   On native Windows, use
+   `py -3.11 -m pipx install --force {url}/api/cli/download`.
+2. **Vendored web SDK in each Solution workspace:**
+   ```bash
+   cd /path/to/solution
+   bifrost solution sdk update
+   ```
+   Review and commit the changed vendored SDK files, then rerun
+   `bifrost solution start` and confirm any stale-SDK warning is gone.
+3. **Installed Codex plugin:**
+   ```bash
+   codex plugin marketplace upgrade bifrost
+   codex plugin list
+   ```
+   If the installed version remains stale, refresh its cached content:
+   ```bash
+   codex plugin remove bifrost@bifrost
+   codex plugin add bifrost@bifrost
+   codex plugin list
+   ```
+   Start a new Codex task (or restart Codex) afterward; the current task keeps
+   the skill text it loaded at startup.
 
 ## Login
 


### PR DESCRIPTION
## Summary

- guard existing host-keyring logins from Codex sandbox false-negatives
- distinguish CLI, vendored web SDK, and Codex plugin update planes
- document independent Solution-catalog and application-header logo manifests
- require a real bound-app local execution compatibility check
- sync public skill mirrors and bump plugin manifests to `1.1.1-dev.6`

## Verification

- `python3 .../quick_validate.py` for Build, Setup, and Migrate
- byte-identical canonical/public skill mirror checks
- `./test.sh tests/unit/test_skill_appendix_fresh.py tests/unit/test_codex_mirror_sync.py tests/unit/test_skill_reference_freshness.py tests/unit/test_skill_examples.py tests/unit/test_cli_surface_smoke.py` (125 passed, 3 expected container skips)
- `./test.sh unit` (5,294 passed, 3 expected host-only skips, 19 deselected)
- clean-room forward test of the updated workflow

Closes #490