### PR TITLE
fix(knowledge): preserve document identity across chunk aliases

### DIFF
--- a/api/src/repositories/knowledge.py
+++ b/api/src/repositories/knowledge.py
@@ -128,8 +128,10 @@ class KnowledgeRepository(OrgScopedRepository[KnowledgeStore]):
         metadata: dict[str, Any] | None,
         organization_id: UUID | None,
         created_by: UUID | None,
+        start_index: int = 0,
+        chunk_count: int | None = None,
     ) -> list[KnowledgeStore]:
-        chunk_count = len(chunks)
+        total_chunk_count = chunk_count if chunk_count is not None else len(chunks)
         return [
             KnowledgeStore(
                 namespace=namespace,
@@ -140,9 +142,11 @@ class KnowledgeRepository(OrgScopedRepository[KnowledgeStore]):
                 embedding=embedding,
                 created_by=created_by,
                 chunk_index=index,
-                chunk_count=chunk_count,
+                chunk_count=total_chunk_count,
             )
-            for index, (chunk, embedding) in enumerate(zip(chunks, embeddings))
+            for index, (chunk, embedding) in enumerate(
+                zip(chunks, embeddings), start=start_index
+            )
         ]
 
     async def store_chunked(
@@ -214,10 +218,12 @@ class KnowledgeRepository(OrgScopedRepository[KnowledgeStore]):
     ) -> list[str]:
         """
         Replace one logical document with freshly chunked-and-embedded rows,
-        keeping its public identity: the first new row reuses ``doc_id`` (so
-        stored references survive edits) and every new row carries the
-        original ``created_at`` (so edits don't reorder created_at-sorted
-        listings). ``updated_at`` resets to now on the new rows.
+        keeping its public identity: the canonical chunk-zero row is updated
+        in place while its sibling rows are replaced. Keeping that row alive
+        lets the route use it as the common lock for every chunk alias, and
+        preserves stored references across edits. Every row carries the
+        original audit fields so edits don't reorder created-at-sorted lists
+        or change creator attribution. ``updated_at`` resets to now.
 
         Old rows are deleted by document identity in the *current* scope and
         new rows are written to ``organization_id`` — when the two differ a
@@ -232,28 +238,49 @@ class KnowledgeRepository(OrgScopedRepository[KnowledgeStore]):
         """
         chunks, embeddings = await self._embed_chunks(content, embedder)
 
+        canonical_result = await self.session.execute(
+            select(KnowledgeStore).where(KnowledgeStore.id == doc_id)
+        )
+        canonical = canonical_result.scalar_one()
+
+        # The canonical row is the stable public identity and serialization
+        # lock. Delete only its siblings, then update it in place.
         await self.session.execute(
             delete(KnowledgeStore).where(
-                *self._identity_clauses(namespace, key, current_organization_id)
+                *self._identity_clauses(namespace, key, current_organization_id),
+                KnowledgeStore.id != doc_id,
             )
         )
         await self.session.flush()
 
-        rows = self._build_chunk_rows(
-            chunks,
-            embeddings,
+        sibling_rows = self._build_chunk_rows(
+            chunks[1:],
+            embeddings[1:],
             namespace=namespace,
             key=key,
             metadata=metadata,
             organization_id=organization_id,
             created_by=created_by,
+            start_index=1,
+            chunk_count=len(chunks),
         )
-        rows[0].id = doc_id
-        for row in rows:
+
+        canonical.namespace = namespace
+        canonical.organization_id = organization_id
+        canonical.key = key
+        canonical.content = chunks[0]
+        canonical.doc_metadata = metadata or {}
+        canonical.embedding = embeddings[0]
+        canonical.created_by = created_by
+        canonical.created_at = created_at
+        canonical.chunk_index = 0
+        canonical.chunk_count = len(chunks)
+
+        for row in sibling_rows:
             row.created_at = created_at
-        self.session.add_all(rows)
+        self.session.add_all(sibling_rows)
         await self.session.flush()
-        return [str(row.id) for row in rows]
+        return [str(canonical.id), *(str(row.id) for row in sibling_rows)]
 
     async def find_document_id(
         self,
@@ -272,6 +299,29 @@ class KnowledgeRepository(OrgScopedRepository[KnowledgeStore]):
                 *self._identity_clauses(namespace, key, organization_id),
                 KnowledgeStore.chunk_index == 0,
             )
+        )
+        return result.scalar_one_or_none()
+
+    async def lock_document(
+        self,
+        namespace: str,
+        key: str | None,
+        organization_id: UUID | None,
+    ) -> KnowledgeStore | None:
+        """Resolve a logical document to chunk zero and lock that stable row.
+
+        Requests may address any physical chunk id. Resolving first makes
+        every alias acquire the same row lock, preventing cross-chunk update
+        deadlocks while preserving the canonical public id.
+        """
+        canonical_id = await self.find_document_id(namespace, key, organization_id)
+        if canonical_id is None:
+            return None
+
+        result = await self.session.execute(
+            select(KnowledgeStore)
+            .where(KnowledgeStore.id == canonical_id)
+            .with_for_update()
         )
         return result.scalar_one_or_none()
 

