### PR TITLE
Fix standalone v2 scaffold height

### DIFF
--- a/api/bifrost/commands/solution.py
+++ b/api/bifrost/commands/solution.py
@@ -520,14 +520,14 @@ export default defineConfig(({ command }) => {
 """
     index_html = f"""\
 <!doctype html>
-<html lang="en">
+<html lang="en" class="h-full">
   <head>
     <meta charset="UTF-8" />
     <meta name="bifrost-app-runtime" content="mount-v1" />
     <title>{slug}</title>
   </head>
-  <body>
-    <div id="root"></div>
+  <body class="h-full">
+    <div id="root" class="h-full"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/api/tests/unit/test_solution_scaffold_app.py
+++ b/api/tests/unit/test_solution_scaffold_app.py
@@ -58,7 +58,11 @@ def test_scaffold_files_shape_and_dev_wiring() -> None:
     # main.tsx follows the explicit lifecycle contract: the immutable module
     # registers mount(), receives bootstrap directly, and returns teardown.
     main = files["src/main.tsx"]
-    assert 'name="bifrost-app-runtime" content="mount-v1"' in files["index.html"]
+    index_html = files["index.html"]
+    assert 'name="bifrost-app-runtime" content="mount-v1"' in index_html
+    assert '<html lang="en" class="h-full">' in index_html
+    assert '<body class="h-full">' in index_html
+    assert '<div id="root" class="h-full"></div>' in index_html
     assert "createRoot" in main
     assert "export function mount" in main
     assert "__BIFROST_APP_MODULES__" in main


### PR DESCRIPTION
## Summary

- add the complete `h-full` height chain to standalone v2 app scaffold documents
- cover the generated `html`, `body`, and `#root` classes with regression assertions
- keep `migrate-app` on the shared `_v2_scaffold_files()` implementation

## Why

Locally scaffolded standalone v2 apps run inside their own Vite document. Without a defined height on `html`, `body`, and `#root`, documented `h-full` layouts collapse to content height even though the production platform container supplies a full-height mount surface.

## Validation

- `./test.sh tests/unit/test_solution_scaffold_app.py -v` — 5 passed
- CLI surface and skill freshness tripwires — 115 passed
- `./test.sh quality api` — Pyright and Ruff passed
- `./test.sh all` — 6,940 passed, 55 skipped, with unrelated cross-suite state pollution; the first observed failure passed in isolation after a clean reset
