### PR TITLE
fix(cli): preserve credential provenance

### DIFF
--- a/api/bifrost/cli.py
+++ b/api/bifrost/cli.py
@@ -231,14 +231,6 @@ def _check_cli_version() -> None:
     if installed in ("unknown", "0.0.0+source"):
         return  # dev/source install — nothing to compare against
 
-    # Re-load dotenv so a CWD-local .env's BIFROST_API_URL is honored even
-    # if bifrost.client's import-time load happened against a different cwd.
-    try:
-        from dotenv import find_dotenv, load_dotenv
-        load_dotenv(find_dotenv(usecwd=True), override=False)
-    except ImportError:
-        pass  # python-dotenv is optional; without it, only os.environ is consulted
-
     # Use credentials._resolve_url (not get_credentials) because the version
     # check only needs the URL — get_credentials returns None unless full
     # tokens are present too, which would skip the check on a logged-out CLI.
@@ -1027,11 +1019,12 @@ Examples:
         return 1
 
     is_password_grant = email is not None and password is not None
+    environment_url = credentials.resolve_environment_url()
 
     if is_password_grant:
         # Resolve URL: --url > BIFROST_API_URL env var > error. No default.
         if not api_url:
-            api_url = os.environ.get("BIFROST_API_URL", "").rstrip("/")
+            api_url = environment_url
         if not api_url:
             print(
                 "Error: password-grant login requires --url or BIFROST_API_URL env var "
@@ -1068,13 +1061,14 @@ Examples:
         return rc
 
     # Browser device-code flow (persistent → keychain or JSON fallback).
-    success = asyncio.run(login_flow(api_url=api_url, auto_open=auto_open))
+    login_url = api_url or environment_url
+    success = asyncio.run(login_flow(api_url=login_url, auto_open=auto_open))
     if not success:
         return 1
 
     # Wire up the CWD .env so subsequent commands in this folder target this URL.
     # The token lives in the keychain keyed by URL; .env just carries the URL.
-    resolved_url = (api_url or os.environ.get("BIFROST_API_URL") or "").rstrip("/")
+    resolved_url = (login_url or "").rstrip("/")
     if not resolved_url:
         # login_flow's default — match what login_flow used so the .env line agrees
         # with where the token landed.

--- a/api/bifrost/client.py
+++ b/api/bifrost/client.py
@@ -9,7 +9,6 @@ Supports two modes:
 
 import asyncio
 import logging
-import os
 import sys
 import threading
 import time
@@ -24,8 +23,11 @@ from .credentials import (
     clear_credentials,
     get_credentials,
     is_token_expired,
-    replace_env_credentials,
+    load_dotenv_context,
+    resolve_credentials,
     resolve_current_connection,
+    resolve_environment_url,
+    save_refreshed_credentials,
     save_credentials,
 )
 
@@ -188,16 +190,9 @@ async def _acquire_refresh_lock(lock: threading.Lock) -> None:
             lock.release()
         raise
 
-# Auto-load .env file if present (for local development).
-# Walk upward from cwd, not from this file. With pipx-installed CLIs, __file__
-# lives in the pipx venv and the default upward walk never reaches the user's
-# workspace, so a .env in the project root is silently ignored.
-try:
-    from dotenv import find_dotenv, load_dotenv
-
-    load_dotenv(find_dotenv(usecwd=True))
-except ImportError:
-    pass  # dotenv not installed, rely on environment variables
+# Preserve non-auth project context without merging auth fields from different
+# sources into one synthetic os.environ tuple.
+load_dotenv_context()
 
 
 async def refresh_connection_access_token(
@@ -213,20 +208,22 @@ async def refresh_connection_access_token(
     """
     normalized_url = api_url.rstrip("/")
     coordinator = _refresh_coordinator(normalized_url)
+    credential_source = "unknown"
     await _acquire_refresh_lock(coordinator.lock)
     try:
-        creds = get_credentials(normalized_url)
-        if not creds:
+        resolved = resolve_credentials(normalized_url)
+        if resolved is None:
+            logger.warning(
+                "Bifrost token refresh failed for %s: no credentials resolved",
+                normalized_url,
+            )
             return None
+        credential_source = resolved.source
+        creds = resolved.credentials
 
-        stored_access_token = str(creds["access_token"])
-        stored_refresh_token = str(creds["refresh_token"])
-        env_url = os.environ.get("BIFROST_API_URL", "").rstrip("/")
-        env_backed = (
-            env_url == normalized_url
-            and bool(os.environ.get("BIFROST_ACCESS_TOKEN"))
-            and bool(os.environ.get("BIFROST_REFRESH_TOKEN"))
-        )
+        stored_access_token = creds.access_token
+        stored_refresh_token = creds.refresh_token
+        env_backed = resolved.source in {"process", "dotenv"}
 
         if coordinator.latest_access_token is not None:
             if observed_access_token != coordinator.latest_access_token:
@@ -248,6 +245,12 @@ async def refresh_connection_access_token(
                 json={"refresh_token": refresh_token},
             )
         if response.status_code != 200:
+            logger.warning(
+                "Bifrost token refresh failed for %s using %s credentials: HTTP %s",
+                normalized_url,
+                credential_source,
+                response.status_code,
+            )
             return None
 
         data = response.json()
@@ -256,24 +259,31 @@ async def refresh_connection_access_token(
             seconds=data.get("expires_in", 1800)
         )
         new_refresh_token = str(data["refresh_token"])
-        replaced_env = replace_env_credentials(
-            normalized_url,
+        saved = save_refreshed_credentials(
+            resolved,
             stored_access_token,
             refresh_token,
             access_token,
             new_refresh_token,
+            expires_at.isoformat(),
         )
-        if not replaced_env:
-            save_credentials(
-                api_url=normalized_url,
-                access_token=access_token,
-                refresh_token=new_refresh_token,
-                expires_at=expires_at.isoformat(),
+        if not saved:
+            logger.warning(
+                "Bifrost token refresh succeeded for %s, but the %s credential "
+                "source changed before rotated tokens could be written back",
+                normalized_url,
+                credential_source,
             )
         coordinator.latest_access_token = access_token
         coordinator.latest_refresh_token = new_refresh_token
         return access_token
-    except Exception:
+    except Exception as exc:
+        logger.warning(
+            "Bifrost token refresh failed for %s using %s credentials: %s",
+            normalized_url,
+            credential_source,
+            type(exc).__name__,
+        )
         return None
     finally:
         coordinator.lock.release()
@@ -365,7 +375,7 @@ async def login_flow(api_url: str | None = None, auto_open: bool = True) -> bool
     """
     # Get API URL
     if not api_url:
-        api_url = os.getenv("BIFROST_API_URL", "http://localhost:8000")
+        api_url = resolve_environment_url() or "http://localhost:8000"
 
     api_url = api_url.rstrip("/")
 

--- a/api/bifrost/commands/solution.py
+++ b/api/bifrost/commands/solution.py
@@ -36,6 +36,7 @@ import click
 import yaml
 
 from bifrost.client import BifrostClient
+from bifrost.credentials import resolve_environment_url
 from bifrost.org_target import org_option, resolve_org_target
 from bifrost.solution_jobs import DEPLOY_JOB_TIMEOUT_SECONDS
 from bifrost.solution_binding import (
@@ -302,7 +303,7 @@ def _scaffold_api_url(api_url: str | None) -> str:
     baking it while logged in against a real instance broke the app's
     `npm install` (the SDK dependency pointed at a dead port; drive finding,
     2026-07-02)."""
-    resolved = api_url or os.getenv("BIFROST_API_URL")
+    resolved = api_url or resolve_environment_url()
     if resolved:
         return resolved
     try:

--- a/api/bifrost/credentials.py
+++ b/api/bifrost/credentials.py
@@ -9,19 +9,29 @@ across multiple Bifrost instances simultaneously, with three backends:
 - JsonBackend: ~/.bifrost/credentials.json as a dict-of-URLs
 - User config: ~/.bifrost/config.json stores the default connection pointer
 
-Resolution order: env vars → selected default → only stored connection → optional prompt.
+Resolution keeps process, nearest-dotenv, and persistent credential tuples
+separate, then selects a complete tuple for the effective API URL.
 """
 
 import json
+import logging
 import os
 import platform
 import sys
 from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Protocol
+from typing import Literal, Protocol
 
 KEYRING_SERVICE = "bifrost"
+AUTH_ENV_KEYS = frozenset({
+    "BIFROST_API_URL",
+    "BIFROST_ACCESS_TOKEN",
+    "BIFROST_REFRESH_TOKEN",
+})
+
+logger = logging.getLogger(__name__)
+_warned_dotenv_mismatches: set[tuple[str, str]] = set()
 
 
 # --------------------------------------------------------------------------- #
@@ -50,6 +60,38 @@ class Credentials:
         )
 
 
+CredentialSource = Literal["process", "dotenv", "persistent", "legacy"]
+
+
+@dataclass(frozen=True)
+class ResolvedCredentials:
+    """One complete credential tuple plus the source that owns it."""
+
+    credentials: Credentials
+    source: CredentialSource
+    dotenv_path: Path | None = None
+
+
+@dataclass(frozen=True)
+class _DotenvConnection:
+    """Bifrost auth fields read together from one nearest dotenv file."""
+
+    path: Path
+    api_url: str
+    access_token: str
+    refresh_token: str
+
+    def credentials(self) -> Credentials | None:
+        if not self.api_url or not self.access_token or not self.refresh_token:
+            return None
+        return Credentials(
+            api_url=self.api_url,
+            access_token=self.access_token,
+            refresh_token=self.refresh_token,
+            expires_at="2099-01-01T00:00:00+00:00",
+        )
+
+
 # --------------------------------------------------------------------------- #
 # Path helpers (unchanged)
 # --------------------------------------------------------------------------- #
@@ -69,6 +111,77 @@ def get_credentials_path() -> Path:
 
 def get_config_path() -> Path:
     return get_config_dir() / "config.json"
+
+
+def _nearest_dotenv_values() -> tuple[Path, dict[str, str | None]] | None:
+    """Read the nearest dotenv without copying any values into the process."""
+    try:
+        from dotenv import dotenv_values, find_dotenv
+    except ImportError:
+        return None
+
+    env_path = find_dotenv(usecwd=True)
+    if not env_path:
+        return None
+    try:
+        values = dotenv_values(env_path)
+    except OSError:
+        return None
+    return Path(env_path), dict(values)
+
+
+def _nearest_dotenv_connection() -> _DotenvConnection | None:
+    snapshot = _nearest_dotenv_values()
+    if snapshot is None:
+        return None
+    path, values = snapshot
+    return _DotenvConnection(
+        path=path,
+        api_url=str(values.get("BIFROST_API_URL") or "").rstrip("/"),
+        access_token=str(values.get("BIFROST_ACCESS_TOKEN") or ""),
+        refresh_token=str(values.get("BIFROST_REFRESH_TOKEN") or ""),
+    )
+
+
+def load_dotenv_context() -> None:
+    """Load non-auth dotenv context without destroying credential provenance.
+
+    Solution bindings and CLI behavior flags historically rely on the nearest
+    dotenv being available through ``os.environ``. The three authentication
+    fields are deliberately excluded and are resolved together on demand.
+    """
+    snapshot = _nearest_dotenv_values()
+    if snapshot is None:
+        return
+    _path, values = snapshot
+    for key, value in values.items():
+        if key not in AUTH_ENV_KEYS and value is not None:
+            os.environ.setdefault(key, value)
+
+
+def resolve_environment_url() -> str | None:
+    """Resolve only the process/dotenv URL, without stored defaults."""
+    process_url = os.environ.get("BIFROST_API_URL", "").rstrip("/")
+    if process_url:
+        return process_url
+    dotenv = _nearest_dotenv_connection()
+    if dotenv is not None and dotenv.api_url:
+        return dotenv.api_url
+    return None
+
+
+def _warn_dotenv_mismatch(dotenv_url: str, selected_url: str) -> None:
+    """Emit one secret-safe mismatch diagnostic per URL pair and process."""
+    mismatch = (dotenv_url, selected_url)
+    if mismatch in _warned_dotenv_mismatches:
+        return
+    _warned_dotenv_mismatches.add(mismatch)
+    logger.warning(
+        "Ignoring complete dotenv credentials for %s because the selected "
+        "API URL is %s; using stored credentials for the selected URL",
+        dotenv_url,
+        selected_url,
+    )
 
 
 # --------------------------------------------------------------------------- #
@@ -318,6 +431,7 @@ def _reset_persistent_backend_for_tests() -> None:
     global _persistent_backend, _keyring_fallback_reason
     _persistent_backend = None
     _keyring_fallback_reason = None
+    _warned_dotenv_mismatches.clear()
 
 
 def _load_config() -> dict[str, str]:
@@ -399,15 +513,19 @@ def resolve_current_connection(
     Order:
       1. The argument (if given).
       2. BIFROST_API_URL env var.
-      3. The user-selected default connection.
-      4. The only stored URL, when exactly one exists.
-      5. Optional interactive selection when multiple URLs exist.
+      3. BIFROST_API_URL from the nearest dotenv file.
+      4. The user-selected default connection.
+      5. The only stored URL, when exactly one exists.
+      6. Optional interactive selection when multiple URLs exist.
     """
     if api_url:
         return api_url.rstrip("/"), "argument"
     env_url = os.environ.get("BIFROST_API_URL", "").rstrip("/")
     if env_url:
         return env_url, "BIFROST_API_URL"
+    dotenv = _nearest_dotenv_connection()
+    if dotenv is not None and dotenv.api_url:
+        return dotenv.api_url, ".env"
 
     urls = get_persistent_backend().list_urls()
     default_url = get_default_connection()
@@ -482,28 +600,24 @@ def _try_migrate_legacy() -> Credentials | None:
     return legacy
 
 
-def get_credentials(
+def resolve_credentials(
     api_url: str | None = None,
     *,
     prompt_for_default: bool = False,
-) -> dict | None:
+) -> ResolvedCredentials | None:
     """
-    Resolve credentials for a given API URL.
+    Resolve one provenance-bound credential tuple for a given API URL.
 
     Resolution order:
-      1. Env vars (EnvBackend) — for ephemeral sessions.
-      2. Persistent backend (keychain or JSON) — for long-lived sessions.
-      3. Legacy single-record JSON — lazily migrated.
+      1. Complete process tuple (EnvBackend) — for ephemeral sessions.
+      2. Complete nearest-dotenv tuple for the same target URL.
+      3. Persistent backend (keychain or JSON) — for long-lived sessions.
+      4. Legacy single-record JSON — lazily migrated.
 
-    If api_url is None, the URL is resolved via _resolve_url(). When even
-    that fails, we fall through to the legacy file as a last resort to
-    learn the URL.
-
-    Returns: dict with keys api_url/access_token/refresh_token/expires_at,
-    or None. Returns dict (not Credentials) for back-compat with existing
-    callers in client.py / cli.py.
+    If api_url is None, the URL is resolved via ``resolve_current_connection``.
+    When even that fails, the legacy file is a last resort for learning one.
     """
-    resolved, _source = resolve_current_connection(
+    resolved, _target_source = resolve_current_connection(
         api_url,
         prompt_for_default=prompt_for_default,
     )
@@ -513,23 +627,54 @@ def get_credentials(
         legacy = _try_migrate_legacy()
         if legacy is None:
             return None
-        return legacy.to_dict()
+        return ResolvedCredentials(legacy, "legacy")
 
-    # 1. Env vars
+    # 1. A complete process tuple always wins when its URL matches.
     env_creds = EnvBackend().get(resolved)
     if env_creds is not None:
-        return env_creds.to_dict()
+        return ResolvedCredentials(env_creds, "process")
 
-    # 2. Persistent backend
+    # 2. Dotenv credentials are one indivisible tuple. They are safe only when
+    # the URL recorded beside the tokens matches the selected target.
+    dotenv = _nearest_dotenv_connection()
+    dotenv_creds = dotenv.credentials() if dotenv is not None else None
+    if dotenv_creds is not None:
+        if dotenv_creds.api_url.rstrip("/") == resolved:
+            return ResolvedCredentials(
+                dotenv_creds,
+                "dotenv",
+                dotenv_path=dotenv.path if dotenv is not None else None,
+            )
+        _warn_dotenv_mismatch(
+            dotenv_creds.api_url,
+            resolved,
+        )
+
+    # 3. Persistent backend
     creds = get_persistent_backend().get(resolved)
     if creds is not None:
-        return creds.to_dict()
+        return ResolvedCredentials(creds, "persistent")
 
-    # 3. Legacy fallback (and migrate if found)
+    # 4. Legacy fallback (and migrate if found)
     legacy = _try_migrate_legacy()
     if legacy is not None and legacy.api_url.rstrip("/") == resolved:
-        return legacy.to_dict()
+        return ResolvedCredentials(legacy, "legacy")
     return None
+
+
+def get_credentials(
+    api_url: str | None = None,
+    *,
+    prompt_for_default: bool = False,
+) -> dict | None:
+    """Return the resolved tuple as the historical four-key dictionary."""
+    resolved = resolve_credentials(
+        api_url,
+        prompt_for_default=prompt_for_default,
+    )
+    if resolved is None:
+        return None
+    return resolved.credentials.to_dict()
 
 
 def save_credentials(
@@ -548,63 +693,66 @@ def save_credentials(
     get_persistent_backend().save(creds)
 
 
-def replace_env_credentials(
-    api_url: str,
+def save_refreshed_credentials(
+    resolved: ResolvedCredentials,
     observed_access_token: str,
     observed_refresh_token: str,
     access_token: str,
     refresh_token: str,
+    expires_at: str,
 ) -> bool:
-    """Replace one rotating credential generation sourced from environment.
+    """Write a rotated token generation back to the source that owns it."""
+    credentials = resolved.credentials
+    normalized_url = credentials.api_url.rstrip("/")
 
-    Password-grant development sessions are loaded from a workspace ``.env``.
-    Their backend is intentionally isolated from the persistent keychain/store,
-    but a read-only environment snapshot cannot survive refresh-token rotation.
-    Update the current process and, when the same generation came from the
-    nearest ``.env``, update that file so the next CLI process can continue it.
+    if resolved.source == "process":
+        current = EnvBackend().get(normalized_url)
+        if (
+            current is None
+            or current.access_token != observed_access_token
+            or current.refresh_token != observed_refresh_token
+        ):
+            return False
+        os.environ["BIFROST_ACCESS_TOKEN"] = access_token
+        os.environ["BIFROST_REFRESH_TOKEN"] = refresh_token
+        return True
 
-    Returns ``True`` only when the observed generation is the active env source.
-    """
-    normalized_url = api_url.rstrip("/")
-    current = EnvBackend().get(normalized_url)
-    if (
-        current is None
-        or current.access_token != observed_access_token
-        or current.refresh_token != observed_refresh_token
-    ):
-        return False
+    if resolved.source == "dotenv":
+        if resolved.dotenv_path is None:
+            return False
+        try:
+            from dotenv import dotenv_values, set_key
 
-    try:
-        from dotenv import dotenv_values, find_dotenv, set_key
-
-        env_path = find_dotenv(usecwd=True)
-        if env_path:
-            values = dotenv_values(env_path)
+            values = dotenv_values(resolved.dotenv_path)
             file_url = str(values.get("BIFROST_API_URL") or "").rstrip("/")
             if (
-                file_url == normalized_url
-                and values.get("BIFROST_ACCESS_TOKEN") == observed_access_token
-                and values.get("BIFROST_REFRESH_TOKEN") == observed_refresh_token
+                file_url != normalized_url
+                or values.get("BIFROST_ACCESS_TOKEN") != observed_access_token
+                or values.get("BIFROST_REFRESH_TOKEN") != observed_refresh_token
             ):
-                set_key(
-                    env_path,
-                    "BIFROST_ACCESS_TOKEN",
-                    access_token,
-                    quote_mode="never",
-                )
-                set_key(
-                    env_path,
-                    "BIFROST_REFRESH_TOKEN",
-                    refresh_token,
-                    quote_mode="never",
-                )
-    except OSError:
-        # The running process can still continue even if its source file became
-        # unwritable after login.
-        pass
+                return False
+            set_key(
+                str(resolved.dotenv_path),
+                "BIFROST_ACCESS_TOKEN",
+                access_token,
+                quote_mode="never",
+            )
+            set_key(
+                str(resolved.dotenv_path),
+                "BIFROST_REFRESH_TOKEN",
+                refresh_token,
+                quote_mode="never",
+            )
+        except (ImportError, OSError):
+            return False
+        return True
 
-    os.environ["BIFROST_ACCESS_TOKEN"] = access_token
-    os.environ["BIFROST_REFRESH_TOKEN"] = refresh_token
+    save_credentials(
+        api_url=normalized_url,
+        access_token=access_token,
+        refresh_token=refresh_token,
+        expires_at=expires_at,
+    )
     return True
 
 

--- a/api/tests/unit/cli/test_cli_version_check.py
+++ b/api/tests/unit/cli/test_cli_version_check.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 import io
 import json
+import os
 from unittest.mock import patch
 
 import httpx
@@ -241,21 +242,25 @@ class TestUrlResolution:
             url = urlopen.call_args[0][0]
             assert url == "http://from-credentials.example/api/version"
 
-    def test_loads_dotenv_before_resolving(self, monkeypatch, tmp_path):
+    def test_resolves_dotenv_without_mutating_process_auth(self, monkeypatch, tmp_path):
         """A project ``.env`` containing BIFROST_API_URL is honored.
 
-        ``_check_cli_version`` runs before the rest of the CLI imports
-        ``bifrost.client`` (which is where dotenv is normally loaded). The
-        check must load dotenv itself so a CWD-local ``.env`` resolves the
-        URL just like the rest of the CLI would.
+        The credential resolver reads the nearest dotenv directly. The version
+        check must honor that URL without copying auth fields into ``os.environ``.
         """
         env_file = tmp_path / ".env"
-        env_file.write_text("BIFROST_API_URL=http://from-dotenv.example\n")
+        env_file.write_text(
+            "BIFROST_API_URL=http://from-dotenv.example\n"
+            "BIFROST_ACCESS_TOKEN=dotenv-access\n"
+            "BIFROST_REFRESH_TOKEN=dotenv-refresh\n"
+        )
 
         monkeypatch.chdir(tmp_path)
         # Make sure the env var isn't already set in the test process so we
         # know the value got there via dotenv, not inheritance.
         monkeypatch.delenv("BIFROST_API_URL", raising=False)
+        monkeypatch.delenv("BIFROST_ACCESS_TOKEN", raising=False)
+        monkeypatch.delenv("BIFROST_REFRESH_TOKEN", raising=False)
 
         _patch_version(monkeypatch, "1.2.3")
         from bifrost import cli
@@ -277,6 +282,9 @@ class TestUrlResolution:
         assert urlopen.called, "httpx.get never called — dotenv URL not resolved"
         url = urlopen.call_args[0][0]
         assert url == "http://from-dotenv.example/api/version"
+        assert "BIFROST_API_URL" not in os.environ
+        assert "BIFROST_ACCESS_TOKEN" not in os.environ
+        assert "BIFROST_REFRESH_TOKEN" not in os.environ
 
 
 class TestTransport:

--- a/api/tests/unit/test_bifrost_client_credentials.py
+++ b/api/tests/unit/test_bifrost_client_credentials.py
@@ -368,11 +368,11 @@ async def test_failed_refresh_logs_status_and_source_without_tokens(
     )
 
     assert result is None
-    assert api_url in caplog.text
-    assert "persistent" in caplog.text
-    assert "401" in caplog.text
-    assert "secret-access" not in caplog.text
-    assert "secret-refresh" not in caplog.text
+    assert len(caplog.records) == 1
+    warning = caplog.records[0]
+    assert warning.args == (api_url, "persistent", 401)
+    assert "secret-access" not in warning.getMessage()
+    assert "secret-refresh" not in warning.getMessage()
 
 
 @pytest.mark.asyncio
@@ -411,11 +411,11 @@ async def test_refresh_exception_logs_class_without_exception_message_or_tokens(
     )
 
     assert result is None
-    assert api_url in caplog.text
-    assert "persistent" in caplog.text
-    assert "RuntimeError" in caplog.text
-    assert "secret-access" not in caplog.text
-    assert "secret-refresh" not in caplog.text
+    assert len(caplog.records) == 1
+    warning = caplog.records[0]
+    assert warning.args == (api_url, "persistent", "RuntimeError")
+    assert "secret-access" not in warning.getMessage()
+    assert "secret-refresh" not in warning.getMessage()
 
 
 @pytest.mark.asyncio

--- a/api/tests/unit/test_bifrost_client_credentials.py
+++ b/api/tests/unit/test_bifrost_client_credentials.py
@@ -1,6 +1,7 @@
 """Tests for BifrostClient credential resolution and refresh coordination."""
 
 import asyncio
+import os
 import threading
 from datetime import datetime, timedelta, timezone
 
@@ -61,6 +62,32 @@ def test_get_instance_does_not_report_default_ambiguity_when_env_selects_url(
 
     with pytest.raises(RuntimeError, match="Not logged in"):
         client_mod.BifrostClient.get_instance(require_auth=True)
+
+
+def test_get_instance_uses_persistent_tuple_for_url_only_process_override(
+    isolated_credentials, monkeypatch, tmp_path
+) -> None:
+    from bifrost import client as client_mod
+
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".env").write_text(
+        "BIFROST_API_URL=http://localhost:36092\n"
+        "BIFROST_ACCESS_TOKEN=localhost-access\n"
+        "BIFROST_REFRESH_TOKEN=localhost-refresh\n"
+    )
+    isolated_credentials.save_credentials(
+        "https://prod.example.com",
+        "production-access",
+        "production-refresh",
+        "2099-01-01T00:00:00+00:00",
+    )
+    monkeypatch.setenv("BIFROST_API_URL", "https://prod.example.com")
+
+    client = client_mod.BifrostClient.get_instance(require_auth=True)
+
+    assert client.api_url == "https://prod.example.com"
+    assert client._access_token == "production-access"
+    client._sync_http.close()
 
 
 @pytest.mark.asyncio
@@ -208,9 +235,6 @@ async def test_env_credentials_survive_multiple_rotating_refreshes(
 
     api_url = "https://api.example.com"
     monkeypatch.chdir(tmp_path)
-    monkeypatch.setenv("BIFROST_API_URL", api_url)
-    monkeypatch.setenv("BIFROST_ACCESS_TOKEN", "access-0")
-    monkeypatch.setenv("BIFROST_REFRESH_TOKEN", "refresh-0")
     (tmp_path / ".env").write_text(
         "BIFROST_API_URL=https://api.example.com\n"
         "BIFROST_ACCESS_TOKEN=access-0\n"
@@ -257,6 +281,141 @@ async def test_env_credentials_survive_multiple_rotating_refreshes(
     env_text = (tmp_path / ".env").read_text()
     assert "BIFROST_ACCESS_TOKEN=access-2" in env_text
     assert "BIFROST_REFRESH_TOKEN=refresh-2" in env_text
+
+
+@pytest.mark.asyncio
+async def test_process_credentials_refresh_in_process_without_persistence(
+    isolated_credentials, monkeypatch
+) -> None:
+    from bifrost import client as client_mod
+
+    api_url = "https://api.example.com"
+    monkeypatch.setenv("BIFROST_API_URL", api_url)
+    monkeypatch.setenv("BIFROST_ACCESS_TOKEN", "access-0")
+    monkeypatch.setenv("BIFROST_REFRESH_TOKEN", "refresh-0")
+
+    class FakeAsyncClient:
+        def __init__(self, *, base_url, timeout):
+            assert base_url == api_url
+            assert timeout == 30.0
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return None
+
+        async def post(self, path, *, json):
+            assert path == "/auth/refresh"
+            assert json == {"refresh_token": "refresh-0"}
+            return httpx.Response(
+                200,
+                json={
+                    "access_token": "access-1",
+                    "refresh_token": "refresh-1",
+                    "expires_in": 1800,
+                },
+                request=httpx.Request("POST", f"{api_url}/auth/refresh"),
+            )
+
+    monkeypatch.setattr(client_mod.httpx, "AsyncClient", FakeAsyncClient)
+
+    result = await client_mod.refresh_connection_access_token(api_url, "access-0")
+
+    assert result == "access-1"
+    assert os.environ["BIFROST_ACCESS_TOKEN"] == "access-1"
+    assert os.environ["BIFROST_REFRESH_TOKEN"] == "refresh-1"
+    assert isolated_credentials.get_persistent_backend().get(api_url) is None
+
+
+@pytest.mark.asyncio
+async def test_failed_refresh_logs_status_and_source_without_tokens(
+    isolated_credentials, monkeypatch, caplog
+) -> None:
+    from bifrost import client as client_mod
+
+    api_url = "https://api.example.com"
+    isolated_credentials.save_credentials(
+        api_url,
+        "secret-access",
+        "secret-refresh",
+        (datetime.now(timezone.utc) - timedelta(minutes=5)).isoformat(),
+    )
+
+    class FakeAsyncClient:
+        def __init__(self, *, base_url, timeout):
+            assert base_url == api_url
+            assert timeout == 30.0
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return None
+
+        async def post(self, path, *, json):
+            assert path == "/auth/refresh"
+            return httpx.Response(
+                401,
+                request=httpx.Request("POST", f"{api_url}/auth/refresh"),
+            )
+
+    monkeypatch.setattr(client_mod.httpx, "AsyncClient", FakeAsyncClient)
+    caplog.set_level("WARNING", logger="bifrost.client")
+
+    result = await client_mod.refresh_connection_access_token(
+        api_url, "secret-access"
+    )
+
+    assert result is None
+    assert api_url in caplog.text
+    assert "persistent" in caplog.text
+    assert "401" in caplog.text
+    assert "secret-access" not in caplog.text
+    assert "secret-refresh" not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_refresh_exception_logs_class_without_exception_message_or_tokens(
+    isolated_credentials, monkeypatch, caplog
+) -> None:
+    from bifrost import client as client_mod
+
+    api_url = "https://api.example.com"
+    isolated_credentials.save_credentials(
+        api_url,
+        "secret-access",
+        "secret-refresh",
+        (datetime.now(timezone.utc) - timedelta(minutes=5)).isoformat(),
+    )
+
+    class FakeAsyncClient:
+        def __init__(self, *, base_url, timeout):
+            assert base_url == api_url
+            assert timeout == 30.0
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return None
+
+        async def post(self, path, *, json):
+            raise RuntimeError("secret-refresh must never appear")
+
+    monkeypatch.setattr(client_mod.httpx, "AsyncClient", FakeAsyncClient)
+    caplog.set_level("WARNING", logger="bifrost.client")
+
+    result = await client_mod.refresh_connection_access_token(
+        api_url, "secret-access"
+    )
+
+    assert result is None
+    assert api_url in caplog.text
+    assert "persistent" in caplog.text
+    assert "RuntimeError" in caplog.text
+    assert "secret-access" not in caplog.text
+    assert "secret-refresh" not in caplog.text
 
 
 @pytest.mark.asyncio

--- a/api/tests/unit/test_credentials.py
+++ b/api/tests/unit/test_credentials.py
@@ -123,11 +123,14 @@ class TestCredentialProvenance:
         assert result["refresh_token"] == "production-refresh"
         assert "BIFROST_ACCESS_TOKEN" not in os.environ
         assert "BIFROST_REFRESH_TOKEN" not in os.environ
-        assert "http://localhost:36092" in caplog.text
-        assert "https://prod.example.com" in caplog.text
-        assert caplog.text.count("Ignoring complete dotenv credentials") == 1
-        assert "localhost-access" not in caplog.text
-        assert "localhost-refresh" not in caplog.text
+        assert len(caplog.records) == 1
+        warning = caplog.records[0]
+        assert warning.args == (
+            "http://localhost:36092",
+            "https://prod.example.com",
+        )
+        assert "localhost-access" not in warning.getMessage()
+        assert "localhost-refresh" not in warning.getMessage()
 
     def test_complete_process_tuple_wins_over_dotenv_and_persistent(
         self, isolated_store, monkeypatch

--- a/api/tests/unit/test_credentials.py
+++ b/api/tests/unit/test_credentials.py
@@ -70,6 +70,190 @@ class TestEnvBackend:
         assert os.environ.get("BIFROST_ACCESS_TOKEN") in (None, "")  # didn't pollute env
 
 
+# ---------- Credential provenance ----------
+
+class TestCredentialProvenance:
+    @pytest.fixture
+    def isolated_store(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(
+            creds_mod,
+            "get_credentials_path",
+            lambda: tmp_path / "credentials.json",
+        )
+        monkeypatch.setattr(
+            creds_mod,
+            "get_config_path",
+            lambda: tmp_path / "config.json",
+        )
+        creds_mod._reset_persistent_backend_for_tests()
+        monkeypatch.setattr(creds_mod, "_persistent_backend", JsonBackend())
+        monkeypatch.delenv("BIFROST_API_URL", raising=False)
+        monkeypatch.delenv("BIFROST_ACCESS_TOKEN", raising=False)
+        monkeypatch.delenv("BIFROST_REFRESH_TOKEN", raising=False)
+        monkeypatch.delenv("BIFROST_SOLUTION_ID", raising=False)
+        monkeypatch.chdir(tmp_path)
+        yield tmp_path
+        creds_mod._reset_persistent_backend_for_tests()
+
+    def test_url_only_process_override_does_not_borrow_dotenv_tokens(
+        self, isolated_store, monkeypatch, caplog
+    ):
+        (isolated_store / ".env").write_text(
+            "BIFROST_API_URL=http://localhost:36092\n"
+            "BIFROST_ACCESS_TOKEN=localhost-access\n"
+            "BIFROST_REFRESH_TOKEN=localhost-refresh\n"
+        )
+        creds_mod.save_credentials(
+            "https://prod.example.com",
+            "production-access",
+            "production-refresh",
+            "2099-01-01T00:00:00+00:00",
+        )
+        monkeypatch.setenv("BIFROST_API_URL", "https://prod.example.com")
+        caplog.set_level("WARNING", logger="bifrost.credentials")
+
+        creds_mod.load_dotenv_context()
+        result = creds_mod.get_credentials()
+        repeated_result = creds_mod.get_credentials()
+
+        assert result is not None
+        assert repeated_result == result
+        assert result["api_url"] == "https://prod.example.com"
+        assert result["access_token"] == "production-access"
+        assert result["refresh_token"] == "production-refresh"
+        assert "BIFROST_ACCESS_TOKEN" not in os.environ
+        assert "BIFROST_REFRESH_TOKEN" not in os.environ
+        assert "http://localhost:36092" in caplog.text
+        assert "https://prod.example.com" in caplog.text
+        assert caplog.text.count("Ignoring complete dotenv credentials") == 1
+        assert "localhost-access" not in caplog.text
+        assert "localhost-refresh" not in caplog.text
+
+    def test_complete_process_tuple_wins_over_dotenv_and_persistent(
+        self, isolated_store, monkeypatch
+    ):
+        (isolated_store / ".env").write_text(
+            "BIFROST_API_URL=http://localhost:36092\n"
+            "BIFROST_ACCESS_TOKEN=localhost-access\n"
+            "BIFROST_REFRESH_TOKEN=localhost-refresh\n"
+        )
+        creds_mod.save_credentials(
+            "https://prod.example.com",
+            "stored-access",
+            "stored-refresh",
+            "2099-01-01T00:00:00+00:00",
+        )
+        monkeypatch.setenv("BIFROST_API_URL", "https://prod.example.com")
+        monkeypatch.setenv("BIFROST_ACCESS_TOKEN", "process-access")
+        monkeypatch.setenv("BIFROST_REFRESH_TOKEN", "process-refresh")
+
+        creds_mod.load_dotenv_context()
+        result = creds_mod.get_credentials()
+
+        assert result is not None
+        assert result["access_token"] == "process-access"
+        assert result["refresh_token"] == "process-refresh"
+
+    def test_complete_nearest_dotenv_tuple_is_used(self, isolated_store):
+        (isolated_store / ".env").write_text(
+            "BIFROST_API_URL=http://localhost:36092\n"
+            "BIFROST_ACCESS_TOKEN=localhost-access\n"
+            "BIFROST_REFRESH_TOKEN=localhost-refresh\n"
+        )
+
+        result = creds_mod.get_credentials()
+
+        assert result is not None
+        assert result["api_url"] == "http://localhost:36092"
+        assert result["access_token"] == "localhost-access"
+        assert result["refresh_token"] == "localhost-refresh"
+
+    def test_matching_url_only_process_override_uses_complete_dotenv_tuple(
+        self, isolated_store, monkeypatch
+    ):
+        (isolated_store / ".env").write_text(
+            "BIFROST_API_URL=http://localhost:36092\n"
+            "BIFROST_ACCESS_TOKEN=localhost-access\n"
+            "BIFROST_REFRESH_TOKEN=localhost-refresh\n"
+        )
+        monkeypatch.setenv("BIFROST_API_URL", "http://localhost:36092")
+
+        result = creds_mod.get_credentials()
+
+        assert result is not None
+        assert result["access_token"] == "localhost-access"
+        assert result["refresh_token"] == "localhost-refresh"
+
+    def test_child_url_only_dotenv_uses_persistent_credentials_not_parent_tokens(
+        self, isolated_store, monkeypatch
+    ):
+        (isolated_store / ".env").write_text(
+            "BIFROST_API_URL=http://localhost:36092\n"
+            "BIFROST_ACCESS_TOKEN=localhost-access\n"
+            "BIFROST_REFRESH_TOKEN=localhost-refresh\n"
+        )
+        child = isolated_store / "solutions" / "sales"
+        child.mkdir(parents=True)
+        (child / ".env").write_text("BIFROST_API_URL=https://prod.example.com\n")
+        creds_mod.save_credentials(
+            "https://prod.example.com",
+            "production-access",
+            "production-refresh",
+            "2099-01-01T00:00:00+00:00",
+        )
+        creds_mod.save_credentials(
+            "http://localhost:36092",
+            "stored-local-access",
+            "stored-local-refresh",
+            "2099-01-01T00:00:00+00:00",
+        )
+        monkeypatch.chdir(child)
+
+        result = creds_mod.get_credentials()
+
+        assert result is not None
+        assert result["api_url"] == "https://prod.example.com"
+        assert result["access_token"] == "production-access"
+        assert result["refresh_token"] == "production-refresh"
+
+    def test_partial_dotenv_tuple_falls_through_to_persistent(
+        self, isolated_store
+    ):
+        (isolated_store / ".env").write_text(
+            "BIFROST_API_URL=https://prod.example.com\n"
+            "BIFROST_ACCESS_TOKEN=partial-access\n"
+        )
+        creds_mod.save_credentials(
+            "https://prod.example.com",
+            "production-access",
+            "production-refresh",
+            "2099-01-01T00:00:00+00:00",
+        )
+
+        result = creds_mod.get_credentials()
+
+        assert result is not None
+        assert result["access_token"] == "production-access"
+        assert result["refresh_token"] == "production-refresh"
+
+    def test_filtered_dotenv_bootstrap_preserves_non_auth_context(
+        self, isolated_store
+    ):
+        (isolated_store / ".env").write_text(
+            "BIFROST_API_URL=http://localhost:36092\n"
+            "BIFROST_ACCESS_TOKEN=localhost-access\n"
+            "BIFROST_REFRESH_TOKEN=localhost-refresh\n"
+            "BIFROST_SOLUTION_ID=solution-id\n"
+        )
+
+        creds_mod.load_dotenv_context()
+
+        assert os.environ["BIFROST_SOLUTION_ID"] == "solution-id"
+        assert "BIFROST_API_URL" not in os.environ
+        assert "BIFROST_ACCESS_TOKEN" not in os.environ
+        assert "BIFROST_REFRESH_TOKEN" not in os.environ
+
+
 # ---------- JsonBackend (multi-record) ----------
 
 class TestJsonBackendMultiRecord:


### PR DESCRIPTION
## Summary

- resolve process, nearest-dotenv, and persistent credentials as provenance-bound tuples
- preserve complete process and matching dotenv sessions while preventing URL-only overrides from borrowing mismatched dotenv tokens
- write refreshed tokens back to their owning source and emit deduplicated, secret-safe failure diagnostics
- keep non-auth dotenv context available for Solution workflows and URL-only CLI operations

## Verification

- `./test.sh quality api`
- `./test.sh tests/unit/test_credentials.py tests/unit/test_bifrost_client_credentials.py tests/unit/cli/test_cli_version_check.py tests/unit/test_cli_login_ephemeral.py tests/unit/test_solution_start_env.py tests/unit/test_cli_surface_smoke.py tests/unit/test_skill_appendix_fresh.py -q` (216 passed)
- `./test.sh all` (7049 passed, 57 skipped)
- installed the API-matched CLI from the isolated worktree debug stack and reproduced the root-dotenv localhost tuple plus URL-only debug override; the CLI selected persistent credentials and `GET /api/solutions` returned 200

Fixes #510