--- a/api/src/routers/knowledge_sources.py
+++ b/api/src/routers/knowledge_sources.py
@@ -502,20 +502,30 @@ async def update_document(
     document already holding the same identity in the target scope 409s
     unless ``replace=true``.
     """
-    # FOR UPDATE serializes concurrent edits of the same document — without
-    # it, two racing PUTs both delete-then-insert the same identity and the
-    # loser dies on the unique constraint at commit.
+    # First resolve the addressed physical chunk without locking it. Every
+    # chunk id is an alias for one logical document, so locking this row would
+    # let requests through different chunks deadlock during group replacement.
     result = await db.execute(
-        select(KnowledgeStore).where(KnowledgeStore.id == doc_id).with_for_update()
+        select(KnowledgeStore).where(KnowledgeStore.id == doc_id)
     )
-    doc = result.scalar_one_or_none()
-    if not doc or doc.namespace != namespace:
+    addressed = result.scalar_one_or_none()
+    if not addressed or addressed.namespace != namespace:
         raise HTTPException(404, f"Document {doc_id} not found in namespace {namespace}")
 
-    # Snapshot identity/audit fields — replace_chunked deletes these rows.
+    # Resolve every alias to chunk zero and lock that persistent canonical row.
+    # This gives concurrent edits one lock order and one stable public id.
+    source_repo = KnowledgeRepository(session=db, org_id=addressed.organization_id)
+    doc = await source_repo.lock_document(
+        namespace, addressed.key, addressed.organization_id
+    )
+    if not doc:
+        raise HTTPException(404, f"Document {doc_id} not found in namespace {namespace}")
+
+    # Snapshot identity/audit fields before sibling replacement.
     doc_key = doc.key
     current_org_id = doc.organization_id
     original_created_at = doc.created_at
+    original_created_by = doc.created_by
     metadata = data.metadata if data.metadata is not None else (doc.doc_metadata or {})
 
     # Resolve the target scope (defaults to the doc's current org when unchanged).
@@ -561,14 +571,14 @@ async def update_document(
 
     try:
         doc_ids = await repo.replace_chunked(
-            doc_id=doc_id,
+            doc_id=doc.id,
             content=data.content,
             namespace=namespace,
             key=doc_key,
             current_organization_id=current_org_id,
             organization_id=target_org_id,
             metadata=metadata,
-            created_by=user.user_id,
+            created_by=original_created_by,
             created_at=original_created_at,
             embedder=client,
         )

--- a/api/tests/unit/routers/test_knowledge_update_document.py
+++ b/api/tests/unit/routers/test_knowledge_update_document.py
@@ -14,6 +14,7 @@ flat per-chunk vector per row, and upserts (replaces) the document's prior
 rows.
 """
 
+import asyncio
 from datetime import datetime, timezone
 from uuid import UUID, uuid4
 from unittest.mock import AsyncMock, patch
@@ -27,6 +28,7 @@ from src.models.contracts.knowledge import (
     KnowledgeDocumentUpdate,
 )
 from src.models.orm.knowledge import KnowledgeStore
+from src.models.orm.users import User
 from src.repositories.knowledge import KnowledgeRepository
 from src.routers.knowledge_sources import (
     create_document,
@@ -667,3 +669,173 @@ async def test_update_embed_valueerror_maps_to_503(db_session):
             )
     assert exc.value.status_code == 503
     assert "Embedding service unavailable" in str(exc.value.detail)
+
+
+@pytest.mark.asyncio
+async def test_update_via_sibling_chunk_preserves_canonical_document_id(db_session):
+    """Every chunk id addresses one logical document, but chunk zero owns its
+    stable public id. Updating through a sibling must not promote that sibling
+    and invalidate references to the canonical id.
+    """
+    user = _User()
+    with _patch_embedder():
+        created = await create_document(
+            namespace="ku14",
+            data=KnowledgeDocumentCreate(
+                content="multi chunk original. " * 1000,
+                key="canonical",
+            ),
+            db=db_session,
+            user=user,
+            scope=None,
+        )
+        rows = (
+            await db_session.execute(
+                select(KnowledgeStore)
+                .where(KnowledgeStore.namespace == "ku14")
+                .order_by(KnowledgeStore.chunk_index)
+            )
+        ).scalars().all()
+        assert len(rows) > 1
+
+        updated = await update_document(
+            namespace="ku14",
+            doc_id=rows[1].id,
+            data=KnowledgeDocumentUpdate(content="replacement"),
+            db=db_session,
+            user=user,
+            scope=None,
+        )
+
+        assert updated.id == created.id
+        fetched = await get_document(
+            namespace="ku14",
+            doc_id=UUID(created.id),
+            db=db_session,
+            user=user,
+        )
+        assert fetched.content == "replacement"
+
+
+@pytest.mark.asyncio
+async def test_update_preserves_original_creator(db_session):
+    """Replacing chunk rows during an edit must retain creator attribution."""
+    creator_id = uuid4()
+    editor_id = uuid4()
+    db_session.add_all(
+        [
+            User(
+                id=creator_id,
+                email=f"creator-{uuid4()}@example.com",
+                is_superuser=True,
+            ),
+            User(
+                id=editor_id,
+                email=f"editor-{uuid4()}@example.com",
+                is_superuser=True,
+            ),
+        ]
+    )
+    await db_session.flush()
+
+    creator = _User()
+    creator.user_id = creator_id
+    editor = _User()
+    editor.user_id = editor_id
+
+    with _patch_embedder():
+        created = await create_document(
+            namespace="ku15",
+            data=KnowledgeDocumentCreate(content="original", key="audit"),
+            db=db_session,
+            user=creator,
+            scope=None,
+        )
+        await update_document(
+            namespace="ku15",
+            doc_id=UUID(created.id),
+            data=KnowledgeDocumentUpdate(content="edited"),
+            db=db_session,
+            user=editor,
+            scope=None,
+        )
+
+    stored_creator = (
+        await db_session.execute(
+            select(KnowledgeStore.created_by).where(
+                KnowledgeStore.id == UUID(created.id)
+            )
+        )
+    ).scalar_one()
+    assert stored_creator == creator_id
+
+
+@pytest.mark.asyncio
+async def test_concurrent_updates_via_different_chunks_serialize(
+    db_session, async_session_factory
+):
+    """Chunk aliases must converge on one lock; locking the addressed rows
+    separately lets the two group-wide replacements deadlock each other.
+    """
+    user = _User()
+    with _patch_embedder():
+        created = await create_document(
+            namespace="ku16",
+            data=KnowledgeDocumentCreate(
+                content="concurrent original. " * 1000,
+                key="serialized",
+            ),
+            db=db_session,
+            user=user,
+            scope=None,
+        )
+    rows = (
+        await db_session.execute(
+            select(KnowledgeStore)
+            .where(KnowledgeStore.namespace == "ku16")
+            .order_by(KnowledgeStore.chunk_index)
+        )
+    ).scalars().all()
+    assert len(rows) > 1
+    canonical_id = UUID(created.id)
+    sibling_id = rows[1].id
+    await db_session.commit()
+
+    async def edit(addressed_id: UUID, content: str):
+        async with async_session_factory() as session:
+            updated = await update_document(
+                namespace="ku16",
+                doc_id=addressed_id,
+                data=KnowledgeDocumentUpdate(content=content),
+                db=session,
+                user=user,
+                scope=None,
+            )
+            await session.commit()
+            return updated
+
+    original_lock = KnowledgeRepository.lock_document
+    lock_barrier = asyncio.Barrier(2)
+
+    async def synchronized_lock(repo, namespace, key, organization_id):
+        # Make both requests resolve their addressed chunk before either gets
+        # the canonical lock. They must then serialize on that one row.
+        await lock_barrier.wait()
+        return await original_lock(repo, namespace, key, organization_id)
+
+    with (
+        patch.object(KnowledgeRepository, "lock_document", synchronized_lock),
+        _patch_embedder(),
+    ):
+        results = await asyncio.wait_for(
+            asyncio.gather(
+                edit(canonical_id, "first concurrent edit"),
+                edit(sibling_id, "second concurrent edit"),
+                return_exceptions=True,
+            ),
+            timeout=10,
+        )
+
+    failures = [result for result in results if isinstance(result, BaseException)]
+    assert not failures, failures
+    assert {result.id for result in results} == {str(canonical_id)}


### PR DESCRIPTION
## Summary
- resolve every physical chunk alias to the canonical chunk-zero document ID
- serialize concurrent alias updates on one persistent row and update it in place, preventing the reproduced PostgreSQL deadlock
- preserve the original `created_by` attribution when re-chunking an edited document

## Context
Immediate maintainer hardening follow-up to #501 by @pszatkowski. Paul’s PR remains the primary fix for #498; this PR contains only the adversarial edge cases found during maintainer review.

## TDD / verification
- reproduced canonical-ID drift when updating through chunk 1
- reproduced creator reassignment from creator to editor
- reproduced a real cross-chunk `DeadlockDetectedError` under concurrent PUTs
- new regressions pass for all three cases
- 44 focused knowledge/router/repository/chunking/org-scope tests pass
- API Pyright: 0 errors, 0 warnings
- API Ruff: all checks pass
- full backend unit + E2E: 7,028 passed, 57 existing configuration-dependent skips, 0 failed (24m58s)
- protected GitHub CI and CodeQL passed on the PR; merge-group validation is required before merge