### PR TITLE
Fix fork pool zombie child reaping

### DIFF
--- a/api/src/services/execution/process_pool.py
+++ b/api/src/services/execution/process_pool.py
@@ -38,7 +38,7 @@ import subprocess
 import time
 import uuid
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from enum import Enum
 from queue import Empty
 from typing import Any, Awaitable, Callable
@@ -54,6 +54,8 @@ from src.services.notification_service import get_notification_service
 from src.services.execution.template_process import TemplateProcess
 
 logger = logging.getLogger(__name__)
+
+_CLEAN_EXIT_RESULT_GRACE = timedelta(seconds=2)
 
 
 async def _notify_requirements_failures(result: RequirementsInstallResult) -> None:
@@ -201,6 +203,9 @@ class ProcessHandle:
     # Used by the orphan sweep to wait out the grace-sleep window before treating
     # a KILLED handle as truly stuck.
     killed_at: datetime | None = None
+    # Timestamp set when the template reports a clean exit before the result
+    # loop has drained the child's result pipe.
+    clean_exit_observed_at: datetime | None = None
 
     @property
     def is_alive(self) -> bool:
@@ -226,29 +231,25 @@ class _PidWrapper:
         self.exitcode: int | None = None
 
     def is_alive(self) -> bool:
+        if self.exitcode is not None:
+            return False
         try:
             os.kill(self.pid, 0)
             return True
         except OSError:
             return False
 
+    def mark_exited(self, exitcode: int) -> None:
+        """Record the authoritative exit status reported by the child parent."""
+        self.exitcode = exitcode
+
     def join(self, timeout: float | None = None) -> None:
-        import time
-        try:
-            if timeout is not None:
-                # Non-blocking waitpid with polling
-                deadline = time.monotonic() + timeout
-                while time.monotonic() < deadline:
-                    pid, status = os.waitpid(self.pid, os.WNOHANG)
-                    if pid != 0:
-                        self.exitcode = os.waitstatus_to_exitcode(status)
-                        return
-                    time.sleep(0.1)
-            else:
-                _, status = os.waitpid(self.pid, 0)
-                self.exitcode = os.waitstatus_to_exitcode(status)
-        except ChildProcessError:
-            pass  # Already reaped
+        """Wait for disappearance without trying to reap a grandchild."""
+        deadline = None if timeout is None else time.monotonic() + timeout
+        while self.is_alive():
+            if deadline is not None and time.monotonic() >= deadline:
+                return
+            time.sleep(0.05)
 
 
 # Type alias for result callback
@@ -1126,6 +1127,8 @@ class ProcessPoolManager:
         """
         to_remove: list[str] = []
 
+        self._collect_child_exit_statuses()
+
         # Snapshot to a list — items() iterator is unsafe across the awaits
         # below (peer coroutines like _handle_result mutate self.processes).
         for process_id, handle in list(self.processes.items()):
@@ -1133,6 +1136,23 @@ class ProcessPoolManager:
             if process_id not in self.processes:
                 continue
             if not handle.is_alive and handle.state != ProcessState.KILLED:
+                if handle.current_execution and not handle.result_reported:
+                    try:
+                        result = handle.result_queue.get_nowait()
+                    except (Empty, EOFError, OSError):
+                        result = None
+
+                    if isinstance(result, dict):
+                        await self._handle_result(handle, result)
+                        continue
+
+                    if handle.process.exitcode == 0:
+                        now = datetime.now(timezone.utc)
+                        if handle.clean_exit_observed_at is None:
+                            handle.clean_exit_observed_at = now
+                        if now - handle.clean_exit_observed_at < _CLEAN_EXIT_RESULT_GRACE:
+                            continue
+
                 # Case A: unexpected crash
                 logger.warning(
                     f"Process {process_id} crashed "
@@ -1176,6 +1196,28 @@ class ProcessPoolManager:
                     removed_any = True
             if removed_any:
                 await self._notify_slot_free()
+
+    def _collect_child_exit_statuses(self) -> None:
+        """Apply exit statuses gathered by the template that owns the children."""
+        template = self._template
+        if template is None:
+            return
+
+        try:
+            exit_statuses = template.collect_child_exit_statuses()
+        except (EOFError, OSError, RuntimeError) as e:
+            logger.warning(f"Could not collect child exit statuses from template: {e}")
+            return
+
+        handles_by_pid = {
+            handle.pid: handle
+            for handle in self.processes.values()
+            if handle.pid is not None
+        }
+        for child_pid, exitcode in exit_statuses.items():
+            handle = handles_by_pid.get(child_pid)
+            if handle is not None and isinstance(handle.process, _PidWrapper):
+                handle.process.mark_exited(exitcode)
 
     async def _report_orphan(self, handle: ProcessHandle) -> None:
         """

