### PR TITLE
Fix Watch hidden-file filtering

### DIFF
--- a/api/bifrost/cli.py
+++ b/api/bifrost/cli.py
@@ -171,9 +171,7 @@ def _build_file_filter(local_root: pathlib.Path) -> "pathspec.PathSpec":
     """
     import pathspec
 
-    # Always start with defaults (.git/, __pycache__, etc.) — .gitignore
-    # never lists .git/ because git handles it implicitly, but we need it.
-    lines = list(_DEFAULT_IGNORE_PATTERNS)
+    lines: list[str] = []
 
     workspace_root = _workspace_root_for(local_root)
     workspace_gitignore = workspace_root / ".gitignore"
@@ -183,6 +181,10 @@ def _build_file_filter(local_root: pathlib.Path) -> "pathspec.PathSpec":
     gitignore_path = local_root / ".gitignore"
     if gitignore_path != workspace_gitignore and gitignore_path.is_file():
         lines.extend(gitignore_path.read_text(encoding="utf-8").splitlines())
+
+    # Canonical safety exclusions are appended last so a .gitignore negation
+    # cannot re-include secrets, agent state, dependency trees, or build output.
+    lines.extend(_DEFAULT_IGNORE_PATTERNS)
 
     return pathspec.PathSpec.from_lines("gitwildmatch", lines)
 
@@ -2210,6 +2212,14 @@ Examples:
         print(f"Error: {parsed.local_path} is not a valid directory", file=sys.stderr)
         return 1
 
+    if resolved == pathlib.Path.home().resolve():
+        print(
+            "Error: refusing to watch your home directory. "
+            "Choose a project or workspace subdirectory instead.",
+            file=sys.stderr,
+        )
+        return 1
+
     # Refuse inside a Solution workspace (D1). `watch` only ever syncs to the
     # global `_repo/` workspace; a Solution developer running it here would
     # silently push their apps/ and workflows/ to `_repo/` instead of the
@@ -2891,10 +2901,15 @@ async def _process_incoming(
     and drops the no-op push.
     """
     ts = datetime.now().strftime('%H:%M:%S')
+    spec = _build_file_filter(base_path)
+    resolved_base = base_path.resolve()
 
     # Process incoming file changes
     for paths, user_name in files:
         for repo_path in paths:
