### PR TITLE
fix: keep solution start transport same-origin

### DIFF
--- a/api/bifrost/commands/solution.py
+++ b/api/bifrost/commands/solution.py
@@ -2208,17 +2208,16 @@ def _vite_child_env(
     *,
     app_id: str,
     org_id: str | None,
-    proxy_origin: str,
     access_token: str,
 ) -> dict[str, str]:
     """Environment for the `solution start` Vite child.
 
-    The bundle-visible BIFROST_API_URL is the LOCAL PROXY origin, never the
-    upstream API: the proxy is where install scope is injected (?solution=,
-    auth, app header) and where local path::fn refs run in-process. Pointing
-    the bundle at the upstream bypasses all of that — local workflow edits
-    silently don't run, install-owned tables 404, declared-location file
-    writes 403 (drive finding, 2026-07-02).
+    The bundle-visible BIFROST_API_URL is `/`, meaning the browser's current
+    origin. That origin is the LOCAL PROXY even when an outer development
+    proxy remaps its loopback port (for example Codex exposing local :3000 as
+    browser-visible :62464). An absolute internal URL would bypass the outer
+    proxy from browser JavaScript. Pointing at the upstream API is also wrong:
+    the local proxy injects install scope and runs local path::fn refs.
     """
     env = dict(base_env)
     env["VITE_BIFROST_APP_ID"] = app_id
@@ -2229,7 +2228,7 @@ def _vite_child_env(
         env["VITE_BIFROST_ORG_ID"] = org_id
     else:
         env.pop("VITE_BIFROST_ORG_ID", None)
-    env["BIFROST_API_URL"] = proxy_origin
+    env["BIFROST_API_URL"] = "/"
     env["BIFROST_ACCESS_TOKEN"] = access_token
     return env
 
@@ -2396,7 +2395,6 @@ def start_cmd(
         dict(os.environ),
         app_id=chosen.app_id,
         org_id=(org_info or {}).get("id"),
-        proxy_origin=proxy_origin,
         access_token=client._access_token,
     )
 

--- a/api/bifrost/solution_dev/proxy.py
+++ b/api/bifrost/solution_dev/proxy.py
@@ -745,8 +745,42 @@ async def _vite_proxy_handler(request: web.Request) -> web.StreamResponse:
     cfg: DevProxyConfig = request.app[_CFG]
     accept = request.headers.get("Accept", "")
     fetch_dest = request.headers.get("Sec-Fetch-Dest", "")
-    if cfg.auth_expired and ("text/html" in accept or fetch_dest in {"document", "iframe"}):
-        return await _dev_auth_expired_page_response(request)
+    is_document = "text/html" in accept or fetch_dest in {"document", "iframe"}
+    if is_document:
+        # A Solution app must never render into a plausible half-authenticated
+        # state (the SDK header historically collapsed every auth failure to
+        # "Account"). Verify the CLI-backed proxy session before handing the
+        # document to Vite. This also refreshes a stale access token once via
+        # the same coordinated authority used by API calls. On failure, reuse
+        # the branded dev diagnostics page before any app JavaScript runs.
+        if cfg.auth_expired:
+            return await _dev_auth_expired_page_response(request)
+        try:
+            auth = await _authed_upstream_request(
+                request,
+                "GET",
+                f"{cfg.upstream_url}/api/auth/me",
+            )
+        except httpx.HTTPError:
+            # Do not render the app into the same misleading "Account" state
+            # when the upstream itself is unavailable. This is connectivity,
+            # not expired auth, so leave cfg.auth_expired untouched.
+            return web.json_response(
+                {"detail": f"Dev API unreachable at {cfg.upstream_url}"},
+                status=502,
+            )
+        if auth is None:
+            return await _dev_auth_expired_page_response(request)
+        if auth.status_code != 200:
+            return web.json_response(
+                {
+                    "detail": (
+                        "Dev API authentication check failed "
+                        f"({auth.status_code}): {auth.text[:200]}"
+                    )
+                },
+                status=502,
+            )
     vite_url = request.app[_VITE]
     if _is_ws_upgrade(request):
         target = _ws_scheme(_join_upstream(vite_url, request.rel_url))

--- a/api/tests/unit/test_solution_dev_command.py
+++ b/api/tests/unit/test_solution_dev_command.py
@@ -548,7 +548,7 @@ def test_start_spawns_npm_via_resolved_path(tmp_path: Path, monkeypatch):
         assert argv[0] == npm_path, f"npm spawn used {argv[0]!r}, not the which() result"
 
 
-def test_start_accepts_bind_host_and_public_url(tmp_path: Path, monkeypatch):
+def test_start_public_url_does_not_change_same_origin_browser_transport(tmp_path: Path, monkeypatch):
     import shutil
     import subprocess
 
@@ -652,7 +652,10 @@ def test_start_accepts_bind_host_and_public_url(tmp_path: Path, monkeypatch):
         "port": 3000,
         "proxy_origin": "http://devbox.test:3000",
     }
