### PR TITLE
fix(cli): use explicit URL selector or saved default

### DIFF
--- a/.claude/skills/bifrost-build/SKILL.md
+++ b/.claude/skills/bifrost-build/SKILL.md
@@ -20,16 +20,18 @@ to run `/bifrost:setup` first.
 
 ## Connection model
 
-Bifrost can store credentials for multiple instance URLs. The nearest `.env`
-in the current folder or a parent binds that workspace to one connection; a
-folder without a binding uses the user's saved default.
+Bifrost can store credentials for multiple instance URLs. Only `.env` in the
+exact invocation directory can select a URL; ancestor dotenv files are never
+discovered implicitly. Credentials remain in the global store keyed by URL and
+are never loaded from `.env`. Without a local URL selector, the CLI uses the
+user's saved default transparently.
 
 `bifrost auth default` is read-only. Its `Default connection` line shows the
 saved fallback, while `Current connection` shows what commands from this
 folder will use. Before discovery or mutation, confirm the current connection
 is the intended instance. If it is wrong, run from the intended workspace or
 neutral folder. Do not change the saved default merely to work with a debug
-stack; the debug skill creates a dedicated folder binding.
+stack; the debug skill creates a dedicated folder selector.
 
 A Codex sandbox may be unable to read the host OS keyring and can therefore
 make an existing login look absent. Before invoking setup or login, rerun the
@@ -37,13 +39,15 @@ same read-only `bifrost auth default` probe with host access from the exact
 workspace you intend to use. If that host probe succeeds, reuse it; never log
 in again merely to work around a sandbox-only credential failure.
 
-Most entity commands do not accept `--url`; the folder binding is their
-connection selector. Never repoint a bound folder by overriding only
-`BIFROST_API_URL`, because folder-loaded tokens may belong to its original URL.
+Most entity commands do not accept `--url`; the exact-directory selector is
+how a workspace overrides the default. The selected URL must already have
+globally stored credentials; authenticate it once if it does not.
 
-`BIFROST_DEV_URL` is only a base for preview and platform links. It does not
-select or prove the authenticated CLI connection. If it is empty and a link is
-needed, ask the user for the base URL. Never invent a host.
+`BIFROST_DEV_URL` is an optional explicit base override for preview and
+platform links. It does not select or prove the authenticated CLI connection.
+When it is empty, use the authenticated `Current connection` reported by
+`bifrost auth default` as the link base. Ask the user only when neither value
+resolves; never invent a host.
 
 ## Step 1: Detect Workspace Mode
 

--- a/.claude/skills/bifrost-debug/SKILL.md
+++ b/.claude/skills/bifrost-debug/SKILL.md
@@ -54,10 +54,11 @@ The user picks the mode by setting (or not setting) `NETBIRD_SETUP_KEY` in `~/.c
 
 ## Connect the CLI
 
-Bifrost can keep credentials for several instances. A folder's nearest `.env`
-selects the connection for commands run there; otherwise the CLI uses the
-user's saved default. Debug should use its own folder binding and must not
-change that saved default.
+Bifrost can keep credentials for several instances. Only `.env` in the exact
+invocation directory selects the URL for commands run there; ancestor dotenv
+files are never discovered implicitly. Credentials remain in the global store
+keyed by URL. Otherwise the CLI uses the user's saved default. Debug should use
+its own scratch-directory selector and must not change that saved default.
 
 After the stack is up, create one scratch directory for this worktree. Never
 run debug CLI commands from bare `/tmp`.
@@ -73,10 +74,11 @@ python3 -m venv .venv
   --email dev@gobifrost.com --password password
 ```
 
-The empty `.env` created before the first CLI call prevents an unrelated
-parent `.env` from being loaded. Login then writes this debug stack's URL and
-tokens into that scratch `.env`. Run all later debug-instance CLI commands
-from the same scratch directory with `./.venv/bin/bifrost ...`.
+The scratch directory's own `.env` is the only local selector the CLI reads;
+ancestor dotenv files are ignored. Login writes only this debug stack's URL
+there and stores its credentials globally under that URL. Run all later
+debug-instance CLI commands from the same scratch directory with
+`./.venv/bin/bifrost ...`.
 
 Run `./debug.sh` commands from the worktree, never from the scratch directory.
 If the connection is ever unclear, `bifrost auth default` is a read-only check:

--- a/.claude/skills/bifrost-setup/SKILL.md
+++ b/.claude/skills/bifrost-setup/SKILL.md
@@ -21,9 +21,11 @@ Before running any commands, introduce the setup process to the user:
 ## Connection model
 
 Bifrost stores credentials separately for each instance URL, so several
-connections can coexist on one computer. A folder's nearest `.env` binds CLI
-commands in that workspace to one of those connections. Without a folder
-binding, the CLI uses the user's saved default.
+connections can coexist on one computer. Only `.env` in the exact invocation
+directory selects a URL; ancestor dotenv files are never discovered
+implicitly. Credentials remain in the global store keyed by URL and are never
+loaded from `.env`. Without that local selector, the CLI uses the user's saved
+default transparently.
 
 `bifrost auth default` only reports these values; it changes nothing. Only
 `bifrost auth use <url>` changes the saved default, so never run it unless the
@@ -124,8 +126,9 @@ that URL and do not log in again.
 
 Do NOT suggest placeholder URLs - every Bifrost instance has a unique URL provided by the user's organization.
 
-`BIFROST_DEV_URL` is for preview and platform links. Do not use it as evidence
-of the authenticated CLI connection.
+`BIFROST_DEV_URL` is an optional override for preview and platform links. Do
+not use it as evidence of the authenticated CLI connection; when it is absent,
+the authenticated current connection is the default link base.
 
 ### Install SDK
 
@@ -195,15 +198,15 @@ This opens a browser for authentication. On Windows, credentials are stored in
 Windows Credential Manager when keyring is available, with
 `%APPDATA%\Bifrost\credentials.json` as the fallback. On Linux/macOS, keyring is
 used when available with `~/.bifrost/credentials.json` as the fallback. Login
-also writes the URL to the current folder's `.env`, binding that folder to the
-connection. Tokens for other instance URLs remain available.
+also writes the URL to the current folder's `.env`, selecting that connection
+for commands run there. Tokens for other instance URLs remain available.
 
 For the repository's local debug stack, use the `bifrost-debug` skill instead;
 it knows the default `dev@gobifrost.com` / `password` credentials and creates a
-dedicated scratch-folder binding without changing the saved default.
+dedicated scratch-folder selector without changing the saved default.
 
 To disconnect a specific instance, use `bifrost logout --url {url}`. It clears
-that URL's stored credentials and offers to remove a matching folder binding.
+that URL's stored credentials and offers to remove a matching folder selector.
 
 ## MCP Configuration
 

--- a/.codex/skills/bifrost-debug/SKILL.md
+++ b/.codex/skills/bifrost-debug/SKILL.md
@@ -54,10 +54,11 @@ The user picks the mode by setting (or not setting) `NETBIRD_SETUP_KEY` in `~/.c
 
 ## Connect the CLI
 
-Bifrost can keep credentials for several instances. A folder's nearest `.env`
-selects the connection for commands run there; otherwise the CLI uses the
-user's saved default. Debug should use its own folder binding and must not
-change that saved default.
+Bifrost can keep credentials for several instances. Only `.env` in the exact
+invocation directory selects the URL for commands run there; ancestor dotenv
+files are never discovered implicitly. Credentials remain in the global store
+keyed by URL. Otherwise the CLI uses the user's saved default. Debug should use
+its own scratch-directory selector and must not change that saved default.
 
 After the stack is up, create one scratch directory for this worktree. Never
 run debug CLI commands from bare `/tmp`.
@@ -73,10 +74,11 @@ python3 -m venv .venv
   --email dev@gobifrost.com --password password
 ```
 