+            rel = _incoming_relative_path(repo_path, repo_prefix)
+            if rel is None or _should_skip_path(rel, spec, repo_path):
+                continue
             try:
                 resp = await client.post("/api/files/read", json={
                     "path": repo_path,
@@ -2906,14 +2921,11 @@ async def _process_incoming(
                     data = resp.json()
                     content = base64.b64decode(data["content"])
                     content_hash = _hash_for_cache(content)
-                    # Convert repo_path to local path
-                    if repo_prefix and repo_path.startswith(repo_prefix + "/"):
-                        rel = repo_path[len(repo_prefix) + 1:]
-                    elif repo_prefix and repo_path.startswith(repo_prefix):
-                        rel = repo_path[len(repo_prefix):]
-                    else:
-                        rel = repo_path
-                    local_file = base_path / rel
+                    local_file = (base_path / rel).resolve()
+                    try:
+                        local_file.relative_to(resolved_base)
+                    except ValueError:
+                        continue
                     local_file.parent.mkdir(parents=True, exist_ok=True)
                     # Skip if we already know the server has this content and
                     # the local file matches (cache hit). Falls back to a byte
@@ -2953,13 +2965,14 @@ async def _process_incoming(
     # Process incoming deletes
     for paths, user_name in deletes:
         for repo_path in paths:
-            if repo_prefix and repo_path.startswith(repo_prefix + "/"):
-                rel = repo_path[len(repo_prefix) + 1:]
-            elif repo_prefix and repo_path.startswith(repo_prefix):
-                rel = repo_path[len(repo_prefix):]
-            else:
-                rel = repo_path
-            local_file = base_path / rel
+            rel = _incoming_relative_path(repo_path, repo_prefix)
+            if rel is None or _should_skip_path(rel, spec, repo_path):
+                continue
+            local_file = (base_path / rel).resolve()
+            try:
+                local_file.relative_to(resolved_base)
+            except ValueError:
+                continue
             if local_file.exists():
                 try:
                     local_file.unlink()
@@ -3202,15 +3215,43 @@ def _strip_repo_prefix(repo_path: str, repo_prefix: str) -> str:
     return repo_path
 
 
+def _has_hidden_path_component(path: str) -> bool:
+    """Return whether a POSIX repo path contains a hidden component."""
+    normalized = path.replace("\\", "/")
+    return any(part.startswith(".") for part in pathlib.PurePosixPath(normalized).parts)
+
+
 def _should_skip_path(
     rel_path: str,
     spec: "pathspec.PathSpec",
     repo_path: str | None = None,
 ) -> bool:
-    """Check if a relative path should be skipped during push/watch."""
+    """Apply hidden-path, canonical, and gitignore filtering."""
+    if _has_hidden_path_component(rel_path):
+        return True
+    if repo_path is not None and _has_hidden_path_component(repo_path):
+        return True
     if spec.match_file(rel_path):
         return True
     return repo_path is not None and repo_path != rel_path and spec.match_file(repo_path)
+
+
+def _incoming_relative_path(repo_path: str, repo_prefix: str) -> str | None:
+    """Map an incoming repo key to a safe, in-scope local relative path."""
+    normalized = repo_path.replace("\\", "/")
+    if not normalized or normalized.startswith("/"):
+        return None
+    if any(part in ("", ".", "..") for part in normalized.split("/")):
+        return None
+
+    if repo_prefix:
+        prefix = repo_prefix.replace("\\", "/").strip("/")
+        prefix_with_slash = prefix + "/"
+        if not normalized.startswith(prefix_with_slash):
+            return None
+        normalized = normalized[len(prefix_with_slash):]
+
+    return normalized or None
 
 
 def _collect_push_files(

--- a/api/bifrost/ignore_patterns.py
+++ b/api/bifrost/ignore_patterns.py
@@ -17,6 +17,12 @@ from __future__ import annotations
 #: and must never leave the workspace via sync OR Solution capture/export.
 DEFAULT_IGNORE_PATTERNS: list[str] = [
     ".git/",
+    # Agent state can contain full conversation transcripts, tool results,
+    # credentials, and caches. Keep explicit entries here as defense in depth
+    # for collectors that use this canonical list without the CLI's blanket
+    # hidden-path rule (for example Solution capture).
+    ".claude/",
+    ".codex/",
     "__pycache__/",
     ".ruff_cache/",
     ".mypy_cache/",

--- a/api/tests/unit/test_cli_watch.py
+++ b/api/tests/unit/test_cli_watch.py
@@ -292,6 +292,30 @@ def test_watch_handler_respects_gitignore(tmp_path):
     assert str(real_path) in state.pending_changes
 
 
+def test_watch_handler_drops_all_hidden_path_events(tmp_path):
+    """Root and nested hidden paths must never enter the watch queue."""
+    state = _WatchState(tmp_path)
+    handler = _WatchChangeHandler(state)
+
+    hidden_paths = (
+        tmp_path / ".bash_history",
+        tmp_path / ".claude" / "projects" / "session.jsonl",
+        tmp_path / ".codex" / "sessions" / "session.jsonl",
+        tmp_path / "src" / ".cache" / "mcp.log",
+    )
+    for hidden_path in hidden_paths:
+        hidden_path.parent.mkdir(parents=True, exist_ok=True)
+        hidden_path.write_text("private\n")
+        handler.dispatch(_fake_event("modified", str(hidden_path)))
+
+    visible_path = tmp_path / "src" / "workflow.py"
+    visible_path.write_text("print('ok')\n")
+    handler.dispatch(_fake_event("modified", str(visible_path)))
+
+    assert state.pending_changes == {str(visible_path)}
+    assert state.pending_deletes == set()
+
+
 def test_watch_handler_respects_root_gitignore_for_subdirectory_watch(tmp_path):
     """Root .gitignore patterns should apply when watching a subdirectory."""
     (tmp_path / ".gitignore").write_text("/apps/my-app/generated/\n*.local\n")
@@ -395,6 +419,18 @@ def test_watch_allowed_in_plain_repo_workspace(tmp_path):
             handle_watch([str(tmp_path)])
         except RuntimeError as e:
             assert str(e) == "stop-after-guard"
+
+
+def test_watch_refuses_home_directory(tmp_path, monkeypatch, capsys):
+    """A mistaken watch from $HOME must fail before auth or filesystem work."""
+    from bifrost.cli import handle_watch
+
+    monkeypatch.setattr(pathlib.Path, "home", lambda: tmp_path)
+    with patch("bifrost.cli.WorkspaceLock") as mock_lock:
+        assert handle_watch([str(tmp_path)]) == 1
+
+    assert "refusing to watch your home directory" in capsys.readouterr().err
+    mock_lock.assert_not_called()
 
 
 # =============================================================================

--- a/api/tests/unit/test_cli_without_bifrost_marker.py
+++ b/api/tests/unit/test_cli_without_bifrost_marker.py
@@ -71,6 +71,48 @@ def test_file_filter_excludes_common_tool_caches(tmp_path: pathlib.Path) -> None
     assert files.keys() == {"workflow.py"}
 
 
+def test_file_filter_excludes_all_hidden_paths(tmp_path: pathlib.Path) -> None:
+    hidden_files = (
+        ".bash_history",
+        ".claude/projects/session.jsonl",
+        ".codex/sessions/session.jsonl",
+        "src/.cache/mcp.log",
+        "src/.private.txt",
+    )
+    for relative in hidden_files:
+        hidden_file = tmp_path / relative
+        hidden_file.parent.mkdir(parents=True, exist_ok=True)
+        hidden_file.write_text("private\n")
+    (tmp_path / "workflow.py").write_text("print('ok')\n")
+
+    files, skipped = cli._collect_push_files(tmp_path, "")
+
+    assert skipped == 0
+    assert files.keys() == {"workflow.py"}
+
+
+def test_gitignore_cannot_reinclude_hidden_or_canonical_ignored_paths(
+    tmp_path: pathlib.Path,
+) -> None:
+    (tmp_path / ".gitignore").write_text(
+        "!.bash_history\n!.claude/**\n!node_modules/**\n"
+    )
+    for relative in (
+        ".bash_history",
+        ".claude/projects/session.jsonl",
+        "node_modules/package/index.js",
+    ):
+        ignored_file = tmp_path / relative
+        ignored_file.parent.mkdir(parents=True, exist_ok=True)
+        ignored_file.write_text("private\n")
+    (tmp_path / "workflow.py").write_text("print('ok')\n")
+
+    files, skipped = cli._collect_push_files(tmp_path, "")
+
+    assert skipped == 0
+    assert files.keys() == {"workflow.py"}
+
+
 def test_subdirectory_push_respects_root_gitignore(tmp_path: pathlib.Path) -> None:
     (tmp_path / ".gitignore").write_text("/apps/my-app/generated/\n*.local\n")
     app_dir = tmp_path / "apps" / "my-app"

--- a/api/tests/unit/test_solution_capture.py
+++ b/api/tests/unit/test_solution_capture.py
@@ -219,6 +219,8 @@ async def test_capture_app_skips_secret_and_build_files(db_session) -> None:
         "apps/portal/node_modules/dep/index.js": b"module.exports = {}",
         "apps/portal/dist/bundle.js": b"compiled",
         "apps/portal/.DS_Store": b"\x00\x01",
+        "apps/portal/.claude/projects/session.jsonl": b"private transcript",
+        "apps/portal/.codex/sessions/session.jsonl": b"private transcript",
     })
 
     await SolutionCaptureService(db, repo=repo).capture(
@@ -237,8 +239,15 @@ async def test_capture_app_skips_secret_and_build_files(db_session) -> None:
     app_dir = apps_yaml["apps"][str(app.id)]["path"]
     assert f"{app_dir}/src/App.tsx" in names
     # Secrets + build junk are excluded — no entry under the app dir for them.
-    for skipped in (".env", ".env.production", "node_modules/dep/index.js",
-                    "dist/bundle.js", ".DS_Store"):
+    for skipped in (
+        ".env",
+        ".env.production",
+        "node_modules/dep/index.js",
+        "dist/bundle.js",
+        ".DS_Store",
+        ".claude/projects/session.jsonl",
+        ".codex/sessions/session.jsonl",
+    ):
         assert f"{app_dir}/{skipped}" not in names, f"{skipped} leaked into export"
 
 

--- a/api/tests/unit/test_watch_echo_suppression.py
+++ b/api/tests/unit/test_watch_echo_suppression.py
@@ -381,3 +381,72 @@ async def test_incoming_delete_evicts_cache(tmp_path: pathlib.Path) -> None:
         state=state,
     )
     assert state.get_known_hash(repo_path) is None
+
+
+@pytest.mark.asyncio
+async def test_incoming_files_drop_hidden_out_of_prefix_and_unsafe_paths(
+    tmp_path: pathlib.Path,
+) -> None:
+    """Inbound events are filtered before the CLI reads or writes them."""
+    root = tmp_path / "workspace"
+    root.mkdir()
+    valid = "apps/demo/src/main.py"
+    rejected = (
+        "apps/demo/.claude/projects/session.jsonl",
+        "apps/demo/src/.codex/session.jsonl",
+        "apps/other/src/main.py",
+        "apps/demo-evil/src/main.py",
+        "apps/demo/../../escape.txt",
+    )
+    server_files = {valid: b"print('ok')\n"}
+    server_files.update({path: b"private\n" for path in rejected})
+    state = _WatchState(root)
+    client: Any = _RecordingClient(server_files=server_files)
+
+    await _process_incoming(
+        client,
+        files=[([valid, *rejected], "user_a")],
+        deletes=[],
+        base_path=root,
+        repo_prefix="apps/demo",
+        state=state,
+    )
+
+    reads = [payload["path"] for url, payload in client.posted if url == "/api/files/read"]
+    assert reads == [valid]
+    assert (root / "src" / "main.py").read_bytes() == b"print('ok')\n"
+    assert not (tmp_path / "escape.txt").exists()
+
+
+@pytest.mark.asyncio
+async def test_incoming_deletes_drop_hidden_and_out_of_prefix_paths(
+    tmp_path: pathlib.Path,
+) -> None:
+    root = tmp_path / "workspace"
+    valid = root / "src" / "remove.py"
+    hidden = root / ".claude" / "session.jsonl"
+    out_of_prefix = root / "apps" / "other" / "keep.py"
+    for local_file in (valid, hidden, out_of_prefix):
+        local_file.parent.mkdir(parents=True, exist_ok=True)
+        local_file.write_text("keep\n")
+
+    state = _WatchState(root)
+    client: Any = _RecordingClient(server_files={})
+    await _process_incoming(
+        client,
+        files=[],
+        deletes=[
+            ([
+                "apps/demo/src/remove.py",
+                "apps/demo/.claude/session.jsonl",
+                "apps/other/keep.py",
+            ], "user_a"),
+        ],
+        base_path=root,
+        repo_prefix="apps/demo",
+        state=state,
+    )
+
+    assert not valid.exists()
+    assert hidden.exists()
+    assert out_of_prefix.exists()


### PR DESCRIPTION
## Summary
- restore blanket hidden-component filtering alongside `.gitignore` and canonical exclusions
- explicitly exclude `.claude/` and `.codex/` from CLI sync and Solution capture
- reject `bifrost watch` when rooted at `$HOME`
- filter inbound Watch events for ignored, out-of-prefix, traversal, and symlink-escape paths before filesystem mutation
- prevent `.gitignore` negations from re-including canonical safety exclusions

## Verification
- `./test.sh tests/e2e/platform/test_subscriptions.py::test_subscription_revoked_on_policy_change tests/unit/test_cli_without_bifrost_marker.py tests/unit/test_cli_watch.py tests/unit/test_watch_echo_suppression.py tests/unit/test_solution_capture.py -q` — 53 passed
- `./test.sh quality api` — Pyright and Ruff passed
- `npm run tsc` — passed
- `npm run lint` — passed with one existing React Hook Form compiler warning
- `./test.sh all` — 7001 passed, 55 skipped, one websocket subscription timeout after the 29-minute aggregate run; that test passed immediately in the isolated verification above

Fixes #492