-    assert popen_envs[0]["BIFROST_API_URL"] == "http://devbox.test:3000"
+    # --public-url only describes the URL printed to the user. The browser
+    # transport stays relative so a second forwarding proxy may rewrite that
+    # origin again without breaking API calls.
+    assert popen_envs[0]["BIFROST_API_URL"] == "/"
 
 
 def test_handle_solution_renders_clickexception_not_traceback(tmp_path, monkeypatch, capsys):

--- a/api/tests/unit/test_solution_dev_proxy.py
+++ b/api/tests/unit/test_solution_dev_proxy.py
@@ -558,7 +558,45 @@ async def test_api_proxy_returns_dev_auth_expired_json_when_refresh_fails():
         await up_runner.cleanup()
 
 
-async def test_vite_proxy_serves_branded_auth_expired_page_after_api_auth_failure():
+async def test_vite_proxy_authenticates_before_serving_the_app():
+    record = {}
+    up_port, vite_port, dev_port = _free_port(), _free_port(), _free_port()
+    up_runner = await _serve(_make_auth_refresh_upstream(record), up_port)
+
+    async def index(_request):
+        return web.Response(text="<html><body>Vite app</body></html>", content_type="text/html")
+
+    vite = web.Application()
+    vite.router.add_get("/", index)
+    vite_runner = await _serve(vite, vite_port)
+    host = _StubHost(set())
+
+    async def refresh_token(observed_token):
+        record["refresh_called"] = observed_token
+        return "fresh-token"
+
+    cfg = DevProxyConfig(
+        upstream_url=f"http://127.0.0.1:{up_port}",
+        token="stale-token",
+        app_id="A",
+        org_id="O",
+        refresh_token=refresh_token,
+    )
+    dev_runner = await _serve(build_dev_app(cfg, host, vite_url=f"http://127.0.0.1:{vite_port}"), dev_port)
+    try:
+        async with httpx.AsyncClient() as c:
+            page = await c.get(f"http://127.0.0.1:{dev_port}/", headers={"Accept": "text/html"})
+        assert page.status_code == 200
+        assert "Vite app" in page.text
+        assert record["refresh_called"] == "stale-token"
+        assert record["auth_headers"] == ["Bearer stale-token", "Bearer fresh-token"]
+    finally:
+        await dev_runner.cleanup()
+        await vite_runner.cleanup()
+        await up_runner.cleanup()
+
+
+async def test_vite_proxy_serves_branded_auth_expired_page_before_the_app():
     record = {}
     up_port, vite_port, dev_port = _free_port(), _free_port(), _free_port()
     up_runner = await _serve(_make_auth_refresh_upstream(record), up_port)
@@ -588,13 +626,11 @@ async def test_vite_proxy_serves_branded_auth_expired_page_after_api_auth_failur
     dev_runner = await _serve(build_dev_app(cfg, host, vite_url=f"http://127.0.0.1:{vite_port}"), dev_port)
     try:
         async with httpx.AsyncClient() as c:
-            api = await c.get(f"http://127.0.0.1:{dev_port}/api/auth/me")
             page = await c.get(f"http://127.0.0.1:{dev_port}/", headers={"Accept": "text/html"})
             logo_resp = await c.get(
                 f"http://127.0.0.1:{dev_port}/logo.svg",
                 headers={"Accept": "image/avif,image/webp,image/apng,image/svg+xml,image/*,*/*;q=0.8"},
             )
-        assert api.status_code == 401
         assert page.status_code == 401
         assert logo_resp.status_code == 200
         assert logo_resp.headers["content-type"].startswith("image/svg+xml")
@@ -609,10 +645,44 @@ async def test_vite_proxy_serves_branded_auth_expired_page_after_api_auth_failur
         assert "Your CLI token has expired" in page.text
         assert "bifrost solution start" in page.text
         assert "Vite app" not in page.text
+        assert record["auth_headers"] == ["Bearer stale-token"]
     finally:
         await dev_runner.cleanup()
         await vite_runner.cleanup()
         await up_runner.cleanup()
+
+
+async def test_vite_proxy_refuses_to_render_app_when_auth_preflight_cannot_reach_api():
+    vite_port, dev_port = _free_port(), _free_port()
+
+    async def index(_request):
+        return web.Response(text="<html><body>Vite app</body></html>", content_type="text/html")
+
+    vite = web.Application()
+    vite.router.add_get("/", index)
+    vite_runner = await _serve(vite, vite_port)
+    cfg = DevProxyConfig(
+        upstream_url=f"http://127.0.0.1:{_free_port()}",
+        token="token",
+        app_id="A",
+        org_id="O",
+    )
+    dev_runner = await _serve(
+        build_dev_app(cfg, _StubHost(set()), vite_url=f"http://127.0.0.1:{vite_port}"),
+        dev_port,
+    )
+    try:
+        async with httpx.AsyncClient() as c:
+            page = await c.get(
+                f"http://127.0.0.1:{dev_port}/",
+                headers={"Accept": "text/html"},
+            )
+        assert page.status_code == 502
+        assert "Dev API unreachable" in page.json()["detail"]
+        assert "Vite app" not in page.text
+    finally:
+        await dev_runner.cleanup()
+        await vite_runner.cleanup()
 
 
 async def test_ws_upgrade_bridges_to_upstream():

