### PR TITLE
Fix Solution CLI deploy builds and bound job lifetimes

### DIFF
--- a/api/bifrost/commands/solution.py
+++ b/api/bifrost/commands/solution.py
@@ -24,16 +24,20 @@ import json
 import os
 import pathlib
 import re
+import shutil
 import subprocess
+import tempfile
 import time
 import zipfile
 from typing import Any
+from uuid import UUID, uuid5
 
 import click
 import yaml
 
 from bifrost.client import BifrostClient
 from bifrost.org_target import org_option, resolve_org_target
+from bifrost.solution_jobs import DEPLOY_JOB_TIMEOUT_SECONDS
 from bifrost.solution_binding import (
     SolutionBindingError,
     binding_from_install,
@@ -1348,6 +1352,221 @@ def _collect_apps(workspace: pathlib.Path) -> list[dict]:
     return entries
 
 
+_LOCAL_BUILD_STEP_TIMEOUT_SECONDS = 10 * 60
+
+
+def _safe_app_build_path(workdir: pathlib.Path, rel: str) -> pathlib.Path:
+    rel_path = pathlib.PurePosixPath(rel)
+    if rel_path.is_absolute() or ".." in rel_path.parts:
+        raise click.ClickException(f"refusing unsafe app build path: {rel}")
+    return workdir.joinpath(*rel_path.parts)
+
+
+def _materialize_local_app(
+    workdir: pathlib.Path,
+    app: dict,
+    api_url: str,
+) -> None:
+    """Write one collected app to an isolated local build directory."""
+    import base64
+
+    for rel, content in (app.get("src_files") or {}).items():
+        target = _safe_app_build_path(workdir, rel)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(content, encoding="utf-8")
+    for rel, content in (app.get("bin_files") or {}).items():
+        target = _safe_app_build_path(workdir, rel)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            target.write_bytes(base64.b64decode(content, validate=True))
+        except (ValueError, TypeError) as exc:
+            raise click.ClickException(
+                f"app '{app.get('slug')}': invalid base64 asset {rel}"
+            ) from exc
+
+    package_path = workdir / "package.json"
+    if package_path.exists():
+        try:
+            package = json.loads(package_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            raise click.ClickException(
+                f"app '{app.get('slug')}': package.json is invalid: {exc}"
+            ) from exc
+        if not isinstance(package, dict):
+            raise click.ClickException(
+                f"app '{app.get('slug')}': package.json must contain an object"
+            )
+    else:
+        package = {"name": app.get("slug") or "bifrost-app", "private": True}
+
+    package_dependencies = package.get("dependencies") or {}
+    manifest_dependencies = app.get("dependencies") or {}
+    if not isinstance(package_dependencies, dict) or not isinstance(
+        manifest_dependencies, dict
+    ):
+        raise click.ClickException(
+            f"app '{app.get('slug')}': dependencies must contain an object"
+        )
+    package["dependencies"] = {
+        **package_dependencies,
+        **manifest_dependencies,
+        "bifrost": f"{api_url.rstrip('/')}/api/sdk/download",
+    }
+    package_path.write_text(json.dumps(package, indent=2), encoding="utf-8")
+
+
+def _run_local_vite_build(
+    workdir: pathlib.Path,
+    *,
+    npm: str,
+    npx: str,
+    base: str,
+) -> None:
+    """Install dependencies and compile one app with the local Node toolchain."""
+    subprocess.run(  # noqa: S603 - executable resolved by shutil.which
+        [npm, "install", "--no-audit", "--no-fund"],
+        cwd=str(workdir),
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=_LOCAL_BUILD_STEP_TIMEOUT_SECONDS,
+    )
+    subprocess.run(  # noqa: S603 - executable resolved by shutil.which
+        [npx, "vite", "build", "--base", base],
+        cwd=str(workdir),
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=_LOCAL_BUILD_STEP_TIMEOUT_SECONDS,
+    )
+
+
+def _prebuild_apps(
+    workspace: pathlib.Path,
+    apps: list[dict],
+    *,
+    install_id: str | UUID,
+    api_url: str,
+) -> dict[str, dict[str, dict[str, str]]]:
+    """Compile source-backed apps locally and return manifest dist overlays.
+
+    Source remains in the uploaded workspace. Only the generated ``dist`` is
+    added to the manifest carried by that upload, allowing the API to take its
+    existing prebuilt fast-path without running npm/Vite in the API pod.
+    """
+    import base64
+
+    del workspace  # collection already confined and materialized the workspace
+    source_apps = [
+        app
+        for app in apps
+        if (app.get("src_files") or app.get("bin_files"))
+    ]
+    if not source_apps:
+        return {}
+
+    try:
+        install_uuid = UUID(str(install_id))
+    except ValueError as exc:
+        raise click.ClickException(
+            f"Solution install id must be a UUID, got {install_id!r}"
+        ) from exc
+
+    npm = shutil.which("npm")
+    npx = shutil.which("npx")
+    if npm is None or npx is None:
+        raise click.ClickException(
+            "Solution app builds require npm and npx on this machine. Install "
+            "Node.js, then re-run `bifrost solution deploy`."
+        )
+
+    built: dict[str, dict[str, dict[str, str]]] = {}
+    for app in source_apps:
+        app_id_text = str(app.get("id") or "")
+        try:
+            manifest_id = UUID(app_id_text)
+        except ValueError as exc:
+            raise click.ClickException(
+                f"app '{app.get('slug')}': id must be a UUID, got {app_id_text!r}"
+            ) from exc
+        deployed_id = uuid5(install_uuid, str(manifest_id))
+        click.echo(f"Building app {app.get('slug') or app_id_text} locally...")
+        try:
+            with tempfile.TemporaryDirectory(prefix="bifrost-app-build-") as tmp:
+                workdir = pathlib.Path(tmp)
+                _materialize_local_app(workdir, app, api_url)
+                _run_local_vite_build(
+                    workdir,
+                    npm=npm,
+                    npx=npx,
+                    base=f"/api/applications/{deployed_id}/dist/",
+                )
+                dist_dir = workdir / "dist"
+                dist_paths = [p for p in dist_dir.rglob("*") if p.is_file()]
+                if not dist_paths:
+                    raise click.ClickException(
+                        f"app '{app.get('slug')}': local build produced no dist files"
+                    )
+                dist_files: dict[str, str] = {}
+                bin_dist_files: dict[str, str] = {}
+                for path in dist_paths:
+                    rel = path.relative_to(dist_dir).as_posix()
+                    data = path.read_bytes()
+                    try:
+                        dist_files[rel] = data.decode("utf-8")
+                    except UnicodeDecodeError:
+                        bin_dist_files[rel] = base64.b64encode(data).decode("ascii")
+        except subprocess.TimeoutExpired as exc:
+            raise click.ClickException(
+                f"app '{app.get('slug')}': local build step timed out after "
+                f"{_LOCAL_BUILD_STEP_TIMEOUT_SECONDS // 60} minutes"
+            ) from exc
+        except subprocess.CalledProcessError as exc:
+            output = (exc.stderr or exc.stdout or "").strip()
+            detail = output[-2000:] if output else f"command exited {exc.returncode}"
+            raise click.ClickException(
+                f"app '{app.get('slug')}': local build failed:\n{detail}"
+            ) from exc
+
+        built[app_id_text] = {
+            "dist_files": dist_files,
+            "bin_dist_files": bin_dist_files,
+        }
+    return built
+
+
+def _apps_manifest_with_prebuilt_dist(
+    workspace: pathlib.Path,
+    prebuilt: dict[str, dict[str, dict[str, str]]],
+) -> str:
+    """Overlay local build output into the uploaded apps manifest only."""
+    apps_file = _bifrost_manifest(workspace, "apps.yaml")
+    if apps_file is None or not apps_file.is_file():
+        raise click.ClickException("cannot add local builds: .bifrost/apps.yaml is missing")
+    data = yaml.safe_load(apps_file.read_text(encoding="utf-8")) or {}
+    entries = data.get("apps") or {}
+    if not isinstance(entries, dict):
+        raise click.ClickException(".bifrost/apps.yaml: apps must contain an object")
+
+    remaining = set(prebuilt)
+    for key, body in entries.items():
+        if not isinstance(body, dict):
+            continue
+        app_id = str(body.get("id", key))
+        dist = prebuilt.get(app_id)
+        if dist is None:
+            continue
+        body["dist_files"] = dist["dist_files"]
+        body["bin_dist_files"] = dist["bin_dist_files"]
+        remaining.discard(app_id)
+    if remaining:
+        raise click.ClickException(
+            "local build output has no apps.yaml entry for: "
+            + ", ".join(sorted(remaining))
+        )
+    return yaml.safe_dump(data, sort_keys=False)
+
+
 class _AmbiguousInstall(Exception):
     """More than one existing install matches (slug, scope); deploy can't pick."""
 
@@ -1633,7 +1852,12 @@ def pull_cmd(path: str, solution_id: str | None, org: str | None, is_global: boo
 
 
 async def _poll_deploy_job(
-    client, job_id: str, *, interval: float = 3.0, action: str = "Deploy"
+    client,
+    job_id: str,
+    *,
+    interval: float = 3.0,
+    action: str = "Deploy",
+    timeout_seconds: float = DEPLOY_JOB_TIMEOUT_SECONDS,
 ) -> int:
     """Poll a deploy/install job until terminal, printing a heartbeat each tick.
 
@@ -1692,7 +1916,15 @@ async def _poll_deploy_job(
         if isinstance(phase, str) and phase and phase != last_phase:
             click.echo(f"{action} phase: {phase}")
             last_phase = phase
-        elapsed = int(time.monotonic() - start)
+        elapsed_seconds = time.monotonic() - start
+        if elapsed_seconds >= timeout_seconds:
+            click.echo(
+                f"{action} timed out after {int(timeout_seconds)}s "
+                f"(job {job_id}). Check the job status before retrying.",
+                err=True,
+            )
+            return 1
+        elapsed = int(elapsed_seconds)
         click.echo(f"Still {gerund.lower()}... {elapsed}s")
         await asyncio.sleep(interval)
 
@@ -1899,9 +2131,31 @@ def deploy_cmd(
             else:
                 click.echo("  no shared dependencies to vendor.")
 
+        source_apps = [
+            app for app in apps if (app.get("src_files") or app.get("bin_files"))
+        ]
+        prebuilt = (
+            _prebuild_apps(
+                workspace,
+                source_apps,
+                install_id=target_id,
+                api_url=client.api_url,
+            )
+            if source_apps
+            else {}
+        )
+        extra_text_files = dict(vendored)
+        if prebuilt:
+            extra_text_files[".bifrost/apps.yaml"] = (
+                _apps_manifest_with_prebuilt_dist(workspace, prebuilt)
+            )
+
         summary = summarize_bundle(bundle_python, apps, len(vendored))
         click.echo(summary.message, err=summary.warn)
-        zip_bytes = _build_deploy_zip(workspace, extra_text_files=vendored)
+        zip_bytes = _build_deploy_zip(
+            workspace,
+            extra_text_files=extra_text_files,
+        )
 
         click.echo("Uploading workspace zip...")
         # Deploy is async server-side; the POST returns a job id quickly. We give

--- a/api/bifrost/solution_jobs.py
+++ b/api/bifrost/solution_jobs.py
@@ -1,0 +1,11 @@
+"""Shared lifecycle limits for asynchronous Solution jobs."""
+
+from datetime import timedelta
+
+
+DEPLOY_JOB_TIMEOUT_SECONDS = 15 * 60
+DEPLOY_JOB_TIMEOUT = timedelta(seconds=DEPLOY_JOB_TIMEOUT_SECONDS)
+DEPLOY_JOB_TIMEOUT_ERROR = (
+    "Solution job exceeded the 15-minute timeout. Re-run it; Solution deploys "
+    "and installs are idempotent."
+)

--- a/api/src/routers/solutions.py
+++ b/api/src/routers/solutions.py
@@ -10,6 +10,7 @@ what end users see (the Solution is invisible to them — criterion 16).
 
 from __future__ import annotations
 
+import asyncio
 import base64
 import json
 import logging
@@ -31,6 +32,11 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import noload
 from starlette.background import BackgroundTask
 
+from bifrost.solution_jobs import (
+    DEPLOY_JOB_TIMEOUT,
+    DEPLOY_JOB_TIMEOUT_ERROR,
+    DEPLOY_JOB_TIMEOUT_SECONDS,
+)
 from src.core.auth import Context, CurrentSuperuser
 from src.models.contracts.solutions import (
     Solution as SolutionDTO,
@@ -99,7 +105,7 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/solutions", tags=["Solutions"])
 
-DEPLOY_JOB_ORPHAN_THRESHOLD = timedelta(minutes=15)
+DEPLOY_JOB_ORPHAN_THRESHOLD = DEPLOY_JOB_TIMEOUT
 UPLOAD_CHUNK_SIZE = 8 * 1024 * 1024
 _ZIP_FILENAME_SAFE_RE = re.compile(r"[^A-Za-z0-9._-]+")
 
@@ -155,6 +161,27 @@ async def reconcile_orphaned_deploy_jobs(
         job.error = error
         job.updated_at = resolved_now
     return len(jobs)
+
+
+def expire_deploy_job_if_timed_out(
+    job: SolutionDeployJob,
+    *,
+    now: datetime | None = None,
+) -> bool:
+    """Move an abandoned queued/running job to a terminal failed state."""
+    if job.status not in ("queued", "running"):
+        return False
+    resolved_now = now or datetime.now(timezone.utc)
+    created_at = job.created_at
+    if created_at.tzinfo is None:
+        created_at = created_at.replace(tzinfo=timezone.utc)
+    if created_at + DEPLOY_JOB_TIMEOUT > resolved_now:
+        return False
+    job.status = "failed"
+    job.error = DEPLOY_JOB_TIMEOUT_ERROR
+    job.result = None
+    job.updated_at = resolved_now
+    return True
 
 
 @router.post("", response_model=SolutionDTO, status_code=status.HTTP_201_CREATED, summary="Create a Solution install (admin only)")
@@ -1291,21 +1318,28 @@ async def _run_deploy_job(
         status_value: str,
         error: str | None = None,
         result: dict | None = None,
-    ) -> None:
+    ) -> bool:
         async with get_db_context() as db:
             job = await db.get(SolutionDeployJob, job_id)
             if job is None:
-                return
+                return False
+            if job.status in ("succeeded", "failed"):
+                return False
             job.status = status_value
             job.error = error
             job.result = result
+            return True
 
     async def _set_phase(phase: str) -> None:
         await _set_status("running", result={"phase": phase})
 
-    await _set_status("running")
+    if not await _set_status("running"):
+        _cleanup_file(zip_path)
+        return
     deploy_result: dict | None = None
-    try:
+
+    async def _execute() -> None:
+        nonlocal deploy_result
         async with get_db_context() as db:
             async with solution_write_lock(solution_id):
                 solution = await db.get(SolutionORM, solution_id)
@@ -1337,6 +1371,13 @@ async def _run_deploy_job(
                     "integrations_shell_created": result.integrations_shell_created,
                     "roles_created": list(result.roles_created),
                 }
+    try:
+        await asyncio.wait_for(
+            _execute(),
+            timeout=DEPLOY_JOB_TIMEOUT_SECONDS,
+        )
+    except TimeoutError:
+        await _set_status("failed", DEPLOY_JOB_TIMEOUT_ERROR)
     except SolutionWriteLockHeld:
         await _set_status(
             "failed",
@@ -1412,18 +1453,27 @@ async def _run_install_job(
         status_value: str,
         error: str | None = None,
         result: dict | None = None,
-    ) -> None:
+    ) -> bool:
         async with get_db_context() as db:
             job = await db.get(SolutionDeployJob, job_id)
             if job is None:
-                return
+                return False
+            if job.status in ("succeeded", "failed"):
+                return False
             job.status = status_value
             job.error = error
             job.result = result
+            return True
 
-    await _set_status("running", result={"phase": "building and deploying bundle"})
+    if not await _set_status(
+        "running", result={"phase": "building and deploying bundle"}
+    ):
+        _cleanup_file(zip_path)
+        return
     install_result: dict | None = None
-    try:
+
+    async def _execute() -> None:
+        nonlocal install_result
         async with get_db_context() as db:
             solution = await install_zip_path(
                 db,
@@ -1438,6 +1488,13 @@ async def _run_install_job(
                 reactivate=reactivate,
             )
             install_result = {"solution_id": str(solution.id), "slug": solution.slug}
+    try:
+        await asyncio.wait_for(
+            _execute(),
+            timeout=DEPLOY_JOB_TIMEOUT_SECONDS,
+        )
+    except TimeoutError:
+        await _set_status("failed", DEPLOY_JOB_TIMEOUT_ERROR)
     except InactiveInstallExists as exc:
         await _set_status(
             "failed",
@@ -1511,14 +1568,17 @@ async def _run_install_from_repo_job(
         status_value: str,
         error: str | None = None,
         result: dict | None = None,
-    ) -> None:
+    ) -> bool:
         async with get_db_context() as db:
             job = await db.get(SolutionDeployJob, job_id)
             if job is None:
-                return
+                return False
+            if job.status in ("succeeded", "failed"):
+                return False
             job.status = status_value
             job.error = error
             job.result = result
+            return True
 
     async def _delete_orphan_install() -> None:
         async with get_db_context() as db:
@@ -1534,9 +1594,15 @@ async def _run_install_from_repo_job(
             if row is not None:
                 await db.delete(row)
 
-    await _set_status("running", result={"phase": "deploying from repo checkout"})
+    if not await _set_status(
+        "running", result={"phase": "deploying from repo checkout"}
+    ):
+        shutil.rmtree(clone_tmp, ignore_errors=True)
+        return
     install_result: dict | None = None
-    try:
+
+    async def _execute() -> None:
+        nonlocal install_result
         async with get_db_context() as db:
             async with solution_write_lock(solution_id):
                 solution = await db.get(SolutionORM, solution_id)
@@ -1549,6 +1615,14 @@ async def _run_install_from_repo_job(
                     "solution_id": str(solution_id),
                     "slug": solution.slug,
                 }
+    try:
+        await asyncio.wait_for(
+            _execute(),
+            timeout=DEPLOY_JOB_TIMEOUT_SECONDS,
+        )
+    except TimeoutError:
+        await _delete_orphan_install()
+        await _set_status("failed", DEPLOY_JOB_TIMEOUT_ERROR)
     except SolutionWriteLockHeld:
         await _set_status(
             "failed",
@@ -1666,6 +1740,9 @@ async def get_deploy_job(
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="Deploy job not found"
         )
+    if expire_deploy_job_if_timed_out(job):
+        await ctx.db.commit()
+        await ctx.db.refresh(job)
     return SolutionDeployJobStatus.model_validate(job)
 
 

--- a/api/tests/e2e/platform/test_solution_deploy_async.py
+++ b/api/tests/e2e/platform/test_solution_deploy_async.py
@@ -10,8 +10,12 @@ from __future__ import annotations
 
 import time
 import uuid
+from datetime import datetime, timedelta, timezone
 
 import pytest
+
+from src.models.orm.solution_deploy_jobs import SolutionDeployJob
+from src.routers.solutions import DEPLOY_JOB_TIMEOUT
 
 pytestmark = pytest.mark.e2e
 
@@ -133,3 +137,29 @@ def test_async_deploy_reports_failure(e2e_client, platform_admin):
     assert status == "failed", f"expected failed, got {body}"
     assert body["error"]
     assert "missing" in body["error"]
+
+
+@pytest.mark.asyncio
+async def test_polling_expires_abandoned_deploy_job(
+    e2e_client, platform_admin, db_session
+):
+    now = datetime.now(timezone.utc)
+    job = SolutionDeployJob(
+        install_id=None,
+        status="running",
+        result={"phase": "building app dist"},
+        created_at=now - DEPLOY_JOB_TIMEOUT - timedelta(seconds=1),
+        updated_at=now - DEPLOY_JOB_TIMEOUT - timedelta(seconds=1),
+    )
+    db_session.add(job)
+    await db_session.commit()
+
+    response = e2e_client.get(
+        f"/api/solutions/deploy-jobs/{job.id}", headers=platform_admin.headers
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == "failed"
+    assert body["result"] is None
+    assert "15-minute" in body["error"]

--- a/api/tests/unit/routers/test_solution_deploy_jobs.py
+++ b/api/tests/unit/routers/test_solution_deploy_jobs.py
@@ -1,12 +1,20 @@
 from __future__ import annotations
 
+from contextlib import asynccontextmanager
 from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock
+from uuid import uuid4
 
 import pytest
 
 from src.models.orm.solution_deploy_jobs import SolutionDeployJob
 from src.models.orm.solutions import Solution
-from src.routers.solutions import reconcile_orphaned_deploy_jobs
+from src.routers.solutions import (
+    DEPLOY_JOB_TIMEOUT,
+    _run_deploy_job,
+    expire_deploy_job_if_timed_out,
+    reconcile_orphaned_deploy_jobs,
+)
 
 
 @pytest.mark.asyncio
@@ -57,3 +65,72 @@ async def test_reconcile_orphaned_deploy_jobs_fails_stale_non_terminal_jobs(db_s
     assert fresh_queued.status == "queued"
     assert fresh_queued.error is None
     assert succeeded.status == "succeeded"
+
+
+@pytest.mark.asyncio
+async def test_expire_deploy_job_if_timed_out_marks_running_job_failed(db_session):
+    now = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    job = SolutionDeployJob(
+        install_id=None,
+        status="running",
+        result={"phase": "building app dist"},
+        created_at=now - DEPLOY_JOB_TIMEOUT - timedelta(seconds=1),
+        updated_at=now - DEPLOY_JOB_TIMEOUT - timedelta(seconds=1),
+    )
+    db_session.add(job)
+    await db_session.flush()
+
+    changed = expire_deploy_job_if_timed_out(job, now=now)
+
+    assert changed is True
+    assert job.status == "failed"
+    assert job.result is None
+    assert "15-minute" in (job.error or "")
+
+
+def test_expire_deploy_job_if_timed_out_leaves_terminal_job_unchanged():
+    now = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    job = SolutionDeployJob(
+        install_id=None,
+        status="succeeded",
+        result={"solution_id": "abc"},
+        created_at=now - DEPLOY_JOB_TIMEOUT - timedelta(seconds=1),
+        updated_at=now,
+    )
+
+    changed = expire_deploy_job_if_timed_out(job, now=now)
+
+    assert changed is False
+    assert job.status == "succeeded"
+    assert job.result == {"solution_id": "abc"}
+
+
+@pytest.mark.asyncio
+async def test_run_deploy_job_does_not_start_after_job_is_terminal(
+    tmp_path, monkeypatch
+):
+    job = SolutionDeployJob(id=uuid4(), install_id=None, status="failed")
+
+    class FakeDB:
+        async def get(self, model, row_id):  # noqa: ANN001, ANN201
+            assert model is SolutionDeployJob
+            assert row_id == job.id
+            return job
+
+    @asynccontextmanager
+    async def fake_db_context():
+        yield FakeDB()
+
+    from src.core import database
+    from src.services.solutions import zip_install
+
+    deploy = AsyncMock()
+    monkeypatch.setattr(database, "get_db_context", fake_db_context)
+    monkeypatch.setattr(zip_install, "deploy_zip_to_solution_path", deploy)
+    zip_path = tmp_path / "deploy.zip"
+    zip_path.write_bytes(b"not used")
+
+    await _run_deploy_job(job.id, uuid4(), zip_path, force=False)
+
+    deploy.assert_not_awaited()
+    assert not zip_path.exists()

--- a/api/tests/unit/test_cli_solution_deploy_phases.py
+++ b/api/tests/unit/test_cli_solution_deploy_phases.py
@@ -136,3 +136,57 @@ def test_deploy_uploads_workspace_zip_not_json_bundle(tmp_path) -> None:
         names = set(zf.namelist())
     assert "bifrost.solution.yaml" in names
     assert "workflows/hello.py" in names
+
+
+def test_deploy_embeds_local_prebuild_without_mutating_workspace(tmp_path) -> None:
+    captured: dict = {}
+    ws = _scaffold(tmp_path)
+    app_id = "11111111-1111-1111-1111-111111111111"
+    (ws / ".bifrost").mkdir()
+    app_dir = ws / "apps" / "dash"
+    app_dir.mkdir(parents=True)
+    (app_dir / "index.html").write_text("<div id='root'></div>")
+    apps_manifest = ws / ".bifrost" / "apps.yaml"
+    apps_manifest.write_text(
+        "apps:\n"
+        f"  {app_id}:\n"
+        f"    id: {app_id}\n"
+        "    slug: dash\n"
+        "    name: Dashboard\n"
+        "    path: apps/dash\n"
+        "    app_model: standalone_v2\n"
+    )
+
+    prebuilt = {
+        app_id: {
+            "dist_files": {"index.html": "<html>built locally</html>"},
+            "bin_dist_files": {"asset.bin": "_wA="},
+        }
+    }
+    with (
+        mock.patch(
+            "bifrost.client.BifrostClient.get_instance",
+            return_value=_client(captured),
+        ),
+        mock.patch(
+            "bifrost.commands.solution._prebuild_apps",
+            return_value=prebuilt,
+        ),
+    ):
+        result = CliRunner().invoke(
+            solution_group, ["deploy", str(ws)], catch_exceptions=False
+        )
+
+    assert result.exit_code == 0, result.output
+    deploy_call = next(
+        kwargs for path, kwargs in captured["posts"] if path.endswith("/deploy")
+    )
+    import io
+    import zipfile
+
+    with zipfile.ZipFile(io.BytesIO(deploy_call["files"]["file"][1])) as zf:
+        uploaded = yaml.safe_load(zf.read(".bifrost/apps.yaml"))
+        assert zf.read("apps/dash/index.html") == b"<div id='root'></div>"
+    assert uploaded["apps"][app_id]["dist_files"] == prebuilt[app_id]["dist_files"]
+    assert uploaded["apps"][app_id]["bin_dist_files"] == prebuilt[app_id]["bin_dist_files"]
+    assert "dist_files" not in yaml.safe_load(apps_manifest.read_text())["apps"][app_id]

--- a/api/tests/unit/test_deploy_cli_poll.py
+++ b/api/tests/unit/test_deploy_cli_poll.py
@@ -118,3 +118,17 @@ def test_poll_prints_phase_changes(capsys):
     assert "storing source artifact" in out
     assert "building app dist" in out
     assert out.count("building app dist") == 1
+
+
+def test_poll_stops_at_job_timeout(capsys):
+    client = _FakeClient({"status": "succeeded"}, running_count=10)
+
+    rc = _run(
+        _poll_deploy_job(client, "job-timeout", interval=0.0, timeout_seconds=0.0)
+    )
+
+    captured = capsys.readouterr()
+    assert rc == 1
+    assert client.calls == 1
+    assert "timed out" in (captured.out + captured.err).lower()
+    assert "job-timeout" in (captured.out + captured.err)

--- a/api/tests/unit/test_solution_cli_prebuild.py
+++ b/api/tests/unit/test_solution_cli_prebuild.py
@@ -1,0 +1,108 @@
+"""Local app prebuilds for ``bifrost solution deploy``."""
+
+from __future__ import annotations
+
+import base64
+import json
+from pathlib import Path
+from uuid import UUID, uuid5
+
+from bifrost.commands import solution as solution_command
+
+
+INSTALL_ID = UUID("33333333-3333-3333-3333-333333333333")
+APP_ID = "11111111-1111-1111-1111-111111111111"
+
+
+def test_prebuild_apps_builds_in_temp_with_install_scoped_base(
+    tmp_path: Path, monkeypatch
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    apps = [
+        {
+            "id": APP_ID,
+            "slug": "dashboard",
+            "name": "Dashboard",
+            "app_model": "standalone_v2",
+            "dependencies": {"react": "^18.0.0"},
+            "src_files": {
+                "index.html": "<div id='root'></div>",
+                "package.json": json.dumps(
+                    {
+                        "name": "dashboard",
+                        "dependencies": {"react-dom": "^18.0.0"},
+                    }
+                ),
+                "src/main.tsx": "export default 1\n",
+            },
+            "bin_files": {
+                "public/logo.png": base64.b64encode(b"PNG-SOURCE").decode("ascii")
+            },
+            "dist_files": None,
+            "bin_dist_files": None,
+        }
+    ]
+    observed: dict[str, object] = {}
+
+    monkeypatch.setattr(solution_command.shutil, "which", lambda name: f"/usr/bin/{name}")
+
+    def fake_build(workdir: Path, *, npm: str, npx: str, base: str) -> None:
+        observed.update(workdir=workdir, npm=npm, npx=npx, base=base)
+        package = json.loads((workdir / "package.json").read_text())
+        assert package["dependencies"] == {
+            "react-dom": "^18.0.0",
+            "react": "^18.0.0",
+            "bifrost": "https://bifrost.example/api/sdk/download",
+        }
+        assert (workdir / "public/logo.png").read_bytes() == b"PNG-SOURCE"
+        dist = workdir / "dist"
+        dist.mkdir()
+        (dist / "index.html").write_text("<html>built</html>")
+        (dist / "asset.bin").write_bytes(b"\xff\x00")
+
+    monkeypatch.setattr(solution_command, "_run_local_vite_build", fake_build)
+
+    built = solution_command._prebuild_apps(
+        workspace,
+        apps,
+        install_id=INSTALL_ID,
+        api_url="https://bifrost.example",
+    )
+
+    deployed_id = uuid5(INSTALL_ID, APP_ID)
+    assert observed["base"] == f"/api/applications/{deployed_id}/dist/"
+    assert observed["npm"] == "/usr/bin/npm"
+    assert observed["npx"] == "/usr/bin/npx"
+    assert built == {
+        APP_ID: {
+            "dist_files": {"index.html": "<html>built</html>"},
+            "bin_dist_files": {
+                "asset.bin": base64.b64encode(b"\xff\x00").decode("ascii")
+            },
+        }
+    }
+    assert not Path(observed["workdir"]).exists()
+
+
+def test_prebuild_apps_preserves_manifest_prebuilt_only_app(tmp_path: Path) -> None:
+    app = {
+        "id": APP_ID,
+        "slug": "dashboard",
+        "name": "Dashboard",
+        "app_model": "standalone_v2",
+        "dependencies": {},
+        "src_files": {},
+        "bin_files": {},
+        "dist_files": {"index.html": "already built"},
+        "bin_dist_files": None,
+    }
+
+    built = solution_command._prebuild_apps(
+        tmp_path,
+        [app],
+        install_id=INSTALL_ID,
+        api_url="https://bifrost.example",
+    )
+
+    assert built == {}


### PR DESCRIPTION
## Summary
- build source-backed Solution apps locally in the CLI and upload source plus prebuilt dist
- make the API use the existing prebuilt fast path instead of running npm/Vite for CLI deploys
- enforce a shared 15-minute deploy/install job timeout with abandoned-job recovery and terminal-state race protection

## Production diagnosis
The affected API pod was OOMKilled while a Solution deploy was in the app build phase. The CLI previously uploaded source without dist files, so the API performed npm/Vite despite the disconnected prebuilt path already existing.

## Verification
- full backend suite: 7,036 passed, 57 skipped
- full client suite: 1,616 passed (serialized to avoid existing timing flakiness)
- pyright and ruff: passed
- TypeScript and ESLint: passed
- post-rebase focused backend suite: 105 passed
- post-rebase provider tests: 11 passed
- live rebased debug deploy: succeeded; app JS asset returned 200; API OOMKilled=false, RestartCount=0