-The empty `.env` created before the first CLI call prevents an unrelated
-parent `.env` from being loaded. Login then writes this debug stack's URL and
-tokens into that scratch `.env`. Run all later debug-instance CLI commands
-from the same scratch directory with `./.venv/bin/bifrost ...`.
+The scratch directory's own `.env` is the only local selector the CLI reads;
+ancestor dotenv files are ignored. Login writes only this debug stack's URL
+there and stores its credentials globally under that URL. Run all later
+debug-instance CLI commands from the same scratch directory with
+`./.venv/bin/bifrost ...`.
 
 Run `./debug.sh` commands from the worktree, never from the scratch directory.
 If the connection is ever unclear, `bifrost auth default` is a read-only check:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,7 +42,7 @@ Use this whenever you need a running Bifrost instance to exercise — clicking a
    ```
    The download endpoint serves the build matching the running API; installing this version avoids the version-mismatch warning that otherwise short-circuits subcommand output.
 
-3. **Log in** inside the scratch directory using password-grant. This writes `.env` (with `BIFROST_API_URL`, `BIFROST_ACCESS_TOKEN`, `BIFROST_REFRESH_TOKEN`) so subsequent commands in this directory pick the tokens up automatically:
+3. **Log in** inside the scratch directory using password-grant. This stores credentials globally under the stack URL and writes only `BIFROST_API_URL` to the scratch directory's `.env`, so subsequent commands there select the correct credentials automatically:
    ```bash
    ./.venv/bin/bifrost login --url <API_URL> --email dev@gobifrost.com --password password
    ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,7 @@ Use this whenever you need a running Bifrost instance to exercise — clicking a
    ```
    The download endpoint serves the build matching the running API; installing this version avoids the version-mismatch warning that otherwise short-circuits subcommand output.
 
-3. **Log in** inside the scratch directory using password-grant. This writes `.env` (with `BIFROST_API_URL`, `BIFROST_ACCESS_TOKEN`, `BIFROST_REFRESH_TOKEN`) so subsequent commands in this directory pick the tokens up automatically:
+3. **Log in** inside the scratch directory using password-grant. This stores credentials globally under the stack URL and writes only `BIFROST_API_URL` to the scratch directory's `.env`, so subsequent commands there select the correct credentials automatically:
    ```bash
    ./.venv/bin/bifrost login --url <API_URL> --email dev@gobifrost.com --password password
    ```

--- a/api/bifrost/cli.py
+++ b/api/bifrost/cli.py
@@ -432,11 +432,10 @@ async def login_flow(api_url: str | None = None, auto_open: bool = True) -> bool
 
 async def password_login_flow(api_url: str, email: str, password: str) -> tuple[int, dict | None]:
     """
-    Password-grant login. Tokens are returned to the caller; the caller
-    decides where to persist them. The CLI's `bifrost login` command writes
-    BIFROST_API_URL + the two tokens to .env in CWD so subsequent commands
-    in that directory inherit them. Suitable only for isolated development
-    stacks with MFA disabled.
+    Password-grant login. Tokens are returned to the caller for storage in the
+    global URL-keyed credential backend. The CLI writes only BIFROST_API_URL to
+    CWD's .env so commands there select the development instance. Suitable only
+    for isolated development stacks with MFA disabled.
 
     Returns (exit_code, payload). On success, payload is the parsed JSON
     response from /auth/login containing access_token / refresh_token.
@@ -583,12 +582,12 @@ def _line_assigns_env_var(line: str, key: str) -> bool:
 
 def _remove_env_connection(api_url: str) -> bool:
     """
-    Remove a matching folder-local Bifrost connection from CWD's .env.
+    Remove a matching folder-local Bifrost URL selector from CWD's .env.
 
     The URL is the binding key. Only when it matches ``api_url`` do we remove
-    the URL plus any password-grant access and refresh tokens from that file.
-    Browser login writes only the URL, while password-grant login writes all
-    three values.
+    the URL plus any legacy access and refresh token lines from that file.
+    Current login flows store credentials globally by URL and write only the
+    URL selector to .env.
 
     Returns True if a matching connection was removed.
     """
@@ -988,12 +987,10 @@ Browser (default): Device-code flow; tokens stored in OS keychain (with JSON
                    On success, writes BIFROST_API_URL=<url> to .env in the
                    current directory so subsequent CLI commands target this
                    instance.
-Password: When --email and --password are passed, performs an ephemeral
-          password-grant login and writes BIFROST_API_URL +
-          BIFROST_ACCESS_TOKEN + BIFROST_REFRESH_TOKEN to .env in the
-          current directory. Subsequent CLI commands from this directory
-          pick the tokens up automatically. For isolated dev stacks only
-          — refuses if MFA is enabled on the instance.
+Password: When --email and --password are passed, performs a password-grant
+          login. Credentials are stored globally by URL; .env receives only
+          BIFROST_API_URL so this directory selects that connection. For
+          isolated dev stacks only — refuses if MFA is enabled.
 
 Options:
   --url, -u URL         API URL (default: BIFROST_API_URL or http://localhost:8000)
@@ -1038,26 +1035,25 @@ Examples:
         assert password is not None
         rc, data = asyncio.run(password_login_flow(api_url, email, password))
         if rc == 0 and data is not None:
-            # Persist URL + tokens to CWD's .env so subsequent `bifrost`
-            # commands from this directory just work — no shell-eval needed.
-            # Isolation is by directory: each sandbox dir has its own .env.
+            expires_at = datetime.now(timezone.utc) + timedelta(
+                seconds=data.get("expires_in", 1800)
+            )
+            credentials.save_credentials(
+                api_url=api_url,
+                access_token=data["access_token"],
+                refresh_token=data["refresh_token"],
+                expires_at=expires_at.isoformat(),
+            )
+
+            # The exact-directory .env selects the URL only. Tokens stay in
+            # the global credential store keyed by that URL.
             try:
                 _write_env_url(api_url)
-                _upsert_env_vars(
-                    {
-                        "BIFROST_ACCESS_TOKEN": data["access_token"],
-                        "BIFROST_REFRESH_TOKEN": data["refresh_token"],
-                    }
-                )
             except OSError as e:
                 print(
                     f"Warning: could not update .env in current directory: {e}",
                     file=sys.stderr,
                 )
-                # Fall back to printing so the caller can eval them.
-                print(f"BIFROST_API_URL={api_url}")
-                print(f"BIFROST_ACCESS_TOKEN={data['access_token']}")
-                print(f"BIFROST_REFRESH_TOKEN={data['refresh_token']}")
         return rc
 
     # Browser device-code flow (persistent → keychain or JSON fallback).
@@ -1112,9 +1108,8 @@ If --url is omitted, logs out from the URL resolved by the same rules as
 connection).
 
 After clearing persistent credentials, if the current directory's .env is
-bound to that URL, you'll be prompted to remove the complete folder binding.
-For browser login this is the URL; for password login it also includes the
-folder-local access and refresh tokens.
+bound to that URL, you'll be prompted to remove its URL selector. Legacy token
+lines in that same file are removed as cleanup.
 
 Options:
   --url, -u URL   Specific URL to log out from

--- a/api/bifrost/client.py
+++ b/api/bifrost/client.py
@@ -223,12 +223,15 @@ async def refresh_connection_access_token(
 
         stored_access_token = creds.access_token
         stored_refresh_token = creds.refresh_token
-        env_backed = resolved.source in {"process", "dotenv"}
+        process_backed = resolved.source == "process"
 
         if coordinator.latest_access_token is not None:
             if observed_access_token != coordinator.latest_access_token:
                 return coordinator.latest_access_token
-            if not env_backed and stored_access_token != coordinator.latest_access_token:
+            if (
+                not process_backed
+                and stored_access_token != coordinator.latest_access_token
+            ):
                 coordinator.latest_access_token = stored_access_token
                 coordinator.latest_refresh_token = stored_refresh_token
                 return stored_access_token

--- a/api/bifrost/commands/solution.py
+++ b/api/bifrost/commands/solution.py
@@ -403,11 +403,11 @@ def _v2_scaffold_files(slug: str, api_url: str) -> dict[str, str]:
     """The files for a working standalone_v2 app skeleton.
 
     Designed so a developer's local ``npm run dev`` works with ZERO token
-    pasting: ``vite.config.ts`` reads the CLI's own ``BIFROST_API_URL`` +
-    ``BIFROST_ACCESS_TOKEN`` (the ones ``bifrost login`` already wrote to .env)
-    and exposes them to the app. Deployed, the platform calls the app's explicit
-    ``mount()`` lifecycle with per-mount bootstrap data. Local Vite dev invokes
-    that same lifecycle with the dev env, so one source runs in both places.
+    pasting: ``vite.config.ts`` reads an optional local URL selector, then asks
+    the CLI for that URL's globally stored token. Deployed, the platform calls
+    the app's explicit ``mount()`` lifecycle with per-mount bootstrap data.
+    Local Vite dev invokes that same lifecycle with the dev env, so one source
+    runs in both places.
     """
     pkg = {
         "name": slug,
@@ -441,7 +441,7 @@ def _v2_scaffold_files(slug: str, api_url: str) -> dict[str, str]:
     vite_config = """\
 import { execFileSync } from "node:child_process";
 import { existsSync, readFileSync } from "node:fs";
-import { dirname, join, parse } from "node:path";
+import { join } from "node:path";
 
 import tailwindcss from "@tailwindcss/vite";
 import react from "@vitejs/plugin-react";
@@ -449,34 +449,25 @@ import { defineConfig } from "vite";
 
 // Tokenless local dev — three sources, in order:
 //   1. process env (the CLI exported BIFROST_API_URL/BIFROST_ACCESS_TOKEN), then
-//   2. the nearest .env walking UP from this app dir (password-grant `login`
-//      writes one), then
+//   2. a BIFROST_API_URL selector from .env in this exact invocation directory,
+//      then
 //   3. the CLI credential store via `bifrost auth token` — device-code login
-//      stores the token in the OS keyring / ~/.bifrost/credentials.json (NOT a
-//      .env), so without this the normal login path leaves `npm run dev`
-//      tokenless (R7-P2-f).
+//      and password-grant login store tokens globally by URL, never in .env.
 // Deployed, the platform passes these values to the app's mount() lifecycle.
 function readBifrostEnv() {
   const out = {
     url: process.env.BIFROST_API_URL || "",
     token: process.env.BIFROST_ACCESS_TOKEN || "",
   };
-  let dir = process.cwd();
-  while (!(out.url && out.token)) {
-    const envPath = join(dir, ".env");
-    if (existsSync(envPath)) {
-      for (const line of readFileSync(envPath, "utf8").split("\\n")) {
-        const m = line.match(/^\\s*(BIFROST_API_URL|BIFROST_ACCESS_TOKEN)\\s*=\\s*(.*)\\s*$/);
-        if (m) {
-          const v = m[2].replace(/^["']|["']$/g, "");
-          if (m[1] === "BIFROST_API_URL" && !out.url) out.url = v;
-          if (m[1] === "BIFROST_ACCESS_TOKEN" && !out.token) out.token = v;
-        }
+  const envPath = join(process.cwd(), ".env");
+  if (existsSync(envPath)) {
+    for (const line of readFileSync(envPath, "utf8").split("\\n")) {
+      const m = line.match(/^\\s*BIFROST_API_URL\\s*=\\s*(.*)\\s*$/);
+      if (m) {
+        const v = m[1].replace(/^["']|["']$/g, "");
+        if (!out.url) out.url = v;
       }
     }
-    const parent = dirname(dir);
-    if (parent === dir || dir === parse(dir).root) break;
-    dir = parent;
   }
   // Fall back to the CLI credential store (keyring / credentials.json).
   if (!out.token) {
@@ -660,11 +651,10 @@ export default function App() {
 }
 """
     env_example = """\
-# OPTIONAL. You normally DON'T need this file: `npm run dev` auto-discovers the
-# token `bifrost login` wrote (env, or the nearest .env up the tree). Create a
-# .env here only to override the instance URL / token for this app.
+# OPTIONAL. You normally DON'T need this file: `npm run dev` uses the CLI's
+# saved default connection. Create .env here only to override the instance URL
+# for this app; credentials remain in the CLI's global URL-keyed store.
 # BIFROST_API_URL=http://localhost:8000
-# BIFROST_ACCESS_TOKEN=
 """
     readme = f"""\
 # {slug} — a Bifrost standalone_v2 app
@@ -672,14 +662,15 @@ export default function App() {
 ## Local dev (no token pasting)
 
 You only need to be logged in with the CLI once — `npm run dev` reads the token
-`bifrost login` already wrote (from the environment, or the nearest `.env` up
-the directory tree). So from your logged-in solution workspace:
+from an explicit process/current-directory override or the CLI's saved default.
+So from your logged-in solution workspace:
 
     npm install     # resolves `bifrost` from {api_url}
     npm run dev     # http://localhost:5173 — already authenticated
 
-(If you run `npm run dev` somewhere the CLI's `.env` isn't reachable, copy
-`.env.example` to `.env` and set the two BIFROST_* values.)
+(To override the saved default for this app, copy `.env.example` to `.env` in
+the directory where you run Vite and set BIFROST_API_URL. Authenticate that URL
+once with the CLI; its credentials remain in the global credential store.)
 
 ## Deploy
 

--- a/api/bifrost/credentials.py
+++ b/api/bifrost/credentials.py
@@ -9,12 +9,12 @@ across multiple Bifrost instances simultaneously, with three backends:
 - JsonBackend: ~/.bifrost/credentials.json as a dict-of-URLs
 - User config: ~/.bifrost/config.json stores the default connection pointer
 
-Resolution keeps process, nearest-dotenv, and persistent credential tuples
-separate, then selects a complete tuple for the effective API URL.
+The process or current-directory dotenv may select an API URL. Credentials
+come from an explicit process tuple or the global URL-keyed persistent store;
+dotenv files never own credentials.
 """
 
 import json
-import logging
 import os
 import platform
 import sys
@@ -29,10 +29,6 @@ AUTH_ENV_KEYS = frozenset({
     "BIFROST_ACCESS_TOKEN",
     "BIFROST_REFRESH_TOKEN",
 })
-
-logger = logging.getLogger(__name__)
-_warned_dotenv_mismatches: set[tuple[str, str]] = set()
-
 
 # --------------------------------------------------------------------------- #
 # Public dataclass
@@ -60,7 +56,7 @@ class Credentials:
         )
 
 
-CredentialSource = Literal["process", "dotenv", "persistent", "legacy"]
+CredentialSource = Literal["process", "persistent", "legacy"]
 
 
 @dataclass(frozen=True)
@@ -69,27 +65,6 @@ class ResolvedCredentials:
 
     credentials: Credentials
     source: CredentialSource
-    dotenv_path: Path | None = None
-
-
-@dataclass(frozen=True)
-class _DotenvConnection:
-    """Bifrost auth fields read together from one nearest dotenv file."""
-
-    path: Path
-    api_url: str
-    access_token: str
-    refresh_token: str
-
-    def credentials(self) -> Credentials | None:
-        if not self.api_url or not self.access_token or not self.refresh_token:
-            return None
-        return Credentials(
-            api_url=self.api_url,
-            access_token=self.access_token,
-            refresh_token=self.refresh_token,
-            expires_at="2099-01-01T00:00:00+00:00",
-        )
 
 
 # --------------------------------------------------------------------------- #
@@ -113,44 +88,45 @@ def get_config_path() -> Path:
     return get_config_dir() / "config.json"
 
 
-def _nearest_dotenv_values() -> tuple[Path, dict[str, str | None]] | None:
-    """Read the nearest dotenv without copying any values into the process."""
+def _current_dotenv_values() -> tuple[Path, dict[str, str | None]] | None:
+    """Read only ``./.env`` without copying values into the process.
+
+    Ancestor dotenv files are ambient state, not an explicit connection choice
+    for this invocation. Local-development scratch directories remain supported
+    because their commands run from the directory that owns the dotenv.
+    """
     try:
-        from dotenv import dotenv_values, find_dotenv
+        from dotenv import dotenv_values
     except ImportError:
         return None
 
-    env_path = find_dotenv(usecwd=True)
-    if not env_path:
+    env_path = Path.cwd() / ".env"
+    if not env_path.is_file():
         return None
     try:
         values = dotenv_values(env_path)
     except OSError:
         return None
-    return Path(env_path), dict(values)
+    return env_path, dict(values)
 
 
-def _nearest_dotenv_connection() -> _DotenvConnection | None:
-    snapshot = _nearest_dotenv_values()
+def _current_dotenv_url() -> str | None:
+    snapshot = _current_dotenv_values()
     if snapshot is None:
         return None
-    path, values = snapshot
-    return _DotenvConnection(
-        path=path,
-        api_url=str(values.get("BIFROST_API_URL") or "").rstrip("/"),
-        access_token=str(values.get("BIFROST_ACCESS_TOKEN") or ""),
-        refresh_token=str(values.get("BIFROST_REFRESH_TOKEN") or ""),
-    )
+    _path, values = snapshot
+    api_url = str(values.get("BIFROST_API_URL") or "").rstrip("/")
+    return api_url or None
 
 
 def load_dotenv_context() -> None:
-    """Load non-auth dotenv context without destroying credential provenance.
+    """Load current-directory non-auth context without mixing credentials.
 
-    Solution bindings and CLI behavior flags historically rely on the nearest
-    dotenv being available through ``os.environ``. The three authentication
-    fields are deliberately excluded and are resolved together on demand.
+    Bifrost URL and token fields are deliberately excluded. The URL is read
+    separately as a selector; credentials always come from process state or
+    the global URL-keyed store. Ancestor dotenv files are never loaded.
     """
-    snapshot = _nearest_dotenv_values()
+    snapshot = _current_dotenv_values()
     if snapshot is None:
         return
     _path, values = snapshot
@@ -160,28 +136,11 @@ def load_dotenv_context() -> None:
 
 
 def resolve_environment_url() -> str | None:
-    """Resolve only the process/dotenv URL, without stored defaults."""
+    """Resolve only the process/current-directory URL, without stored defaults."""
     process_url = os.environ.get("BIFROST_API_URL", "").rstrip("/")
     if process_url:
         return process_url
-    dotenv = _nearest_dotenv_connection()
-    if dotenv is not None and dotenv.api_url:
-        return dotenv.api_url
-    return None
-
-
-def _warn_dotenv_mismatch(dotenv_url: str, selected_url: str) -> None:
-    """Emit one secret-safe mismatch diagnostic per URL pair and process."""
-    mismatch = (dotenv_url, selected_url)
-    if mismatch in _warned_dotenv_mismatches:
-        return
-    _warned_dotenv_mismatches.add(mismatch)
-    logger.warning(
-        "Ignoring complete dotenv credentials for %s because the selected "
-        "API URL is %s; using stored credentials for the selected URL",
-        dotenv_url,
-        selected_url,
-    )
+    return _current_dotenv_url()
 
 
 # --------------------------------------------------------------------------- #
@@ -431,7 +390,6 @@ def _reset_persistent_backend_for_tests() -> None:
     global _persistent_backend, _keyring_fallback_reason
     _persistent_backend = None
     _keyring_fallback_reason = None
-    _warned_dotenv_mismatches.clear()
 
 
 def _load_config() -> dict[str, str]:
@@ -513,7 +471,7 @@ def resolve_current_connection(
     Order:
       1. The argument (if given).
       2. BIFROST_API_URL env var.
-      3. BIFROST_API_URL from the nearest dotenv file.
+      3. BIFROST_API_URL from ``./.env``.
       4. The user-selected default connection.
       5. The only stored URL, when exactly one exists.
       6. Optional interactive selection when multiple URLs exist.
@@ -523,9 +481,9 @@ def resolve_current_connection(
     env_url = os.environ.get("BIFROST_API_URL", "").rstrip("/")
     if env_url:
         return env_url, "BIFROST_API_URL"
-    dotenv = _nearest_dotenv_connection()
-    if dotenv is not None and dotenv.api_url:
-        return dotenv.api_url, ".env"
+    dotenv_url = _current_dotenv_url()
+    if dotenv_url:
+        return dotenv_url, ".env"
 
     urls = get_persistent_backend().list_urls()
     default_url = get_default_connection()
@@ -610,9 +568,8 @@ def resolve_credentials(
 
     Resolution order:
       1. Complete process tuple (EnvBackend) — for ephemeral sessions.
-      2. Complete nearest-dotenv tuple for the same target URL.
-      3. Persistent backend (keychain or JSON) — for long-lived sessions.
-      4. Legacy single-record JSON — lazily migrated.
+      2. Persistent backend (keychain or JSON) for the selected URL.
+      3. Legacy single-record JSON — lazily migrated.
 
     If api_url is None, the URL is resolved via ``resolve_current_connection``.
     When even that fails, the legacy file is a last resort for learning one.
@@ -634,28 +591,12 @@ def resolve_credentials(
     if env_creds is not None:
         return ResolvedCredentials(env_creds, "process")
 
-    # 2. Dotenv credentials are one indivisible tuple. They are safe only when
-    # the URL recorded beside the tokens matches the selected target.
-    dotenv = _nearest_dotenv_connection()
-    dotenv_creds = dotenv.credentials() if dotenv is not None else None
-    if dotenv_creds is not None:
-        if dotenv_creds.api_url.rstrip("/") == resolved:
-            return ResolvedCredentials(
-                dotenv_creds,
-                "dotenv",
-                dotenv_path=dotenv.path if dotenv is not None else None,
-            )
-        _warn_dotenv_mismatch(
-            dotenv_creds.api_url,
-            resolved,
-        )
-
-    # 3. Persistent backend
+    # 2. Persistent credentials are keyed globally by the selected URL.
     creds = get_persistent_backend().get(resolved)
     if creds is not None:
         return ResolvedCredentials(creds, "persistent")
 
-    # 4. Legacy fallback (and migrate if found)
+    # 3. Legacy fallback (and migrate if found)
     legacy = _try_migrate_legacy()
     if legacy is not None and legacy.api_url.rstrip("/") == resolved:
         return ResolvedCredentials(legacy, "legacy")
@@ -717,36 +658,6 @@ def save_refreshed_credentials(
         os.environ["BIFROST_REFRESH_TOKEN"] = refresh_token
         return True
 
-    if resolved.source == "dotenv":
-        if resolved.dotenv_path is None:
-            return False
-        try:
-            from dotenv import dotenv_values, set_key
-
-            values = dotenv_values(resolved.dotenv_path)
-            file_url = str(values.get("BIFROST_API_URL") or "").rstrip("/")
-            if (
-                file_url != normalized_url
-                or values.get("BIFROST_ACCESS_TOKEN") != observed_access_token
-                or values.get("BIFROST_REFRESH_TOKEN") != observed_refresh_token
-            ):
-                return False
-            set_key(
-                str(resolved.dotenv_path),
-                "BIFROST_ACCESS_TOKEN",
-                access_token,
-                quote_mode="never",
-            )
-            set_key(
-                str(resolved.dotenv_path),
-                "BIFROST_REFRESH_TOKEN",
-                refresh_token,
-                quote_mode="never",
-            )
-        except (ImportError, OSError):
-            return False
-        return True
-
     save_credentials(
         api_url=normalized_url,
         access_token=access_token,
@@ -761,7 +672,7 @@ def clear_credentials(api_url: str | None = None) -> None:
     Remove a single URL's credentials from the persistent backend.
 
     No-arg behavior uses the same resolution as get_credentials(): an explicit
-    environment/folder binding, the saved default, or the sole stored URL. So
+    environment/folder URL selector, the saved default, or the sole stored URL. So
     a `bifrost logout` targets the same connection `get_credentials()` would
     have returned.
     """

--- a/api/tests/unit/cli/test_cli_version_check.py
+++ b/api/tests/unit/cli/test_cli_version_check.py
@@ -8,10 +8,10 @@ concerns the gate must honor regardless of which gate fires:
 * Skip silently for source/dev installs (``__version__`` of ``"unknown"`` or
   ``"0.0.0+source"``).
 * Resolve the API URL via ``credentials._resolve_url`` so a project
-  ``.env`` (loaded by python-dotenv before the call) is honored alongside
-  the keyring/JSON store. We use ``_resolve_url`` (not ``get_credentials``)
-  because the version check only needs the URL — a logged-out CLI with
-  ``BIFROST_API_URL`` set in ``.env`` should still get checked.
+  ``.env`` URL selector is honored alongside the keyring/JSON store. We use
+  ``_resolve_url`` (not ``get_credentials``) because the version check only
+  needs the URL — a logged-out CLI with ``BIFROST_API_URL`` set in ``.env``
+  should still get checked.
 * Route the request through httpx (not urllib) so CDN/WAF UA blocking doesn't
   silently no-op the check.
 
@@ -40,10 +40,9 @@ def _isolate_version_check_state():
 
     * The memoized ``_persistent_backend`` global in ``bifrost.credentials``,
       which downstream credentials tests rely on being unset.
-    * ``BIFROST_API_URL`` written to ``os.environ`` by ``python-dotenv`` in
-      the dotenv-resolution test — monkeypatch doesn't track it because
-      load_dotenv writes to os.environ directly. Subsequent SDK credentials
-      tests assume the env var is unset and resolve via the JSON store.
+    * Any ``BIFROST_API_URL`` inherited from a previous test. Subsequent SDK
+      credential tests assume the env var is unset and resolve via the global
+      URL-keyed store.
     """
     import os
 
@@ -219,11 +218,10 @@ class TestUrlResolution:
     def test_delegates_to_credentials_resolve_url(self, monkeypatch):
         """Version check must delegate URL resolution to credentials._resolve_url.
 
-        ``_resolve_url`` already implements the full chain (env → keyring/JSON
-        store) and honors python-dotenv-loaded BIFROST_API_URL. The check
-        should not reinvent it. Using ``_resolve_url`` (not
-        ``get_credentials``) means a logged-out CLI in an env with
-        ``BIFROST_API_URL`` set still gets a version check — we only need the
+        ``_resolve_url`` already implements the full selector chain and honors
+        exact-directory BIFROST_API_URL. The check should not reinvent it.
+        Using ``_resolve_url`` (not ``get_credentials``) means a logged-out CLI
+        with a local URL selector still gets a version check — we only need the
         URL, not full tokens.
         """
         _patch_version(monkeypatch, "1.2.3")
@@ -245,8 +243,9 @@ class TestUrlResolution:
     def test_resolves_dotenv_without_mutating_process_auth(self, monkeypatch, tmp_path):
         """A project ``.env`` containing BIFROST_API_URL is honored.
 
-        The credential resolver reads the nearest dotenv directly. The version
-        check must honor that URL without copying auth fields into ``os.environ``.
+        The credential resolver reads the current directory's dotenv directly.
+        The version check must honor that URL without copying auth fields into
+        ``os.environ``.
         """
         env_file = tmp_path / ".env"
         env_file.write_text(
@@ -265,8 +264,8 @@ class TestUrlResolution:
         _patch_version(monkeypatch, "1.2.3")
         from bifrost import cli
 
-        # No persistent-store credentials should be returned — we want the
-        # resolution to land on the env var written by dotenv.
+        # No persistent-store credentials are needed — URL resolution reads the
+        # selector directly from the exact-directory dotenv.
         with patch(
             "bifrost.credentials.get_persistent_backend"
         ) as get_backend, patch(

--- a/api/tests/unit/test_bifrost_client_credentials.py
+++ b/api/tests/unit/test_bifrost_client_credentials.py
@@ -228,7 +228,7 @@ async def test_refresh_reuses_credentials_replaced_by_another_caller(
 
 
 @pytest.mark.asyncio
-async def test_env_credentials_survive_multiple_rotating_refreshes(
+async def test_global_credentials_survive_multiple_rotating_refreshes(
     isolated_credentials, monkeypatch, tmp_path
 ) -> None:
     from bifrost import client as client_mod
@@ -239,6 +239,12 @@ async def test_env_credentials_survive_multiple_rotating_refreshes(
         "BIFROST_API_URL=https://api.example.com\n"
         "BIFROST_ACCESS_TOKEN=access-0\n"
         "BIFROST_REFRESH_TOKEN=refresh-0\n"
+    )
+    isolated_credentials.save_credentials(
+        api_url,
+        "access-0",
+        "refresh-0",
+        (datetime.now(timezone.utc) - timedelta(minutes=5)).isoformat(),
     )
     refresh_tokens_seen: list[str] = []
 
@@ -275,12 +281,12 @@ async def test_env_credentials_survive_multiple_rotating_refreshes(
     assert first == "access-1"
     assert second == "access-2"
     assert refresh_tokens_seen == ["refresh-0", "refresh-1"]
-    assert isolated_credentials.get_persistent_backend().get(api_url) is None
+    assert isolated_credentials.get_persistent_backend().get(api_url) is not None
     assert isolated_credentials.get_credentials(api_url)["access_token"] == "access-2"
     assert isolated_credentials.get_credentials(api_url)["refresh_token"] == "refresh-2"
     env_text = (tmp_path / ".env").read_text()
-    assert "BIFROST_ACCESS_TOKEN=access-2" in env_text
-    assert "BIFROST_REFRESH_TOKEN=refresh-2" in env_text
+    assert "BIFROST_ACCESS_TOKEN=access-0" in env_text
+    assert "BIFROST_REFRESH_TOKEN=refresh-0" in env_text
 
 
 @pytest.mark.asyncio

--- a/api/tests/unit/test_cli_login_ephemeral.py
+++ b/api/tests/unit/test_cli_login_ephemeral.py
@@ -4,13 +4,33 @@ Two login modes:
   * Browser device-code (default) — token stored in keychain (or JSON
     fallback). On success, login also writes BIFROST_API_URL=<url> to the
     CWD .env so subsequent CLI commands in this folder target this stack.
-  * Password-grant (when --email and --password are passed) — URL +
-    access + refresh tokens written to .env in CWD so subsequent CLI
-    commands from that directory inherit the session. Tokens are NOT
-    written to the OS keychain. Refuses MFA-enabled instances.
+  * Password-grant (when --email and --password are passed) — credentials
+    stored globally by URL, with only BIFROST_API_URL written to CWD's .env.
+    Refuses MFA-enabled instances.
 """
 
+import pytest
+
 from bifrost import cli
+from bifrost import credentials as creds_mod
+
+
+@pytest.fixture
+def isolated_credentials(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        creds_mod,
+        "get_credentials_path",
+        lambda: tmp_path / "credentials.json",
+    )
+    monkeypatch.setattr(
+        creds_mod,
+        "get_config_path",
+        lambda: tmp_path / "config.json",
+    )
+    monkeypatch.setattr(creds_mod, "_select_persistent_backend", creds_mod.JsonBackend)
+    creds_mod._reset_persistent_backend_for_tests()
+    yield
+    creds_mod._reset_persistent_backend_for_tests()
 
 
 def _stub_post(json_payload: dict, status_code: int = 200):
@@ -65,8 +85,8 @@ class TestPasswordLoginFlagParsing:
 
 
 class TestPasswordLoginSuccess:
-    def test_writes_three_vars_to_env_and_warning_to_stderr(
-        self, capsys, monkeypatch, tmp_path,
+    def test_writes_only_url_to_env_and_credentials_to_global_store(
+        self, capsys, monkeypatch, tmp_path, isolated_credentials,
     ):
         stub = _stub_post({
             "access_token": "at_value",
@@ -85,31 +105,34 @@ class TestPasswordLoginSuccess:
 
         env_text = (tmp_path / ".env").read_text()
         assert "BIFROST_API_URL=http://localhost:38421" in env_text
-        assert "BIFROST_ACCESS_TOKEN=at_value" in env_text
-        assert "BIFROST_REFRESH_TOKEN=rt_value" in env_text
+        assert "BIFROST_ACCESS_TOKEN" not in env_text
+        assert "BIFROST_REFRESH_TOKEN" not in env_text
+        stored = creds_mod.get_credentials("http://localhost:38421")
+        assert stored is not None
+        assert stored["access_token"] == "at_value"
+        assert stored["refresh_token"] == "rt_value"
 
         # Warning to stderr
         captured = capsys.readouterr()
         assert "MFA" in captured.err
         assert "ephemeral" in captured.err.lower()
 
-    def test_does_not_write_to_keychain(self, capsys, monkeypatch, tmp_path):
-        """Password-grant must not touch the persistent (keychain/JSON) store.
-
-        The session is per-directory via .env; persistence is intentionally
-        excluded so a password-grant login on a dev machine doesn't end up
-        in the long-lived auth list visible to `bifrost auth list`.
-        """
+    def test_does_not_change_saved_default(
+        self, capsys, monkeypatch, tmp_path, isolated_credentials,
+    ):
         stub = _stub_post({
             "access_token": "at",
             "refresh_token": "rt",
             "expires_in": 1800,
         })
         monkeypatch.setattr("httpx.AsyncClient", stub)
-        monkeypatch.setattr(
-            "bifrost.credentials.get_credentials_path",
-            lambda: tmp_path / "credentials.json",
+        creds_mod.save_credentials(
+            "https://prod.example.com",
+            "prod-at",
+            "prod-rt",
+            "2099-01-01T00:00:00+00:00",
         )
+        creds_mod.set_default_connection("https://prod.example.com")
         monkeypatch.chdir(tmp_path)
 
         cli.handle_login([
@@ -118,10 +141,8 @@ class TestPasswordLoginSuccess:
             "--url", "http://localhost:38421",
         ])
 
-        # No keychain / JSON-fallback record was written.
-        assert not (tmp_path / "credentials.json").exists()
-        # .env IS written (that's the new contract).
-        assert (tmp_path / ".env").exists()
+        assert creds_mod.get_default_connection() == "https://prod.example.com"
+        assert creds_mod.get_credentials("http://localhost:38421") is not None
 
 
 class TestPasswordLoginMfaRefusal:
@@ -151,7 +172,9 @@ class TestPasswordLoginMfaRefusal:
 
 
 class TestPasswordLoginUsesBifrostApiUrl:
-    def test_falls_back_to_env_var_for_url(self, capsys, monkeypatch, tmp_path):
+    def test_falls_back_to_env_var_for_url(
+        self, capsys, monkeypatch, tmp_path, isolated_credentials,
+    ):
         stub = _stub_post({
             "access_token": "at",
             "refresh_token": "rt",
@@ -267,7 +290,7 @@ class TestLogoutClearsKeychainAndPromptsEnv:
         assert creds_mod.get_credentials("https://prod.example.com") is None
         assert creds_mod.get_credentials("http://localhost:38421") is not None
 
-    def test_logout_yes_removes_matching_browser_env_binding(self, monkeypatch, tmp_path):
+    def test_logout_yes_removes_matching_env_selector(self, monkeypatch, tmp_path):
         from bifrost import credentials as creds_mod
         monkeypatch.setattr(
             creds_mod,
@@ -296,7 +319,7 @@ class TestLogoutClearsKeychainAndPromptsEnv:
         assert "OTHER_VAR=keep-me" in env_text
         assert "BIFROST_API_URL=" not in env_text
 
-    def test_logout_yes_removes_complete_password_grant_binding(
+    def test_logout_yes_removes_legacy_token_lines_with_selector(
         self, monkeypatch, tmp_path,
     ):
         from bifrost import credentials as creds_mod
@@ -327,7 +350,7 @@ class TestLogoutClearsKeychainAndPromptsEnv:
         assert rc == 0
         assert (tmp_path / ".env").read_text() == "OTHER_VAR=keep-me\n"
 
-    def test_logout_does_not_remove_different_folder_binding(
+    def test_logout_does_not_remove_different_folder_selector(
         self, monkeypatch, tmp_path,
     ):
         from bifrost import credentials as creds_mod

--- a/api/tests/unit/test_credentials.py
+++ b/api/tests/unit/test_credentials.py
@@ -95,8 +95,8 @@ class TestCredentialProvenance:
         yield tmp_path
         creds_mod._reset_persistent_backend_for_tests()
 
-    def test_url_only_process_override_does_not_borrow_dotenv_tokens(
-        self, isolated_store, monkeypatch, caplog
+    def test_process_url_ignores_dotenv_tokens(
+        self, isolated_store, monkeypatch
     ):
         (isolated_store / ".env").write_text(
             "BIFROST_API_URL=http://localhost:36092\n"
@@ -110,7 +110,6 @@ class TestCredentialProvenance:
             "2099-01-01T00:00:00+00:00",
         )
         monkeypatch.setenv("BIFROST_API_URL", "https://prod.example.com")
-        caplog.set_level("WARNING", logger="bifrost.credentials")
 
         creds_mod.load_dotenv_context()
         result = creds_mod.get_credentials()
@@ -123,14 +122,6 @@ class TestCredentialProvenance:
         assert result["refresh_token"] == "production-refresh"
         assert "BIFROST_ACCESS_TOKEN" not in os.environ
         assert "BIFROST_REFRESH_TOKEN" not in os.environ
-        assert len(caplog.records) == 1
-        warning = caplog.records[0]
-        assert warning.args == (
-            "http://localhost:36092",
-            "https://prod.example.com",
-        )
-        assert "localhost-access" not in warning.getMessage()
-        assert "localhost-refresh" not in warning.getMessage()
 
     def test_complete_process_tuple_wins_over_dotenv_and_persistent(
         self, isolated_store, monkeypatch
@@ -157,21 +148,99 @@ class TestCredentialProvenance:
         assert result["access_token"] == "process-access"
         assert result["refresh_token"] == "process-refresh"
 
-    def test_complete_nearest_dotenv_tuple_is_used(self, isolated_store):
+    def test_dotenv_url_selects_global_credentials_and_ignores_tokens(
+        self, isolated_store
+    ):
         (isolated_store / ".env").write_text(
             "BIFROST_API_URL=http://localhost:36092\n"
             "BIFROST_ACCESS_TOKEN=localhost-access\n"
             "BIFROST_REFRESH_TOKEN=localhost-refresh\n"
+        )
+        creds_mod.save_credentials(
+            "http://localhost:36092",
+            "stored-local-access",
+            "stored-local-refresh",
+            "2099-01-01T00:00:00+00:00",
         )
 
         result = creds_mod.get_credentials()
 
         assert result is not None
         assert result["api_url"] == "http://localhost:36092"
-        assert result["access_token"] == "localhost-access"
-        assert result["refresh_token"] == "localhost-refresh"
+        assert result["access_token"] == "stored-local-access"
+        assert result["refresh_token"] == "stored-local-refresh"
 
-    def test_matching_url_only_process_override_uses_complete_dotenv_tuple(
+    def test_parent_dotenv_never_overrides_default(
+        self, isolated_store, monkeypatch
+    ):
+        (isolated_store / ".env").write_text(
+            "BIFROST_API_URL=http://localhost:36092\n"
+            "BIFROST_ACCESS_TOKEN=localhost-access\n"
+            "BIFROST_REFRESH_TOKEN=localhost-refresh\n"
+            "BIFROST_SOLUTION_ID=parent-solution\n"
+        )
+        child_repo = isolated_store / "solutions" / "aspen"
+        child_repo.mkdir(parents=True)
+        creds_mod.save_credentials(
+            "https://bifrost.gocovi.com",
+            "production-access",
+            "production-refresh",
+            "2099-01-01T00:00:00+00:00",
+        )
+        creds_mod.save_credentials(
+            "http://localhost:36092",
+            "stored-local-access",
+            "stored-local-refresh",
+            "2099-01-01T00:00:00+00:00",
+        )
+        creds_mod.set_default_connection("https://bifrost.gocovi.com")
+        monkeypatch.chdir(child_repo)
+
+        creds_mod.load_dotenv_context()
+        current_url, source = creds_mod.resolve_current_connection()
+        result = creds_mod.get_credentials()
+
+        assert current_url == "https://bifrost.gocovi.com"
+        assert source == "default"
+        assert result is not None
+        assert result["api_url"] == "https://bifrost.gocovi.com"
+        assert result["access_token"] == "production-access"
+        assert "BIFROST_SOLUTION_ID" not in os.environ
+
+    def test_only_current_directory_dotenv_is_an_explicit_override(
+        self, isolated_store, monkeypatch
+    ):
+        scratch = isolated_store / "debug-scratch"
+        scratch.mkdir()
+        (scratch / ".env").write_text(
+            "BIFROST_API_URL=http://localhost:36092\n"
+            "BIFROST_ACCESS_TOKEN=localhost-access\n"
+            "BIFROST_REFRESH_TOKEN=localhost-refresh\n"
+        )
+        creds_mod.save_credentials(
+            "https://bifrost.gocovi.com",
+            "production-access",
+            "production-refresh",
+            "2099-01-01T00:00:00+00:00",
+        )
+        creds_mod.save_credentials(
+            "http://localhost:36092",
+            "stored-local-access",
+            "stored-local-refresh",
+            "2099-01-01T00:00:00+00:00",
+        )
+        creds_mod.set_default_connection("https://bifrost.gocovi.com")
+        monkeypatch.chdir(scratch)
+
+        current_url, source = creds_mod.resolve_current_connection()
+        result = creds_mod.get_credentials()
+
+        assert current_url == "http://localhost:36092"
+        assert source == ".env"
+        assert result is not None
+        assert result["access_token"] == "stored-local-access"
+
+    def test_process_url_uses_global_credentials_not_dotenv_tokens(
         self, isolated_store, monkeypatch
     ):
         (isolated_store / ".env").write_text(
@@ -179,13 +248,19 @@ class TestCredentialProvenance:
             "BIFROST_ACCESS_TOKEN=localhost-access\n"
             "BIFROST_REFRESH_TOKEN=localhost-refresh\n"
         )
+        creds_mod.save_credentials(
+            "http://localhost:36092",
+            "stored-local-access",
+            "stored-local-refresh",
+            "2099-01-01T00:00:00+00:00",
+        )
         monkeypatch.setenv("BIFROST_API_URL", "http://localhost:36092")
 
         result = creds_mod.get_credentials()
 
         assert result is not None
-        assert result["access_token"] == "localhost-access"
-        assert result["refresh_token"] == "localhost-refresh"
+        assert result["access_token"] == "stored-local-access"
+        assert result["refresh_token"] == "stored-local-refresh"
 
     def test_child_url_only_dotenv_uses_persistent_credentials_not_parent_tokens(
         self, isolated_store, monkeypatch

--- a/api/tests/unit/test_solution_scaffold_app.py
+++ b/api/tests/unit/test_solution_scaffold_app.py
@@ -34,16 +34,19 @@ def test_scaffold_files_shape_and_dev_wiring() -> None:
     assert "lucide-react" in pkg["dependencies"]
     assert pkg["scripts"]["dev"] == "vite"
 
-    # vite.config reads the CLI's own token (env OR the nearest .env up the
-    # tree), so `npm run dev` authenticates with NO token pasting.
+    # vite.config reads a URL selector (process env or exact-directory .env)
+    # and gets credentials from process env or the global CLI store, so
+    # `npm run dev` authenticates with NO token pasting.
     vc = files["vite.config.ts"]
     assert "BIFROST_ACCESS_TOKEN" in vc
     assert "VITE_BIFROST_TOKEN" in vc
     assert "process.env.BIFROST_ACCESS_TOKEN" in vc  # env first
-    assert "dirname" in vc  # walks up to find the .env
-    # R7-P2-f: device-code login stores the token in the keyring / credentials.json
-    # (not a .env), so the config must fall back to the CLI credential store via
-    # `bifrost auth token` — otherwise the normal login path starts dev tokenless.
+    assert 'join(process.cwd(), ".env")' in vc
+    assert "dirname" not in vc
+    assert "(BIFROST_API_URL|BIFROST_ACCESS_TOKEN)" not in vc
+    assert "BIFROST_ACCESS_TOKEN" not in files[".env.example"]
+    # Tokens live in the keyring / credentials.json, so the config must fall
+    # back to the CLI store via `bifrost auth token`.
     assert "auth" in vc and "token" in vc
     assert "execFileSync" in vc
     # SECURITY (Codex R6-P1-c): the token is injected ONLY for `vite` serve

--- a/plugins/bifrost/skills/bifrost-build/SKILL.md
+++ b/plugins/bifrost/skills/bifrost-build/SKILL.md
@@ -20,16 +20,18 @@ to run `/bifrost:setup` first.
 
 ## Connection model
 
-Bifrost can store credentials for multiple instance URLs. The nearest `.env`
-in the current folder or a parent binds that workspace to one connection; a
-folder without a binding uses the user's saved default.
+Bifrost can store credentials for multiple instance URLs. Only `.env` in the
+exact invocation directory can select a URL; ancestor dotenv files are never
+discovered implicitly. Credentials remain in the global store keyed by URL and
+are never loaded from `.env`. Without a local URL selector, the CLI uses the
+user's saved default transparently.
 
 `bifrost auth default` is read-only. Its `Default connection` line shows the
 saved fallback, while `Current connection` shows what commands from this
 folder will use. Before discovery or mutation, confirm the current connection
 is the intended instance. If it is wrong, run from the intended workspace or
 neutral folder. Do not change the saved default merely to work with a debug
-stack; the debug skill creates a dedicated folder binding.
+stack; the debug skill creates a dedicated folder selector.
 
 A Codex sandbox may be unable to read the host OS keyring and can therefore
 make an existing login look absent. Before invoking setup or login, rerun the
@@ -37,13 +39,15 @@ same read-only `bifrost auth default` probe with host access from the exact
 workspace you intend to use. If that host probe succeeds, reuse it; never log
 in again merely to work around a sandbox-only credential failure.
 
-Most entity commands do not accept `--url`; the folder binding is their
-connection selector. Never repoint a bound folder by overriding only
-`BIFROST_API_URL`, because folder-loaded tokens may belong to its original URL.
+Most entity commands do not accept `--url`; the exact-directory selector is
+how a workspace overrides the default. The selected URL must already have
+globally stored credentials; authenticate it once if it does not.
 
-`BIFROST_DEV_URL` is only a base for preview and platform links. It does not
-select or prove the authenticated CLI connection. If it is empty and a link is
-needed, ask the user for the base URL. Never invent a host.
+`BIFROST_DEV_URL` is an optional explicit base override for preview and
+platform links. It does not select or prove the authenticated CLI connection.
+When it is empty, use the authenticated `Current connection` reported by
+`bifrost auth default` as the link base. Ask the user only when neither value
+resolves; never invent a host.
 
 ## Step 1: Detect Workspace Mode
 

--- a/plugins/bifrost/skills/bifrost-setup/SKILL.md
+++ b/plugins/bifrost/skills/bifrost-setup/SKILL.md
@@ -21,9 +21,11 @@ Before running any commands, introduce the setup process to the user:
 ## Connection model
 
 Bifrost stores credentials separately for each instance URL, so several
-connections can coexist on one computer. A folder's nearest `.env` binds CLI
-commands in that workspace to one of those connections. Without a folder
-binding, the CLI uses the user's saved default.
+connections can coexist on one computer. Only `.env` in the exact invocation
+directory selects a URL; ancestor dotenv files are never discovered
+implicitly. Credentials remain in the global store keyed by URL and are never
+loaded from `.env`. Without that local selector, the CLI uses the user's saved
+default transparently.
 
 `bifrost auth default` only reports these values; it changes nothing. Only
 `bifrost auth use <url>` changes the saved default, so never run it unless the
@@ -124,8 +126,9 @@ that URL and do not log in again.
 
 Do NOT suggest placeholder URLs - every Bifrost instance has a unique URL provided by the user's organization.
 
-`BIFROST_DEV_URL` is for preview and platform links. Do not use it as evidence
-of the authenticated CLI connection.
+`BIFROST_DEV_URL` is an optional override for preview and platform links. Do
+not use it as evidence of the authenticated CLI connection; when it is absent,
+the authenticated current connection is the default link base.
 
 ### Install SDK
 
@@ -195,15 +198,15 @@ This opens a browser for authentication. On Windows, credentials are stored in
 Windows Credential Manager when keyring is available, with
 `%APPDATA%\Bifrost\credentials.json` as the fallback. On Linux/macOS, keyring is
 used when available with `~/.bifrost/credentials.json` as the fallback. Login
-also writes the URL to the current folder's `.env`, binding that folder to the
-connection. Tokens for other instance URLs remain available.
+also writes the URL to the current folder's `.env`, selecting that connection
+for commands run there. Tokens for other instance URLs remain available.
 
 For the repository's local debug stack, use the `bifrost-debug` skill instead;
 it knows the default `dev@gobifrost.com` / `password` credentials and creates a
-dedicated scratch-folder binding without changing the saved default.
+dedicated scratch-folder selector without changing the saved default.
 
 To disconnect a specific instance, use `bifrost logout --url {url}`. It clears
-that URL's stored credentials and offers to remove a matching folder binding.
+that URL's stored credentials and offers to remove a matching folder selector.
 
 ## MCP Configuration
 


### PR DESCRIPTION
## Summary
- stop discovering Bifrost dotenv files in ancestor directories
- treat exact-directory .env as a URL selector only; keep credentials globally keyed by URL
- use the authenticated current/default connection for preview links when BIFROST_DEV_URL is absent
- align password login, token refresh, scaffolded Vite config, skills, and docs with the same ownership model

## Verification
- 176 focused tests passed, 2 environment-dependent mirror checks skipped
- 5,352 broader unit tests passed, 3 existing skips, 20 slow tests deselected
- Pyright: 0 errors
- Ruff: passed
- skill mirrors and git diff checks clean

The Aspen repository and install were not touched.