--- a/api/tests/unit/test_solution_start_env.py
+++ b/api/tests/unit/test_solution_start_env.py
@@ -4,8 +4,9 @@ The proxy is where install scope gets injected (?solution=, auth, app header).
 Pointing the app bundle's BIFROST_API_URL at the upstream API bypasses that
 injection entirely: local workflow edits silently don't run locally, the
 install's own tables 404, and declared-location file writes 403 (drive
-finding, 2026-07-02). The one authoritative origin for a `solution start`
-browser session is the proxy origin.
+finding, 2026-07-02). The browser must address that proxy through its own
+successful origin, not an internal loopback URL that an outer Codex/VPN proxy
+may have remapped to a different browser-visible port.
 """
 from bifrost.commands import solution as solution_cmd
 from bifrost.commands.solution import _scaffold_api_url, _vite_child_env
@@ -49,16 +50,17 @@ class TestScaffoldApiUrl:
         assert _scaffold_api_url(None) == "http://localhost:8000"
 
 
-def test_vite_child_env_points_bundle_at_local_proxy():
+def test_vite_child_env_points_bundle_at_browser_same_origin():
     env = _vite_child_env(
         {"PATH": "/usr/bin", "BIFROST_API_URL": "http://upstream:34173"},
         app_id="2a9d06da-cc86-49ff-b3b5-26748c31f73e",
         org_id="org-1",
-        proxy_origin="http://127.0.0.1:3777",
         access_token="tok",
     )
-    # The bundle-visible API URL is the PROXY, never the upstream.
-    assert env["BIFROST_API_URL"] == "http://127.0.0.1:3777"
+    # `/` tells BifrostProvider to use the browser's current origin. If Codex
+    # exposes localhost:3777 as localhost:62464, API + websocket traffic must
+    # stay on :62464 so the outer forwarder can carry it to the local proxy.
+    assert env["BIFROST_API_URL"] == "/"
     assert env["VITE_BIFROST_APP_ID"] == "2a9d06da-cc86-49ff-b3b5-26748c31f73e"
     assert env["VITE_BIFROST_ORG_ID"] == "org-1"
     assert env["BIFROST_ACCESS_TOKEN"] == "tok"
@@ -77,7 +79,6 @@ def test_vite_child_env_omits_org_var_for_global_installs():
         {"PATH": "/usr/bin"},
         app_id="2a9d06da-cc86-49ff-b3b5-26748c31f73e",
         org_id=None,
-        proxy_origin="http://127.0.0.1:3777",
         access_token="tok",
     )
     assert "VITE_BIFROST_ORG_ID" not in env

--- a/client/src/lib/app-sdk/provider.test.tsx
+++ b/client/src/lib/app-sdk/provider.test.tsx
@@ -64,6 +64,31 @@ describe("BifrostProvider", () => {
     expect(captured!.auth).toBe("Bearer tok-abc");
   });
 
+  it("treats / as the browser's same-origin transport", async () => {
+    let captured: string | null = null;
+    const fakeFetch = (async (input: RequestInfo | URL) => {
+      captured = String(input);
+      return new Response("{}", { status: 200 });
+    }) as typeof fetch;
+
+    function Caller() {
+      const { baseUrl, authedFetch } = useBifrostContext();
+      void authedFetch("/api/auth/me");
+      return <span>{baseUrl || "same-origin"}</span>;
+    }
+
+    render(
+      <BifrostProvider baseUrl="/" token="tok-forwarded" fetchImpl={fakeFetch}>
+        <Caller />
+      </BifrostProvider>,
+    );
+    await Promise.resolve();
+
+    expect(screen.getByText("same-origin")).toBeInTheDocument();
+    expect(captured).toBe("/api/auth/me");
+    expect(getBifrostTransport().baseUrl).toBe("");
+  });
+
   it("attaches X-Bifrost-App on authedFetch so workflow calls carry the app scope", async () => {
     // Tables/files scope via the transport's X-Bifrost-App header; workflow
     // execution goes through authedFetch. Both must carry the same context


### PR DESCRIPTION
Fixes #499

## Summary

- make `bifrost solution start` use browser-relative same-origin API and WebSocket transport
- preserve the loopback `--host` default and the local Bifrost proxy
- authenticate document requests before serving the Vite app, reusing the branded expired-session diagnostic instead of rendering a misleading unauthenticated app
- return an explicit 502 instead of rendering the app when the upstream API is unreachable

## Verification

- live outer-port forwarding POC: page, `/api/auth/me`, and a local workflow all succeeded through a different browser-visible localhost port
- `./test.sh all`: 7011 passed, 55 skipped
- `./test.sh quality api`: passed
- client typecheck and lint: passed (one pre-existing lint warning)
- focused proxy/env/provider tests: passed
- full client suite has pre-existing `ExecutionHistory` timeout/cleanup flakiness; the failures reproduce with this branch's only client test excluded, while the affected files and new provider test pass in isolation