--- a/api/src/services/execution/template_process.py
+++ b/api/src/services/execution/template_process.py
@@ -87,7 +87,24 @@ class _RecvQueue:
 
 # Commands sent from consumer to template via pipe
 CMD_FORK = "fork"
+CMD_GET_EXIT_STATUSES = "get_exit_statuses"
 CMD_SHUTDOWN = "shutdown"
+
+
+def _reap_children(exit_statuses: dict[int, int]) -> None:
+    """Reap exited fork children and retain their exit status for the consumer."""
+    while True:
+        try:
+            child_pid, status = os.waitpid(-1, os.WNOHANG)
+        except ChildProcessError:
+            return
+        except InterruptedError:
+            continue
+
+        if child_pid == 0:
+            return
+
+        exit_statuses[child_pid] = os.waitstatus_to_exitcode(status)
 
 
 def _template_main(
@@ -248,7 +265,10 @@ def _template_main(
 
     # ----- Fork loop -----
     # Single-threaded, no event loop. Just wait for commands and fork.
+    exit_statuses: dict[int, int] = {}
     while True:
+        _reap_children(exit_statuses)
+
         try:
             if not pipe.poll(timeout=1.0):
                 continue
@@ -262,6 +282,16 @@ def _template_main(
         if cmd.get("action") == CMD_SHUTDOWN:
             logger.info("Template received shutdown command")
             break
+
+        if cmd.get("action") == CMD_GET_EXIT_STATUSES:
+            # A child may have exited after the sweep at the top of the loop.
+            _reap_children(exit_statuses)
+            pipe.send({
+                "status": "exit_statuses",
+                "exit_statuses": list(exit_statuses.items()),
+            })
+            exit_statuses.clear()
+            continue
 
         if cmd.get("action") == CMD_FORK:
             worker_id = cmd.get("worker_id", "unknown")
@@ -593,6 +623,24 @@ class TemplateProcess:
             work_queue,
             result_queue,
         )
+
+    def collect_child_exit_statuses(self) -> dict[int, int]:
+        """Return statuses for children reaped by the template since the last call."""
+        if self._pipe is None or not self.is_alive():
+            return {}
+
+        self._pipe.send({"action": CMD_GET_EXIT_STATUSES})
+        if not self._pipe.poll(timeout=5):
+            raise RuntimeError("Template process did not return child exit statuses within 5s")
+
+        msg = self._pipe.recv()
+        if msg.get("status") != "exit_statuses":
+            raise RuntimeError(f"Unexpected template exit-status response: {msg}")
+
+        return {
+            int(child_pid): int(exit_code)
+            for child_pid, exit_code in msg.get("exit_statuses", [])
+        }
 
     def shutdown(self) -> None:
         """Send shutdown command to template and wait for it to exit."""

--- a/api/tests/e2e/platform/test_fork_pool.py
+++ b/api/tests/e2e/platform/test_fork_pool.py
@@ -251,7 +251,7 @@ class TestForkBasedExecution:
         asyncio.set_event_loop(loop)
         try:
             execution_ids = loop.run_until_complete(
-                asyncio.gather(*[run_one(i) for i in range(5)])
+                asyncio.gather(*[run_one(i) for i in range(30)])
             )
         finally:
             loop.close()
@@ -274,7 +274,7 @@ class TestForkBasedExecution:
 
         results = poll_until(check_all_completed, max_wait=30.0, interval=0.5)
         assert results is not None, "Not all executions completed within timeout"
-        assert len(results) == 5, f"Expected 5 results, got {len(results)}"
+        assert len(results) == 30, f"Expected 30 results, got {len(results)}"
 
         # All should succeed
         for r in results:
@@ -283,7 +283,7 @@ class TestForkBasedExecution:
         # Results should have correct indices
         result_data = [r.get("result", {}) for r in results]
         indices = sorted(d.get("index") for d in result_data)
-        assert indices == [0, 1, 2, 3, 4], f"Wrong indices: {indices}"
+        assert indices == list(range(30)), f"Wrong indices: {indices}"
 
     def test_execution_timeout(self, e2e_client, platform_admin, timeout_workflow):
         """Timeout should still kill forked processes."""

--- a/api/tests/unit/execution/test_process_pool.py
+++ b/api/tests/unit/execution/test_process_pool.py
@@ -10,6 +10,7 @@ NOTE: These tests use mocks to avoid spawning real processes.
 
 import asyncio
 from datetime import datetime, timedelta, timezone
+from queue import Empty
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -19,6 +20,7 @@ from src.services.execution.process_pool import (
     ProcessHandle,
     ProcessPoolManager,
     ProcessState,
+    _PidWrapper,
 )
 from src.services.execution.simple_worker import (
     FailedPackage,
@@ -157,6 +159,29 @@ class TestProcessHandle:
 
         uptime = handle.uptime_seconds
         assert 59.0 < uptime < 61.0
+
+
+class TestPidWrapper:
+    """Tests for grandchild PID lifecycle tracking."""
+
+    def test_template_exit_status_makes_process_not_alive(self):
+        wrapper = _PidWrapper(12345)
+
+        wrapper.mark_exited(0)
+
+        with patch("src.services.execution.process_pool.os.kill") as mock_kill:
+            assert wrapper.is_alive() is False
+        assert wrapper.exitcode == 0
+        mock_kill.assert_not_called()
+
+    def test_join_never_attempts_to_reap_from_grandparent(self):
+        wrapper = _PidWrapper(12345)
+        wrapper.mark_exited(-9)
+
+        with patch("src.services.execution.process_pool.os.waitpid") as mock_waitpid:
+            wrapper.join(timeout=0.1)
+
+        mock_waitpid.assert_not_called()
 
 
 class TestProcessPoolManagerInit:
@@ -994,6 +1019,110 @@ class TestCrashedProcessReport:
 
         # Handle still removed from pool (cleanup still happens)
         assert "process-sigkill-2" not in pool.processes
+
+    @pytest.mark.asyncio
+    async def test_clean_exit_waits_for_pending_result_instead_of_reporting_crash(self):
+        """A reaped clean exit gets time for its result pipe to become readable."""
+        callback = AsyncMock()
+        pool = ProcessPoolManager(max_workers=5, on_result=callback)
+
+        mock_process = MagicMock()
+        mock_process.is_alive.return_value = False
+        mock_process.exitcode = 0
+
+        result = {
+            "type": "result",
+            "execution_id": "exec-clean",
+            "success": True,
+            "result": {"status": "ok"},
+        }
+        result_queue = MagicMock()
+        result_queue.get_nowait.side_effect = Empty
+        handle = ProcessHandle(
+            id="process-clean",
+            process=mock_process,
+            pid=99997,
+            state=ProcessState.BUSY,
+            work_queue=MagicMock(),
+            result_queue=result_queue,
+            started_at=datetime.now(timezone.utc),
+            current_execution=ExecutionInfo(
+                execution_id="exec-clean",
+                started_at=datetime.now(timezone.utc),
+                timeout_seconds=300,
+            ),
+        )
+        pool.processes[handle.id] = handle
+
+        await pool._check_process_health()
+
+        callback.assert_not_awaited()
+        assert handle.id in pool.processes
+        assert handle.clean_exit_observed_at is not None
+
+        result_queue.get_nowait.side_effect = None
+        result_queue.get_nowait.return_value = result
+        await pool._check_process_health()
+
+        callback.assert_awaited_once_with(result)
+        assert handle.id not in pool.processes
+
+    @pytest.mark.asyncio
+    async def test_clean_exit_without_result_reports_crash_after_grace(self):
+        """A clean exit that never produced a result eventually fails loudly."""
+        callback = AsyncMock()
+        pool = ProcessPoolManager(max_workers=5, on_result=callback)
+
+        mock_process = MagicMock()
+        mock_process.is_alive.return_value = False
+        mock_process.exitcode = 0
+        result_queue = MagicMock()
+        result_queue.get_nowait.side_effect = Empty
+        handle = ProcessHandle(
+            id="process-clean-no-result",
+            process=mock_process,
+            pid=99996,
+            state=ProcessState.BUSY,
+            work_queue=MagicMock(),
+            result_queue=result_queue,
+            started_at=datetime.now(timezone.utc),
+            current_execution=ExecutionInfo(
+                execution_id="exec-clean-no-result",
+                started_at=datetime.now(timezone.utc),
+                timeout_seconds=300,
+            ),
+            clean_exit_observed_at=(
+                datetime.now(timezone.utc) - timedelta(seconds=3)
+            ),
+        )
+        pool.processes[handle.id] = handle
+
+        await pool._check_process_health()
+
+        callback.assert_awaited_once()
+        assert callback.await_args.args[0]["error_type"] == "ProcessCrashError"
+        assert handle.id not in pool.processes
+
+    def test_collects_authoritative_exit_status_from_template(self):
+        pool = ProcessPoolManager(max_workers=5)
+        template = MagicMock()
+        template.collect_child_exit_statuses.return_value = {99995: -9}
+        pool._template = template
+        wrapper = _PidWrapper(99995)
+        handle = ProcessHandle(
+            id="process-reaped",
+            process=wrapper,
+            pid=99995,
+            state=ProcessState.BUSY,
+            work_queue=MagicMock(),
+            result_queue=MagicMock(),
+            started_at=datetime.now(timezone.utc),
+        )
+        pool.processes[handle.id] = handle
+
+        pool._collect_child_exit_statuses()
+
+        assert wrapper.exitcode == -9
 
 
 # ---------------------------------------------------------------------------

--- a/api/tests/unit/execution/test_template_process.py
+++ b/api/tests/unit/execution/test_template_process.py
@@ -45,6 +45,24 @@ def _wait_for_pid_to_die(pid: int, timeout: float = 5.0) -> None:
     # Best-effort — don't raise if still alive (zombie will be reaped by template)
 
 
+def _wait_for_pid_to_disappear(pid: int, timeout: float = 5.0) -> None:
+    """Wait until a template child is gone from the process table."""
+    deadline = time.monotonic() + timeout
+    last_state = "unknown"
+    while time.monotonic() < deadline:
+        try:
+            with open(f"/proc/{pid}/stat") as stat_file:
+                last_state = stat_file.read().split()[2]
+        except FileNotFoundError:
+            return
+        time.sleep(0.05)
+
+    pytest.fail(
+        f"forked child PID {pid} remained in the process table "
+        f"with state {last_state}"
+    )
+
+
 class TestTemplateProcessLifecycle:
     """Tests for template process startup and shutdown."""
 
@@ -117,22 +135,53 @@ class TestTemplateProcessFork:
         try:
             for _ in range(3):
                 child_pid, wq, rq = template.fork()
-                children.append(child_pid)
+                children.append((child_pid, wq, rq))
 
             # All should be unique PIDs
-            assert len(set(children)) == 3
+            child_pids = [child_pid for child_pid, _, _ in children]
+            assert len(set(child_pids)) == 3
 
             # All should be alive
-            for pid in children:
+            for pid in child_pids:
                 os.kill(pid, 0)  # Should not raise
         finally:
-            for pid in children:
+            for pid, work_queue, result_queue in children:
                 try:
                     os.kill(pid, signal.SIGTERM)
                     _wait_for_pid_to_die(pid)
                 except OSError as e:
                     # Child already gone (race with shutdown) — fine
                     logger.debug(f"could not signal child {pid} during cleanup: {e}")
+                work_queue.close()
+                result_queue.close()
+            template.shutdown()
+
+    def test_exited_child_is_reaped_by_template(self):
+        """A one-shot child must not remain as a zombie under the template."""
+        template = TemplateProcess()
+        template.start()
+        child_pid = None
+        work_queue = None
+        result_queue = None
+        try:
+            child_pid, work_queue, result_queue = template.fork()
+
+            # Closing the only sending end makes the idle child receive EOF and
+            # exit without requiring a full workflow execution.
+            work_queue.close()
+
+            _wait_for_pid_to_disappear(child_pid)
+            assert template.collect_child_exit_statuses()[child_pid] == 0
+        finally:
+            if work_queue is not None:
+                work_queue.close()
+            if result_queue is not None:
+                result_queue.close()
+            if child_pid is not None:
+                try:
+                    os.kill(child_pid, signal.SIGKILL)
+                except ProcessLookupError:
+                    pass
             template.shutdown()
 
     def test_forked_child_can_execute_and_return_result(self):
@@ -251,15 +300,15 @@ class TestForkPerformance:
 
             start = time.monotonic()
             for i in range(10):
-                child_pid, _, _ = template.fork(
+                child_pid, work_queue, result_queue = template.fork(
                     worker_id=f"mem-{i}", persistent=True,
                 )
-                children.append(child_pid)
+                children.append((child_pid, work_queue, result_queue))
             fork_all_ms = (time.monotonic() - start) * 1000
 
             time.sleep(0.1)
 
-            alive = sum(1 for pid in children if _is_pid_alive(pid))
+            alive = sum(1 for pid, _, _ in children if _is_pid_alive(pid))
 
             print(f"\n  Template RSS: {template_rss_mb:.0f}MB")
             print(f"  Forked 10 children in {fork_all_ms:.0f}ms ({alive} alive)")
@@ -268,12 +317,14 @@ class TestForkPerformance:
 
             assert alive >= 8, f"Only {alive}/10 children alive"
         finally:
-            for pid in children:
+            for pid, work_queue, result_queue in children:
                 try:
                     os.kill(pid, signal.SIGTERM)
                 except OSError as e:
                     # Child already gone — fine
                     logger.debug(f"could not signal child {pid} during cleanup: {e}")
+                work_queue.close()
+                result_queue.close()
             time.sleep(0.3)
             template.shutdown()
 

--- a/api/tests/unit/execution/test_template_process.py
+++ b/api/tests/unit/execution/test_template_process.py
@@ -181,6 +181,7 @@ class TestTemplateProcessFork:
                 try:
                     os.kill(child_pid, signal.SIGKILL)
                 except ProcessLookupError:
+                    # Expected once the template has already reaped the child.
                     pass
             template.shutdown()
 


### PR DESCRIPTION
## Summary
- reap forked worker children in the template process that actually owns them
- propagate authoritative exit codes to the pool without calling waitpid from the grandparent
- drain or briefly await a clean child result before crash classification
- cover real zombie disappearance and 30 concurrent workflow executions

## Reproduction
The new real-process regression failed on origin/main with the exited child remaining in /proc with state Z. It passes with this change.

## Testing
- ./test.sh quality api
- ./test.sh tests/unit/execution/test_template_process.py -m "" -v
- ./test.sh tests/unit/execution/test_process_pool.py tests/e2e/platform/test_fork_pool.py -m "" -v
- 30 concurrent executions completed successfully; worker zombie count afterward: 0
- unrelated failures from the long full-suite run passed 16/16 when rerun in isolation

Fixes #508