### PR TITLE
fix(cli): recover long-running Solution previews

### DIFF
--- a/.claude/skills/bifrost-build/generated/cli-reference.md
+++ b/.claude/skills/bifrost-build/generated/cli-reference.md
@@ -1729,7 +1729,7 @@ Commands:
   pull          Pull captured entities into the local .bifrost/ manifest...
   scaffold-app  Scaffold a standalone_v2 React app (package.json, vite,...
   sdk           Manage the app's vendored Bifrost SDK.
-  start         Run the app's dev server + local workflows (one origin).
+  start         Run the app's dev server + local workflows on one stable...
   swap-slugs    Atomically exchange two apps' slugs (v1→v2 migration...
 ```
 
@@ -1963,11 +1963,13 @@ Options:
 ```
 Usage: solution start [OPTIONS] [APP_SLUG]
 
-  Run the app's dev server + local workflows (one origin).
+  Run the app's dev server + local workflows on one stable origin. Preview
+  credentials are renewed automatically.
 
 Options:
   --solution TEXT    Install id or unique slug.
-  --port INTEGER     Local origin port.  [default: 3000]
+  --port INTEGER     Stable local proxy origin port; reuse it across restarts.
+                     [default: 3000]
   --host TEXT        Address for the local origin to bind.  [default:
                      127.0.0.1]
   --public-url TEXT  Browser-visible origin for the local proxy, e.g.

--- a/.claude/skills/bifrost-build/references/solutions.md
+++ b/.claude/skills/bifrost-build/references/solutions.md
@@ -102,6 +102,15 @@ Runs the app's Vite dev server and local workflow functions behind one origin â€
 
 Open the origin the command prints (the **proxy** port; `--port` sets it, default 3000). Vite itself binds to **`--port + 1`** behind the proxy â€” drive the app at the proxy port the command prints, not the Vite port.
 
+The preview renews its CLI access token before expiry and replaces the
+bundle's token on realtime reconnects. An expired access token does **not**
+require restarting `solution start`. If the underlying refresh session has
+also expired, run `bifrost login` in another terminal; the active preview keeps
+retrying and adopts the new credentials. If the CLI process itself must be
+restarted, reuse the same `--port`: an open preview on that stable origin
+detects the new proxy session and reloads automatically. The CLI never moves a
+requested proxy or Vite port to a random replacement.
+
 After any CLI, server, or web-SDK execution-transport change, drive an actual
 bound app through this origin; a scaffold or mocked unit test is not enough.
 For a local workflow, verify the terminal `POST /api/workflows/execute`

--- a/api/bifrost/commands/solution.py
+++ b/api/bifrost/commands/solution.py
@@ -2488,10 +2488,22 @@ def _vite_child_env(
     return env
 
 
-@solution_group.command(name="start", help="Run the app's dev server + local workflows (one origin).")
+@solution_group.command(
+    name="start",
+    help=(
+        "Run the app's dev server + local workflows on one stable origin. "
+        "Preview credentials are renewed automatically."
+    ),
+)
 @click.argument("app_slug", required=False)
 @click.option("--solution", "solution_ref", default=None, help="Install id or unique slug.")
-@click.option("--port", default=3000, show_default=True, type=int, help="Local origin port.")
+@click.option(
+    "--port",
+    default=3000,
+    show_default=True,
+    type=int,
+    help="Stable local proxy origin port; reuse it across restarts.",
+)
 @click.option("--host", "bind_host", default="127.0.0.1", show_default=True,
               help="Address for the local origin to bind.")
 @click.option("--public-url", default=None,
@@ -2574,6 +2586,7 @@ def start_cmd(
     # Cheap, deterministic refusals come BEFORE a possibly-minutes install:
     # aborting on a busy port after the user sat through npm is hostile.
     vite_port = port + 1
+    _ensure_port_free(port)
     _ensure_port_free(vite_port)
 
     original_sdk_spec = _heal_sdk_dep(chosen.app_dir, client.api_url)

--- a/api/bifrost/solution_dev/proxy.py
+++ b/api/bifrost/solution_dev/proxy.py
@@ -12,14 +12,17 @@ Routes:
   everything else              → reverse-proxy to the Vite dev server (the app),
                                  including Vite's own HMR websocket.
 
-The upstream proxy injects the CLI token (Authorization), the bound install org
-(X-Bifrost-Org), and the bound install id (``?solution=`` / ``solution_id``) so
-data-plane calls run under the same install scope as deployed.
+The upstream proxy injects the current CLI token (Authorization), the bound
+install org (X-Bifrost-Org), and the bound install id (``?solution=`` /
+``solution_id``) so data-plane calls run under the same install scope as
+deployed. The proxy renews JWT-shaped access tokens before expiry and still
+refreshes reactively on an upstream 401.
 
-WebSockets are NOT given the injected Authorization header: the browser
-authenticates the realtime socket via cookies or a `token` query param (see
-client/src/services/websocket.ts). The `token` query param rides along in
-`rel_url`; cookies are forwarded explicitly on the upstream handshake.
+WebSockets cannot carry the injected Authorization header. For platform
+realtime sockets, the proxy replaces the bundle's static `token` query param
+with its current renewed CLI token on every upstream handshake (see
+client/src/lib/app-sdk/ws-client.ts). Cookies are forwarded explicitly too.
+Vite HMR sockets remain untouched.
 Requested subprotocols (e.g. Vite's `vite-hmr`) are echoed back to the client
 and forwarded upstream — browsers fail the connection otherwise. When either
 side closes, the bridge tears down both sockets (no half-open pump leaks).
@@ -27,10 +30,13 @@ side closes, the bridge tears down both sockets (no half-open pump leaks).
 from __future__ import annotations
 
 import asyncio
+import base64
 import html
+import json
 import re
+import time
 import uuid as _uuid
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Awaitable, Callable
 
 import aiohttp
@@ -60,7 +66,14 @@ class _UpstreamAuthorityError(ValueError):
     """The constructed proxy target's authority is not the trusted base's."""
 
 
-DEV_AUTH_EXPIRED_DETAIL = "Your CLI token has expired. Restart `bifrost solution start`."
+DEV_AUTH_EXPIRED_DETAIL = (
+    "The local preview could not renew your CLI credentials yet. It will keep "
+    "trying automatically; run `bifrost login` only if your refresh session has expired."
+)
+_AUTH_REFRESH_LEEWAY_SECONDS = 60.0
+_AUTH_REFRESH_POLL_SECONDS = 30.0
+_AUTH_REFRESH_RETRY_SECONDS = 2.0
+_DEV_SESSION_PATH = "/__bifrost_dev/session"
 
 
 def _join_upstream(base_url: str, rel_url: yarl.URL) -> str:
@@ -111,6 +124,7 @@ class DevProxyConfig:
     auth_expired: bool = False
     branding: dict[str, Any] | None = None
     branding_loaded: bool = False
+    session_id: str = field(default_factory=lambda: str(_uuid.uuid4()))
 
 
 # Typed app keys (avoid aiohttp's NotAppKeyWarning for plain-string keys).
@@ -129,6 +143,7 @@ def build_dev_app(cfg: DevProxyConfig, host, vite_url: str) -> web.Application:
     app[_HTTP] = httpx.AsyncClient(timeout=120.0)
     app[_WARNED_UUID_REFS] = set()
 
+    app.router.add_get(_DEV_SESSION_PATH, _dev_session_handler)
     app.router.add_post("/api/workflows/execute", _execute_handler)
     app.router.add_route("*", "/ws/{tail:.*}", _ws_handler)
     app.router.add_route("*", "/api/{tail:.*}", _api_proxy_handler)
@@ -137,6 +152,7 @@ def build_dev_app(cfg: DevProxyConfig, host, vite_url: str) -> web.Application:
     async def _close(app):
         await app[_HTTP].aclose()
 
+    app.cleanup_ctx.append(_proactive_auth_refresh_context)
     app.on_cleanup.append(_close)
     return app
 
@@ -170,20 +186,93 @@ def _passthrough_headers(resp, default_content_type: str) -> dict[str, str]:
     return headers
 
 
-async def _refresh_cli_token(cfg: DevProxyConfig, observed_access_token: str) -> bool:
+def _jwt_expiry(token: str) -> float | None:
+    """Read an unverified JWT exp hint for renewal scheduling.
+
+    Authentication still happens upstream. This parser only decides when to
+    call the real refresh endpoint, so opaque/non-JWT tokens simply retain the
+    existing refresh-on-401 behavior.
+    """
+    try:
+        payload_segment = token.split(".")[1]
+        padding = "=" * (-len(payload_segment) % 4)
+        payload = json.loads(base64.urlsafe_b64decode(payload_segment + padding))
+        if not isinstance(payload, dict):
+            return None
+        expiry = payload.get("exp")
+        if isinstance(expiry, (int, float)) and not isinstance(expiry, bool):
+            return float(expiry)
+    except (IndexError, ValueError, TypeError):
+        pass
+    return None
+
+
+async def _refresh_cli_token(
+    cfg: DevProxyConfig,
+    observed_access_token: str,
+    *,
+    mark_expired_on_failure: bool = True,
+) -> bool:
     if cfg.refresh_token is None:
-        cfg.auth_expired = True
+        if mark_expired_on_failure:
+            cfg.auth_expired = True
         return False
     try:
         token = await cfg.refresh_token(observed_access_token)
     except Exception:
         token = None
     if not token:
-        cfg.auth_expired = True
+        if mark_expired_on_failure:
+            cfg.auth_expired = True
         return False
     cfg.token = token
     cfg.auth_expired = False
     return True
+
+
+async def _proactive_auth_refresh_loop(app: web.Application) -> None:
+    """Renew an active preview token before its JWT expiry.
+
+    The shared client refresh coordinator serializes this with any reactive
+    HTTP refresh. A transient early failure does not poison the preview while
+    the current token remains valid; the loop retries and only marks auth as
+    expired after the actual exp time passes.
+    """
+    cfg: DevProxyConfig = app[_CFG]
+    while True:
+        expiry = _jwt_expiry(cfg.token)
+        if expiry is None:
+            await asyncio.sleep(_AUTH_REFRESH_POLL_SECONDS)
+            continue
+
+        remaining = expiry - time.time()
+        if remaining > _AUTH_REFRESH_LEEWAY_SECONDS:
+            await asyncio.sleep(
+                min(
+                    _AUTH_REFRESH_POLL_SECONDS,
+                    remaining - _AUTH_REFRESH_LEEWAY_SECONDS,
+                )
+            )
+            continue
+
+        observed_access_token = cfg.token
+        refreshed = await _refresh_cli_token(
+            cfg,
+            observed_access_token,
+            mark_expired_on_failure=remaining <= 0,
+        )
+        if refreshed and cfg.token != observed_access_token:
+            continue
+        await asyncio.sleep(_AUTH_REFRESH_RETRY_SECONDS)
+
+
+async def _proactive_auth_refresh_context(app: web.Application):
+    task = asyncio.create_task(_proactive_auth_refresh_loop(app))
+    try:
+        yield
+    finally:
+        task.cancel()
+        await asyncio.gather(task, return_exceptions=True)
 
 
 async def _authed_upstream_request(
@@ -233,6 +322,43 @@ def _dev_auth_expired_json_response() -> web.Response:
     )
 
 
+async def _dev_session_handler(request: web.Request) -> web.Response:
+    cfg: DevProxyConfig = request.app[_CFG]
+    return web.json_response(
+        {"session_id": cfg.session_id},
+        headers={"Cache-Control": "no-store"},
+    )
+
+
+def _dev_recovery_script(session_id: str) -> str:
+    encoded_session_id = json.dumps(session_id)
+    return f"""<script data-bifrost-dev-recovery>
+(() => {{
+  const sessionId = {encoded_session_id};
+  const checkSession = async () => {{
+    try {{
+      const response = await fetch("{_DEV_SESSION_PATH}", {{ cache: "no-store" }});
+      if (!response.ok) return;
+      const current = await response.json();
+      if (current.session_id !== sessionId) window.location.reload();
+    }} catch (_) {{
+      // Keep polling while the CLI proxy is restarting on this same origin.
+    }}
+  }};
+  window.setInterval(checkSession, 5000);
+}})();
+</script>"""
+
+
+def _inject_dev_recovery_script(body: bytes, session_id: str) -> bytes:
+    script = _dev_recovery_script(session_id).encode()
+    marker = b"</head>"
+    offset = body.lower().find(marker)
+    if offset == -1:
+        return script + body
+    return body[:offset] + script + body[offset:]
+
+
 async def _get_branding(request: web.Request) -> dict[str, Any]:
     cfg: DevProxyConfig = request.app[_CFG]
     if cfg.branding_loaded:
@@ -275,6 +401,9 @@ async def _dev_auth_expired_page_response(request: web.Request) -> web.Response:
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>{escaped_product_name} Dev Auth Expired</title>
+    <script>
+      window.setTimeout(() => window.location.reload(), 3000);
+    </script>
     <script>
       try {{
         if ((localStorage.getItem("theme") || "dark") === "dark") {{
@@ -489,9 +618,9 @@ async def _dev_auth_expired_page_response(request: web.Request) -> web.Response:
           <div class="actions">
             <h2>What you can do:</h2>
             <ul>
-              <li>• Stop this server and restart <code>bifrost solution start</code></li>
-              <li>• If restarting does not fix it, run <code>bifrost login</code></li>
-              <li>• Refresh this page after the Solution dev server is running again</li>
+              <li>• This page retries automatically; no CLI restart is needed</li>
+              <li>• If it does not recover, run <code>bifrost login</code> in another terminal</li>
+              <li>• Keep <code>bifrost solution start</code> running on this origin</li>
             </ul>
           </div>
         </div>
@@ -523,6 +652,11 @@ def _ws_scheme(http_url: str) -> str:
     if http_url.startswith("http://"):
         return "ws://" + http_url[len("http://"):]
     return http_url
+
+
+def _with_cli_token(rel_url: yarl.URL, token: str) -> yarl.URL:
+    """Replace a bundle-baked websocket token with the live proxy token."""
+    return rel_url.update_query(token=token)
 
 
 async def _ws_proxy(request: web.Request, target_ws_url: str) -> web.WebSocketResponse:
@@ -579,7 +713,12 @@ async def _ws_proxy(request: web.Request, target_ws_url: str) -> web.WebSocketRe
 async def _ws_handler(request: web.Request) -> web.WebSocketResponse:
     """Bridge realtime (/ws/...) sockets to the dev API."""
     cfg: DevProxyConfig = request.app[_CFG]
-    target = _ws_scheme(_join_upstream(cfg.upstream_url, request.rel_url))
+    target = _ws_scheme(
+        _join_upstream(
+            cfg.upstream_url,
+            _with_cli_token(request.rel_url, cfg.token),
+        )
+    )
     return await _ws_proxy(request, target)
 
 
@@ -716,7 +855,12 @@ async def _execute_handler(request: web.Request) -> web.Response:
 async def _api_proxy_handler(request: web.Request) -> web.StreamResponse:
     cfg: DevProxyConfig = request.app[_CFG]
     if _is_ws_upgrade(request):
-        target = _ws_scheme(_join_upstream(cfg.upstream_url, request.rel_url))
+        target = _ws_scheme(
+            _join_upstream(
+                cfg.upstream_url,
+                _with_cli_token(request.rel_url, cfg.token),
+            )
+        )
         return await _ws_proxy(request, target)
     data = await request.read()
     try:
@@ -751,10 +895,10 @@ async def _vite_proxy_handler(request: web.Request) -> web.StreamResponse:
         # state (the SDK header historically collapsed every auth failure to
         # "Account"). Verify the CLI-backed proxy session before handing the
         # document to Vite. This also refreshes a stale access token once via
-        # the same coordinated authority used by API calls. On failure, reuse
-        # the branded dev diagnostics page before any app JavaScript runs.
-        if cfg.auth_expired:
-            return await _dev_auth_expired_page_response(request)
+        # the same coordinated authority used by API calls. Even after an
+        # earlier failure, retry here so a rotated credential written by
+        # another CLI process can be adopted without restarting this preview.
+        # On failure, reuse the branded diagnostics page before app JS runs.
         try:
             auth = await _authed_upstream_request(
                 request,
@@ -815,7 +959,16 @@ async def _vite_proxy_handler(request: web.Request) -> web.StreamResponse:
             {"detail": f"Error talking to the app dev server (vite): {type(exc).__name__}: {exc}"},
             status=502,
         )
+    body = resp.content
+    response_headers = _passthrough_headers(resp, "text/html")
+    content_type = response_headers["content-type"].lower()
+    if resp.status_code == 200 and content_type.startswith("text/html"):
+        body = _inject_dev_recovery_script(body, cfg.session_id)
+        # A cached document would retain an obsolete session id and could
+        # reload-loop after a proxy restart.
+        response_headers["cache-control"] = "no-store"
     return web.Response(
-        body=resp.content, status=resp.status_code,
-        headers=_passthrough_headers(resp, "text/html"),
+        body=body,
+        status=resp.status_code,
+        headers=response_headers,
     )

--- a/api/bifrost/solution_dev/proxy.py
+++ b/api/bifrost/solution_dev/proxy.py
@@ -203,7 +203,7 @@ def _jwt_expiry(token: str) -> float | None:
         if isinstance(expiry, (int, float)) and not isinstance(expiry, bool):
             return float(expiry)
     except (IndexError, ValueError, TypeError):
-        pass
+        return None
     return None
 
 

--- a/api/tests/unit/test_solution_dev_command.py
+++ b/api/tests/unit/test_solution_dev_command.py
@@ -534,7 +534,11 @@ def test_start_spawns_npm_via_resolved_path(tmp_path: Path, monkeypatch):
         return None
 
     monkeypatch.setattr("bifrost.commands.solution._serve", _fake_serve)
-    monkeypatch.setattr("bifrost.commands.solution._ensure_port_free", lambda port: None)
+    checked_ports: list[int] = []
+    monkeypatch.setattr(
+        "bifrost.commands.solution._ensure_port_free",
+        checked_ports.append,
+    )
     monkeypatch.setattr("bifrost.commands.solution._wait_for_vite", lambda proc, port: None)
     monkeypatch.setattr(
         "bifrost.commands.solution._terminate_process_group", lambda proc: None
@@ -546,6 +550,7 @@ def test_start_spawns_npm_via_resolved_path(tmp_path: Path, monkeypatch):
     assert len(spawned) == 2
     for argv in spawned:
         assert argv[0] == npm_path, f"npm spawn used {argv[0]!r}, not the which() result"
+    assert checked_ports == [3000, 3001]
 
 
 def test_start_public_url_does_not_change_same_origin_browser_transport(tmp_path: Path, monkeypatch):
@@ -627,7 +632,11 @@ def test_start_public_url_does_not_change_same_origin_browser_transport(tmp_path
 
     monkeypatch.setattr(subprocess, "Popen", _fake_popen)
     monkeypatch.setattr("bifrost.commands.solution._serve", _fake_serve)
-    monkeypatch.setattr("bifrost.commands.solution._ensure_port_free", lambda port: None)
+    checked_ports: list[int] = []
+    monkeypatch.setattr(
+        "bifrost.commands.solution._ensure_port_free",
+        checked_ports.append,
+    )
     monkeypatch.setattr("bifrost.commands.solution._wait_for_vite", lambda proc, port: None)
     monkeypatch.setattr(
         "bifrost.commands.solution._terminate_process_group", lambda proc: None
@@ -652,6 +661,7 @@ def test_start_public_url_does_not_change_same_origin_browser_transport(tmp_path
         "port": 3000,
         "proxy_origin": "http://devbox.test:3000",
     }
+    assert checked_ports == [3000, 3001]
     # --public-url only describes the URL printed to the user. The browser
     # transport stays relative so a second forwarding proxy may rewrite that
     # origin again without breaking API calls.
@@ -1209,3 +1219,13 @@ def test_start_port_conflict_is_reported_before_any_npm_work(tmp_path, monkeypat
     assert result.exit_code == 1
     assert "already in use" in result.output
     assert spawned == []  # no npm install happened
+
+
+def test_start_help_documents_stable_preview_origin():
+    result = CliRunner().invoke(solution_group, ["start", "--help"])
+
+    assert result.exit_code == 0
+    help_text = result.output.lower()
+    assert "renewed automatically" in help_text
+    assert "stable local proxy origin" in help_text
+    assert "reuse it across restarts" in help_text

--- a/api/tests/unit/test_solution_dev_proxy.py
+++ b/api/tests/unit/test_solution_dev_proxy.py
@@ -1,5 +1,8 @@
 import asyncio
+import base64
+import json
 import socket
+import time
 
 import aiohttp
 import httpx
@@ -10,7 +13,22 @@ from bifrost.solution_dev.function_host import (
     LocalWorkflowImportError,
     LocalWorkflowResolutionError,
 )
-from bifrost.solution_dev.proxy import DevProxyConfig, _join_upstream, build_dev_app
+from bifrost.solution_dev.proxy import (
+    DEV_AUTH_EXPIRED_DETAIL,
+    DevProxyConfig,
+    _join_upstream,
+    build_dev_app,
+)
+
+
+def _jwt_with_exp(exp: float) -> str:
+    """Build an unsigned JWT-shaped token; the proxy only reads the exp hint."""
+
+    def _segment(value: dict) -> str:
+        raw = json.dumps(value, separators=(",", ":")).encode()
+        return base64.urlsafe_b64encode(raw).decode().rstrip("=")
+
+    return f"{_segment({'alg': 'none'})}.{_segment({'exp': exp})}."
 
 
 def test_join_upstream_keeps_trusted_authority():
@@ -524,6 +542,45 @@ async def test_api_proxy_refreshes_cli_token_once_after_401():
         await up_runner.cleanup()
 
 
+async def test_active_preview_proactively_renews_token_before_a_request_401():
+    record = {}
+    up_port, dev_port = _free_port(), _free_port()
+    up_runner = await _serve(_make_auth_refresh_upstream(record), up_port)
+    refreshed = asyncio.Event()
+
+    async def refresh_token(observed_token):
+        record["refresh_called"] = observed_token
+        refreshed.set()
+        return "fresh-token"
+
+    expired_token = _jwt_with_exp(time.time() - 1)
+    cfg = DevProxyConfig(
+        upstream_url=f"http://127.0.0.1:{up_port}",
+        token=expired_token,
+        app_id="A",
+        org_id="O",
+        refresh_token=refresh_token,
+    )
+    dev_runner = await _serve(
+        build_dev_app(cfg, _StubHost(set()), vite_url="http://127.0.0.1:1"),
+        dev_port,
+    )
+    try:
+        await asyncio.wait_for(refreshed.wait(), timeout=1)
+        await asyncio.sleep(0)
+        async with httpx.AsyncClient() as c:
+            response = await c.get(f"http://127.0.0.1:{dev_port}/api/auth/me")
+        assert response.status_code == 200
+        assert record["refresh_called"] == expired_token
+        # Renewal happened before browser traffic, so the request never sent
+        # the expired token and never needed the reactive 401 path.
+        assert record["auth_headers"] == ["Bearer fresh-token"]
+        assert cfg.auth_expired is False
+    finally:
+        await dev_runner.cleanup()
+        await up_runner.cleanup()
+
+
 async def test_api_proxy_returns_dev_auth_expired_json_when_refresh_fails():
     record = {}
     up_port, dev_port = _free_port(), _free_port()
@@ -549,12 +606,64 @@ async def test_api_proxy_returns_dev_auth_expired_json_when_refresh_fails():
         assert r.headers["x-bifrost-dev-auth"] == "expired"
         assert r.json() == {
             "error": "bifrost_dev_auth_expired",
-            "detail": "Your CLI token has expired. Restart `bifrost solution start`.",
+            "detail": DEV_AUTH_EXPIRED_DETAIL,
         }
         assert record["refresh_called"] == "stale-token"
         assert record["auth_headers"] == ["Bearer stale-token"]
     finally:
         await dev_runner.cleanup()
+        await up_runner.cleanup()
+
+
+async def test_document_reload_recovers_after_credentials_are_replaced():
+    record = {}
+    up_port, vite_port, dev_port = _free_port(), _free_port(), _free_port()
+    up_runner = await _serve(_make_auth_refresh_upstream(record), up_port)
+
+    async def index(_request):
+        return web.Response(text="<html><body>Vite app</body></html>", content_type="text/html")
+
+    vite = web.Application()
+    vite.router.add_get("/", index)
+    vite_runner = await _serve(vite, vite_port)
+    can_refresh = False
+
+    async def refresh_token(_observed_token):
+        return "fresh-token" if can_refresh else None
+
+    cfg = DevProxyConfig(
+        upstream_url=f"http://127.0.0.1:{up_port}",
+        token="stale-token",
+        app_id="A",
+        org_id="O",
+        refresh_token=refresh_token,
+    )
+    dev_runner = await _serve(
+        build_dev_app(cfg, _StubHost(set()), vite_url=f"http://127.0.0.1:{vite_port}"),
+        dev_port,
+    )
+    try:
+        async with httpx.AsyncClient() as c:
+            failed = await c.get(f"http://127.0.0.1:{dev_port}/api/auth/me")
+            assert failed.status_code == 401
+            assert cfg.auth_expired is True
+
+            # Another CLI process/login can replace the stored credential tuple.
+            # The already-running preview must adopt it on the next automatic or
+            # manual document reload; auth_expired cannot be a permanent latch.
+            can_refresh = True
+            recovered = await c.get(
+                f"http://127.0.0.1:{dev_port}/",
+                headers={"Accept": "text/html"},
+            )
+
+        assert recovered.status_code == 200
+        assert "Vite app" in recovered.text
+        assert cfg.token == "fresh-token"
+        assert cfg.auth_expired is False
+    finally:
+        await dev_runner.cleanup()
+        await vite_runner.cleanup()
         await up_runner.cleanup()
 
 
@@ -642,7 +751,8 @@ async def test_vite_proxy_serves_branded_auth_expired_page_before_the_app():
         assert "/api/branding/logo/square" not in page.text
         assert "/api/branding/logo/rectangle" not in page.text
         assert "#aa3366" in page.text
-        assert "Your CLI token has expired" in page.text
+        assert "will keep trying automatically" in page.text
+        assert "no CLI restart is needed" in page.text
         assert "bifrost solution start" in page.text
         assert "Vite app" not in page.text
         assert record["auth_headers"] == ["Bearer stale-token"]
@@ -685,26 +795,90 @@ async def test_vite_proxy_refuses_to_render_app_when_auth_preflight_cannot_reach
         await vite_runner.cleanup()
 
 
-async def test_ws_upgrade_bridges_to_upstream():
+async def test_ws_upgrade_replaces_baked_token_with_live_cli_token():
     record = {}
     up_port, dev_port = _free_port(), _free_port()
     up_runner = await _serve(_make_upstream(record), up_port)
     host = _StubHost(set())
-    cfg = DevProxyConfig(upstream_url=f"http://127.0.0.1:{up_port}", token="t", app_id="A", org_id="O")
+    cfg = DevProxyConfig(
+        upstream_url=f"http://127.0.0.1:{up_port}",
+        token="live-cli-token",
+        app_id="A",
+        org_id="O",
+    )
     dev_runner = await _serve(build_dev_app(cfg, host, vite_url="http://127.0.0.1:1"), dev_port)
     try:
         async with aiohttp.ClientSession() as session:
             async with session.ws_connect(
-                f"http://127.0.0.1:{dev_port}/ws/echo?channels=x&token=tok"
+                f"http://127.0.0.1:{dev_port}/ws/echo?channels=x&token=baked-stale-token"
             ) as ws:
                 await ws.send_str("ping")
                 msg = await ws.receive()
                 assert msg.type == aiohttp.WSMsgType.TEXT
                 assert msg.data == "echo:ping"
-        # rel_url (channels + token) is forwarded verbatim to the dev API.
-        assert record["ws_query"] == "channels=x&token=tok"
+        # A Vite bundle is static for the lifetime of the child process. The
+        # proxy must replace its baked token on every upstream WS handshake.
+        assert record["ws_query"] == "channels=x&token=live-cli-token"
     finally:
         await dev_runner.cleanup()
+        await up_runner.cleanup()
+
+
+async def test_browser_session_reload_signal_changes_after_same_origin_restart():
+    record = {}
+    up_port, vite_port, dev_port = _free_port(), _free_port(), _free_port()
+    up_runner = await _serve(_make_auth_refresh_upstream(record), up_port)
+
+    async def index(_request):
+        return web.Response(text="<html><head></head><body>Vite app</body></html>",
+                            content_type="text/html")
+
+    vite = web.Application()
+    vite.router.add_get("/", index)
+    vite_runner = await _serve(vite, vite_port)
+
+    async def _start_proxy():
+        cfg = DevProxyConfig(
+            upstream_url=f"http://127.0.0.1:{up_port}",
+            token="fresh-token",
+            app_id="A",
+            org_id="O",
+        )
+        runner = await _serve(
+            build_dev_app(cfg, _StubHost(set()), vite_url=f"http://127.0.0.1:{vite_port}"),
+            dev_port,
+        )
+        return cfg, runner
+
+    origin = f"http://127.0.0.1:{dev_port}"
+    first_cfg, first_runner = await _start_proxy()
+    try:
+        async with httpx.AsyncClient() as c:
+            first_page = await c.get(f"{origin}/", headers={"Accept": "text/html"})
+            first_session = (await c.get(f"{origin}/__bifrost_dev/session")).json()
+    finally:
+        await first_runner.cleanup()
+
+    second_cfg, second_runner = await _start_proxy()
+    try:
+        async with httpx.AsyncClient() as c:
+            second_page = await c.get(f"{origin}/", headers={"Accept": "text/html"})
+            second_session = (await c.get(f"{origin}/__bifrost_dev/session")).json()
+
+        assert first_cfg.session_id != second_cfg.session_id
+        assert first_session == {"session_id": first_cfg.session_id}
+        assert second_session == {"session_id": second_cfg.session_id}
+        assert "data-bifrost-dev-recovery" in first_page.text
+        assert first_cfg.session_id in first_page.text
+        assert "window.location.reload()" in first_page.text
+        assert "data-bifrost-dev-recovery" in second_page.text
+        # Both generations used the exact same browser-visible origin. An open
+        # page can poll it through downtime, see the new session id, and reload.
+        assert str(first_page.url).startswith(origin)
+        assert str(second_page.url).startswith(origin)
+    finally:
+        await second_runner.cleanup()
+        await vite_runner.cleanup()
         await up_runner.cleanup()
 
 

--- a/plugins/bifrost/skills/bifrost-build/generated/cli-reference.md
+++ b/plugins/bifrost/skills/bifrost-build/generated/cli-reference.md
@@ -1729,7 +1729,7 @@ Commands:
   pull          Pull captured entities into the local .bifrost/ manifest...
   scaffold-app  Scaffold a standalone_v2 React app (package.json, vite,...
   sdk           Manage the app's vendored Bifrost SDK.
-  start         Run the app's dev server + local workflows (one origin).
+  start         Run the app's dev server + local workflows on one stable...
   swap-slugs    Atomically exchange two apps' slugs (v1→v2 migration...
 ```
 
@@ -1963,11 +1963,13 @@ Options:
 ```
 Usage: solution start [OPTIONS] [APP_SLUG]
 
-  Run the app's dev server + local workflows (one origin).
+  Run the app's dev server + local workflows on one stable origin. Preview
+  credentials are renewed automatically.
 
 Options:
   --solution TEXT    Install id or unique slug.
-  --port INTEGER     Local origin port.  [default: 3000]
+  --port INTEGER     Stable local proxy origin port; reuse it across restarts.
+                     [default: 3000]
   --host TEXT        Address for the local origin to bind.  [default:
                      127.0.0.1]
   --public-url TEXT  Browser-visible origin for the local proxy, e.g.

--- a/plugins/bifrost/skills/bifrost-build/references/solutions.md
+++ b/plugins/bifrost/skills/bifrost-build/references/solutions.md
@@ -102,6 +102,15 @@ Runs the app's Vite dev server and local workflow functions behind one origin â€
 
 Open the origin the command prints (the **proxy** port; `--port` sets it, default 3000). Vite itself binds to **`--port + 1`** behind the proxy â€” drive the app at the proxy port the command prints, not the Vite port.
 
+The preview renews its CLI access token before expiry and replaces the
+bundle's token on realtime reconnects. An expired access token does **not**
+require restarting `solution start`. If the underlying refresh session has
+also expired, run `bifrost login` in another terminal; the active preview keeps
+retrying and adopts the new credentials. If the CLI process itself must be
+restarted, reuse the same `--port`: an open preview on that stable origin
+detects the new proxy session and reloads automatically. The CLI never moves a
+requested proxy or Vite port to a random replacement.
+
 After any CLI, server, or web-SDK execution-transport change, drive an actual
 bound app through this origin; a scaffold or mocked unit test is not enough.
 For a local workflow, verify the terminal `POST /api/workflows/execute`


### PR DESCRIPTION
## Summary

- proactively renew Solution preview CLI credentials before JWT expiry
- replace stale browser-bundled credentials for HTTP and WebSocket upstream connections
- let expired preview pages retry and adopt refreshed credentials without restarting the CLI
- reload existing browser tabs when the proxy restarts on the same stable origin
- preflight and document the stable public proxy port lifecycle

## Root cause

The local preview only refreshed credentials reactively after an HTTP 401. WebSocket reconnects continued forwarding the stale token embedded in the Vite bundle, and a failed refresh permanently latched document requests onto the expired-token page. The browser also had no session-generation signal to recover after a same-port proxy restart.

## Verification

- focused Solution preview lifecycle tests: 63 passed
- API Pyright and Ruff: passed
- CLI surface and generated skill mirror checks: 115 passed, 2 skipped
- full backend suite: 7,059 passed, 57 skipped, 0 failed
- git diff check: clean

The Aspen POC repository was not modified or deployed.