### PR TITLE
Clarify app-wide theme support guidance

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "bifrost",
   "description": "Bifrost — MSP automation platform. Skills for building workflows, forms, agents, apps, tables, and files with the Bifrost SDK + CLI. Includes :build (create and debug artifacts), :setup (install CLI, authenticate, configure MCP), and :copilot-cowork-package (package Bifrost agents as Microsoft 365 Copilot Cowork plugins), :migrate (move a legacy v1 inline app + its backing entities into an installable v2 Solution).",
-  "version": "1.1.1-dev.6",
+  "version": "1.1.1-dev.9",
   "author": {
     "name": "Jack Musick",
     "url": "https://github.com/gobifrost/bifrost"

--- a/.claude/skills/bifrost-build/references/apps.md
+++ b/.claude/skills/bifrost-build/references/apps.md
@@ -327,6 +327,21 @@ if (!state?.name) return <Navigate to="/" />;
 
 Apps go through the platform's per-app Tailwind v4 pipeline at bundle time.
 
+`supportsTheme` on `<BifrostProvider>` is an **app-wide capability contract**. It does not theme the
+application for you; it exposes the `BifrostHeader` toggle and applies the root `.dark` class. Keep
+it only when the entire app responds correctly. Audit every route, layout, overlay, form control,
+table, chart, and loading/empty/error state—not just the header.
+
+- Prefer semantic tokens: `bg-background`, `text-foreground`, `bg-card`,
+  `text-card-foreground`, `border-border`, `bg-muted`, `text-muted-foreground`, `bg-primary`,
+  `text-primary-foreground`, and `text-destructive`.
+- Replace hardcoded light utilities such as `bg-white`, `text-slate-*`, and `border-gray-*`.
+- For intentional brand or data-series colors, define paired `:root` and `.dark` variables. Use
+  `dark:` variants only when the semantic token system cannot express the design.
+- Verify every route and overlay after toggling both light and dark modes. A themed header above a
+  light-only app is a failure. If full support is out of scope, remove `supportsTheme` so the toggle
+  is not shown.
+
 What works: all standard utilities, host shadcn theme tokens (`bg-background`, `text-muted-foreground`), arbitrary values, `@apply` in `styles.css`, `@layer components`, `:root` and `.dark` CSS variable blocks, per-app `tailwind.config.ts` with `theme.extend`.
 
 What is NOT supported: Tailwind plugins beyond `@tailwindcss/typography`; `@source` directives outside the app root.

--- a/.claude/skills/bifrost-build/references/solutions.md
+++ b/.claude/skills/bifrost-build/references/solutions.md
@@ -27,6 +27,12 @@ Scaffolds a `standalone_v2` React app under `apps/my-app/`. Config files sit at 
 
 > The scaffold wires up Tailwind (`@tailwindcss/vite` + shadcn theme tokens in `src/index.css`) but the generated `App.tsx` uses minimal **inline styles** (`style={{ padding: 24 }}`) as a plain starting point. Replace them with Tailwind classes (`className="p-6 ..."`) before building — the infrastructure is ready. See `references/apps.md` for v2 styling patterns.
 
+> The scaffold also opts into `<BifrostProvider supportsTheme>`, so `BifrostHeader` exposes the
+> theme toggle. Before deploy, make the **whole app** theme-aware with semantic tokens and verify
+> every route/overlay in light and dark mode. If that work is intentionally out of scope, remove
+> `supportsTheme`; never ship a toggle that changes only the header. See the theme contract in
+> `references/apps.md`.
+
 To migrate a v1 inline app to standalone_v2, use `bifrost solution migrate-app <source-slug> <v2-slug>` — it ports source + rewrites imports + prints a judgment checklist.
 
 ### Logos have two independent scopes

--- a/.claude/skills/bifrost-build/references/web-sdk-v2.md
+++ b/.claude/skills/bifrost-build/references/web-sdk-v2.md
@@ -28,7 +28,7 @@ Key props:
 | `token` | yes | Bearer access token |
 | `orgScope` | no | Active org UUID; null = caller's default |
 | `appId` | no | This install's app UUID — required for correct `path::function` resolution at deploy; omit in dev |
-| `supportsTheme` | no (default false) | When true, BifrostHeader shows the light/dark toggle |
+| `supportsTheme` | no (default false) | Declares app-wide theme support and makes BifrostHeader show the light/dark toggle |
 | `fetchImpl` | no | Override fetch (tests / non-browser) |
 | `onLogout` | no | Called when the app requests logout |
 | `theme` / `onThemeChange` | no | Host-controlled theme sync |
@@ -55,7 +55,12 @@ import { BifrostHeader } from "bifrost";
 <BifrostHeader title="My App" />
 ```
 
-The light/dark toggle only appears when the parent `<BifrostProvider supportsTheme>` prop is set. An app with hardcoded colors should omit `supportsTheme` so the toggle is never shown.
+The light/dark toggle only appears when the parent `<BifrostProvider supportsTheme>` prop is set.
+This is an app-wide capability declaration: the provider applies the root `.dark` class, but the
+application must use semantic theme tokens or paired light/dark variables for all of its own
+surfaces and states. Verify every route and overlay in both modes. An app with hardcoded light
+colors must be converted before retaining `supportsTheme`, or omit the prop so the toggle is never
+shown. See `references/apps.md` for the required styling audit.
 
 The platform does not add this header automatically. A v2 app owns its layout and composes `<BifrostHeader>` when it wants Bifrost chrome. The SDK header carries its own responsive inline styling: title text ellipsizes, right-side controls can wrap on narrow screens, and the account menu stays within the viewport.
 

--- a/.claude/skills/bifrost-migrate/SKILL.md
+++ b/.claude/skills/bifrost-migrate/SKILL.md
@@ -141,10 +141,15 @@ renders UNSTYLED. Verify with `vite build` (step 8) AND a screenshot, not just a
 - **package.json**: union of the scaffold's deps + everything the import scan surfaced (every
   `lucide-react`, `react-router-dom`, each shadcn dep, `clsx`, `tailwind-merge`, …). Don't ship
   deps nothing imports.
-- **BifrostProvider + theme**: the scaffold already wraps the tree and passes `theme={theme}` from
-  the platform boot. If the app is theme-aware (keys styles off the `dark` class / Tailwind
-  `dark:`), add `supportsTheme` to `<BifrostProvider>` so `BifrostHeader` shows the light/dark
-  toggle and recolors its own chrome. If the app has hardcoded light colors, omit `supportsTheme`.
+- **BifrostProvider + theme**: the scaffold passes the platform theme and opts into
+  `supportsTheme`, which makes `BifrostHeader` show the light/dark toggle. Treat that prop as an
+  **app-wide contract**, not a header option. Before retaining it, migrate every route, layout,
+  dialog, table, form control, empty/loading/error state, and chart surface to semantic theme
+  tokens (`bg-background`, `text-foreground`, `bg-card`, `text-card-foreground`, `border-border`,
+  `bg-muted`, `text-muted-foreground`, etc.). Replace hardcoded light utilities such as `bg-white`,
+  `text-slate-*`, and `border-gray-*`; for intentional brand/data colors, define paired `:root`
+  and `.dark` CSS variables. Use `dark:` only when a semantic token cannot express the design.
+  If the full app is not theme-aware, remove `supportsTheme` so the toggle is not exposed.
 - **BifrostHeader**: keep it in `App.tsx` for the familiar chrome (back-to-Bifrost, user menu).
 - **basename**: the scaffold sets `basename` from the boot; v2 apps mount at `/apps/{slug}`.
 - **brand icon**: port the tracked image in both scopes. Set the Solution-root-relative `logo:` in
@@ -179,7 +184,9 @@ Then drive it:
 bifrost solution start <new-slug>     # app Vite server + local @workflow functions, one origin
 ```
 Open the printed URL; click every page. (Skip this loop only if the user opted out in the prefs.)
-Iterate on layout/theme until it matches the v1 app.
+Iterate on layout/theme until it matches the v1 app. When `supportsTheme` is present, toggle light
+and dark mode and inspect every route plus overlays and interactive states; a dark header above a
+light-only app is a failed migration.
 
 ### 9. Cutover by slug swap + capture the backing entities
 
@@ -227,6 +234,8 @@ A's Solution would orphan B's reference across the scope boundary. Report it; le
 ## Verification before declaring done
 
 - The v2 app builds + runs under `bifrost solution start`, every page works.
+- If `supportsTheme` is present, every page and overlay is visually verified in both light and dark
+  mode and uses theme tokens throughout; otherwise the theme toggle is absent.
 - Capture `--dry-run` shows no dangling refs after rename (refs rewritten).
 - The live slug now serves the v2 app (`bifrost api GET /api/applications/<old-slug>` → the v2 row).
 - Both the Solution catalog record and application record carry the migrated logo when the v1 app

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "bifrost",
-  "version": "1.1.1-dev.6",
+  "version": "1.1.1-dev.9",
   "description": "Bifrost — MSP automation platform. Skills for building workflows, forms, agents, apps, tables, and files with the Bifrost SDK + CLI, setting up local Bifrost development, and packaging Bifrost agents as Microsoft 365 Copilot Cowork plugins, :migrate (move a legacy v1 inline app + its backing entities into an installable v2 Solution).",
   "author": {
     "name": "Jack Musick",

--- a/plugins/bifrost/.codex-plugin/plugin.json
+++ b/plugins/bifrost/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "bifrost",
-  "version": "1.1.1-dev.6",
+  "version": "1.1.1-dev.9",
   "description": "Bifrost — MSP automation platform. Skills for building workflows, forms, agents, apps, tables, and files with the Bifrost SDK + CLI, setting up local Bifrost development, and packaging Bifrost agents as Microsoft 365 Copilot Cowork plugins, :migrate (move a legacy v1 inline app + its backing entities into an installable v2 Solution).",
   "author": {
     "name": "Jack Musick",

--- a/plugins/bifrost/skills/bifrost-build/references/apps.md
+++ b/plugins/bifrost/skills/bifrost-build/references/apps.md
@@ -327,6 +327,21 @@ if (!state?.name) return <Navigate to="/" />;
 
 Apps go through the platform's per-app Tailwind v4 pipeline at bundle time.
 
+`supportsTheme` on `<BifrostProvider>` is an **app-wide capability contract**. It does not theme the
+application for you; it exposes the `BifrostHeader` toggle and applies the root `.dark` class. Keep
+it only when the entire app responds correctly. Audit every route, layout, overlay, form control,
+table, chart, and loading/empty/error state—not just the header.
+
+- Prefer semantic tokens: `bg-background`, `text-foreground`, `bg-card`,
+  `text-card-foreground`, `border-border`, `bg-muted`, `text-muted-foreground`, `bg-primary`,
+  `text-primary-foreground`, and `text-destructive`.
+- Replace hardcoded light utilities such as `bg-white`, `text-slate-*`, and `border-gray-*`.
+- For intentional brand or data-series colors, define paired `:root` and `.dark` variables. Use
+  `dark:` variants only when the semantic token system cannot express the design.
+- Verify every route and overlay after toggling both light and dark modes. A themed header above a
+  light-only app is a failure. If full support is out of scope, remove `supportsTheme` so the toggle
+  is not shown.
+
 What works: all standard utilities, host shadcn theme tokens (`bg-background`, `text-muted-foreground`), arbitrary values, `@apply` in `styles.css`, `@layer components`, `:root` and `.dark` CSS variable blocks, per-app `tailwind.config.ts` with `theme.extend`.
 
 What is NOT supported: Tailwind plugins beyond `@tailwindcss/typography`; `@source` directives outside the app root.

--- a/plugins/bifrost/skills/bifrost-build/references/solutions.md
+++ b/plugins/bifrost/skills/bifrost-build/references/solutions.md
@@ -27,6 +27,12 @@ Scaffolds a `standalone_v2` React app under `apps/my-app/`. Config files sit at 
 
 > The scaffold wires up Tailwind (`@tailwindcss/vite` + shadcn theme tokens in `src/index.css`) but the generated `App.tsx` uses minimal **inline styles** (`style={{ padding: 24 }}`) as a plain starting point. Replace them with Tailwind classes (`className="p-6 ..."`) before building — the infrastructure is ready. See `references/apps.md` for v2 styling patterns.
 
+> The scaffold also opts into `<BifrostProvider supportsTheme>`, so `BifrostHeader` exposes the
+> theme toggle. Before deploy, make the **whole app** theme-aware with semantic tokens and verify
+> every route/overlay in light and dark mode. If that work is intentionally out of scope, remove
+> `supportsTheme`; never ship a toggle that changes only the header. See the theme contract in
+> `references/apps.md`.
+
 To migrate a v1 inline app to standalone_v2, use `bifrost solution migrate-app <source-slug> <v2-slug>` — it ports source + rewrites imports + prints a judgment checklist.
 
 ### Logos have two independent scopes

--- a/plugins/bifrost/skills/bifrost-build/references/web-sdk-v2.md
+++ b/plugins/bifrost/skills/bifrost-build/references/web-sdk-v2.md
@@ -28,7 +28,7 @@ Key props:
 | `token` | yes | Bearer access token |
 | `orgScope` | no | Active org UUID; null = caller's default |
 | `appId` | no | This install's app UUID — required for correct `path::function` resolution at deploy; omit in dev |
-| `supportsTheme` | no (default false) | When true, BifrostHeader shows the light/dark toggle |
+| `supportsTheme` | no (default false) | Declares app-wide theme support and makes BifrostHeader show the light/dark toggle |
 | `fetchImpl` | no | Override fetch (tests / non-browser) |
 | `onLogout` | no | Called when the app requests logout |
 | `theme` / `onThemeChange` | no | Host-controlled theme sync |
@@ -55,7 +55,12 @@ import { BifrostHeader } from "bifrost";
 <BifrostHeader title="My App" />
 ```
 
-The light/dark toggle only appears when the parent `<BifrostProvider supportsTheme>` prop is set. An app with hardcoded colors should omit `supportsTheme` so the toggle is never shown.
+The light/dark toggle only appears when the parent `<BifrostProvider supportsTheme>` prop is set.
+This is an app-wide capability declaration: the provider applies the root `.dark` class, but the
+application must use semantic theme tokens or paired light/dark variables for all of its own
+surfaces and states. Verify every route and overlay in both modes. An app with hardcoded light
+colors must be converted before retaining `supportsTheme`, or omit the prop so the toggle is never
+shown. See `references/apps.md` for the required styling audit.
 
 The platform does not add this header automatically. A v2 app owns its layout and composes `<BifrostHeader>` when it wants Bifrost chrome. The SDK header carries its own responsive inline styling: title text ellipsizes, right-side controls can wrap on narrow screens, and the account menu stays within the viewport.
 

--- a/plugins/bifrost/skills/bifrost-migrate/SKILL.md
+++ b/plugins/bifrost/skills/bifrost-migrate/SKILL.md
@@ -141,10 +141,15 @@ renders UNSTYLED. Verify with `vite build` (step 8) AND a screenshot, not just a
 - **package.json**: union of the scaffold's deps + everything the import scan surfaced (every
   `lucide-react`, `react-router-dom`, each shadcn dep, `clsx`, `tailwind-merge`, …). Don't ship
   deps nothing imports.
-- **BifrostProvider + theme**: the scaffold already wraps the tree and passes `theme={theme}` from
-  the platform boot. If the app is theme-aware (keys styles off the `dark` class / Tailwind
-  `dark:`), add `supportsTheme` to `<BifrostProvider>` so `BifrostHeader` shows the light/dark
-  toggle and recolors its own chrome. If the app has hardcoded light colors, omit `supportsTheme`.
+- **BifrostProvider + theme**: the scaffold passes the platform theme and opts into
+  `supportsTheme`, which makes `BifrostHeader` show the light/dark toggle. Treat that prop as an
+  **app-wide contract**, not a header option. Before retaining it, migrate every route, layout,
+  dialog, table, form control, empty/loading/error state, and chart surface to semantic theme
+  tokens (`bg-background`, `text-foreground`, `bg-card`, `text-card-foreground`, `border-border`,
+  `bg-muted`, `text-muted-foreground`, etc.). Replace hardcoded light utilities such as `bg-white`,
+  `text-slate-*`, and `border-gray-*`; for intentional brand/data colors, define paired `:root`
+  and `.dark` CSS variables. Use `dark:` only when a semantic token cannot express the design.
+  If the full app is not theme-aware, remove `supportsTheme` so the toggle is not exposed.
 - **BifrostHeader**: keep it in `App.tsx` for the familiar chrome (back-to-Bifrost, user menu).
 - **basename**: the scaffold sets `basename` from the boot; v2 apps mount at `/apps/{slug}`.
 - **brand icon**: port the tracked image in both scopes. Set the Solution-root-relative `logo:` in
@@ -179,7 +184,9 @@ Then drive it:
 bifrost solution start <new-slug>     # app Vite server + local @workflow functions, one origin
 ```
 Open the printed URL; click every page. (Skip this loop only if the user opted out in the prefs.)
-Iterate on layout/theme until it matches the v1 app.
+Iterate on layout/theme until it matches the v1 app. When `supportsTheme` is present, toggle light
+and dark mode and inspect every route plus overlays and interactive states; a dark header above a
+light-only app is a failed migration.
 
 ### 9. Cutover by slug swap + capture the backing entities
 
@@ -227,6 +234,8 @@ A's Solution would orphan B's reference across the scope boundary. Report it; le
 ## Verification before declaring done
 
 - The v2 app builds + runs under `bifrost solution start`, every page works.
+- If `supportsTheme` is present, every page and overlay is visually verified in both light and dark
+  mode and uses theme tokens throughout; otherwise the theme toggle is absent.
 - Capture `--dry-run` shows no dangling refs after rename (refs rewritten).
 - The live slug now serves the v2 app (`bifrost api GET /api/applications/<old-slug>` → the v2 row).
 - Both the Solution catalog record and application record carry the migrated logo when the v1 app


### PR DESCRIPTION
## Summary

- define `supportsTheme` as an app-wide capability contract rather than a header-only option
- require semantic theme tokens or paired light/dark variables across routes, overlays, controls, tables, charts, and UI states
- require light/dark visual verification during migrations and Solution app builds
- direct agents to remove `supportsTheme` when full theme support is out of scope
- sync public skill mirrors and bump the Bifrost plugin manifests to `1.1.1-dev.9`

## Why

The v2 scaffold opts into `supportsTheme`, but previous migration guidance allowed the app body to retain hardcoded light colors. The result was a toggle that changed the `BifrostHeader` while leaving the application light-only.

## Validation

- skill validator passed for `bifrost-migrate`
- skill validator passed for `bifrost-build`
- `test_skill_appendix_fresh.py` passed
- canonical and public skill mirrors are byte-identical
- `git diff --check` passed
