### PR TITLE
Make agent run history hierarchical and easier to follow

### DIFF
--- a/api/src/models/contracts/agent_runs.py
+++ b/api/src/models/contracts/agent_runs.py
@@ -65,9 +65,24 @@ class AgentRunResponse(BaseModel):
     parent_run_id: UUID | None = None
 
 
+class AgentRunChildResponse(BaseModel):
+    """User-facing summary of a delegated child run."""
+
+    id: UUID
+    agent_id: UUID
+    agent_name: str
+    status: str
+    asked: str | None = None
+    did: str | None = None
+    answered: str | None = None
+    duration_ms: int | None = None
+    created_at: datetime
+
+
 class AgentRunDetailResponse(AgentRunResponse):
     steps: list[AgentRunStepResponse] = Field(default_factory=list)
     child_run_ids: list[UUID] = Field(default_factory=list)
+    child_runs: list[AgentRunChildResponse] = Field(default_factory=list)
     ai_usage: list[AIUsagePublicSimple] | None = None
     ai_totals: AIUsageTotalsSimple | None = None
 

--- a/api/src/routers/agent_runs.py
+++ b/api/src/routers/agent_runs.py
@@ -12,7 +12,7 @@ from uuid import UUID
 
 from fastapi import APIRouter, HTTPException, Query, status
 from sqlalchemy import desc, func, literal_column, or_, select
-from sqlalchemy.orm import selectinload
+from sqlalchemy.orm import joinedload, selectinload
 
 from src.core.auth import CurrentActiveUser
 from src.core.cache.keys import agent_run_steps_stream_key
@@ -26,6 +26,7 @@ from src.models.contracts.agent_run_flag_conversations import (
 )
 from src.models.contracts.agent_runs import (
     AgentRunCreateRequest,
+    AgentRunChildResponse,
     AgentRunDetailResponse,
     AgentRunListResponse,
     AgentRunRerunResponse,
@@ -142,8 +143,12 @@ async def list_agent_runs(
     offset: int = Query(0, ge=0),
 ) -> AgentRunListResponse:
     """List agent runs with optional filters."""
-    # Build base query — exclude delegation sub-runs from top-level list
-    query = select(AgentRun).join(AgentRun.agent).where(AgentRun.parent_run_id.is_(None))
+    # Global history stays root-only so one orchestration is counted once.
+    # An individual agent's history includes delegated runs because those are
+    # real executions of that agent and should not disappear from its Runs tab.
+    query = select(AgentRun).join(AgentRun.agent)
+    if agent_id is None:
+        query = query.where(AgentRun.parent_run_id.is_(None))
 
     # Org filter: non-superusers see only their org's runs
     if not user.is_superuser:
@@ -496,13 +501,30 @@ async def get_agent_run(
             call_count=int(totals_row.call_count or 0),
         )
 
-    # Fetch child run IDs for delegation sub-runs
-    child_ids_result = await db.execute(
-        select(AgentRun.id)
+    # Fetch delegation sub-runs and their agents in one ordered query. Keep the
+    # legacy ID list while also returning enough context for a user-facing view.
+    child_runs_result = await db.execute(
+        select(AgentRun)
+        .options(joinedload(AgentRun.agent))
         .where(AgentRun.parent_run_id == run_id)
-        .order_by(AgentRun.created_at)
+        .order_by(AgentRun.created_at, AgentRun.id)
     )
-    child_run_ids = [row[0] for row in child_ids_result.all()]
+    child_runs = child_runs_result.scalars().all()
+    child_run_ids = [child.id for child in child_runs]
+    child_runs_response = [
+        AgentRunChildResponse(
+            id=child.id,
+            agent_id=child.agent_id,
+            agent_name=child.agent.name,
+            status=child.status,
+            asked=child.asked,
+            did=child.did,
+            answered=child.answered,
+            duration_ms=child.duration_ms,
+            created_at=child.created_at,
+        )
+        for child in child_runs
+    ]
 
     # Dual-read steps: Redis Stream when in-progress, DB when complete
     steps_response: list[AgentRunStepResponse] = []
@@ -590,6 +612,7 @@ async def get_agent_run(
         completed_at=run.completed_at,
         parent_run_id=run.parent_run_id,
         child_run_ids=child_run_ids,
+        child_runs=child_runs_response,
         steps=steps_response,
         ai_usage=ai_usage_list,
         ai_totals=ai_totals_response,
@@ -1272,5 +1295,3 @@ async def cancel_backfill_job(
     )
 
     return SummaryBackfillJobResponse.model_validate(job)
-
-

--- a/api/src/services/execution/autonomous_agent_executor.py
+++ b/api/src/services/execution/autonomous_agent_executor.py
@@ -77,6 +77,8 @@ class AutonomousAgentExecutor:
         self._tool_workflow_id_map: dict[str, UUID] = {}
         self._current_run_id: str = ""
         self._last_delegation_run_id: str | None = None
+        self._last_workflow_execution_id: str | None = None
+        self._last_workflow_execution_is_error = False
         # Caller_user_id for the active run, threaded into MCP dispatch.
         # ``None`` means the run is autonomous (scheduled / webhook /
         # event-trigger), in which case dispatch resolves to the
@@ -295,17 +297,25 @@ class AutonomousAgentExecutor:
 
                 tool_start = time.time()
                 try:
+                    # Workflow execution IDs are captured as transient
+                    # per-invocation metadata by _execute_tool. Reset before
+                    # every dispatch so non-workflow calls cannot inherit the
+                    # previous workflow's execution ID.
+                    self._last_workflow_execution_id = None
+                    self._last_workflow_execution_is_error = False
                     result = await self._execute_tool(tc, agent)
                     tool_duration = int((time.time() - tool_start) * 1000)
 
                     step_content: dict = {
                         "tool_name": tc.name,
                         "result": str(result)[:20000],
-                        "is_error": False,
+                        "is_error": self._last_workflow_execution_is_error,
                     }
                     # Include child_run_id for delegation steps
                     if tc.name.startswith("delegate_to_") and self._last_delegation_run_id:
                         step_content["child_run_id"] = self._last_delegation_run_id
+                    if self._last_workflow_execution_id:
+                        step_content["execution_id"] = self._last_workflow_execution_id
 
                     step_number += 1
                     await self._record_step(run_id, step_number, "tool_result", step_content, duration_ms=tool_duration)
@@ -463,8 +473,10 @@ class AutonomousAgentExecutor:
             is_platform_admin=False,
             is_agent=True,
         )
+        self._last_workflow_execution_id = response.execution_id
+        self._last_workflow_execution_is_error = response.status.value != "Success"
 
-        if response.status.value != "Success":
+        if self._last_workflow_execution_is_error:
             error_msg = response.error or f"Tool execution failed with status: {response.status.value}"
             return f"Error: {error_msg}"
 

--- a/api/tests/e2e/api/test_agent_run_children.py
+++ b/api/tests/e2e/api/test_agent_run_children.py
@@ -1,0 +1,183 @@
+"""GET /api/agent-runs/{id} delegation summaries."""
+from datetime import datetime, timedelta, timezone
+from uuid import UUID, uuid4
+
+import pytest
+from sqlalchemy import delete
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.models.orm.agent_runs import AgentRun
+
+
+pytestmark = pytest.mark.asyncio
+
+
+def _create_agent(e2e_client, platform_admin, name: str) -> dict:
+    response = e2e_client.post(
+        "/api/agents",
+        json={
+            "name": name,
+            "description": "Delegation history test agent",
+            "system_prompt": "Test delegated work.",
+            "channels": [],
+            "access_level": "authenticated",
+        },
+        headers=platform_admin.headers,
+    )
+    assert response.status_code == 201, response.text
+    return response.json()
+
+
+async def test_run_detail_returns_ordered_child_summaries_with_agent_names(
+    e2e_client,
+    platform_admin,
+    db_session: AsyncSession,
+):
+    root_agent = _create_agent(
+        e2e_client, platform_admin, f"Coordinator {uuid4().hex[:8]}"
+    )
+    first_agent = _create_agent(
+        e2e_client, platform_admin, f"Inventory Specialist {uuid4().hex[:8]}"
+    )
+    second_agent = _create_agent(
+        e2e_client, platform_admin, f"Troubleshooting Specialist {uuid4().hex[:8]}"
+    )
+
+    root_id = uuid4()
+    first_id = uuid4()
+    second_id = uuid4()
+    started = datetime(2026, 7, 22, 14, 0, tzinfo=timezone.utc)
+    root = AgentRun(
+        id=root_id,
+        agent_id=UUID(root_agent["id"]),
+        trigger_type="api",
+        status="completed",
+        created_at=started,
+    )
+    # Insert in reverse chronological order so the response must honor
+    # created_at rather than insertion order.
+    second = AgentRun(
+        id=second_id,
+        agent_id=UUID(second_agent["id"]),
+        parent_run_id=root_id,
+        trigger_type="delegation",
+        status="running",
+        asked="Diagnose the device problem",
+        did="Checked services and disk health",
+        duration_ms=2300,
+        created_at=started + timedelta(seconds=2),
+    )
+    first = AgentRun(
+        id=first_id,
+        agent_id=UUID(first_agent["id"]),
+        parent_run_id=root_id,
+        trigger_type="delegation",
+        status="completed",
+        asked="Find the affected device",
+        did="Matched the ticket to WS-104",
+        answered="WS-104 is the affected device",
+        duration_ms=1200,
+        created_at=started + timedelta(seconds=1),
+    )
+    db_session.add_all([root, second, first])
+    await db_session.commit()
+
+    try:
+        response = e2e_client.get(
+            f"/api/agent-runs/{root_id}",
+            headers=platform_admin.headers,
+        )
+        assert response.status_code == 200, response.text
+        body = response.json()
+
+        assert body["child_run_ids"] == [str(first_id), str(second_id)]
+        assert [child["id"] for child in body["child_runs"]] == [
+            str(first_id),
+            str(second_id),
+        ]
+        assert [child["agent_name"] for child in body["child_runs"]] == [
+            first_agent["name"],
+            second_agent["name"],
+        ]
+        assert body["child_runs"][0] == {
+            "id": str(first_id),
+            "agent_id": first_agent["id"],
+            "agent_name": first_agent["name"],
+            "status": "completed",
+            "asked": "Find the affected device",
+            "did": "Matched the ticket to WS-104",
+            "answered": "WS-104 is the affected device",
+            "duration_ms": 1200,
+            "created_at": "2026-07-22T14:00:01Z",
+        }
+        assert body["child_runs"][1]["agent_name"] == second_agent["name"]
+        assert body["child_runs"][1]["status"] == "running"
+    finally:
+        await db_session.execute(delete(AgentRun).where(AgentRun.id == root_id))
+        await db_session.commit()
+        for agent in (root_agent, first_agent, second_agent):
+            e2e_client.delete(
+                f"/api/agents/{agent['id']}", headers=platform_admin.headers
+            )
+
+
+async def test_agent_scoped_history_includes_delegated_runs(
+    e2e_client,
+    platform_admin,
+    db_session: AsyncSession,
+):
+    root_agent = _create_agent(
+        e2e_client, platform_admin, f"Coordinator {uuid4().hex[:8]}"
+    )
+    child_agent = _create_agent(
+        e2e_client, platform_admin, f"Delegated Specialist {uuid4().hex[:8]}"
+    )
+    root_id = uuid4()
+    child_id = uuid4()
+    created_at = datetime(2026, 7, 22, 15, 0, tzinfo=timezone.utc)
+    db_session.add_all(
+        [
+            AgentRun(
+                id=root_id,
+                agent_id=UUID(root_agent["id"]),
+                trigger_type="api",
+                status="completed",
+                created_at=created_at,
+            ),
+            AgentRun(
+                id=child_id,
+                agent_id=UUID(child_agent["id"]),
+                parent_run_id=root_id,
+                trigger_type="delegation",
+                status="completed",
+                asked="Investigate the endpoint",
+                created_at=created_at + timedelta(seconds=1),
+            ),
+        ]
+    )
+    await db_session.commit()
+
+    try:
+        scoped_response = e2e_client.get(
+            "/api/agent-runs",
+            params={"agent_id": child_agent["id"]},
+            headers=platform_admin.headers,
+        )
+        assert scoped_response.status_code == 200, scoped_response.text
+        scoped_ids = {item["id"] for item in scoped_response.json()["items"]}
+        assert str(child_id) in scoped_ids
+
+        global_response = e2e_client.get(
+            "/api/agent-runs",
+            headers=platform_admin.headers,
+        )
+        assert global_response.status_code == 200, global_response.text
+        global_ids = {item["id"] for item in global_response.json()["items"]}
+        assert str(child_id) not in global_ids
+    finally:
+        await db_session.execute(delete(AgentRun).where(AgentRun.id == root_id))
+        await db_session.commit()
+        for agent in (root_agent, child_agent):
+            e2e_client.delete(
+                f"/api/agents/{agent['id']}", headers=platform_admin.headers
+            )

--- a/api/tests/unit/services/test_autonomous_agent_executor.py
+++ b/api/tests/unit/services/test_autonomous_agent_executor.py
@@ -5,6 +5,8 @@ import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
+from src.models.contracts.executions import WorkflowExecutionResponse
+from src.models.enums import ExecutionStatus
 from src.services.execution.agent_helpers import find_delegated_agent
 from src.services.execution.autonomous_agent_executor import (
     AutonomousAgentExecutor,
@@ -121,8 +123,10 @@ class TestAutonomousAgentExecutor:
     async def test_run_with_tool_calls(self, mock_resolve_tools, mock_get_llm, mock_session, mock_agent):
         """Run executes tools and continues the loop until no more tool calls."""
         workflow_id = uuid4()
+        workflow_execution_id = str(uuid4())
+        mock_agent.system_tools = ["system_tool"]
         mock_resolve_tools.return_value = (
-            [MagicMock(name="my_tool")],
+            [MagicMock(name="my_tool"), MagicMock(name="system_tool")],
             {"my_tool": workflow_id},
         )
 
@@ -131,7 +135,10 @@ class TestAutonomousAgentExecutor:
         mock_llm.complete = AsyncMock(side_effect=[
             LLMResponse(
                 content=None,
-                tool_calls=[ToolCallRequest(id="tc1", name="my_tool", arguments={"x": 1})],
+                tool_calls=[
+                    ToolCallRequest(id="tc1", name="my_tool", arguments={"x": 1}),
+                    ToolCallRequest(id="tc2", name="system_tool", arguments={}),
+                ],
                 finish_reason="tool_use",
                 input_tokens=100,
                 output_tokens=50,
@@ -148,9 +155,14 @@ class TestAutonomousAgentExecutor:
 
         # Mock the workflow tool execution (imported inside _execute_tool)
         with patch("src.services.execution.service.execute_tool") as mock_exec_tool:
-            mock_exec_tool.return_value = MagicMock(result="tool output", status=MagicMock(value="completed"))
+            mock_exec_tool.return_value = WorkflowExecutionResponse(
+                execution_id=workflow_execution_id,
+                status=ExecutionStatus.SUCCESS,
+                result="tool output",
+            )
 
             executor = AutonomousAgentExecutor(mock_session)
+            executor._execute_system_tool = AsyncMock(return_value="system output")
             result = await executor.run(
                 agent=mock_agent,
                 input_data={"task": "do something"},
@@ -161,6 +173,88 @@ class TestAutonomousAgentExecutor:
         assert result["output"] == "Final answer"
         assert result["iterations_used"] == 2
         assert result["tokens_used"] == 450  # 150 + 300
+        tool_result_steps = {
+            step["content"]["tool_name"]: step["content"]
+            for step in executor._pending_steps
+            if step["type"] == "tool_result"
+        }
+        assert tool_result_steps["my_tool"]["execution_id"] == workflow_execution_id
+        assert tool_result_steps["my_tool"]["is_error"] is False
+        assert "execution_id" not in tool_result_steps["system_tool"]
+        assert tool_result_steps["system_tool"]["is_error"] is False
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "workflow_status",
+        [
+            ExecutionStatus.FAILED,
+            ExecutionStatus.TIMEOUT,
+            ExecutionStatus.CANCELLED,
+            ExecutionStatus.COMPLETED_WITH_ERRORS,
+        ],
+    )
+    @patch("src.services.execution.autonomous_agent_executor.get_llm_client")
+    @patch("src.services.execution.autonomous_agent_executor.resolve_agent_tools")
+    async def test_run_marks_terminal_workflow_failures_as_errored_results(
+        self,
+        mock_resolve_tools,
+        mock_get_llm,
+        mock_session,
+        mock_agent,
+        workflow_status,
+    ):
+        """Terminal non-success workflow responses retain their ID and record an error."""
+        workflow_execution_id = str(uuid4())
+        mock_resolve_tools.return_value = (
+            [MagicMock(name="my_tool")],
+            {"my_tool": uuid4()},
+        )
+
+        mock_llm = AsyncMock()
+        mock_llm.complete = AsyncMock(
+            side_effect=[
+                LLMResponse(
+                    content=None,
+                    tool_calls=[
+                        ToolCallRequest(
+                            id="tc1",
+                            name="my_tool",
+                            arguments={},
+                        )
+                    ],
+                    finish_reason="tool_use",
+                    input_tokens=10,
+                    output_tokens=5,
+                ),
+                LLMResponse(
+                    content="Handled failure",
+                    tool_calls=None,
+                    finish_reason="end_turn",
+                    input_tokens=10,
+                    output_tokens=5,
+                ),
+            ]
+        )
+        mock_get_llm.return_value = mock_llm
+
+        with patch("src.services.execution.service.execute_tool") as mock_exec_tool:
+            mock_exec_tool.return_value = WorkflowExecutionResponse(
+                execution_id=workflow_execution_id,
+                status=workflow_status,
+                error=f"Workflow ended with {workflow_status.value}",
+            )
+
+            executor = AutonomousAgentExecutor(mock_session)
+            await executor.run(agent=mock_agent, run_id=str(uuid4()))
+
+        tool_result = next(
+            step["content"]
+            for step in executor._pending_steps
+            if step["type"] == "tool_result"
+        )
+        assert tool_result["execution_id"] == workflow_execution_id
+        assert tool_result["is_error"] is True
+        assert tool_result["result"].startswith("Error:")
 
     @pytest.mark.asyncio
     @patch("src.services.execution.autonomous_agent_executor.get_llm_client")

--- a/api/tests/unit/test_agent_run_response_includes_new_fields.py
+++ b/api/tests/unit/test_agent_run_response_includes_new_fields.py
@@ -1,5 +1,9 @@
-"""AgentRunResponse + AgentRunDetailResponse include new fields."""
-from src.models.contracts.agent_runs import AgentRunResponse, AgentRunDetailResponse
+"""Agent-run response contracts expose the expected summary fields."""
+from src.models.contracts.agent_runs import (
+    AgentRunChildResponse,
+    AgentRunDetailResponse,
+    AgentRunResponse,
+)
 
 
 def test_agent_run_response_has_new_fields():
@@ -18,3 +22,18 @@ def test_agent_run_detail_response_inherits_new_fields():
         "verdict", "verdict_note",
     ):
         assert name in fields
+
+
+def test_agent_run_detail_response_has_lean_child_summaries():
+    assert "child_runs" in AgentRunDetailResponse.model_fields
+    assert set(AgentRunChildResponse.model_fields) == {
+        "id",
+        "agent_id",
+        "agent_name",
+        "status",
+        "asked",
+        "did",
+        "answered",
+        "duration_ms",
+        "created_at",
+    }

--- a/client/e2e/agents-detail-runs.admin.spec.ts
+++ b/client/e2e/agents-detail-runs.admin.spec.ts
@@ -11,8 +11,601 @@
  */
 
 import { test, expect } from "./fixtures/api-fixture";
+import type { Page } from "@playwright/test";
+
+function makeRun(
+	agentId: string,
+	index: number,
+	parentRunId: string | null = null,
+) {
+	const createdAt = new Date(Date.now() - index * 60_000).toISOString();
+	return {
+		id: `90000000-0000-4000-8000-${String(index).padStart(12, "0")}`,
+		agent_id: agentId,
+		agent_name: "Viewport Test Agent",
+		trigger_type: "manual",
+		trigger_source: "Playwright",
+		conversation_id: null,
+		event_delivery_id: null,
+		input: { ticket_id: String(430000 + index) },
+		output: { routed: true },
+		status: "completed",
+		error: null,
+		org_id: null,
+		caller_user_id: null,
+		caller_email: null,
+		caller_name: "E2E Operator",
+		iterations_used: 4,
+		tokens_used: 20_000 + index * 100,
+		budget_max_iterations: 50,
+		budget_max_tokens: 100_000,
+		duration_ms: 18_000 + index * 250,
+		llm_model: "gpt-5.2",
+		asked: `Mock run ${index}: triage ticket ${430000 + index}`,
+		did: "Reviewed the ticket, validated the client context, and routed it to the correct queue.",
+		answered: "The ticket was triaged successfully.",
+		metadata: {
+			ticket_id: String(430000 + index),
+			client: index % 2 ? "Northwind Services" : "Contoso",
+			impact: "Single User",
+		},
+		confidence: 0.92,
+		confidence_reason: "The ticket fields agreed.",
+		summary_status: "completed",
+		summary_error: null,
+		verdict: null,
+		verdict_note: null,
+		verdict_set_at: null,
+		verdict_set_by: null,
+		created_at: createdAt,
+		started_at: createdAt,
+		completed_at: createdAt,
+		parent_run_id: parentRunId,
+	};
+}
+
+async function mockRunHistory(page: Page, agentId: string, count = 24) {
+	const runs = Array.from({ length: count }, (_, index) =>
+		makeRun(agentId, index + 1),
+	);
+	runs[0] = {
+		...runs[0],
+		trigger_type: "delegation",
+		parent_run_id: "80000000-0000-4000-8000-000000000001",
+	};
+
+	await page.route("**/api/agent-runs*", async (route) => {
+		const request = route.request();
+		const url = new URL(request.url());
+		if (
+			request.method() !== "GET" ||
+			url.pathname !== "/api/agent-runs" ||
+			url.searchParams.get("agent_id") !== agentId
+		) {
+			await route.fallback();
+			return;
+		}
+
+		const limit = Number(url.searchParams.get("limit") ?? 50);
+		const offset = Number(url.searchParams.get("offset") ?? 0);
+		const nextOffset = offset + limit;
+		await route.fulfill({
+			status: 200,
+			contentType: "application/json",
+			body: JSON.stringify({
+				items: runs.slice(offset, nextOffset),
+				total: runs.length,
+				next_cursor: nextOffset < runs.length ? nextOffset : null,
+			}),
+		});
+	});
+}
+
+async function mockHierarchicalRun(page: Page, agentId: string) {
+	const parentId = "91000000-0000-4000-8000-000000000001";
+	const childId = "91000000-0000-4000-8000-000000000002";
+	const grandchildId = "91000000-0000-4000-8000-000000000003";
+	const createdAt = new Date().toISOString();
+	const step = (
+		runId: string,
+		stepNumber: number,
+		type: string,
+		content: Record<string, unknown>,
+	) => ({
+		id: `${runId.slice(0, 24)}${String(stepNumber).padStart(12, "0")}`,
+		run_id: runId,
+		step_number: stepNumber,
+		type,
+		content,
+		tokens_used: type.startsWith("llm") ? 2100 : null,
+		duration_ms: stepNumber * 900,
+		created_at: createdAt,
+	});
+	const detail = (
+		id: string,
+		agentName: string,
+		asked: string,
+		did: string,
+		steps: ReturnType<typeof step>[],
+		childRunIds: string[],
+		childRuns: Array<Record<string, unknown>> = [],
+	) => ({
+		...makeRun(agentId, 1),
+		id,
+		agent_id: agentId,
+		agent_name: agentName,
+		asked,
+		did,
+		answered: "Work completed successfully.",
+		input: { ticket_id: 428950, request: asked },
+		output: { ticket_id: 428950, completed: true },
+		steps,
+		child_run_ids: childRunIds,
+		child_runs: childRuns,
+	});
+
+	const runs = new Map([
+		[
+			parentId,
+			detail(
+				parentId,
+				"Service Desk Triage",
+				"Triage ticket 428950",
+				"Looked up the ticket with [ai_ticketing_get_ticket_details], then asked [delegate_to_troubleshooting_agent] to collect evidence.",
+				[
+					step(parentId, 1, "llm_request", {
+						messages_count: 2,
+						tools_count: 17,
+					}),
+					step(parentId, 2, "llm_response", {
+						content: "",
+						tool_calls: [
+							{ name: "ai_ticketing_get_ticket_details" },
+						],
+					}),
+					step(parentId, 3, "tool_call", {
+						tool_name: "ai_ticketing_get_ticket_details",
+						arguments: { ticket_id: 428950 },
+					}),
+					step(parentId, 4, "tool_result", {
+						tool_name: "ai_ticketing_get_ticket_details",
+						execution_id: "92000000-0000-4000-8000-000000000001",
+						result: {
+							ticket_id: 428950,
+							status: "open",
+							matched: true,
+						},
+					}),
+					step(parentId, 5, "tool_call", {
+						tool_name: "delegate_to_troubleshooting_agent",
+						arguments: { task: "Collect endpoint evidence" },
+					}),
+					step(parentId, 6, "tool_result", {
+						tool_name: "delegate_to_troubleshooting_agent",
+						result: { status: "complete" },
+						child_run_id: childId,
+					}),
+				],
+				[childId],
+				[
+					{
+						id: childId,
+						agent_id: agentId,
+						agent_name: "Troubleshooting Specialist",
+						status: "completed",
+						asked: "Collect endpoint evidence",
+						did: "Resolved the device and checked disk space and alerts.",
+						answered: "Work completed successfully.",
+						duration_ms: 18_250,
+						created_at: createdAt,
+					},
+				],
+			),
+		],
+		[
+			childId,
+			detail(
+				childId,
+				"Troubleshooting Specialist",
+				"Collect endpoint evidence",
+				"Resolved the device and checked disk space and alerts.",
+				[
+					step(childId, 1, "tool_call", {
+						tool_name: "ninja_get_device_details",
+						arguments: { ticket_id: 428950 },
+					}),
+					step(childId, 2, "tool_result", {
+						tool_name: "ninja_get_device_details",
+						result: { device: "ELIJAH-LT", matched: true },
+					}),
+				],
+				// This intentionally has no matching delegation step. It covers
+				// historical children reconstructed from parent_run_id alone.
+				[grandchildId],
+				[
+					{
+						id: grandchildId,
+						agent_id: agentId,
+						agent_name: "Asset Resolver",
+						status: "completed",
+						asked: "Confirm the managed asset",
+						did: "Matched the requester to ELIJAH-LT.",
+						answered: "Work completed successfully.",
+						duration_ms: 18_250,
+						created_at: createdAt,
+					},
+				],
+			),
+		],
+		[
+			grandchildId,
+			detail(
+				grandchildId,
+				"Asset Resolver",
+				"Confirm the managed asset",
+				"Matched the requester to ELIJAH-LT.",
+				[
+					step(grandchildId, 1, "tool_result", {
+						tool_name: "rmm_resolve_asset",
+						result: { device: "ELIJAH-LT", matched: true },
+					}),
+				],
+				[],
+			),
+		],
+	]);
+
+	await page.route("**/api/agent-runs*", async (route) => {
+		const request = route.request();
+		const url = new URL(request.url());
+		if (
+			request.method() === "GET" &&
+			url.pathname === "/api/agent-runs" &&
+			url.searchParams.get("agent_id") === agentId
+		) {
+			await route.fulfill({
+				status: 200,
+				contentType: "application/json",
+				body: JSON.stringify({
+					items: [runs.get(parentId)],
+					total: 1,
+					next_cursor: null,
+				}),
+			});
+			return;
+		}
+		await route.fallback();
+	});
+
+	await page.route(/\/api\/agent-runs\/[^/?]+(?:\?.*)?$/, async (route) => {
+		if (route.request().method() !== "GET") {
+			await route.fallback();
+			return;
+		}
+		const runId = new URL(route.request().url()).pathname.split("/").at(-1);
+		const run = runId ? runs.get(runId) : undefined;
+		if (!run) {
+			await route.fallback();
+			return;
+		}
+		await route.fulfill({
+			status: 200,
+			contentType: "application/json",
+			body: JSON.stringify(run),
+		});
+	});
+
+	return { parentId, childId, grandchildId };
+}
 
 test.describe("Agent Detail — Runs Tab (admin)", () => {
+	test("groups run activity, expands delegated traces, and reserves raw data for Advanced", async ({
+		page,
+		api,
+	}) => {
+		const create = await api.post("/api/agents", {
+			data: {
+				name: `E2E Activity Story ${Date.now()}`,
+				description: "Hierarchical run activity coverage",
+				system_prompt: "test",
+				channels: ["chat"],
+				access_level: "authenticated",
+			},
+		});
+		expect(create.ok()).toBeTruthy();
+		const agent = await create.json();
+		const { parentId, grandchildId } = await mockHierarchicalRun(
+			page,
+			agent.id,
+		);
+
+		try {
+			await page.setViewportSize({ width: 1440, height: 1000 });
+			await page.goto(`/agents/${agent.id}/runs/${parentId}`);
+			const activity = page.locator('[data-slot="run-activity"]');
+			await expect(activity).toBeVisible();
+			await expect(
+				activity.getByText("Looked up ticket details", { exact: true }),
+			).toBeVisible();
+			await expect(
+				activity.getByText(
+					"Ticket: 428950 · Status: Open · Match found",
+				),
+			).toBeVisible();
+			const ticketAction = activity
+				.locator('[data-activity-kind="action"]')
+				.filter({ hasText: "Looked up ticket details" });
+			const ticketReference = page.getByRole("link", {
+				name: "Show Looked up ticket details in Activity",
+			});
+			await expect(ticketReference).toBeVisible();
+			await ticketReference.hover();
+			await expect(ticketAction).toHaveAttribute(
+				"data-highlighted",
+				"true",
+			);
+			await page.getByText("What was asked", { exact: true }).hover();
+			await expect(ticketAction).toHaveAttribute(
+				"data-highlighted",
+				"false",
+			);
+			await ticketReference.click();
+			await expect(ticketAction).toBeInViewport();
+			await expect(ticketAction).toBeFocused();
+			await page.mouse.move(1, 1);
+			await expect(ticketAction).toHaveAttribute(
+				"data-highlighted",
+				"false",
+			);
+			await expect(
+				ticketAction.getByRole("link", { name: "Execution" }),
+			).toHaveAttribute(
+				"href",
+				"/history/92000000-0000-4000-8000-000000000001",
+			);
+			await expect(
+				page.getByText("Troubleshooting Specialist", { exact: true }),
+			).toHaveCount(2);
+			await expect(
+				activity.getByRole("link", {
+					name: "Open Troubleshooting Specialist run",
+				}),
+			).toHaveAttribute(
+				"href",
+				`/agents/${agent.id}/runs/91000000-0000-4000-8000-000000000002`,
+			);
+			const delegatedActivity = activity
+				.locator("[data-activity-kind='delegation']")
+				.filter({ hasText: "Troubleshooting Specialist" })
+				.first();
+			const delegatedTitle = delegatedActivity.getByText(
+				"Troubleshooting Specialist",
+				{ exact: true },
+			);
+			const delegatedStatus = delegatedActivity.getByLabel(
+				"Delegated run status: Completed",
+			);
+			await expect(delegatedStatus).toBeVisible();
+			const delegatedTitleBox = await delegatedTitle.boundingBox();
+			const delegatedStatusBox = await delegatedStatus.boundingBox();
+			expect(
+				Math.abs(
+					(delegatedTitleBox?.y ?? 0) +
+						(delegatedTitleBox?.height ?? 0) / 2 -
+						((delegatedStatusBox?.y ?? 0) +
+							(delegatedStatusBox?.height ?? 0) / 2),
+				),
+			).toBeLessThanOrEqual(4);
+			await expect(
+				page.getByText("Raw input", { exact: true }),
+			).toHaveCount(0);
+			await expect(
+				page.getByText("Called ai_ticketing_get_ticket_details", {
+					exact: true,
+				}),
+			).not.toBeVisible();
+			await expect(page.getByText("Run ID", { exact: true })).toHaveCount(
+				0,
+			);
+			await expect(
+				page.getByText("gpt-5.2", { exact: true }),
+			).toHaveCount(0);
+
+			await delegatedTitle.click();
+			await expect(
+				delegatedActivity.getByRole("button", {
+					name: /hide details for troubleshooting specialist/i,
+				}),
+			).toHaveAttribute("aria-expanded", "true");
+			await expect(
+				page.getByText(
+					"Resolved the device and checked disk space and alerts.",
+				),
+			).toBeVisible();
+			const nestedDelegation = delegatedActivity
+				.locator("[data-activity-kind='delegation']")
+				.filter({ hasText: "Asset Resolver" });
+			await nestedDelegation
+				.getByText("Confirm the managed asset", { exact: true })
+				.click();
+			await expect(
+				page.getByText("Asset Resolver", {
+					exact: true,
+				}),
+			).toBeVisible();
+			await expect(
+				page.getByText("Matched the requester to ELIJAH-LT."),
+			).toBeVisible();
+			await expect(
+				nestedDelegation.getByRole("button", {
+					name: /hide details for asset resolver/i,
+				}),
+			).toHaveAttribute("aria-expanded", "true");
+
+			await nestedDelegation
+				.getByRole("link", { name: "Open Asset Resolver run" })
+				.click();
+			await expect(page).toHaveURL(
+				new RegExp(`/agents/${agent.id}/runs/${grandchildId}$`),
+			);
+			const contextualBack = page.getByTestId("run-context-back");
+			await expect(contextualBack).toHaveText(
+				"Back to Service Desk Triage run",
+			);
+			await expect(contextualBack).toHaveAttribute(
+				"href",
+				`/agents/${agent.id}/runs/${parentId}`,
+			);
+			await contextualBack.click();
+			await expect(page).toHaveURL(
+				new RegExp(`/agents/${agent.id}/runs/${parentId}$`),
+			);
+			await expect(
+				delegatedActivity.getByRole("button", {
+					name: /hide details for troubleshooting specialist/i,
+				}),
+			).toHaveAttribute("aria-expanded", "true");
+			await expect(
+				nestedDelegation.getByRole("button", {
+					name: /hide details for asset resolver/i,
+				}),
+			).toHaveAttribute("aria-expanded", "true");
+			await expect(nestedDelegation).toBeInViewport();
+
+			await page
+				.getByRole("button", { name: "Advanced", exact: true })
+				.click();
+			await expect(
+				page.getByText("Called ai_ticketing_get_ticket_details", {
+					exact: true,
+				}),
+			).not.toBeVisible();
+			await ticketAction.getByText("Details", { exact: true }).click();
+			await expect(
+				ticketAction.getByText("ai_ticketing_get_ticket_details", {
+					exact: true,
+				}),
+			).toBeVisible();
+			await expect(
+				page.getByText("Raw input", { exact: true }),
+			).toBeVisible();
+			await expect(page.getByText(/\{"ticket_id"/)).toHaveCount(0);
+			await expect(
+				ticketAction.getByText("ticket_id:", { exact: true }),
+			).toHaveCount(2);
+			await page.getByText("Raw executor trace", { exact: true }).click();
+			await expect(
+				page.getByText("Called ai_ticketing_get_ticket_details", {
+					exact: true,
+				}),
+			).toBeVisible();
+			await expect(
+				page.getByText("Run ID", { exact: true }),
+			).toBeVisible();
+			await expect(
+				page.getByText("gpt-5.2", { exact: true }),
+			).toBeVisible();
+
+			await page.setViewportSize({ width: 390, height: 844 });
+			await page.reload();
+			await expect(activity).toBeVisible();
+			expect(
+				await activity.evaluate(
+					(element) => element.scrollWidth - element.clientWidth,
+				),
+			).toBeLessThanOrEqual(1);
+			const mobileOpenRun = activity.getByRole("link", {
+				name: "Open Troubleshooting Specialist run",
+			});
+			const mobileShowDetails = activity.getByRole("button", {
+				name: "Show details for Troubleshooting Specialist",
+			});
+			await expect(mobileOpenRun).toBeVisible();
+			await expect(mobileShowDetails).toBeVisible();
+			const mobileOpenRunBox = await mobileOpenRun.boundingBox();
+			const mobileShowDetailsBox = await mobileShowDetails.boundingBox();
+			expect(mobileOpenRunBox?.height).toBeGreaterThanOrEqual(44);
+			expect(mobileOpenRunBox?.height).toBeLessThanOrEqual(60);
+			expect(mobileShowDetailsBox?.height).toBeGreaterThanOrEqual(44);
+			expect(mobileShowDetailsBox?.width).toBeGreaterThan(
+				mobileOpenRunBox?.width ?? 0,
+			);
+			await mobileShowDetails
+				.getByText("Collect endpoint evidence", { exact: true })
+				.click();
+			await expect(
+				activity.getByRole("button", {
+					name: "Hide details for Troubleshooting Specialist",
+				}),
+			).toHaveAttribute("aria-expanded", "true");
+		} finally {
+			await api.delete(`/api/agents/${agent.id}`);
+		}
+	});
+
+	test("uses the same human activity view in the Runs drawer", async ({
+		page,
+		api,
+	}) => {
+		const create = await api.post("/api/agents", {
+			data: {
+				name: `E2E Runs Drawer Activity ${Date.now()}`,
+				description: "Runs drawer activity coverage",
+				system_prompt: "test",
+				channels: ["chat"],
+				access_level: "authenticated",
+			},
+		});
+		expect(create.ok()).toBeTruthy();
+		const agent = await create.json();
+		await mockHierarchicalRun(page, agent.id);
+
+		try {
+			await page.setViewportSize({ width: 1440, height: 900 });
+			await page.goto(`/agents/${agent.id}?tab=runs`);
+			const runHistory = page.getByRole("region", {
+				name: "Run history",
+			});
+			await expect(runHistory).toBeVisible();
+			await runHistory
+				.locator('[data-slot="run-card"] > [role="button"]')
+				.first()
+				.click();
+
+			const sheet = page.getByRole("dialog");
+			await expect(sheet).toBeVisible();
+			await expect(sheet).toHaveAttribute("aria-label", "Run review");
+			const activity = sheet.locator('[data-slot="run-activity"]');
+			await expect(
+				activity.getByRole("heading", { name: "Activity" }),
+			).toBeVisible();
+			await expect(
+				activity.getByText("Looked up ticket details", {
+					exact: true,
+				}),
+			).toBeVisible();
+			await expect(
+				activity.getByText("Troubleshooting Specialist", {
+					exact: true,
+				}),
+			).toBeVisible();
+			await expect(
+				sheet.getByText("Raw executor trace", { exact: true }),
+			).toHaveCount(0);
+
+			await activity
+				.getByText("Collect endpoint evidence", { exact: true })
+				.click();
+			await expect(
+				activity.getByText("Looked up device details", {
+					exact: true,
+				}),
+			).toBeVisible();
+		} finally {
+			await api.delete(`/api/agents/${agent.id}`);
+		}
+	});
+
 	test("shows agent detail with tabs and Runs view", async ({
 		page,
 		api,
@@ -73,11 +666,393 @@ test.describe("Agent Detail — Runs Tab (admin)", () => {
 		page,
 	}) => {
 		await page.goto("/agents/new");
-		await expect(
-			page.getByRole("tab", { name: /settings/i }),
-		).toBeVisible({ timeout: 10000 });
+		await expect(page.getByRole("tab", { name: /settings/i })).toBeVisible({
+			timeout: 10000,
+		});
 		// Overview/Runs disabled in create mode.
 		const overviewTab = page.getByRole("tab", { name: /overview/i });
 		await expect(overviewTab).toBeDisabled();
+	});
+
+	test("does not reserve an empty scrollbar lane for sparse recent activity", async ({
+		page,
+		api,
+	}) => {
+		const create = await api.post("/api/agents", {
+			data: {
+				name: `E2E Sparse Overview ${Date.now()}`,
+				description: "Sparse recent activity gutter coverage",
+				system_prompt: "test",
+				channels: ["chat"],
+				access_level: "authenticated",
+			},
+		});
+		expect(create.ok()).toBeTruthy();
+		const agent = await create.json();
+		await mockRunHistory(page, agent.id, 1);
+
+		try {
+			await page.setViewportSize({ width: 1440, height: 900 });
+			await page.goto(`/agents/${agent.id}`);
+			const recentRegion = page.getByRole("region", {
+				name: "Recent activity",
+			});
+			const recentRun = recentRegion.getByRole("link").filter({
+				hasText: "Mock run 1",
+			});
+			await expect(recentRun).toBeVisible();
+			expect(
+				await recentRegion.evaluate(
+					(element) => getComputedStyle(element).scrollbarGutter,
+				),
+			).toBe("auto");
+
+			const [regionBox, runBox] = await Promise.all([
+				recentRegion.boundingBox(),
+				recentRun.boundingBox(),
+			]);
+			if (!regionBox || !runBox) {
+				throw new Error("Expected sparse recent activity geometry");
+			}
+			expect(
+				Math.abs(
+					regionBox.x + regionBox.width - (runBox.x + runBox.width),
+				),
+			).toBeLessThanOrEqual(1);
+		} finally {
+			await api.delete(`/api/agents/${agent.id}`);
+		}
+	});
+
+	test("keeps Overview context fixed and View all runs navigates", async ({
+		page,
+		api,
+	}) => {
+		const create = await api.post("/api/agents", {
+			data: {
+				name: `E2E Overview Workspace ${Date.now()}`,
+				description: "Overview viewport ownership regression coverage",
+				system_prompt: "test",
+				channels: ["chat"],
+				access_level: "authenticated",
+			},
+		});
+		expect(create.ok()).toBeTruthy();
+		const agent = await create.json();
+		await mockRunHistory(page, agent.id);
+
+		try {
+			await page.setViewportSize({ width: 1440, height: 900 });
+			await page.goto(`/agents/${agent.id}`);
+
+			const main = page.locator("main");
+			const heading = page.getByRole("heading", { name: agent.name });
+			const tabs = page.getByRole("tablist");
+			const activityHeading = page.getByText(/Activity — last 7 days/i);
+			const recentRegion = page.getByRole("region", {
+				name: "Recent activity",
+			});
+			await expect(recentRegion).toBeVisible();
+			await expect(
+				recentRegion.getByText("Delegated", { exact: true }).first(),
+			).toBeVisible();
+
+			expect(
+				await main.evaluate(
+					(element) => element.scrollHeight - element.clientHeight,
+				),
+			).toBeLessThanOrEqual(1);
+			await main.evaluate((element) => {
+				element.scrollTop = element.scrollHeight;
+			});
+			expect(await main.evaluate((element) => element.scrollTop)).toBe(0);
+
+			const desktopMetrics = await recentRegion.evaluate((element) => ({
+				overflowY: getComputedStyle(element).overflowY,
+				clientHeight: element.clientHeight,
+				scrollHeight: element.scrollHeight,
+			}));
+			expect(desktopMetrics.overflowY).toBe("auto");
+			expect(desktopMetrics.scrollHeight).toBeGreaterThan(
+				desktopMetrics.clientHeight,
+			);
+
+			const contextBefore = await Promise.all([
+				heading.boundingBox(),
+				tabs.boundingBox(),
+				activityHeading.boundingBox(),
+			]);
+			if (contextBefore.some((bounds) => bounds === null)) {
+				throw new Error("Expected Overview context to be visible");
+			}
+
+			await recentRegion.evaluate((element) => {
+				element.scrollTop = element.scrollHeight;
+			});
+			await expect
+				.poll(() =>
+					recentRegion.evaluate((element) => element.scrollTop),
+				)
+				.toBeGreaterThan(0);
+			expect(await main.evaluate((element) => element.scrollTop)).toBe(0);
+
+			const contextAfter = await Promise.all([
+				heading.boundingBox(),
+				tabs.boundingBox(),
+				activityHeading.boundingBox(),
+			]);
+			for (let index = 0; index < contextBefore.length; index += 1) {
+				expect(
+					Math.abs(
+						(contextAfter[index]?.y ?? 0) -
+							(contextBefore[index]?.y ?? 0),
+					),
+				).toBeLessThanOrEqual(1);
+			}
+
+			await page.getByRole("link", { name: /view all runs/i }).click();
+			await expect(page).toHaveURL(
+				new RegExp(`/agents/${agent.id}\\?tab=runs$`),
+			);
+			await expect(
+				page.getByRole("tab", { name: /runs/i }),
+			).toHaveAttribute("aria-selected", "true");
+
+			for (const viewport of [
+				{ width: 390, height: 844 },
+				{ width: 1440, height: 650 },
+			]) {
+				await page.setViewportSize(viewport);
+				await page.goto(`/agents/${agent.id}`);
+				await expect(recentRegion).toBeVisible();
+
+				const fallbackMetrics = await recentRegion.evaluate(
+					(element) => ({
+						overflowY: getComputedStyle(element).overflowY,
+						clientHeight: element.clientHeight,
+						scrollHeight: element.scrollHeight,
+					}),
+				);
+				expect(fallbackMetrics.overflowY).not.toBe("auto");
+				expect(
+					Math.abs(
+						fallbackMetrics.scrollHeight -
+							fallbackMetrics.clientHeight,
+					),
+				).toBeLessThanOrEqual(1);
+				expect(
+					await main.evaluate(
+						(element) =>
+							element.scrollHeight - element.clientHeight,
+					),
+				).toBeGreaterThan(0);
+				expect(
+					await main.evaluate(
+						(element) => element.scrollWidth - element.clientWidth,
+					),
+				).toBeLessThanOrEqual(1);
+			}
+		} finally {
+			await api.delete(`/api/agents/${agent.id}`);
+		}
+	});
+
+	test("keeps run context fixed on desktop and falls back to page scrolling", async ({
+		page,
+		api,
+	}) => {
+		const create = await api.post("/api/agents", {
+			data: {
+				name: `E2E Run Workspace ${Date.now()}`,
+				description: "Viewport ownership regression coverage",
+				system_prompt: "test",
+				channels: ["chat"],
+				access_level: "authenticated",
+			},
+		});
+		expect(create.ok()).toBeTruthy();
+		const agent = await create.json();
+		await mockRunHistory(page, agent.id);
+
+		try {
+			await page.setViewportSize({ width: 1440, height: 900 });
+			await page.goto(`/agents/${agent.id}?tab=runs`);
+
+			const main = page.locator("main");
+			const heading = page.getByRole("heading", { name: agent.name });
+			const tabs = page.getByRole("tablist");
+			const search = page.getByLabel("Search runs");
+			const runRegion = page.getByRole("region", {
+				name: "Run history",
+			});
+			await expect(runRegion).toBeVisible();
+			await expect(
+				runRegion.getByText("Delegated", { exact: true }).first(),
+			).toBeVisible();
+			const mainOverflow = await main.evaluate(
+				(element) => element.scrollHeight - element.clientHeight,
+			);
+			expect(mainOverflow).toBeLessThanOrEqual(1);
+			await main.evaluate((element) => {
+				element.scrollTop = element.scrollHeight;
+			});
+			expect(await main.evaluate((element) => element.scrollTop)).toBe(0);
+
+			const desktopMetrics = await runRegion.evaluate((element) => ({
+				overflowY: getComputedStyle(element).overflowY,
+				clientHeight: element.clientHeight,
+				scrollHeight: element.scrollHeight,
+			}));
+			expect(desktopMetrics.overflowY).toBe("auto");
+			expect(desktopMetrics.scrollHeight).toBeGreaterThan(
+				desktopMetrics.clientHeight,
+			);
+			const firstRunCard = runRegion
+				.locator('[data-slot="run-card"]')
+				.first();
+			const [tabsBox, runCardBox] = await Promise.all([
+				tabs.boundingBox(),
+				firstRunCard.boundingBox(),
+			]);
+			if (!tabsBox || !runCardBox) {
+				throw new Error("Expected tab and run card geometry");
+			}
+			expect(Math.abs(tabsBox.x - runCardBox.x)).toBeLessThanOrEqual(1);
+			expect(
+				Math.abs(
+					tabsBox.x +
+						tabsBox.width -
+						(runCardBox.x + runCardBox.width),
+				),
+			).toBeLessThanOrEqual(1);
+			const runRegionSpacing = await runRegion.evaluate((element) => {
+				const style = getComputedStyle(element);
+				return {
+					scrollbarGutter: style.scrollbarGutter,
+					paddingRight: style.paddingRight,
+				};
+			});
+			expect(runRegionSpacing).toEqual({
+				scrollbarGutter: "auto",
+				paddingRight: "0px",
+			});
+
+			const contextBefore = await Promise.all([
+				heading.boundingBox(),
+				tabs.boundingBox(),
+				search.boundingBox(),
+			]);
+			if (contextBefore.some((bounds) => bounds === null)) {
+				throw new Error(
+					"Expected agent context controls to be visible",
+				);
+			}
+
+			await runRegion.evaluate((element) => {
+				element.scrollTop = element.scrollHeight;
+			});
+			await expect
+				.poll(() => runRegion.evaluate((element) => element.scrollTop))
+				.toBeGreaterThan(0);
+			expect(await main.evaluate((element) => element.scrollTop)).toBe(0);
+			await expect(
+				page.getByText(/Mock run 24:/).first(),
+			).toBeInViewport();
+
+			const contextAfter = await Promise.all([
+				heading.boundingBox(),
+				tabs.boundingBox(),
+				search.boundingBox(),
+			]);
+			for (let index = 0; index < contextBefore.length; index += 1) {
+				expect(contextAfter[index]?.y).toBeCloseTo(
+					contextBefore[index]?.y ?? 0,
+					1,
+				);
+			}
+
+			await page.setViewportSize({ width: 1440, height: 720 });
+			const addCapturedDataFilter = page.getByRole("button", {
+				name: "Add captured data filter",
+			});
+			for (let index = 0; index < 6; index += 1) {
+				await addCapturedDataFilter.click();
+			}
+			const filterRegion = page.locator(".agent-runs-filter-region");
+			const filterMetrics = await filterRegion.evaluate((element) => ({
+				overflowY: getComputedStyle(element).overflowY,
+				clientHeight: element.clientHeight,
+				scrollHeight: element.scrollHeight,
+			}));
+			expect(filterMetrics.overflowY).toBe("auto");
+			expect(filterMetrics.scrollHeight).toBeGreaterThan(
+				filterMetrics.clientHeight,
+			);
+			expect(
+				await runRegion.evaluate((element) => element.clientHeight),
+			).toBeGreaterThan(0);
+			expect(
+				await main.evaluate(
+					(element) => element.scrollHeight - element.clientHeight,
+				),
+			).toBeLessThanOrEqual(1);
+			await filterRegion.evaluate((element) => {
+				element.scrollTop = element.scrollHeight;
+			});
+			await expect
+				.poll(() =>
+					filterRegion.evaluate((element) => element.scrollTop),
+				)
+				.toBeGreaterThan(0);
+
+			for (const viewport of [
+				{ width: 390, height: 844 },
+				{ width: 1440, height: 650 },
+			]) {
+				await page.setViewportSize(viewport);
+				await page.reload();
+				await expect(runRegion).toBeVisible();
+
+				const fallbackMetrics = await runRegion.evaluate((element) => ({
+					overflowY: getComputedStyle(element).overflowY,
+					clientHeight: element.clientHeight,
+					scrollHeight: element.scrollHeight,
+				}));
+				expect(fallbackMetrics.overflowY).not.toBe("auto");
+				expect(
+					Math.abs(
+						fallbackMetrics.scrollHeight -
+							fallbackMetrics.clientHeight,
+					),
+				).toBeLessThanOrEqual(1);
+				expect(
+					await main.evaluate(
+						(element) =>
+							element.scrollHeight - element.clientHeight,
+					),
+				).toBeGreaterThan(0);
+
+				await runRegion.evaluate((element) => {
+					element.scrollTop = 100;
+				});
+				expect(
+					await runRegion.evaluate((element) => element.scrollTop),
+				).toBe(0);
+
+				await main.evaluate((element) => {
+					element.scrollTop = element.scrollHeight;
+				});
+				await expect
+					.poll(() => main.evaluate((element) => element.scrollTop))
+					.toBeGreaterThan(0);
+
+				const horizontalOverflow = await main.evaluate(
+					(element) => element.scrollWidth - element.clientWidth,
+				);
+				expect(horizontalOverflow).toBeLessThanOrEqual(1);
+			}
+		} finally {
+			await api.delete(`/api/agents/${agent.id}`);
+		}
 	});
 });

--- a/client/e2e/scheduled-execution.spec.ts
+++ b/client/e2e/scheduled-execution.spec.ts
@@ -179,17 +179,13 @@ test.describe("Scheduled executions", () => {
 		expect(body.status).toBe("Scheduled");
 
 		await page.goto("/history");
-		await page.getByRole("tab", { name: "Scheduled" }).click();
 
-		const row = rowForWorkflow(page, WORKFLOW_FUNCTION, "Scheduled");
-		await expect(row).toBeVisible({ timeout: 15_000 });
-		await expect(row.getByText("Scheduled", { exact: true })).toBeVisible();
-
-		// Poll: hit refresh, check for `Completed` on ANY tab. Once the
-		// promoter fires, the row leaves the Scheduled tab (status becomes
-		// Pending → Running → Success/Completed), so we switch to All to
-		// keep the row locator stable.
-		await page.getByRole("tab", { name: "All" }).click();
+		// The API response above proves the run was initially Scheduled. The
+		// promoter can tick between that response and the first page paint, so
+		// pinning this assertion to the Scheduled tab is inherently racy: the
+		// row may already be Pending or Running. The long-delay cancellation
+		// test covers the Scheduled badge itself; follow this short-delay run
+		// from All so its locator remains stable through every transition.
 		const rowOnAll = rowForWorkflow(page, WORKFLOW_FUNCTION);
 
 		// Target the status badge specifically to avoid matching the

--- a/client/e2e/solution-runtime-contract.admin.spec.ts
+++ b/client/e2e/solution-runtime-contract.admin.spec.ts
@@ -204,7 +204,10 @@ function workspaceZip(): Buffer {
 				},
 			}),
 		},
-		{ path: ".bifrost/files.yaml", content: JSON.stringify({ locations: ["docs"] }) },
+		{
+			path: ".bifrost/files.yaml",
+			content: JSON.stringify({ locations: ["docs"] }),
+		},
 		{
 			path: ".bifrost/apps.yaml",
 			content: JSON.stringify({
@@ -218,7 +221,10 @@ function workspaceZip(): Buffer {
 						access_level: "authenticated",
 						path: `apps/${APP_SLUG}`,
 						// Prebuilt fast-path: no src_files, dist carried inline.
-						dist_files: { "index.html": INDEX_HTML, "main.js": ENTRY_JS },
+						dist_files: {
+							"index.html": INDEX_HTML,
+							"main.js": ENTRY_JS,
+						},
 					},
 				},
 			}),
@@ -227,6 +233,20 @@ function workspaceZip(): Buffer {
 }
 
 test.describe("deployed solution runtime contract", () => {
+	let createdSolutionId: string | null = null;
+
+	test.afterEach(async ({ api }) => {
+		if (!createdSolutionId) return;
+		const cleanup = await api.delete(
+			`/api/solutions/${createdSolutionId}`,
+			{
+				params: { confirm: SLUG },
+			},
+		);
+		expect(cleanup.ok(), await cleanup.text()).toBeTruthy();
+		createdSolutionId = null;
+	});
+
 	test("workflow/table/file resolve via the header contract in the browser", async ({
 		page,
 		api,
@@ -240,27 +260,37 @@ test.describe("deployed solution runtime contract", () => {
 
 		// --- create the install, then deploy the workspace zip ---
 		const sol = await api.post("/api/solutions", {
-			data: { slug: SLUG, name: SLUG, scope: "global", global_repo_access: false },
+			data: {
+				slug: SLUG,
+				name: SLUG,
+				organization_id: null,
+				global_repo_access: false,
+			},
 		});
 		expect(sol.ok(), await sol.text()).toBeTruthy();
 		const sid = (await sol.json()).id;
+		createdSolutionId = sid;
 
-		const dep = await page.context().request.post(`/api/solutions/${sid}/deploy`, {
-			headers: await api.csrfHeader(),
-			multipart: {
-				file: {
-					name: "solution.zip",
-					mimeType: "application/zip",
-					buffer: workspaceZip(),
+		const dep = await page
+			.context()
+			.request.post(`/api/solutions/${sid}/deploy`, {
+				headers: await api.csrfHeader(),
+				multipart: {
+					file: {
+						name: "solution.zip",
+						mimeType: "application/zip",
+						buffer: workspaceZip(),
+					},
 				},
-			},
-		});
+			});
 		expect(dep.status(), await dep.text()).toBe(202);
 		const jobId = (await dep.json()).deploy_job_id;
 		await expect
 			.poll(
 				async () => {
-					const st = await api.get(`/api/solutions/deploy-jobs/${jobId}`);
+					const st = await api.get(
+						`/api/solutions/deploy-jobs/${jobId}`,
+					);
 					const body = await st.json();
 					if (body.status === "failed") {
 						throw new Error(`deploy failed: ${body.error}`);

--- a/client/e2e/users.admin.spec.ts
+++ b/client/e2e/users.admin.spec.ts
@@ -26,14 +26,13 @@ test.describe("User Listing", () => {
 			page.getByRole("heading", { name: /users/i }).first(),
 		).toBeVisible({ timeout: 10000 });
 
-		// Either we see users in the table or an empty state message
-		const hasUsers = (await page.locator("table tbody tr").count()) > 0;
-		const hasEmptyState = await page
-			.getByText(/no users/i)
-			.isVisible()
-			.catch(() => false);
-
-		expect(hasUsers || hasEmptyState).toBe(true);
+		// The heading renders before the users query settles. Wait for the
+		// loaded table or its empty state instead of sampling during skeletons.
+		const userRows = page.locator("table tbody tr");
+		const emptyState = page.getByText(/no users/i);
+		await expect(userRows.first().or(emptyState)).toBeVisible({
+			timeout: 10000,
+		});
 	});
 
 	test("should show create user button", async ({ page }) => {
@@ -60,6 +59,8 @@ test.describe("User Details", () => {
 
 		// Find a user row
 		const userRow = page.locator("table tbody tr").first();
+		const emptyState = page.getByText(/no users/i);
+		await expect(userRow.or(emptyState)).toBeVisible({ timeout: 10000 });
 		const hasUserRow = await userRow.isVisible().catch(() => false);
 
 		if (hasUserRow) {

--- a/client/e2e/workflows.admin.spec.ts
+++ b/client/e2e/workflows.admin.spec.ts
@@ -35,13 +35,15 @@ test.describe("Workflow Listing", () => {
 		const actionButtons = page.getByRole("button", {
 			name: /execute workflow|test tool|preview data/i,
 		});
-		const hasWorkflows = (await actionButtons.count()) > 0;
-		const hasEmptyState = await page
-			.getByText(/no workflows available|no workflows match/i)
-			.isVisible()
-			.catch(() => false);
+		const emptyState = page.getByText(
+			/no workflows available|no workflows match/i,
+		);
 
-		expect(hasWorkflows || hasEmptyState).toBe(true);
+		// The heading renders before the workflow query settles. Wait for the
+		// loaded list or its empty state instead of sampling during skeletons.
+		await expect(actionButtons.first().or(emptyState)).toBeVisible({
+			timeout: 10000,
+		});
 	});
 
 	test("should show workflow details when clicked", async ({ page }) => {
@@ -88,15 +90,15 @@ test.describe("Workflow Execution", () => {
 		const executeButton = page
 			.getByRole("button", { name: /execute|run/i })
 			.first();
+		const emptyState = page.getByText(
+			/no workflows available|no workflows match/i,
+		);
 
-		// Either we have execute buttons or no workflows
-		const hasButton = await executeButton.isVisible().catch(() => false);
-		const hasEmptyState = await page
-			.getByText(/no workflows available|no workflows match/i)
-			.isVisible()
-			.catch(() => false);
-
-		expect(hasButton || hasEmptyState).toBe(true);
+		// The heading renders before the workflow query settles. Wait for the
+		// loaded list or its empty state instead of sampling during skeletons.
+		await expect(executeButton.or(emptyState)).toBeVisible({
+			timeout: 10000,
+		});
 	});
 
 	test("should navigate to execute page when clicking execute", async ({
@@ -113,6 +115,13 @@ test.describe("Workflow Execution", () => {
 		const executeButton = page
 			.getByRole("button", { name: /execute|run/i })
 			.first();
+		const emptyState = page.getByText(
+			/no workflows available|no workflows match/i,
+		);
+
+		await expect(executeButton.or(emptyState)).toBeVisible({
+			timeout: 10000,
+		});
 
 		if (await executeButton.isVisible().catch(() => false)) {
 			await executeButton.click();
@@ -126,7 +135,6 @@ test.describe("Workflow Execution", () => {
 			expect(isOnExecutePage || hasExecutionForm).toBe(true);
 		}
 	});
-
 });
 
 test.describe("Workflow Discovery", () => {

--- a/client/src/components/agents/AgentOverviewTab.test.tsx
+++ b/client/src/components/agents/AgentOverviewTab.test.tsx
@@ -6,7 +6,17 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { Route, Routes, useLocation } from "react-router-dom";
 import { renderWithProviders, screen } from "@/test-utils";
+
+function NavigationStateProbe() {
+	const location = useLocation();
+	return (
+		<pre data-testid="navigation-state">
+			{JSON.stringify(location.state)}
+		</pre>
+	);
+}
 
 const mockUseAgentStats = vi.fn();
 vi.mock("@/services/agents", () => ({
@@ -96,6 +106,43 @@ describe("AgentOverviewTab", () => {
 	it("renders the recent runs list", async () => {
 		await renderTab();
 		expect(screen.getByText(/help me/i)).toBeInTheDocument();
+		expect(
+			screen.getByRole("img", { name: "Status: Completed" }),
+		).toBeInTheDocument();
+	});
+
+	it("keeps the overview as the origin when a recent run is opened", async () => {
+		const { AgentOverviewTab } = await import("./AgentOverviewTab");
+		const { user } = renderWithProviders(
+			<Routes>
+				<Route
+					path="/agents/:agentId"
+					element={<AgentOverviewTab agentId="agent-1" />}
+				/>
+				<Route
+					path="/agents/:agentId/runs/:runId"
+					element={<NavigationStateProbe />}
+				/>
+			</Routes>,
+			{ initialEntries: ["/agents/agent-1?tab=overview"] },
+		);
+
+		await user.click(screen.getByRole("link", { name: /help me/i }));
+		expect(screen.getByTestId("navigation-state")).toHaveTextContent(
+			JSON.stringify({
+				agentRunOrigin: {
+					href: "/agents/agent-1?tab=overview",
+					label: "Back to Triage overview",
+				},
+			}),
+		);
+	});
+
+	it("links View all runs directly to the Runs tab", async () => {
+		await renderTab();
+		expect(
+			screen.getByRole("link", { name: /view all runs/i }),
+		).toHaveAttribute("href", "/agents/agent-1?tab=runs");
 	});
 
 	it("hides the 'Needs attention' card when no flagged runs", async () => {
@@ -133,7 +180,11 @@ describe("AgentOverviewTab", () => {
 		});
 		mockUseAgentRuns.mockReturnValue({
 			data: {
-				items: [makeRun(), makeRun({ id: "run-2" }), makeRun({ id: "run-3" })],
+				items: [
+					makeRun(),
+					makeRun({ id: "run-2" }),
+					makeRun({ id: "run-3" }),
+				],
 				total: 3,
 				next_cursor: null,
 			},

--- a/client/src/components/agents/AgentOverviewTab.tsx
+++ b/client/src/components/agents/AgentOverviewTab.tsx
@@ -6,16 +6,13 @@
  *   side column  →  needs-attention card (red), Configuration KV, Budgets KV
  */
 
-import { Link } from "react-router-dom";
+import { Link, useLocation } from "react-router-dom";
 import {
 	Activity,
 	AlertTriangle,
-	CheckCircle,
-	Clock,
 	Info,
 	ThumbsDown,
 	ThumbsUp,
-	XCircle,
 } from "lucide-react";
 
 import { Skeleton } from "@/components/ui/skeleton";
@@ -33,18 +30,17 @@ import {
 } from "@/components/agents/design-tokens";
 import { Sparkline } from "@/components/agents/Sparkline";
 import { StatCard } from "@/components/agents/StatCard";
-import { SummaryPlaceholder } from "@/components/agents/SummaryPlaceholder";
+import { RunSummaryContent } from "@/components/agents/RunSummaryContent";
 import { useAgent } from "@/hooks/useAgents";
 import { useAgentRunUpdates } from "@/hooks/useAgentRunUpdates";
 import { useAgentRuns } from "@/services/agentRuns";
 import { useAgentStats } from "@/services/agents";
 import {
-	cn,
-	formatCost,
-	formatDuration,
-	formatNumber,
-	formatRelativeTime,
-} from "@/lib/utils";
+	createAgentRunNavigationState,
+	getLocationHref,
+	type AgentRunNavigationOrigin,
+} from "@/lib/agent-run-navigation";
+import { cn, formatCost, formatDuration, formatNumber } from "@/lib/utils";
 import type { components } from "@/lib/v1";
 
 type AgentRun = components["schemas"]["AgentRunResponse"];
@@ -54,6 +50,7 @@ export interface AgentOverviewTabProps {
 }
 
 export function AgentOverviewTab({ agentId }: AgentOverviewTabProps) {
+	const location = useLocation();
 	const { data: agent } = useAgent(agentId);
 	const { data: stats, isLoading: statsLoading } = useAgentStats(agentId);
 	const { data: runsList, isLoading: runsLoading } = useAgentRuns({
@@ -68,20 +65,44 @@ export function AgentOverviewTab({ agentId }: AgentOverviewTabProps) {
 
 	const successRate = stats?.success_rate ?? 0;
 	const sparkColor = successRateTone(successRate);
+	const runNavigationOrigin: AgentRunNavigationOrigin = {
+		href: getLocationHref(location),
+		label: `Back to ${agent?.name ?? "agent"} overview`,
+	};
 
 	return (
-		<div className={cn("grid lg:grid-cols-[minmax(0,1fr)_320px]", GAP_CARD)}>
+		<div
+			className={cn(
+				"agent-overview-tab grid min-w-0 grid-cols-[minmax(0,1fr)] lg:grid-cols-[minmax(0,1fr)_320px]",
+				GAP_CARD,
+			)}
+		>
 			{/* Main column */}
-			<div className={cn("flex flex-col", GAP_CARD)}>
+			<div
+				className={cn(
+					"agent-overview-main flex min-w-0 flex-col",
+					GAP_CARD,
+				)}
+			>
 				{/* Stat row — 4 stats */}
 				{statsLoading ? (
-					<div className={cn("grid grid-cols-2 md:grid-cols-4", GAP_CARD)}>
+					<div
+						className={cn(
+							"grid grid-cols-2 md:grid-cols-4",
+							GAP_CARD,
+						)}
+					>
 						{[...Array(4)].map((_, i) => (
 							<Skeleton key={i} className="h-[92px] w-full" />
 						))}
 					</div>
 				) : stats ? (
-					<div className={cn("grid grid-cols-2 md:grid-cols-4", GAP_CARD)}>
+					<div
+						className={cn(
+							"grid grid-cols-2 md:grid-cols-4",
+							GAP_CARD,
+						)}
+					>
 						<StatCard
 							label="Runs (7d)"
 							value={formatNumber(stats.runs_7d)}
@@ -90,7 +111,9 @@ export function AgentOverviewTab({ agentId }: AgentOverviewTabProps) {
 							label="Success rate"
 							value={`${Math.round(successRate * 100)}%`}
 							delta={
-								stats.runs_7d > 0 ? `${stats.runs_7d} runs` : "—"
+								stats.runs_7d > 0
+									? `${stats.runs_7d} runs`
+									: "—"
 							}
 						/>
 						<StatCard
@@ -112,9 +135,14 @@ export function AgentOverviewTab({ agentId }: AgentOverviewTabProps) {
 							CARD_HEADER,
 						)}
 					>
-						<div className={cn("flex items-center gap-2", TYPE_CARD_TITLE)}>
-							<Activity className="h-3.5 w-3.5" /> Activity — last 7
-							days
+						<div
+							className={cn(
+								"flex items-center gap-2",
+								TYPE_CARD_TITLE,
+							)}
+						>
+							<Activity className="h-3.5 w-3.5" /> Activity — last
+							7 days
 						</div>
 						<span className={TYPE_MUTED}>Daily buckets</span>
 					</div>
@@ -135,7 +163,12 @@ export function AgentOverviewTab({ agentId }: AgentOverviewTabProps) {
 				</div>
 
 				{/* Recent activity */}
-				<div className={cn(CARD_SURFACE, "overflow-hidden")}>
+				<div
+					className={cn(
+						CARD_SURFACE,
+						"agent-overview-recent overflow-hidden",
+					)}
+				>
 					<div
 						className={cn(
 							"flex items-center justify-between",
@@ -143,13 +176,8 @@ export function AgentOverviewTab({ agentId }: AgentOverviewTabProps) {
 						)}
 					>
 						<div className={TYPE_CARD_TITLE}>Recent activity</div>
-						<button
-							type="button"
-							onClick={() => {
-								document.querySelector<HTMLElement>(
-									'[role="tab"][value="runs"]',
-								)?.click();
-							}}
+						<Link
+							to={`/agents/${agentId}?tab=runs`}
 							className={cn(
 								TYPE_SMALL,
 								TONE_MUTED,
@@ -157,9 +185,13 @@ export function AgentOverviewTab({ agentId }: AgentOverviewTabProps) {
 							)}
 						>
 							View all runs →
-						</button>
+						</Link>
 					</div>
-					<div>
+					<div
+						className="agent-overview-recent-list"
+						role="region"
+						aria-label="Recent activity"
+					>
 						{runsLoading ? (
 							<div className="space-y-1 p-3">
 								<Skeleton className="h-12 w-full" />
@@ -171,20 +203,29 @@ export function AgentOverviewTab({ agentId }: AgentOverviewTabProps) {
 								No runs yet for this agent.
 							</p>
 						) : (
-							recentRuns.slice(0, 6).map((r) => (
-								<ActivityRow
-									key={r.id}
-									run={r}
-									agentId={agentId}
-								/>
-							))
+							recentRuns
+								.slice(0, 6)
+								.map((r) => (
+									<ActivityRow
+										key={r.id}
+										run={r}
+										runNavigationOrigin={
+											runNavigationOrigin
+										}
+									/>
+								))
 						)}
 					</div>
 				</div>
 			</div>
 
 			{/* Side column */}
-			<div className={cn("flex flex-col", GAP_CARD)}>
+			<div
+				className={cn(
+					"agent-overview-sidebar flex min-w-0 flex-col",
+					GAP_CARD,
+				)}
+			>
 				{needsReview > 0 ? (
 					<Link
 						to={`/agents/${agentId}/review`}
@@ -212,7 +253,8 @@ export function AgentOverviewTab({ agentId }: AgentOverviewTabProps) {
 							{unreviewed > 0 ? (
 								<div className="text-muted-foreground">
 									{unreviewed} completed run
-									{unreviewed === 1 ? "" : "s"} awaiting review
+									{unreviewed === 1 ? "" : "s"} awaiting
+									review
 								</div>
 							) : null}
 							<div className="mt-1 w-full rounded-md bg-rose-500/15 px-3 py-1.5 text-center text-[12.5px] font-medium text-rose-500">
@@ -229,7 +271,12 @@ export function AgentOverviewTab({ agentId }: AgentOverviewTabProps) {
 						)}
 					>
 						<div className={CARD_HEADER}>
-							<div className={cn("flex items-center gap-2", TYPE_CARD_TITLE)}>
+							<div
+								className={cn(
+									"flex items-center gap-2",
+									TYPE_CARD_TITLE,
+								)}
+							>
 								<Info className="h-3.5 w-3.5" />
 								{unreviewed} to review
 							</div>
@@ -257,7 +304,9 @@ export function AgentOverviewTab({ agentId }: AgentOverviewTabProps) {
 						)}
 					>
 						<dt className={TONE_MUTED}>Model</dt>
-						<dd className={TYPE_MONO}>{agent?.llm_model ?? "default"}</dd>
+						<dd className={TYPE_MONO}>
+							{agent?.llm_model ?? "default"}
+						</dd>
 						<dt className={TONE_MUTED}>Channels</dt>
 						<dd>{(agent?.channels ?? []).join(", ") || "—"}</dd>
 						<dt className={TONE_MUTED}>Access</dt>
@@ -303,70 +352,38 @@ export function AgentOverviewTab({ agentId }: AgentOverviewTabProps) {
 
 function ActivityRow({
 	run,
-	agentId,
+	runNavigationOrigin,
 }: {
 	run: AgentRun;
-	agentId: string;
+	runNavigationOrigin: AgentRunNavigationOrigin;
 }) {
-	const status = (run.status ?? "").toLowerCase();
-	const iconTone =
-		status === "completed"
-			? "bg-emerald-500/15 text-emerald-500"
-			: status === "failed" || status === "budget_exceeded"
-				? "bg-rose-500/15 text-rose-500"
-				: "bg-muted text-muted-foreground";
-	const Icon =
-		status === "completed"
-			? CheckCircle
-			: status === "running"
-				? Clock
-				: XCircle;
-
 	return (
 		<Link
-			to={`/agents/${agentId}/runs/${run.id}`}
-			className="flex items-center gap-3 border-b px-4 py-3 text-[13px] last:border-b-0 hover:bg-accent/40"
+			to={`/agents/${run.agent_id}/runs/${run.id}`}
+			state={createAgentRunNavigationState(runNavigationOrigin)}
+			className="flex items-start border-b px-4 py-3 last:border-b-0 hover:bg-accent/40"
 		>
-			<div
-				className={cn(
-					"grid h-6 w-6 shrink-0 place-items-center rounded-full",
-					iconTone,
-				)}
-			>
-				<Icon className="h-3 w-3" />
-			</div>
-			<div className="min-w-0 flex-1">
-				<div className="truncate" title={run.asked ?? undefined}>
-					{run.asked || (
-						<SummaryPlaceholder
-							status={run.summary_status}
-							runStatus={run.status}
-						/>
-					)}
-				</div>
-				<div
-					className="mt-0.5 truncate text-[12px] text-muted-foreground"
-					title={run.did ?? undefined}
-				>
-					{run.did || (
-						<SummaryPlaceholder
-							status={run.summary_status}
-							runStatus={run.status}
-							muted
-						/>
-					)}{" "}
-					·{" "}
-					{formatRelativeTime(run.started_at ?? run.created_at ?? "")}{" "}
-					·{" "}
-					{formatDuration(run.duration_ms ?? 0)}
-				</div>
-			</div>
-			{run.verdict === "up" ? (
-				<ThumbsUp className="h-3.5 w-3.5 text-emerald-500" />
-			) : run.verdict === "down" ? (
-				<ThumbsDown className="h-3.5 w-3.5 text-rose-500" />
-			) : null}
+			<RunSummaryContent
+				run={run}
+				density="compact"
+				titleTrailing={
+					run.verdict === "up" ? (
+						<span role="img" aria-label="Verdict: Good">
+							<ThumbsUp
+								aria-hidden="true"
+								className="h-3.5 w-3.5 text-emerald-500"
+							/>
+						</span>
+					) : run.verdict === "down" ? (
+						<span role="img" aria-label="Verdict: Wrong">
+							<ThumbsDown
+								aria-hidden="true"
+								className="h-3.5 w-3.5 text-rose-500"
+							/>
+						</span>
+					) : null
+				}
+			/>
 		</Link>
 	);
 }
-

--- a/client/src/components/agents/AgentRunsPanel.test.tsx
+++ b/client/src/components/agents/AgentRunsPanel.test.tsx
@@ -1,0 +1,80 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Route, Routes, useLocation } from "react-router-dom";
+
+import { renderWithProviders, screen } from "@/test-utils";
+
+const mockUseInfiniteAgentRuns = vi.hoisted(() => vi.fn());
+const mockUseRerunAgentRun = vi.hoisted(() => vi.fn());
+
+vi.mock("@/services/agentRuns", () => ({
+	useInfiniteAgentRuns: () => mockUseInfiniteAgentRuns(),
+	useAgentRunListStream: () => undefined,
+	useRerunAgentRun: () => mockUseRerunAgentRun(),
+}));
+
+import { AgentRunsPanel } from "./AgentRunsPanel";
+
+function NavigationStateProbe() {
+	const location = useLocation();
+	return (
+		<pre data-testid="navigation-state">
+			{JSON.stringify(location.state)}
+		</pre>
+	);
+}
+
+const run = {
+	id: "run-1",
+	agent_id: "agent-1",
+	agent_name: "Service Desk Triage",
+	trigger_type: "manual",
+	status: "completed",
+	iterations_used: 2,
+	tokens_used: 1200,
+	asked: "Triage ticket 428950",
+	did: "Triaged the ticket.",
+	input: {},
+	output: {},
+	verdict: null,
+	created_at: "2026-07-23T12:00:00Z",
+	started_at: "2026-07-23T12:00:00Z",
+};
+
+beforeEach(() => {
+	mockUseInfiniteAgentRuns.mockReturnValue({
+		data: { pages: [{ items: [run], total: 1 }] },
+		isLoading: false,
+		hasNextPage: false,
+		isFetchingNextPage: false,
+		fetchNextPage: vi.fn(),
+	});
+	mockUseRerunAgentRun.mockReturnValue({
+		mutate: vi.fn(),
+		isPending: false,
+	});
+});
+
+describe("AgentRunsPanel", () => {
+	it("keeps fleet run history as the origin when opening a run", async () => {
+		const { user } = renderWithProviders(
+			<Routes>
+				<Route path="/history" element={<AgentRunsPanel />} />
+				<Route
+					path="/agents/:agentId/runs/:runId"
+					element={<NavigationStateProbe />}
+				/>
+			</Routes>,
+			{ initialEntries: ["/history?type=agents"] },
+		);
+
+		await user.click(screen.getByText("Triage ticket 428950"));
+		expect(screen.getByTestId("navigation-state")).toHaveTextContent(
+			JSON.stringify({
+				agentRunOrigin: {
+					href: "/history?type=agents",
+					label: "Back to run history",
+				},
+			}),
+		);
+	});
+});

--- a/client/src/components/agents/AgentRunsPanel.tsx
+++ b/client/src/components/agents/AgentRunsPanel.tsx
@@ -9,7 +9,7 @@
  * runs tab.
  */
 
-import { useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 import { toast } from "sonner";
 import {
 	AlertCircle,
@@ -41,6 +41,10 @@ import {
 	useInfiniteAgentRuns,
 	useRerunAgentRun,
 } from "@/services/agentRuns";
+import {
+	createAgentRunNavigationState,
+	getLocationHref,
+} from "@/lib/agent-run-navigation";
 import { formatDate, formatDuration } from "@/lib/utils";
 import type { components } from "@/lib/v1";
 
@@ -89,6 +93,11 @@ function VerdictGlyph({ verdict }: { verdict: AgentRun["verdict"] }) {
 
 export function AgentRunsPanel() {
 	const navigate = useNavigate();
+	const location = useLocation();
+	const runNavigationState = createAgentRunNavigationState({
+		href: getLocationHref(location),
+		label: "Back to run history",
+	});
 	const {
 		data,
 		isLoading,
@@ -119,6 +128,7 @@ export function AgentRunsPanel() {
 						if (source) {
 							navigate(
 								`/agents/${source.agent_id}/runs/${data.run_id}`,
+								{ state: runNavigationState },
 							);
 						}
 					}
@@ -174,6 +184,7 @@ export function AgentRunsPanel() {
 							onClick={() =>
 								navigate(
 									`/agents/${run.agent_id}/runs/${run.id}`,
+									{ state: runNavigationState },
 								)
 							}
 						>

--- a/client/src/components/agents/AgentRunsTab.test.tsx
+++ b/client/src/components/agents/AgentRunsTab.test.tsx
@@ -115,6 +115,16 @@ describe("AgentRunsTab — list", () => {
 		).toBeInTheDocument();
 	});
 
+	it("exposes the run collection as a named scroll region", async () => {
+		await renderTab();
+		const region = screen.getByRole("region", { name: /run history/i });
+
+		expect(region).toHaveClass("agent-runs-scroll-region");
+		expect(region).toContainElement(
+			screen.getByText(/how do i reset my password/i),
+		);
+	});
+
 	it("shows an empty message when the list is empty", async () => {
 		mockUseInfiniteAgentRuns.mockReturnValue(makeInfinitePages([], 0));
 		await renderTab();

--- a/client/src/components/agents/AgentRunsTab.tsx
+++ b/client/src/components/agents/AgentRunsTab.tsx
@@ -143,7 +143,7 @@ export function AgentRunsTab({ agentId }: AgentRunsTabProps) {
 	}
 
 	return (
-		<div className="flex flex-col gap-4">
+		<div className="agent-runs-tab flex flex-col gap-4">
 			{/* Search + filter bar */}
 			<div className="flex flex-wrap items-center gap-3">
 				<div className="relative flex-1 min-w-[240px] max-w-md">
@@ -209,11 +209,13 @@ export function AgentRunsTab({ agentId }: AgentRunsTabProps) {
 				) : null}
 			</div>
 
-			<CapturedDataFilter
-				agentId={agentId}
-				value={metadataConditions}
-				onChange={setMetadataConditions}
-			/>
+			<div className="agent-runs-filter-region">
+				<CapturedDataFilter
+					agentId={agentId}
+					value={metadataConditions}
+					onChange={setMetadataConditions}
+				/>
+			</div>
 
 			{flaggedCount > 0 ? (
 				<QueueBanner
@@ -224,7 +226,11 @@ export function AgentRunsTab({ agentId }: AgentRunsTabProps) {
 			) : null}
 
 			{/* Run list */}
-			<div className="flex flex-col gap-2">
+			<div
+				className="agent-runs-scroll-region flex flex-col gap-2"
+				role="region"
+				aria-label="Run history"
+			>
 				{isLoading ? (
 					<>
 						<Skeleton className="h-20 w-full" />

--- a/client/src/components/agents/DidNarrative.test.tsx
+++ b/client/src/components/agents/DidNarrative.test.tsx
@@ -1,144 +1,115 @@
-/**
- * DidNarrative tests — markers split correctly, chips match steps, and the
- * popover surfaces args/result for matched tool calls.
- */
-
-import { describe, it, expect } from "vitest";
-import { fireEvent } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
 
 import { renderWithProviders, screen } from "@/test-utils";
+
 import { DidNarrative } from "./DidNarrative";
-import type { components } from "@/lib/v1";
-
-type AgentRunStep = components["schemas"]["AgentRunStepResponse"];
-
-function makeStep(
-	type: string,
-	content: Record<string, unknown>,
-	overrides: Partial<AgentRunStep> = {},
-): AgentRunStep {
-	return {
-		id: `s-${Math.random().toString(36).slice(2, 8)}`,
-		run_id: "00000000-0000-0000-0000-000000000001",
-		step_number: 1,
-		type,
-		content,
-		duration_ms: null,
-		created_at: "2026-04-24T00:00:00Z",
-		...overrides,
-	};
-}
 
 describe("DidNarrative", () => {
-	it("renders plain prose with chips for [tool] markers", () => {
-		const steps = [
-			makeStep(
-				"tool_call",
-				{
-					tool_name: "ai_ticketing_get_ticket_details",
-					arguments: { ticket_id: 423068 },
-				},
-				{ duration_ms: 120 },
-			),
-			makeStep("tool_result", {
-				tool_name: "ai_ticketing_get_ticket_details",
-				result: "ticket #423068 details...",
-			}),
-		];
+	it("replaces machine markers with quiet human-readable references", () => {
 		renderWithProviders(
-			<DidNarrative
-				text="I called [ai_ticketing_get_ticket_details] to fetch the ticket."
-				steps={steps}
-			/>,
+			<DidNarrative text="I used [ai_ticketing_get_ticket_details] to fetch the ticket." />,
 		);
-		// Chip renders the tool name; surrounding prose renders too.
+
+		expect(screen.getByText("Get ticket details")).toBeInTheDocument();
 		expect(
-			screen.getByText("ai_ticketing_get_ticket_details"),
-		).toBeInTheDocument();
-		expect(
-			screen.getByText(/I called/i),
-		).toBeInTheDocument();
-		expect(
-			screen.getByText(/to fetch the ticket/i),
-		).toBeInTheDocument();
+			screen.queryByText("ai_ticketing_get_ticket_details"),
+		).not.toBeInTheDocument();
+		expect(screen.queryByRole("link")).not.toBeInTheDocument();
 	});
 
-	it("clicking a chip pops a panel with args + result for that call", () => {
-		const steps = [
-			makeStep(
-				"tool_call",
-				{
-					tool_name: "send_email",
-					arguments: { to: "user@x.com", subject: "Hi" },
-				},
-				{ duration_ms: 80 },
-			),
-			makeStep("tool_result", {
-				tool_name: "send_email",
-				result: "Email queued (id=42)",
-			}),
-		];
-		renderWithProviders(
+	it("links a verified marker to its recorded activity and previews it on hover", async () => {
+		const onPreview = vi.fn();
+		const onActivate = vi.fn();
+		const { user } = renderWithProviders(
 			<DidNarrative
-				text="Then I called [send_email] to confirm."
-				steps={steps}
+				text="Then [send_email] confirmed the update."
+				activityReferences={{
+					send_email: [
+						{
+							activityId: "activity-1",
+							label: "Sent email",
+						},
+					],
+				}}
+				onReferencePreview={onPreview}
+				onReferenceActivate={onActivate}
 			/>,
 		);
-		fireEvent.click(
-			screen.getByRole("button", { name: /show details for send_email/i }),
-		);
-		// Args + result both surface inside the popover. Use getAllByText
-		// because the matched tool name appears in trigger and popover header.
-		expect(screen.getByText(/Arguments/i)).toBeInTheDocument();
-		expect(screen.getByText(/Result/i)).toBeInTheDocument();
-		expect(
-			screen.getByText(/Email queued \(id=42\)/),
-		).toBeInTheDocument();
-	});
 
-	it("renders an unmatched chip when the marker has no recorded call", () => {
-		// Defensive: summarizer might hallucinate a tool name that wasn't
-		// actually called. Chip should still render so the prose isn't
-		// fragmented, but the styling indicates 'no record'.
-		renderWithProviders(
-			<DidNarrative
-				text="Maybe I called [phantom_tool] once."
-				steps={[]}
-			/>,
-		);
-		const btn = screen.getByRole("button", {
-			name: /phantom_tool.*no matching call recorded/i,
+		const reference = screen.getByRole("link", {
+			name: "Show Sent email in Activity",
 		});
-		expect(btn).toBeInTheDocument();
+		expect(reference).toHaveAttribute(
+			"href",
+			"#run-activity-item-activity-1",
+		);
+
+		await user.hover(reference);
+		expect(onPreview).toHaveBeenLastCalledWith("activity-1");
+		await user.unhover(reference);
+		expect(onPreview).toHaveBeenLastCalledWith(null);
+		await user.click(reference);
+		expect(onActivate).toHaveBeenCalledWith("activity-1");
 	});
 
-	it("returns the fallback when text is empty/null", () => {
+	it("uses the recorded child agent name for delegation references", () => {
+		renderWithProviders(
+			<DidNarrative
+				text="I asked [delegate_to_troubleshooting_agent] to investigate."
+				activityReferences={{
+					delegate_to_troubleshooting_agent: [
+						{
+							activityId: "delegation-1",
+							label: "Troubleshooting Specialist",
+						},
+					],
+				}}
+				onReferenceActivate={() => {}}
+			/>,
+		);
+
+		const reference = screen.getByText("Troubleshooting Specialist");
+		expect(reference).toHaveAttribute("data-slot", "activity-reference");
+		expect(
+			screen.queryByText("delegate_to_troubleshooting_agent"),
+		).not.toBeInTheDocument();
+	});
+
+	it("uses a neutral delegation label when no child run was recorded", () => {
+		renderWithProviders(
+			<DidNarrative text="I asked [delegate_to_missing_agent] to investigate." />,
+		);
+		expect(screen.getByText("Delegated agent")).toBeInTheDocument();
+		expect(screen.queryByText("Missing Agent")).not.toBeInTheDocument();
+		expect(screen.queryByRole("link")).not.toBeInTheDocument();
+	});
+
+	it("returns the fallback when text is empty", () => {
 		renderWithProviders(
 			<DidNarrative
 				text={null}
-				steps={[]}
-				fallback={<span data-testid="fb">placeholder</span>}
+				fallback={<span data-testid="fallback">No summary</span>}
 			/>,
 		);
-		expect(screen.getByTestId("fb")).toBeInTheDocument();
+		expect(screen.getByTestId("fallback")).toBeInTheDocument();
 	});
 
-	it("supports multiple chips on one line in order", () => {
-		const steps = [
-			makeStep("tool_call", { tool_name: "alpha", arguments: {} }),
-			makeStep("tool_call", { tool_name: "beta", arguments: {} }),
-		];
+	it("pairs repeated markers with recorded activity occurrences in order", () => {
 		const { container } = renderWithProviders(
 			<DidNarrative
-				text="First [alpha] then [beta]."
-				steps={steps}
+				text="First [search_knowledge], then [search_knowledge]."
+				activityReferences={{
+					search_knowledge: [
+						{ activityId: "search-1", label: "Searched knowledge" },
+						{ activityId: "search-2", label: "Searched knowledge" },
+					],
+				}}
+				onReferenceActivate={() => {}}
 			/>,
 		);
-		const buttons = container.querySelectorAll("button");
-		const labels = Array.from(buttons).map((b) =>
-			b.getAttribute("aria-label") ?? "",
-		);
-		expect(labels[0]).toMatch(/alpha/);
-		expect(labels[1]).toMatch(/beta/);
+		const references = Array.from(
+			container.querySelectorAll('[data-slot="activity-reference"]'),
+		).map((element) => element.getAttribute("data-activity-reference-id"));
+		expect(references).toEqual(["search-1", "search-2"]);
 	});
 });

--- a/client/src/components/agents/DidNarrative.tsx
+++ b/client/src/components/agents/DidNarrative.tsx
@@ -1,110 +1,39 @@
 /**
- * DidNarrative — renders the summarizer's prose `did` field with bracketed
- * `[tool_name]` markers turned into clickable chips.
- *
- * The summarizer (prompt v3) produces sentences like:
- *
- *   "I called [ai_ticketing_get_ticket_details] to fetch the ticket, then
- *    delegated to [security_subagent] when the alert turned out to be EOL."
- *
- * Each `[name]` is matched against the run's `tool_call` steps; clicking
- * the chip pops a clean technical view of THAT specific call (args + result
- * + duration). Unmatched markers still render as a chip but with the
- * "no record" hint — defensive against the summarizer hallucinating a
- * tool name. Plain prose between chips is preserved as text.
+ * Render summarizer prose without leaking executor identifiers into the
+ * normal review surface. Verified `[exact_tool_name]` markers can link to
+ * their grouped Activity item; unmatched legacy markers remain ordinary
+ * human-readable text instead of pretending to be controls.
  */
 
-import { useMemo, type ReactNode } from "react";
-import { Wrench } from "lucide-react";
+import type { ReactNode } from "react";
+
+import { cn } from "@/lib/utils";
 
 import {
-	Popover,
-	PopoverContent,
-	PopoverTrigger,
-} from "@/components/ui/popover";
-import { cn } from "@/lib/utils";
-import { formatDuration } from "@/lib/utils";
-import type { components } from "@/lib/v1";
-
-import { JsonTree, isEmptyJson } from "./JsonTree";
-
-type AgentRunStep = components["schemas"]["AgentRunStepResponse"];
+	activityDomId,
+	delegationTarget,
+	humanizeToolReference,
+	type RunActivityReferenceIndex,
+} from "./run-activity";
 
 export interface DidNarrativeProps {
 	text: string | null | undefined;
-	steps: AgentRunStep[] | null | undefined;
+	/** Recorded actions keyed by exact tool name and ordered by occurrence. */
+	activityReferences?: Readonly<RunActivityReferenceIndex>;
+	onReferencePreview?: (activityId: string | null) => void;
+	onReferenceActivate?: (activityId: string) => void;
 	/** When true (drawer/sheet variants), use compact spacing. */
 	compact?: boolean;
-	/** Renderer for non-prose fallback (e.g. SummaryPlaceholder). */
 	fallback?: ReactNode;
-}
-
-interface ToolCallSummary {
-	tool: string;
-	args: unknown;
-	result?: string;
-	is_error?: boolean;
-	duration_ms: number | null;
-}
-
-/** Pull a tool-name → first-call summary map out of run.steps.
- *
- * If the same tool runs multiple times, we only surface the first call —
- * the prose can mention a tool more than once and we don't currently track
- * which mention pairs with which call. Good enough for v1; revisit when
- * users complain.
- */
-function indexCallsByTool(
-	steps: AgentRunStep[] | null | undefined,
-): Record<string, ToolCallSummary> {
-	if (!steps) return {};
-	const out: Record<string, ToolCallSummary> = {};
-	for (let i = 0; i < steps.length; i++) {
-		const s = steps[i];
-		if (s.type !== "tool_call") continue;
-		const content = (s.content ?? {}) as {
-			tool_name?: string;
-			arguments?: unknown;
-		};
-		const name = content.tool_name;
-		if (!name || out[name]) continue;
-		// Find the matching tool_result step (next step with same tool_name).
-		let result: string | undefined;
-		let is_error: boolean | undefined;
-		for (let j = i + 1; j < steps.length; j++) {
-			const r = steps[j];
-			if (r.type !== "tool_result" && r.type !== "tool_error") continue;
-			const rc = (r.content ?? {}) as {
-				tool_name?: string;
-				result?: string;
-				is_error?: boolean;
-			};
-			if (rc.tool_name === name) {
-				result = rc.result;
-				is_error = rc.is_error || r.type === "tool_error";
-				break;
-			}
-		}
-		out[name] = {
-			tool: name,
-			args: content.arguments ?? {},
-			result,
-			is_error,
-			duration_ms: s.duration_ms ?? null,
-		};
-	}
-	return out;
 }
 
 const TOOL_MARKER = /\[([a-zA-Z_][a-zA-Z0-9_.-]*)\]/g;
 
-/** Split a string on `[tool]` markers preserving order. */
-function splitOnMarkers(text: string): Array<
-	{ kind: "text"; value: string } | { kind: "tool"; name: string }
-> {
-	const parts: Array<
-		{ kind: "text"; value: string } | { kind: "tool"; name: string }
-	> = [];
+type NarrativePart =
+	{ kind: "text"; value: string } | { kind: "tool"; name: string };
+
+function splitOnMarkers(text: string): NarrativePart[] {
+	const parts: NarrativePart[] = [];
 	let cursor = 0;
 	for (const match of text.matchAll(TOOL_MARKER)) {
 		const start = match.index ?? 0;
@@ -122,18 +51,16 @@ function splitOnMarkers(text: string): Array<
 
 export function DidNarrative({
 	text,
-	steps,
+	activityReferences,
+	onReferencePreview,
+	onReferenceActivate,
 	compact,
 	fallback,
 }: DidNarrativeProps) {
-	const callIndex = useMemo(() => indexCallsByTool(steps), [steps]);
-	const parts = useMemo(
-		() => (text ? splitOnMarkers(text) : []),
-		[text],
-	);
-	if (!text || !text.trim()) {
-		return <>{fallback}</>;
-	}
+	if (!text || !text.trim()) return <>{fallback}</>;
+	const parts = splitOnMarkers(text);
+	const occurrenceByTool: Record<string, number> = {};
+
 	return (
 		<div
 			className={cn(
@@ -141,161 +68,58 @@ export function DidNarrative({
 				compact ? "text-xs" : "text-sm",
 			)}
 		>
-			{parts.map((p, i) =>
-				p.kind === "text" ? (
-					<span key={i}>{p.value}</span>
-				) : (
-					<ToolMentionChip
-						key={i}
-						name={p.name}
-						call={callIndex[p.name]}
-					/>
-				),
-			)}
+			{parts.map((part, index) => {
+				if (part.kind === "text")
+					return <span key={index}>{part.value}</span>;
+				const delegated = !!delegationTarget(part.name);
+				const occurrence = occurrenceByTool[part.name] ?? 0;
+				occurrenceByTool[part.name] = occurrence + 1;
+				const reference = activityReferences?.[part.name]?.[occurrence];
+				const label =
+					reference?.label ?? humanizeToolReference(part.name);
+
+				if (!reference || !onReferenceActivate) {
+					return (
+						<span
+							key={index}
+							data-slot="activity-reference-label"
+							className="font-medium text-foreground/80"
+						>
+							{label}
+						</span>
+					);
+				}
+
+				return (
+					<a
+						key={index}
+						href={`#${activityDomId(reference.activityId)}`}
+						data-slot="activity-reference"
+						data-activity-reference-id={reference.activityId}
+						aria-label={`Show ${label} in Activity`}
+						onMouseEnter={() =>
+							onReferencePreview?.(reference.activityId)
+						}
+						onMouseLeave={() => onReferencePreview?.(null)}
+						onFocus={() =>
+							onReferencePreview?.(reference.activityId)
+						}
+						onBlur={() => onReferencePreview?.(null)}
+						onClick={(event) => {
+							event.preventDefault();
+							onReferenceActivate(reference.activityId);
+						}}
+						className={cn(
+							"mx-0.5 inline-flex cursor-pointer rounded-md px-1.5 py-0.5 align-baseline text-[0.9em] font-medium outline-none transition-[background-color,box-shadow] duration-150 motion-reduce:transition-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1",
+							delegated
+								? "bg-violet-500/12 text-violet-700 ring-1 ring-violet-500/20 hover:bg-violet-500/20 dark:text-violet-300"
+								: "bg-blue-500/10 text-blue-700 ring-1 ring-blue-500/15 hover:bg-blue-500/20 dark:text-blue-300",
+						)}
+					>
+						{label}
+					</a>
+				);
+			})}
 		</div>
 	);
-}
-
-interface ToolMentionChipProps {
-	name: string;
-	call?: ToolCallSummary;
-}
-
-function ToolMentionChip({ name, call }: ToolMentionChipProps) {
-	const matched = !!call;
-	return (
-		<Popover>
-			<PopoverTrigger asChild>
-				<button
-					type="button"
-					className={cn(
-						"mx-0.5 inline-flex items-center gap-1 rounded border px-1.5 py-0.5 align-baseline font-mono text-[11px] transition-colors",
-						matched
-							? "border-blue-500/30 bg-blue-500/10 text-blue-700 hover:bg-blue-500/20 dark:text-blue-300"
-							: "border-muted-foreground/30 bg-muted/40 text-muted-foreground",
-					)}
-					aria-label={
-						matched
-							? `Show details for ${name}`
-							: `${name} (no matching call recorded)`
-					}
-				>
-					<Wrench className="h-2.5 w-2.5" />
-					{name}
-				</button>
-			</PopoverTrigger>
-			<PopoverContent
-				side="top"
-				align="start"
-				className="w-[420px] max-w-[90vw] p-0"
-			>
-				<div className="border-b px-3 py-2">
-					<div className="flex items-center gap-2 text-xs font-medium">
-						<Wrench className="h-3 w-3" />
-						<span className="font-mono">{name}</span>
-						{call?.duration_ms != null ? (
-							<span className="ml-auto text-muted-foreground">
-								{formatDuration(call.duration_ms)}
-							</span>
-						) : null}
-					</div>
-				</div>
-				<div className="grid gap-2 px-3 py-2 text-xs">
-					{!matched ? (
-						<p className="text-muted-foreground">
-							No matching tool call recorded on this run.
-						</p>
-					) : (
-						<>
-							<ChipSection label="Arguments">
-								<JsonBlock value={call!.args} />
-							</ChipSection>
-							{call!.result !== undefined ? (
-								<ChipSection
-									label={call!.is_error ? "Error" : "Result"}
-								>
-									<div
-										className={cn(
-											"max-h-[180px] overflow-y-auto rounded-md bg-muted/50 ring-1 ring-foreground/5 px-2 py-1.5 text-[11px] whitespace-pre-wrap break-words",
-											call!.is_error
-												? "ring-rose-500/30 text-rose-700 dark:text-rose-300"
-												: "",
-										)}
-									>
-										<ResultBlock value={call!.result} isError={call!.is_error} />
-									</div>
-								</ChipSection>
-							) : null}
-						</>
-					)}
-				</div>
-			</PopoverContent>
-		</Popover>
-	);
-}
-
-function ChipSection({
-	label,
-	children,
-}: {
-	label: string;
-	children: ReactNode;
-}) {
-	return (
-		<div className="grid gap-1">
-			<div className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
-				{label}
-			</div>
-			{children}
-		</div>
-	);
-}
-
-function JsonBlock({ value }: { value: unknown }) {
-	if (isEmptyJson(value)) {
-		return <p className="text-muted-foreground">No arguments.</p>;
-	}
-	if (typeof value === "string") {
-		return (
-			<pre className="max-h-[180px] overflow-y-auto rounded-md bg-muted/50 ring-1 ring-foreground/5 px-2 py-1.5 font-mono text-[11px] whitespace-pre-wrap break-words">
-				{value}
-			</pre>
-		);
-	}
-	return (
-		<div className="max-h-[180px] overflow-y-auto rounded-md bg-muted/50 ring-1 ring-foreground/5 px-2 py-1.5">
-			<JsonTree value={value} />
-		</div>
-	);
-}
-
-/** Tool results come from `_record_step(..., "tool_result", { result: "..."})`
- * — always a string, often a JSON-shaped one. Try to parse and pretty-print
- * with the JsonTree; fall back to raw text for plain strings. */
-function ResultBlock({ value, isError }: { value: string; isError?: boolean }) {
-	const parsed = !isError ? tryParseJsonish(value) : UNPARSEABLE_RB;
-	if (parsed !== UNPARSEABLE_RB) {
-		return <JsonTree value={parsed} />;
-	}
-	return (
-		<pre className="font-mono whitespace-pre-wrap break-words">{value}</pre>
-	);
-}
-
-const UNPARSEABLE_RB = Symbol("unparseable");
-function tryParseJsonish(value: string): unknown {
-	const trimmed = value.trim();
-	if (
-		!(
-			(trimmed.startsWith("{") && trimmed.endsWith("}")) ||
-			(trimmed.startsWith("[") && trimmed.endsWith("]"))
-		)
-	) {
-		return UNPARSEABLE_RB;
-	}
-	try {
-		return JSON.parse(trimmed);
-	} catch {
-		return UNPARSEABLE_RB;
-	}
 }

--- a/client/src/components/agents/FlaggedRunCard.tsx
+++ b/client/src/components/agents/FlaggedRunCard.tsx
@@ -1,6 +1,8 @@
 import { useState } from "react";
 import { ChevronDown, ThumbsDown } from "lucide-react";
+import { useLocation } from "react-router-dom";
 
+import { getLocationHref } from "@/lib/agent-run-navigation";
 import { cn } from "@/lib/utils";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useAgentRun } from "@/services/agentRuns";
@@ -17,6 +19,7 @@ export interface FlaggedRunCardProps {
 }
 
 export function FlaggedRunCard({ run }: FlaggedRunCardProps) {
+	const location = useLocation();
 	const [open, setOpen] = useState(false);
 	const { data: detail, isLoading } = useAgentRun(
 		open ? run.id : undefined,
@@ -70,6 +73,10 @@ export function FlaggedRunCard({ run }: FlaggedRunCardProps) {
 							onVerdict={() => {}}
 							onNote={() => {}}
 							hideVerdictBar
+							runNavigationOrigin={{
+								href: getLocationHref(location),
+								label: `Back to ${run.agent_name ?? "agent"} tuning`,
+							}}
 						/>
 					)}
 				</div>

--- a/client/src/components/agents/RunCard.test.tsx
+++ b/client/src/components/agents/RunCard.test.tsx
@@ -40,9 +40,11 @@ describe("RunCard", () => {
 		expect(screen.getByText(/routed to support/i)).toBeInTheDocument();
 	});
 
-	it("renders the status badge", () => {
+	it("renders the subtle status indicator", () => {
 		renderWithProviders(<RunCard run={baseRun} />);
-		expect(screen.getByText(/^completed$/i)).toBeInTheDocument();
+		expect(
+			screen.getByRole("img", { name: "Status: Completed" }),
+		).toBeInTheDocument();
 	});
 
 	it("renders 'Good' verdict badge when verdict='up'", () => {
@@ -63,7 +65,9 @@ describe("RunCard", () => {
 		const { user } = renderWithProviders(
 			<RunCard run={baseRun} onOpen={onOpen} />,
 		);
-		await user.click(screen.getByRole("button", { name: /how do i reset/i }));
+		await user.click(
+			screen.getByRole("button", { name: /how do i reset/i }),
+		);
 		expect(onOpen).toHaveBeenCalled();
 	});
 
@@ -73,9 +77,7 @@ describe("RunCard", () => {
 		const { user } = renderWithProviders(
 			<RunCard run={baseRun} onOpen={onOpen} onVerdict={onVerdict} />,
 		);
-		await user.click(
-			screen.getByRole("button", { name: /mark as good/i }),
-		);
+		await user.click(screen.getByRole("button", { name: /mark as good/i }));
 		expect(onVerdict).toHaveBeenCalledWith("up");
 		expect(onOpen).not.toHaveBeenCalled();
 	});
@@ -150,7 +152,10 @@ describe("RunCard", () => {
 			await user.keyboard("  escalate to tier 2  ");
 			// Blur by tabbing away — userEvent handles this
 			input.blur();
-			expect(onNote).toHaveBeenCalledWith(baseRun.id, "escalate to tier 2");
+			expect(onNote).toHaveBeenCalledWith(
+				baseRun.id,
+				"escalate to tier 2",
+			);
 		});
 
 		it("does not call onNote on blur when value is unchanged", async () => {

--- a/client/src/components/agents/RunCard.tsx
+++ b/client/src/components/agents/RunCard.tsx
@@ -1,30 +1,22 @@
 /**
  * Compact card for one agent run, used in the agent detail Runs tab.
  *
- * Shows: status badge, asked text, did/error text, verdict badge,
+ * Shows: status indicator, asked text, did/error text, verdict badge,
  * timing metadata (when, duration, tokens), and inline verdict toggles.
  *
  * Adapted from the mockup's `RunCard` (AgentDetailPage.tsx) — replaces inline
  * styles with Tailwind + shadcn primitives.
  */
 
-import { Clock, Hash, ThumbsUp, ThumbsDown } from "lucide-react";
-import {
-	CheckCircle,
-	XCircle,
-	Loader2,
-	AlertTriangle,
-} from "lucide-react";
+import { ThumbsDown, ThumbsUp } from "lucide-react";
 import type { MouseEvent } from "react";
 
-import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
 import { cn } from "@/lib/utils";
-import { formatDuration, formatNumber, formatRelativeTime } from "@/lib/utils";
 import type { components } from "@/lib/v1";
 
 import type { Verdict } from "./RunReviewPanel";
-import { SummaryPlaceholder } from "./SummaryPlaceholder";
+import { RunSummaryContent } from "./RunSummaryContent";
 
 type AgentRun = components["schemas"]["AgentRunResponse"];
 
@@ -40,37 +32,6 @@ export interface RunCardProps {
 	conversationCount?: number;
 }
 
-function StatusBadge({ status }: { status: string }) {
-	switch (status) {
-		case "completed":
-			return (
-				<Badge variant="default" className="bg-emerald-500 text-white">
-					<CheckCircle className="h-3 w-3" /> Completed
-				</Badge>
-			);
-		case "failed":
-			return (
-				<Badge variant="destructive">
-					<XCircle className="h-3 w-3" /> Failed
-				</Badge>
-			);
-		case "running":
-			return (
-				<Badge variant="secondary">
-					<Loader2 className="h-3 w-3 animate-spin" /> Running
-				</Badge>
-			);
-		case "budget_exceeded":
-			return (
-				<Badge variant="warning">
-					<AlertTriangle className="h-3 w-3" /> Budget exceeded
-				</Badge>
-			);
-		default:
-			return <Badge variant="outline">{status}</Badge>;
-	}
-}
-
 export function RunCard({
 	run,
 	verdict = null,
@@ -80,26 +41,6 @@ export function RunCard({
 	onNote,
 	conversationCount = 0,
 }: RunCardProps) {
-	const q = highlight?.trim().toLowerCase() ?? "";
-	const metadataEntries = run.metadata ? Object.entries(run.metadata) : [];
-	const ranked = q
-		? [...metadataEntries].sort((a, b) => {
-				const aHit =
-					a[0].toLowerCase().includes(q) ||
-					a[1].toLowerCase().includes(q)
-						? -1
-						: 0;
-				const bHit =
-					b[0].toLowerCase().includes(q) ||
-					b[1].toLowerCase().includes(q)
-						? -1
-						: 0;
-				return aHit - bHit;
-			})
-		: metadataEntries;
-	const visibleChips = ranked.slice(0, 3);
-	const overflow = metadataEntries.length - visibleChips.length;
-	const startedAt = run.started_at ?? run.created_at;
 	const canVerdict = run.status === "completed";
 
 	function handleVerdict(target: Verdict, e: MouseEvent) {
@@ -117,172 +58,108 @@ export function RunCard({
 			)}
 			data-slot="run-card"
 		>
-		<div
-			role={onOpen ? "button" : undefined}
-			tabIndex={onOpen ? 0 : undefined}
-			onClick={onOpen}
-			onKeyDown={(e) => {
-				if (onOpen && (e.key === "Enter" || e.key === " ")) {
-					e.preventDefault();
-					onOpen();
-				}
-			}}
-			className={cn(
-				"flex items-start gap-3 p-3",
-				onOpen && "cursor-pointer",
-			)}
-		>
-			<div className="flex min-w-0 flex-1 flex-col gap-1.5">
-				<div className="flex flex-wrap items-center gap-2">
-					<StatusBadge status={run.status} />
-					<div
-						className="min-w-0 flex-1 truncate text-sm"
-						title={run.asked ?? undefined}
-					>
-						{run.asked || (
-							<SummaryPlaceholder status={run.summary_status} runStatus={run.status} />
-						)}
-					</div>
-					{verdict === "up" ? (
-						<span className="inline-flex items-center gap-1 rounded border border-emerald-500/30 bg-emerald-500/10 px-1.5 py-0.5 text-[11px] font-medium text-emerald-700 dark:text-emerald-300">
-							<ThumbsUp size={11} /> Good
-						</span>
-					) : verdict === "down" ? (
-						<span className="inline-flex items-center gap-1 rounded border border-rose-500/30 bg-rose-500/10 px-1.5 py-0.5 text-[11px] font-medium text-rose-700 dark:text-rose-300">
-							<ThumbsDown size={11} /> Wrong
-							{conversationCount > 0
-								? ` · ${conversationCount} msg`
-								: ""}
-						</span>
-					) : null}
-				</div>
-				<div
-					className="min-w-0 truncate text-sm text-muted-foreground"
-					title={run.did ?? undefined}
-				>
-					{run.did ||
-						(run.error ? (
-							`error: ${run.error}`
-						) : (
-							<SummaryPlaceholder status={run.summary_status} runStatus={run.status} muted />
-						))}
-				</div>
-				<div className="flex flex-wrap items-center gap-1.5 text-xs text-muted-foreground">
-					<span className="inline-flex items-center gap-1">
-						<Clock size={11} />
-						{formatRelativeTime(startedAt)}
-					</span>
-					{run.duration_ms != null ? (
-						<>
-							<span>·</span>
-							<span>{formatDuration(run.duration_ms)}</span>
-						</>
-					) : null}
-					<span>·</span>
-					<span className="inline-flex items-center gap-1">
-						<Hash size={11} />
-						{formatNumber(run.tokens_used)}
-					</span>
-					{visibleChips.length > 0 ? <span>·</span> : null}
-					<div className="inline-flex flex-wrap gap-1">
-						{visibleChips.map(([k, v]) => {
-							const isHit =
-								q &&
-								(k.toLowerCase().includes(q) ||
-									v.toLowerCase().includes(q));
-							return (
-								<span
-									key={k}
-									title={`${k}=${v}`}
-									className={cn(
-										"inline-flex items-center gap-1 rounded border px-1.5 py-0.5 text-[11px]",
-										isHit
-											? "border-transparent bg-yellow-500/15 text-yellow-700 dark:text-yellow-300"
-											: "border-border bg-card text-foreground",
-									)}
-								>
-									<span className="text-muted-foreground">
-										{k}
-									</span>
-									<span className="font-mono">{v}</span>
-								</span>
-							);
-						})}
-						{overflow > 0 ? (
-							<span className="inline-flex items-center rounded border border-border bg-card px-1.5 py-0.5 text-[11px]">
-								+{overflow}
-							</span>
-						) : null}
-					</div>
-				</div>
-			</div>
-
 			<div
-				className="flex shrink-0 items-center"
-				onClick={(e) => e.stopPropagation()}
-			>
-				{canVerdict && onVerdict ? (
-					<div className="flex gap-1">
-						<button
-							type="button"
-							aria-label="Mark as good"
-							aria-pressed={verdict === "up"}
-							title="Good"
-							onClick={(e) => handleVerdict("up", e)}
-							className={cn(
-								"grid h-7 w-7 place-items-center rounded-full border transition-colors",
-								verdict === "up"
-									? "border-emerald-500 bg-emerald-500/15 text-emerald-600 dark:text-emerald-400"
-									: "bg-background hover:bg-accent",
-							)}
-						>
-							<ThumbsUp size={14} />
-						</button>
-						<button
-							type="button"
-							aria-label="Mark as wrong"
-							aria-pressed={verdict === "down"}
-							title="Wrong"
-							onClick={(e) => handleVerdict("down", e)}
-							className={cn(
-								"grid h-7 w-7 place-items-center rounded-full border transition-colors",
-								verdict === "down"
-									? "border-rose-500 bg-rose-500/15 text-rose-600 dark:text-rose-400"
-									: "bg-background hover:bg-accent",
-							)}
-						>
-							<ThumbsDown size={14} />
-						</button>
-					</div>
-				) : (
-					<span className="text-[11px] text-muted-foreground">n/a</span>
+				role={onOpen ? "button" : undefined}
+				tabIndex={onOpen ? 0 : undefined}
+				onClick={onOpen}
+				onKeyDown={(e) => {
+					if (onOpen && (e.key === "Enter" || e.key === " ")) {
+						e.preventDefault();
+						onOpen();
+					}
+				}}
+				className={cn(
+					"flex items-start gap-3 p-3",
+					onOpen && "cursor-pointer",
 				)}
-			</div>
-		</div>
-		{showNoteInput ? (
-			<div className="border-t px-3 py-2">
-				<Input
-					type="text"
-					aria-label="What should it have done?"
-					placeholder="What should it have done?"
-					defaultValue={run.verdict_note ?? ""}
-					onClick={(e) => e.stopPropagation()}
-					onKeyDown={(e) => {
-						e.stopPropagation();
-						if (e.key === "Enter") {
-							(e.currentTarget as HTMLInputElement).blur();
-						}
-					}}
-					onBlur={(e) => {
-						const next = e.currentTarget.value.trim();
-						const prev = run.verdict_note ?? "";
-						if (next !== prev) onNote?.(run.id, next);
-					}}
-					className="h-7 text-xs"
-					data-testid="run-card-note-input"
+			>
+				<RunSummaryContent
+					run={run}
+					highlight={highlight}
+					titleTrailing={
+						verdict === "up" ? (
+							<span className="inline-flex items-center gap-1 rounded border border-emerald-500/30 bg-emerald-500/10 px-1.5 py-0.5 text-[11px] font-medium text-emerald-700 dark:text-emerald-300">
+								<ThumbsUp size={11} /> Good
+							</span>
+						) : verdict === "down" ? (
+							<span className="inline-flex items-center gap-1 rounded border border-rose-500/30 bg-rose-500/10 px-1.5 py-0.5 text-[11px] font-medium text-rose-700 dark:text-rose-300">
+								<ThumbsDown size={11} /> Wrong
+								{conversationCount > 0
+									? ` · ${conversationCount} msg`
+									: ""}
+							</span>
+						) : null
+					}
 				/>
+
+				<div
+					className="flex shrink-0 items-center"
+					onClick={(e) => e.stopPropagation()}
+				>
+					{canVerdict && onVerdict ? (
+						<div className="flex gap-1">
+							<button
+								type="button"
+								aria-label="Mark as good"
+								aria-pressed={verdict === "up"}
+								title="Good"
+								onClick={(e) => handleVerdict("up", e)}
+								className={cn(
+									"grid h-7 w-7 place-items-center rounded-full border transition-colors",
+									verdict === "up"
+										? "border-emerald-500 bg-emerald-500/15 text-emerald-600 dark:text-emerald-400"
+										: "bg-background hover:bg-accent",
+								)}
+							>
+								<ThumbsUp size={14} />
+							</button>
+							<button
+								type="button"
+								aria-label="Mark as wrong"
+								aria-pressed={verdict === "down"}
+								title="Wrong"
+								onClick={(e) => handleVerdict("down", e)}
+								className={cn(
+									"grid h-7 w-7 place-items-center rounded-full border transition-colors",
+									verdict === "down"
+										? "border-rose-500 bg-rose-500/15 text-rose-600 dark:text-rose-400"
+										: "bg-background hover:bg-accent",
+								)}
+							>
+								<ThumbsDown size={14} />
+							</button>
+						</div>
+					) : (
+						<span className="text-[11px] text-muted-foreground">
+							n/a
+						</span>
+					)}
+				</div>
 			</div>
-		) : null}
+			{showNoteInput ? (
+				<div className="border-t px-3 py-2">
+					<Input
+						type="text"
+						aria-label="What should it have done?"
+						placeholder="What should it have done?"
+						defaultValue={run.verdict_note ?? ""}
+						onClick={(e) => e.stopPropagation()}
+						onKeyDown={(e) => {
+							e.stopPropagation();
+							if (e.key === "Enter") {
+								(e.currentTarget as HTMLInputElement).blur();
+							}
+						}}
+						onBlur={(e) => {
+							const next = e.currentTarget.value.trim();
+							const prev = run.verdict_note ?? "";
+							if (next !== prev) onNote?.(run.id, next);
+						}}
+						className="h-7 text-xs"
+						data-testid="run-card-note-input"
+					/>
+				</div>
+			) : null}
 		</div>
 	);
 }

--- a/client/src/components/agents/RunReviewPanel.test.tsx
+++ b/client/src/components/agents/RunReviewPanel.test.tsx
@@ -1,5 +1,4 @@
 import { describe, it, expect, vi } from "vitest";
-import { fireEvent } from "@testing-library/react";
 import { renderWithProviders, screen } from "@/test-utils";
 import type { components } from "@/lib/v1";
 
@@ -17,7 +16,7 @@ vi.mock("@/services/agentRuns", () => ({
 	}),
 }));
 
-import { RunReviewPanel } from "./RunReviewPanel";
+import { RunPayloads, RunReviewPanel } from "./RunReviewPanel";
 
 type AgentRunDetail = components["schemas"]["AgentRunDetailResponse"];
 
@@ -39,6 +38,8 @@ const baseRun: AgentRunDetail = {
 	created_at: "2026-04-21T10:00:00Z",
 	metadata: {},
 	steps: [],
+	child_run_ids: [],
+	child_runs: [],
 };
 
 describe("RunReviewPanel", () => {
@@ -57,8 +58,43 @@ describe("RunReviewPanel", () => {
 		).toBeInTheDocument();
 	});
 
+	it("keeps raw run payloads out of the normal review panel", () => {
+		renderWithProviders(
+			<RunReviewPanel
+				run={baseRun}
+				verdict={null}
+				note=""
+				onVerdict={() => {}}
+				onNote={() => {}}
+			/>,
+		);
+		expect(screen.queryByText("Raw input")).not.toBeInTheDocument();
+		expect(screen.queryByText("Raw output")).not.toBeInTheDocument();
+	});
+
+	it("renders raw payloads only when the advanced payload component is used", async () => {
+		const { user } = renderWithProviders(
+			<RunPayloads input={{ ticket_id: 42 }} output={{ routed: true }} />,
+		);
+		expect(screen.getByText("Raw input")).toBeInTheDocument();
+		expect(screen.getByText("Raw output")).toBeInTheDocument();
+		const inputDisclosure = screen.getByRole("button", {
+			name: /raw input/i,
+		});
+		expect(inputDisclosure).toHaveAttribute("aria-expanded", "false");
+		await user.click(inputDisclosure);
+		expect(inputDisclosure).toHaveAttribute("aria-expanded", "true");
+		const variableName = screen.getByText("ticket_id:");
+		expect(inputDisclosure).toHaveAttribute(
+			"aria-controls",
+			variableName.closest("div[id]")?.id,
+		);
+		expect(variableName).toBeInTheDocument();
+		expect(screen.getByText("42")).toBeInTheDocument();
+	});
+
 	it("renders the agent answer when completed (answered field, falls back to did)", () => {
-		// `did` is also rendered in the "What it did" prose section, so the
+		// `did` is also rendered in the "What the agent did" prose section, so the
 		// text appears in both places; either is fine — we just need at
 		// least one match.
 		renderWithProviders(
@@ -70,7 +106,9 @@ describe("RunReviewPanel", () => {
 				onNote={() => {}}
 			/>,
 		);
-		expect(screen.getAllByText(/routed to support/i).length).toBeGreaterThan(0);
+		expect(
+			screen.getAllByText(/routed to support/i).length,
+		).toBeGreaterThan(0);
 	});
 
 	it("uses `answered` over `did` in the answer section when both present", () => {
@@ -90,6 +128,28 @@ describe("RunReviewPanel", () => {
 		expect(
 			screen.getByText("Sent password-reset link"),
 		).toBeInTheDocument();
+	});
+
+	it("humanizes executor markers when older `did` prose is the answer fallback", () => {
+		renderWithProviders(
+			<RunReviewPanel
+				run={{
+					...baseRun,
+					did: "Checked the ticket with [ai_ticketing_get_ticket_details].",
+					answered: null,
+				}}
+				verdict={null}
+				note=""
+				onVerdict={() => {}}
+				onNote={() => {}}
+			/>,
+		);
+		expect(
+			screen.getAllByText("Get ticket details").length,
+		).toBeGreaterThan(0);
+		expect(
+			screen.queryByText("ai_ticketing_get_ticket_details"),
+		).not.toBeInTheDocument();
 	});
 
 	it("calls onVerdict('up') when good toggle clicked", async () => {
@@ -188,7 +248,7 @@ describe("RunReviewPanel", () => {
 				onNote={() => {}}
 			/>,
 		);
-		// `did` renders in both "What it did" prose AND falls back into
+		// `did` renders in both "What the agent did" prose AND falls back into
 		// "What the agent answered" when `answered` is null — both fine.
 		expect(
 			screen.getAllByText(/looked up the ticket and routed to tier 2/i)
@@ -196,14 +256,101 @@ describe("RunReviewPanel", () => {
 		).toBeGreaterThan(0);
 		// Tool-call list should NOT render — we have prose to show instead.
 		expect(
-			screen.queryByText(/what it did · 0 tool call/i),
+			screen.queryByText(/what the agent did · 0 actions/i),
 		).not.toBeInTheDocument();
 	});
 
-	it("renders tool call section when steps include tool calls", () => {
-		// Fallback path: when there's no `did` summary, fall back to the raw
-		// tool-call list. Step content is { tool_name, arguments } per
-		// autonomous_agent_executor.py _record_step(..., "tool_call", ...).
+	it("uses the recorded child agent name in delegation prose", () => {
+		const run: AgentRunDetail = {
+			...baseRun,
+			did: "Asked [delegate_to_troubleshooting_agent] to collect evidence.",
+			steps: [
+				{
+					id: "s1",
+					run_id: baseRun.id,
+					step_number: 1,
+					type: "tool_result",
+					content: {
+						tool_name: "delegate_to_troubleshooting_agent",
+						child_run_id: "child-1",
+						result: { status: "completed" },
+					},
+					created_at: baseRun.created_at,
+				},
+			],
+			child_run_ids: ["child-1"],
+			child_runs: [
+				{
+					id: "child-1",
+					agent_id: "agent-child",
+					agent_name: "Endpoint Troubleshooter",
+					status: "completed",
+					asked: "Collect endpoint evidence",
+					did: null,
+					answered: null,
+					duration_ms: 1000,
+					created_at: baseRun.created_at,
+				},
+			],
+		};
+		renderWithProviders(
+			<RunReviewPanel
+				run={run}
+				verdict={null}
+				note=""
+				onVerdict={() => {}}
+				onNote={() => {}}
+			/>,
+		);
+
+		expect(screen.getAllByText("Endpoint Troubleshooter")).toHaveLength(2);
+		expect(
+			screen.queryByText("Troubleshooting Agent"),
+		).not.toBeInTheDocument();
+	});
+
+	it("connects verified narrative references to their grouped activity item", async () => {
+		const onPreview = vi.fn();
+		const onActivate = vi.fn();
+		const run: AgentRunDetail = {
+			...baseRun,
+			did: "Checked [ai_ticketing_get_ticket_details] before triage.",
+			steps: [
+				{
+					id: "s1",
+					run_id: baseRun.id,
+					step_number: 1,
+					type: "tool_call",
+					content: {
+						tool_name: "ai_ticketing_get_ticket_details",
+						arguments: { ticket_id: 423068 },
+					},
+					created_at: baseRun.created_at,
+				},
+			],
+		};
+		const { user } = renderWithProviders(
+			<RunReviewPanel
+				run={run}
+				verdict={null}
+				note=""
+				onVerdict={() => {}}
+				onNote={() => {}}
+				onActivityReferencePreview={onPreview}
+				onActivityReferenceActivate={onActivate}
+			/>,
+		);
+
+		const reference = screen.getAllByRole("link", {
+			name: /show looked up ticket details in activity/i,
+		})[0];
+		await user.hover(reference);
+		expect(onPreview).toHaveBeenLastCalledWith("s1");
+		await user.click(reference);
+		expect(onActivate).toHaveBeenCalledWith("s1");
+	});
+
+	it("renders a friendly action summary when prose is unavailable", () => {
 		const run: AgentRunDetail = {
 			...baseRun,
 			did: null,
@@ -231,27 +378,66 @@ describe("RunReviewPanel", () => {
 				onNote={() => {}}
 			/>,
 		);
-		expect(screen.getByText(/what it did · 1 tool call/i)).toBeInTheDocument();
-		// Real tool name must render, not the generic "tool" placeholder.
 		expect(
-			screen.getByText("ai_ticketing_get_ticket_details"),
+			screen.getByText(/what the agent did · 1 action/i),
 		).toBeInTheDocument();
-		// Args are collapsed by default behind a chevron disclosure; expand
-		// them and confirm the args render via the JsonTree (key + value).
-		fireEvent.click(
-			screen.getByRole("button", { name: /show arguments/i }),
-		);
-		expect(screen.getByText(/"ticket_id"/)).toBeInTheDocument();
-		expect(screen.getByText("423068")).toBeInTheDocument();
+		expect(
+			screen.getByText("Looked up ticket details"),
+		).toBeInTheDocument();
+		expect(
+			screen.queryByText("ai_ticketing_get_ticket_details"),
+		).not.toBeInTheDocument();
+		expect(screen.queryByText(/423068/)).not.toBeInTheDocument();
 	});
 
-	it("renders tool call rows even when arguments object is empty", () => {
-		// Regression guard for the `tool {}` screenshot — zero-arg tool calls
-		// must still show the tool name as the row label, but the args column
-		// renders nothing (no `{}` clutter) and there's no expand affordance.
+	it("does not present a failed fallback action as successful", () => {
 		const run: AgentRunDetail = {
 			...baseRun,
-			did: null,  // force the fallback tool-call list
+			did: null,
+			steps: [
+				{
+					id: "s1",
+					run_id: baseRun.id,
+					step_number: 1,
+					type: "tool_call",
+					content: {
+						tool_name: "ai_ticketing_submit_triage",
+						arguments: {},
+					},
+					created_at: baseRun.created_at,
+				},
+				{
+					id: "s2",
+					run_id: baseRun.id,
+					step_number: 2,
+					type: "tool_error",
+					content: {
+						tool_name: "ai_ticketing_submit_triage",
+						error: "Permission denied",
+					},
+					created_at: baseRun.created_at,
+				},
+			],
+		};
+		const { container } = renderWithProviders(
+			<RunReviewPanel
+				run={run}
+				verdict={null}
+				note=""
+				onVerdict={() => {}}
+				onNote={() => {}}
+			/>,
+		);
+		expect(screen.getByText("Could not submit triage")).toBeInTheDocument();
+		expect(
+			container.querySelector('[data-activity-kind="error"]'),
+		).toBeInTheDocument();
+	});
+
+	it("renders zero-argument actions without empty-object clutter", () => {
+		const run: AgentRunDetail = {
+			...baseRun,
+			did: null, // force the fallback tool-call list
 			steps: [
 				{
 					id: "s1",
@@ -273,18 +459,14 @@ describe("RunReviewPanel", () => {
 				onNote={() => {}}
 			/>,
 		);
-		expect(screen.getByText("list_workflows")).toBeInTheDocument();
-		// No "{}" placeholder should appear; no expand button either.
+		expect(screen.getByText("Listed workflows")).toBeInTheDocument();
 		expect(screen.queryByText("{}")).not.toBeInTheDocument();
-		expect(
-			screen.queryByRole("button", { name: /show arguments/i }),
-		).not.toBeInTheDocument();
 	});
 
-	it("collapses non-empty tool args behind a disclosure that expands inline", () => {
+	it("keeps non-empty tool arguments out of the normal review", () => {
 		const run: AgentRunDetail = {
 			...baseRun,
-			did: null,  // force the fallback tool-call list
+			did: null, // force the fallback tool-call list
 			steps: [
 				{
 					id: "s1",
@@ -309,19 +491,18 @@ describe("RunReviewPanel", () => {
 				onNote={() => {}}
 			/>,
 		);
-		// Collapsed: button with the show-args label; one-line preview visible.
-		const expandBtn = screen.getByRole("button", { name: /show arguments/i });
-		expect(expandBtn).toHaveAttribute("aria-expanded", "false");
-		fireEvent.click(expandBtn);
-		expect(
-			screen.getByRole("button", { name: /hide arguments/i }),
-		).toHaveAttribute("aria-expanded", "true");
+		expect(screen.getByText("Sent email")).toBeInTheDocument();
+		expect(screen.queryByText(/user@x.com/i)).not.toBeInTheDocument();
+		expect(screen.queryByText(/show arguments/i)).not.toBeInTheDocument();
 	});
 
 	it("renders metadata chips when metadata present", () => {
 		renderWithProviders(
 			<RunReviewPanel
-				run={{ ...baseRun, metadata: { ticket_id: "4821", org: "acme" } }}
+				run={{
+					...baseRun,
+					metadata: { ticket_id: "4821", org: "acme" },
+				}}
 				verdict={null}
 				note=""
 				onVerdict={() => {}}
@@ -365,7 +546,12 @@ describe("RunReviewPanel", () => {
 	it("shows the in-panel regenerate bar when summary is pending", () => {
 		renderWithProviders(
 			<RunReviewPanel
-				run={{ ...baseRun, summary_status: "pending", asked: "", did: "" }}
+				run={{
+					...baseRun,
+					summary_status: "pending",
+					asked: "",
+					did: "",
+				}}
 				verdict={null}
 				note=""
 				onVerdict={() => {}}
@@ -381,7 +567,12 @@ describe("RunReviewPanel", () => {
 		mockAuth.mockReturnValueOnce({ isPlatformAdmin: false });
 		renderWithProviders(
 			<RunReviewPanel
-				run={{ ...baseRun, summary_status: "failed", asked: "", did: "" }}
+				run={{
+					...baseRun,
+					summary_status: "failed",
+					asked: "",
+					did: "",
+				}}
 				verdict={null}
 				note=""
 				onVerdict={() => {}}

--- a/client/src/components/agents/RunReviewPanel.tsx
+++ b/client/src/components/agents/RunReviewPanel.tsx
@@ -7,13 +7,16 @@
  *   - variant="drawer": runs sheet (compact side panel)
  *
  * Consistent UX across all three: same summary structure (asked / did / output),
- * same tool-call preview, same verdict capture bar.
+ * same human-readable action fallback, same verdict capture bar.
  */
 
 import { Link } from "react-router-dom";
 import {
 	User,
 	Bot,
+	Check,
+	CircleDot,
+	GitBranch,
 	Wrench,
 	ThumbsUp,
 	ThumbsDown,
@@ -24,23 +27,31 @@ import {
 } from "lucide-react";
 import { toast } from "sonner";
 import { useQueryClient } from "@tanstack/react-query";
-import { useState, type ReactNode } from "react";
+import { useId, useState, type ReactNode } from "react";
 
 import { Input } from "@/components/ui/input";
+import { VariablesTreeView } from "@/components/ui/variables-tree-view";
 import { cn } from "@/lib/utils";
 import { formatDuration } from "@/lib/utils";
+import {
+	createAgentRunNavigationState,
+	type AgentRunNavigationOrigin,
+} from "@/lib/agent-run-navigation";
 import { useAuth } from "@/contexts/AuthContext";
 import { useRegenerateSummary } from "@/services/agentRuns";
 import type { components } from "@/lib/v1";
 
 import { DidNarrative } from "./DidNarrative";
-import { isEmptyJson, JsonTree } from "./JsonTree";
+import {
+	buildActivityReferenceIndex,
+	buildRunActivity,
+	type RunActivityItem,
+} from "./run-activity";
 import { SummaryPlaceholder } from "./SummaryPlaceholder";
 
 export type Verdict = "up" | "down" | null;
 
 type AgentRunDetail = components["schemas"]["AgentRunDetailResponse"];
-type AgentRunStep = components["schemas"]["AgentRunStepResponse"];
 
 export type RunReviewVariant = "page" | "flipbook" | "drawer";
 
@@ -52,110 +63,92 @@ export interface RunReviewPanelProps {
 	onNote: (n: string) => void;
 	variant?: RunReviewVariant;
 	hideVerdictBar?: boolean;
+	runNavigationOrigin?: AgentRunNavigationOrigin;
+	onActivityReferencePreview?: (activityId: string | null) => void;
+	onActivityReferenceActivate?: (activityId: string) => void;
 }
 
-interface ToolCallContent {
-	// Shape emitted by autonomous_agent_executor.py _record_step(..., "tool_call", ...)
-	tool_name?: string;
-	arguments?: unknown;
-}
-
-/** Pull tool calls out of run.steps.
- *
- * The executor records one `tool_call` step per invocation with
- * `content = { tool_name, arguments }` (see
- * api/src/services/execution/autonomous_agent_executor.py). Older code in
- * this component read `content.tool` / `content.args` which don't exist —
- * that's why every row rendered as `tool {}`.
- */
-function extractToolCalls(steps: AgentRunStep[] | undefined): {
-	tool: string;
-	args: unknown;
-	duration_ms: number | null;
-}[] {
-	if (!steps) return [];
-	return steps
-		.filter((s) => s.type === "tool_call")
-		.map((s) => {
-			const content = (s.content ?? {}) as ToolCallContent;
-			return {
-				tool: content.tool_name ?? "tool",
-				args: content.arguments ?? {},
-				duration_ms: s.duration_ms ?? null,
-			};
-		});
-}
-
-interface ToolCallRowProps {
-	tool: string;
-	args: unknown;
-	duration_ms: number | null;
-}
-
-/** Tool-call row: tool name + (when args non-empty) chevron-disclosure +
- * duration. No inline args preview — that pushed long objects past the
- * card's right edge. Expanded form uses the shared JsonTree viewer.
- */
-function ToolCallRow({ tool, args, duration_ms }: ToolCallRowProps) {
-	const [open, setOpen] = useState(false);
-	const empty = isEmptyJson(args);
-	const expandable = !empty;
-
+/** Human fallback for runs that predate prose summaries. */
+function ActivityFallbackRow({ item }: { item: RunActivityItem }) {
+	const delegated = item.kind === "delegation";
+	const failed = item.isError || item.kind === "error";
+	const completed = !!item.resultStep && !failed;
+	const Icon = failed
+		? AlertCircle
+		: delegated
+			? GitBranch
+			: completed
+				? Check
+				: CircleDot;
+	const iconTone = failed
+		? "bg-rose-500/15 text-rose-600 dark:text-rose-300"
+		: delegated
+			? "bg-violet-500/15 text-violet-600 dark:text-violet-300"
+			: completed
+				? "bg-emerald-500/15 text-emerald-600 dark:text-emerald-300"
+				: "bg-muted text-muted-foreground";
 	return (
-		<div className="overflow-hidden rounded-md bg-muted/50 ring-1 ring-foreground/5 text-xs">
-			<button
-				type="button"
-				onClick={() => expandable && setOpen((v) => !v)}
-				disabled={!expandable}
-				aria-expanded={expandable ? open : undefined}
-				aria-label={
-					expandable
-						? open
-							? "Hide arguments"
-							: "Show arguments"
-						: undefined
-				}
+		<div
+			className="flex items-center gap-2 rounded-md bg-muted/50 px-2.5 py-2 text-xs ring-1 ring-foreground/5"
+			data-activity-kind={failed ? "error" : item.kind}
+		>
+			<div
 				className={cn(
-					"flex w-full items-center gap-2 px-2 py-1.5 text-left",
-					expandable && "hover:bg-accent/40",
+					"grid h-5 w-5 shrink-0 place-items-center rounded-full",
+					iconTone,
 				)}
 			>
-				{expandable ? (
-					<ChevronRight
-						className={cn(
-							"h-3 w-3 shrink-0 text-muted-foreground transition-transform",
-							open && "rotate-90",
-						)}
-					/>
-				) : (
-					<span className="h-3 w-3 shrink-0" />
-				)}
-				<span className="min-w-0 flex-1 truncate font-mono font-medium">
-					{tool}
+				<Icon className="h-3 w-3" />
+			</div>
+			<span className="min-w-0 flex-1 font-medium">{item.title}</span>
+			{item.durationMs != null ? (
+				<span className="shrink-0 text-[11px] tabular-nums text-muted-foreground">
+					{formatDuration(item.durationMs)}
 				</span>
-				<span className="shrink-0 text-[11px] text-muted-foreground">
-					{duration_ms != null ? formatDuration(duration_ms) : ""}
-				</span>
-			</button>
-			{expandable && open ? (
-				<div className="max-h-[240px] overflow-y-auto border-t bg-muted px-3 py-2">
-					<JsonTree value={args} />
-				</div>
 			) : null}
 		</div>
 	);
 }
 
-
-/** Render input/output that may be a string OR a JSON object. */
-function renderPayload(value: unknown): string {
-	if (value === null || value === undefined) return "";
+function payloadText(value: unknown): string {
 	if (typeof value === "string") return value;
 	try {
 		return JSON.stringify(value, null, 2);
 	} catch {
 		return String(value);
 	}
+}
+
+export function RunPayloads({
+	input,
+	output,
+	compact = false,
+}: {
+	input: unknown;
+	output: unknown;
+	compact?: boolean;
+}) {
+	const hasInput = input !== null && input !== undefined && input !== "";
+	const hasOutput = output !== null && output !== undefined && output !== "";
+	if (!hasInput && !hasOutput) return null;
+	return (
+		<div className="grid gap-2" data-slot="run-payloads">
+			{hasInput ? (
+				<RawDisclosure
+					label="Raw input"
+					value={input}
+					compact={compact}
+				/>
+			) : null}
+			{hasOutput ? (
+				<RawDisclosure
+					label="Raw output"
+					value={output}
+					compact={compact}
+				/>
+			) : null}
+		</div>
+	);
 }
 
 export function RunReviewPanel({
@@ -166,24 +159,26 @@ export function RunReviewPanel({
 	onNote,
 	variant = "page",
 	hideVerdictBar = false,
+	runNavigationOrigin,
+	onActivityReferencePreview,
+	onActivityReferenceActivate,
 }: RunReviewPanelProps) {
-	const toolCalls = extractToolCalls(run.steps);
-	// "What it did" rendering decision tree:
-	//   v3+ summary with prose `did`     → render DidNarrative (chips inline
-	//                                       when [tool_name] markers present;
-	//                                       graceful plain-prose otherwise).
-	//   no `did` but has tool_call steps → fall back to the raw tool-call
-	//                                       list (v1/v2 era, pre-summary).
-	//   neither                          → hide the section entirely.
+	const activity = buildRunActivity(
+		run.steps,
+		run.child_run_ids,
+		run.child_runs,
+	);
+	const fallbackActions = activity.filter((item) => item.kind !== "response");
+	const activityReferences = buildActivityReferenceIndex(activity);
+	// Prefer summary prose, safely humanizing any old [tool_name] markers.
+	// Runs without prose get a short action list derived from recorded calls;
+	// exact identifiers and payloads live only in the detail page's Advanced view.
 	const hasDidProse = !!run.did && run.did.trim().length > 0;
 	const canVerdict = run.status === "completed" && !hideVerdictBar;
 	const compact = variant === "drawer";
-	const maxToolCalls = compact ? 3 : 4;
-	const visibleTools = toolCalls.slice(0, maxToolCalls);
-	const overflow = toolCalls.length - visibleTools.length;
-	const inputText = renderPayload(run.input);
-	const outputText = renderPayload(run.output);
-
+	const maxActions = compact ? 3 : 4;
+	const visibleActions = fallbackActions.slice(0, maxActions);
+	const overflow = fallbackActions.length - visibleActions.length;
 	const { isPlatformAdmin } = useAuth();
 	const queryClient = useQueryClient();
 	const regenSummary = useRegenerateSummary();
@@ -229,7 +224,8 @@ export function RunReviewPanel({
 						)}
 					>
 						<div className="flex items-center gap-2">
-							{summaryStatus === "generating" || regenSummary.isPending ? (
+							{summaryStatus === "generating" ||
+							regenSummary.isPending ? (
 								<Loader2 className="h-3.5 w-3.5 animate-spin" />
 							) : (
 								<RefreshCw className="h-3.5 w-3.5 text-muted-foreground" />
@@ -249,7 +245,9 @@ export function RunReviewPanel({
 						{summaryStatus !== "generating" ? (
 							<button
 								type="button"
-								disabled={!isPlatformAdmin || regenSummary.isPending}
+								disabled={
+									!isPlatformAdmin || regenSummary.isPending
+								}
 								title={
 									isPlatformAdmin
 										? "Re-run summarization"
@@ -282,7 +280,10 @@ export function RunReviewPanel({
 						)}
 					>
 						{run.asked || (
-							<SummaryPlaceholder status={run.summary_status} runStatus={run.status} />
+							<SummaryPlaceholder
+								status={run.summary_status}
+								runStatus={run.status}
+							/>
 						)}
 					</div>
 				</Section>
@@ -291,7 +292,7 @@ export function RunReviewPanel({
 					<Section
 						icon={<Wrench size={13} />}
 						iconClassName="bg-blue-500/15 text-blue-600 dark:text-blue-400"
-						label="What it did"
+						label="What the agent did"
 						compact={compact}
 					>
 						<div
@@ -302,28 +303,29 @@ export function RunReviewPanel({
 						>
 							<DidNarrative
 								text={run.did}
-								steps={run.steps}
+								activityReferences={activityReferences}
+								onReferencePreview={onActivityReferencePreview}
+								onReferenceActivate={
+									onActivityReferenceActivate
+								}
 								compact={compact}
 							/>
 						</div>
 					</Section>
-				) : toolCalls.length > 0 ? (
+				) : fallbackActions.length > 0 ? (
 					// No `did` summary at all (pre-summary or summary failed)
-					// — fall back to the raw tool-call list so the user
-					// still sees what the agent did.
+					// — preserve visibility with human-readable action names.
 					<Section
 						icon={<Wrench size={13} />}
 						iconClassName="bg-blue-500/15 text-blue-600 dark:text-blue-400"
-						label={`What it did · ${toolCalls.length} tool call${toolCalls.length === 1 ? "" : "s"}`}
+						label={`What the agent did · ${fallbackActions.length} action${fallbackActions.length === 1 ? "" : "s"}`}
 						compact={compact}
 					>
 						<div className="grid gap-1.5">
-							{visibleTools.map((c, i) => (
-								<ToolCallRow
-									key={i}
-									tool={c.tool}
-									args={c.args}
-									duration_ms={c.duration_ms}
+							{visibleActions.map((item) => (
+								<ActivityFallbackRow
+									key={item.id}
+									item={item}
 								/>
 							))}
 							{overflow > 0 ? (
@@ -331,6 +333,13 @@ export function RunReviewPanel({
 									+{overflow} more —{" "}
 									<Link
 										to={`/agents/${run.agent_id}/runs/${run.id}`}
+										state={
+											runNavigationOrigin
+												? createAgentRunNavigationState(
+														runNavigationOrigin,
+													)
+												: undefined
+										}
 										className="text-primary hover:underline"
 									>
 										open full detail
@@ -354,14 +363,29 @@ export function RunReviewPanel({
 								compact ? "text-xs" : "text-sm",
 							)}
 						>
-							{run.answered ||
-								// Fall back to `did` for v1/v2 summaries (no
-								// separate `answered` field). Shows the
-								// generic-but-better-than-nothing one-liner.
-								run.did ||
-								(
-									<SummaryPlaceholder status={run.summary_status} runStatus={run.status} />
-								)}
+							{run.answered ? (
+								run.answered
+							) : run.did ? (
+								// Older summaries have no separate answer and
+								// may still contain executor markers. Reuse the
+								// safe narrative renderer for that fallback.
+								<DidNarrative
+									text={run.did}
+									activityReferences={activityReferences}
+									onReferencePreview={
+										onActivityReferencePreview
+									}
+									onReferenceActivate={
+										onActivityReferenceActivate
+									}
+									compact={compact}
+								/>
+							) : (
+								<SummaryPlaceholder
+									status={run.summary_status}
+									runStatus={run.status}
+								/>
+							)}
 						</div>
 					</Section>
 				) : (
@@ -404,19 +428,6 @@ export function RunReviewPanel({
 						</div>
 					</Section>
 				) : null}
-
-				{inputText || outputText ? (
-					<Section label="Raw payloads" compact={compact} plain>
-						<div className="grid gap-2">
-							{inputText ? (
-								<RawDisclosure label="Raw input" text={inputText} compact={compact} />
-							) : null}
-							{outputText ? (
-								<RawDisclosure label="Raw output" text={outputText} compact={compact} />
-							) : null}
-						</div>
-					</Section>
-				) : null}
 			</div>
 
 			{canVerdict ? (
@@ -431,7 +442,9 @@ export function RunReviewPanel({
 					data-slot="verdict-bar"
 				>
 					<div className="flex items-center gap-2">
-						<div className="text-sm text-muted-foreground">Verdict</div>
+						<div className="text-sm text-muted-foreground">
+							Verdict
+						</div>
 						<button
 							type="button"
 							aria-label="Mark as good"
@@ -538,18 +551,23 @@ function Section({
 
 interface RawDisclosureProps {
 	label: string;
-	text: string;
+	value: unknown;
 	compact?: boolean;
 }
 
-/** Collapsible raw input/output block. Opaque unless admin explicitly opens it. */
-function RawDisclosure({ label, text, compact }: RawDisclosureProps) {
+/** Collapsible input/output block. Structured values use the shared variable tree. */
+function RawDisclosure({ label, value, compact }: RawDisclosureProps) {
 	const [open, setOpen] = useState(false);
+	const contentId = useId();
+	const serialized = payloadText(value);
+	const structuredValue = parseStructuredPayload(value);
 	return (
 		<div className="overflow-hidden rounded-md bg-muted/50 ring-1 ring-foreground/5">
 			<button
 				type="button"
 				onClick={() => setOpen((v) => !v)}
+				aria-expanded={open}
+				aria-controls={contentId}
 				className={cn(
 					"flex w-full items-center gap-1.5 px-3 py-1.5 text-left text-muted-foreground hover:text-foreground",
 					compact ? "text-xs" : "text-[13px]",
@@ -563,21 +581,54 @@ function RawDisclosure({ label, text, compact }: RawDisclosureProps) {
 				/>
 				<span>{label}</span>
 				<span className="ml-auto text-[11px]">
-					{text.length.toLocaleString()} chars
+					{serialized.length.toLocaleString()} chars
 				</span>
 			</button>
 			{open ? (
-				<pre
+				<div
+					id={contentId}
 					className={cn(
-						"max-h-[240px] overflow-auto border-t bg-muted px-3 py-2 font-mono whitespace-pre-wrap break-words",
+						"max-h-[240px] overflow-auto border-t bg-muted px-3 py-2 whitespace-pre-wrap break-words",
 						compact ? "text-[11px]" : "text-xs",
 					)}
 				>
-					{text}
-				</pre>
+					{structuredValue !== UNPARSEABLE_PAYLOAD ? (
+						<VariablesTreeView
+							data={asPayloadVariables(structuredValue)}
+						/>
+					) : (
+						serialized
+					)}
+				</div>
 			) : null}
 		</div>
 	);
+}
+
+const UNPARSEABLE_PAYLOAD = Symbol("unparseable-payload");
+
+function parseStructuredPayload(value: unknown): unknown {
+	if (value !== null && typeof value === "object") return value;
+	if (typeof value !== "string") return UNPARSEABLE_PAYLOAD;
+	const trimmed = value.trim();
+	if (!(
+		(trimmed.startsWith("{") && trimmed.endsWith("}")) ||
+		(trimmed.startsWith("[") && trimmed.endsWith("]"))
+	)) {
+		return UNPARSEABLE_PAYLOAD;
+	}
+	try {
+		return JSON.parse(trimmed);
+	} catch {
+		return UNPARSEABLE_PAYLOAD;
+	}
+}
+
+function asPayloadVariables(value: unknown): Record<string, unknown> {
+	if (value !== null && typeof value === "object" && !Array.isArray(value)) {
+		return value as Record<string, unknown>;
+	}
+	return { value };
 }
 
 export interface MetadataChipsProps {
@@ -594,7 +645,8 @@ export function MetadataChips({ metadata, highlight }: MetadataChipsProps) {
 			{entries.map(([k, v]) => {
 				const isHit =
 					q &&
-					(k.toLowerCase().includes(q) || v.toLowerCase().includes(q));
+					(k.toLowerCase().includes(q) ||
+						v.toLowerCase().includes(q));
 				return (
 					<span
 						key={k}

--- a/client/src/components/agents/RunReviewSheet.test.tsx
+++ b/client/src/components/agents/RunReviewSheet.test.tsx
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
+import { Route, Routes, useLocation } from "react-router-dom";
 import { renderWithProviders, screen } from "@/test-utils";
 import type { components } from "@/lib/v1";
 
@@ -8,12 +9,27 @@ vi.mock("@/contexts/AuthContext", () => ({
 
 vi.mock("@/services/agentRuns", () => ({
 	useRegenerateSummary: () => ({ mutate: vi.fn(), isPending: false }),
+	useAgentRun: () => ({
+		data: undefined,
+		isLoading: false,
+		isError: false,
+	}),
 }));
 
 import { RunReviewSheet } from "./RunReviewSheet";
 
 type AgentRunDetail = components["schemas"]["AgentRunDetailResponse"];
-type FlagConversationResponse = components["schemas"]["FlagConversationResponse"];
+type FlagConversationResponse =
+	components["schemas"]["FlagConversationResponse"];
+
+function NavigationStateProbe() {
+	const location = useLocation();
+	return (
+		<pre data-testid="navigation-state">
+			{JSON.stringify(location.state)}
+		</pre>
+	);
+}
 
 const baseRun: AgentRunDetail = {
 	id: "00000000-0000-0000-0000-000000000001",
@@ -41,6 +57,36 @@ const baseConversation: FlagConversationResponse = {
 	messages: [],
 	created_at: baseRun.created_at,
 	last_updated_at: baseRun.created_at,
+};
+
+const activityRun: AgentRunDetail = {
+	...baseRun,
+	did: "Looked up [get_ticket] before routing.",
+	answered: "The ticket was routed.",
+	steps: [
+		{
+			id: "step-1",
+			run_id: baseRun.id,
+			step_number: 1,
+			type: "tool_call",
+			content: {
+				tool_name: "get_ticket",
+				arguments: { ticket_id: 428950 },
+			},
+			created_at: baseRun.created_at,
+		},
+		{
+			id: "step-2",
+			run_id: baseRun.id,
+			step_number: 2,
+			type: "tool_result",
+			content: {
+				tool_name: "get_ticket",
+				result: { ticket_id: 428950, status: "open" },
+			},
+			created_at: baseRun.created_at,
+		},
+	],
 };
 
 describe("RunReviewSheet", () => {
@@ -77,7 +123,9 @@ describe("RunReviewSheet", () => {
 		);
 		const titles = screen.getAllByText(/routed to support/i);
 		expect(titles.length).toBeGreaterThan(0);
-		expect(screen.getByRole("tab", { name: /^review$/i })).toBeInTheDocument();
+		expect(
+			screen.getByRole("tab", { name: /^review$/i }),
+		).toBeInTheDocument();
 		expect(screen.getByRole("tab", { name: /tune/i })).toBeInTheDocument();
 	});
 
@@ -100,6 +148,65 @@ describe("RunReviewSheet", () => {
 		expect(
 			screen.getAllByText(/how do i reset my password/i).length,
 		).toBeGreaterThan(0);
+	});
+
+	it("shows the human activity view and links summary references to it", async () => {
+		const scrollIntoView = vi.fn();
+		Object.defineProperty(HTMLElement.prototype, "scrollIntoView", {
+			configurable: true,
+			value: scrollIntoView,
+		});
+		const { user } = renderWithProviders(
+			<RunReviewSheet
+				open={true}
+				onOpenChange={() => {}}
+				run={activityRun}
+				verdict={null}
+				note=""
+				onVerdict={() => {}}
+				onNote={() => {}}
+				conversation={baseConversation}
+				onSendChat={() => {}}
+			/>,
+		);
+
+		expect(
+			screen.getByRole("region", { name: "Activity" }),
+		).toBeInTheDocument();
+		const activityRegion = screen.getByRole("region", {
+			name: "Activity",
+		});
+		expect(activityRegion).toHaveTextContent("Looked up ticket");
+		expect(
+			screen.getByText("Ticket: 428950 · Status: Open"),
+		).toBeInTheDocument();
+		expect(
+			screen.queryByText("Raw executor trace"),
+		).not.toBeInTheDocument();
+
+		const reference = screen.getByRole("link", {
+			name: "Show Looked up ticket in Activity",
+		});
+		const activity = document.querySelector('[data-activity-id="step-1"]');
+		expect(activity).toHaveAttribute("data-highlighted", "false");
+
+		await user.hover(reference);
+		expect(activity).toHaveAttribute("data-highlighted", "true");
+		await user.hover(
+			screen.getByRole("heading", { name: "Activity" }),
+		);
+		expect(activity).toHaveAttribute("data-highlighted", "false");
+
+		await user.click(reference);
+		expect(scrollIntoView).toHaveBeenCalledWith({
+			behavior: "smooth",
+			block: "center",
+		});
+		await user.hover(
+			screen.getByRole("heading", { name: "Activity" }),
+		);
+		expect(activity).toHaveFocus();
+		expect(activity).toHaveAttribute("data-highlighted", "false");
 	});
 
 	it("switches to Tune tab on click", async () => {
@@ -180,6 +287,50 @@ describe("RunReviewSheet", () => {
 		expect(link).toHaveAttribute(
 			"href",
 			`/agents/${baseRun.agent_id}/runs/${baseRun.id}`,
+		);
+	});
+
+	it("returns full-run navigation to the runs view that opened the sheet", async () => {
+		const { user } = renderWithProviders(
+			<Routes>
+				<Route
+					path="/agents/:agentId"
+					element={
+						<RunReviewSheet
+							open={true}
+							onOpenChange={() => {}}
+							run={baseRun}
+							verdict={null}
+							note=""
+							onVerdict={() => {}}
+							onNote={() => {}}
+							conversation={baseConversation}
+							onSendChat={() => {}}
+						/>
+					}
+				/>
+				<Route
+					path="/agents/:agentId/runs/:runId"
+					element={<NavigationStateProbe />}
+				/>
+			</Routes>,
+			{
+				initialEntries: [
+					`/agents/${baseRun.agent_id}?tab=runs&summary=failed`,
+				],
+			},
+		);
+
+		await user.click(
+			screen.getByRole("link", { name: /open full run/i }),
+		);
+		expect(screen.getByTestId("navigation-state")).toHaveTextContent(
+			JSON.stringify({
+				agentRunOrigin: {
+					href: `/agents/${baseRun.agent_id}?tab=runs&summary=failed`,
+					label: "Back to Tier-1 Triage runs",
+				},
+			}),
 		);
 	});
 });

--- a/client/src/components/agents/RunReviewSheet.tsx
+++ b/client/src/components/agents/RunReviewSheet.tsx
@@ -7,8 +7,9 @@
  * component is purely presentational.
  */
 
-import { ExternalLink, Sparkles } from "lucide-react";
-import { Link } from "react-router-dom";
+import { useState } from "react";
+import { ExternalLink, ListTree, Sparkles } from "lucide-react";
+import { Link, useLocation } from "react-router-dom";
 
 import {
 	Sheet,
@@ -16,19 +17,21 @@ import {
 	SheetHeader,
 	SheetTitle,
 } from "@/components/ui/sheet";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import {
-	Tabs,
-	TabsContent,
-	TabsList,
-	TabsTrigger,
-} from "@/components/ui/tabs";
+	createAgentRunNavigationState,
+	getLocationHref,
+} from "@/lib/agent-run-navigation";
 import type { components } from "@/lib/v1";
 
 import { FlagConversation } from "./FlagConversation";
 import { RunReviewPanel, type Verdict } from "./RunReviewPanel";
+import { Timeline } from "./Timeline";
+import { activityDomId } from "./run-activity";
 
 type AgentRunDetail = components["schemas"]["AgentRunDetailResponse"];
-type FlagConversationResponse = components["schemas"]["FlagConversationResponse"];
+type FlagConversationResponse =
+	components["schemas"]["FlagConversationResponse"];
 
 export interface RunReviewSheetProps {
 	open: boolean;
@@ -59,9 +62,46 @@ export function RunReviewSheet({
 	onTestAgainstRun,
 	defaultTab = "review",
 }: RunReviewSheetProps) {
+	const location = useLocation();
+	const [activityPreview, setActivityPreview] = useState<{
+		runId: string;
+		activityId: string;
+	} | null>(null);
+
 	if (!run) return null;
+	const runId = run.id;
+	const runNavigationOrigin = {
+		href: getLocationHref(location),
+		label: `Back to ${run.agent_name ?? "agent"} runs`,
+	};
+
+	const highlightedActivityId =
+		activityPreview?.runId === runId ? activityPreview.activityId : null;
+
+	function handleActivityReferencePreview(activityId: string | null) {
+		setActivityPreview(activityId ? { runId, activityId } : null);
+	}
+
+	function handleActivityReferenceActivate(activityId: string) {
+		const target = document.getElementById(activityDomId(activityId));
+		if (!target) return;
+		const reduceMotion =
+			window.matchMedia?.("(prefers-reduced-motion: reduce)").matches ??
+			false;
+		target.scrollIntoView({
+			behavior: reduceMotion ? "auto" : "smooth",
+			block: "center",
+		});
+		target.focus({ preventScroll: true });
+	}
+
+	function handleOpenChange(nextOpen: boolean) {
+		if (!nextOpen) setActivityPreview(null);
+		onOpenChange(nextOpen);
+	}
+
 	return (
-		<Sheet open={open} onOpenChange={onOpenChange}>
+		<Sheet open={open} onOpenChange={handleOpenChange}>
 			<SheetContent
 				side="right"
 				aria-label="Run review"
@@ -80,6 +120,9 @@ export function RunReviewSheet({
 						</SheetTitle>
 						<Link
 							to={`/agents/${run.agent_id}/runs/${run.id}`}
+							state={createAgentRunNavigationState(
+								runNavigationOrigin,
+							)}
 							className="inline-flex shrink-0 items-center gap-1 text-xs font-medium text-muted-foreground hover:text-foreground"
 							aria-label="Open full run page"
 						>
@@ -109,7 +152,40 @@ export function RunReviewSheet({
 							onVerdict={onVerdict}
 							onNote={onNote}
 							variant="drawer"
+							runNavigationOrigin={runNavigationOrigin}
+							onActivityReferencePreview={
+								handleActivityReferencePreview
+							}
+							onActivityReferenceActivate={
+								handleActivityReferenceActivate
+							}
 						/>
+						<section
+							className="border-t px-4 pb-5 pt-4"
+							data-slot="run-activity"
+							aria-labelledby="run-review-sheet-activity-title"
+						>
+							<div className="mb-4">
+								<h3
+									id="run-review-sheet-activity-title"
+									className="flex items-center gap-2 text-sm font-semibold"
+								>
+									<ListTree className="h-4 w-4 text-muted-foreground" />
+									Activity
+								</h3>
+								<p className="mt-1 text-xs text-muted-foreground">
+									How the agent handled this run, in order
+								</p>
+							</div>
+							<Timeline
+								steps={run.steps ?? []}
+								childRunIds={run.child_run_ids ?? []}
+								childRuns={run.child_runs ?? []}
+								runStatus={run.status}
+								highlightedActivityId={highlightedActivityId}
+								childRunOrigin={runNavigationOrigin}
+							/>
+						</section>
 					</TabsContent>
 					<TabsContent
 						value="tune"

--- a/client/src/components/agents/RunSummaryContent.test.tsx
+++ b/client/src/components/agents/RunSummaryContent.test.tsx
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+
+import { renderWithProviders, screen } from "@/test-utils";
+import type { components } from "@/lib/v1";
+
+import { RunSummaryContent } from "./RunSummaryContent";
+
+type AgentRun = components["schemas"]["AgentRunResponse"];
+
+const run: AgentRun = {
+	id: "00000000-0000-0000-0000-000000000001",
+	agent_id: "00000000-0000-0000-0000-000000000002",
+	trigger_type: "test",
+	status: "completed",
+	iterations_used: 1,
+	tokens_used: 1234,
+	asked: "Triage ticket 428950",
+	did: "Routed it to Support",
+	input: {},
+	output: {},
+	metadata: { ticket_id: "428950", client: "Contoso" },
+	summary_status: "completed",
+	created_at: "2026-04-21T10:00:00Z",
+	started_at: "2026-04-21T10:00:00Z",
+	duration_ms: 2500,
+};
+
+describe("RunSummaryContent", () => {
+	it("uses a subtle, accessible status indicator and consistent run hierarchy", () => {
+		renderWithProviders(<RunSummaryContent run={run} />);
+
+		expect(
+			screen.getByRole("img", { name: "Status: Completed" }),
+		).toBeInTheDocument();
+		expect(screen.getByText("Triage ticket 428950")).toBeInTheDocument();
+		expect(screen.getByText("Routed it to Support")).toBeInTheDocument();
+		expect(screen.getByText("1,234")).toBeInTheDocument();
+		expect(screen.getByText("ticket_id")).toBeInTheDocument();
+		expect(screen.getByText("428950")).toBeInTheDocument();
+	});
+
+	it("falls back to the run error when no did summary exists", () => {
+		renderWithProviders(
+			<RunSummaryContent
+				run={{ ...run, status: "failed", did: null, error: "boom" }}
+			/>,
+		);
+
+		expect(
+			screen.getByRole("img", { name: "Status: Failed" }),
+		).toBeInTheDocument();
+		expect(screen.getByText("Error: boom")).toBeInTheDocument();
+	});
+
+	it("identifies runs performed as a delegation", () => {
+		renderWithProviders(
+			<RunSummaryContent
+				run={{
+					...run,
+					parent_run_id:
+						"00000000-0000-0000-0000-000000000003",
+				}}
+			/>,
+		);
+
+		expect(screen.getByText("Delegated")).toBeInTheDocument();
+	});
+
+	it("prioritizes matching captured data without hiding overflow", () => {
+		renderWithProviders(
+			<RunSummaryContent
+				run={{
+					...run,
+					metadata: { a: "1", b: "2", c: "3", target: "needle" },
+				}}
+				highlight="needle"
+			/>,
+		);
+
+		expect(screen.getByText("target")).toBeInTheDocument();
+		expect(screen.getByText("+1")).toBeInTheDocument();
+	});
+});

--- a/client/src/components/agents/RunSummaryContent.tsx
+++ b/client/src/components/agents/RunSummaryContent.tsx
@@ -1,0 +1,216 @@
+import {
+	AlertTriangle,
+	CheckCircle,
+	Clock,
+	GitBranch,
+	Hash,
+	Loader2,
+	XCircle,
+} from "lucide-react";
+import type { ReactNode } from "react";
+
+import {
+	cn,
+	formatDuration,
+	formatNumber,
+	formatRelativeTime,
+} from "@/lib/utils";
+import type { components } from "@/lib/v1";
+
+import { SummaryPlaceholder } from "./SummaryPlaceholder";
+
+type AgentRun = components["schemas"]["AgentRunResponse"];
+
+export interface RunSummaryContentProps {
+	run: AgentRun;
+	highlight?: string;
+	density?: "compact" | "comfortable";
+	titleTrailing?: ReactNode;
+	className?: string;
+}
+
+const STATUS_PRESENTATION = {
+	completed: {
+		label: "Completed",
+		icon: CheckCircle,
+		className: "bg-emerald-500/15 text-emerald-500",
+	},
+	failed: {
+		label: "Failed",
+		icon: XCircle,
+		className: "bg-rose-500/15 text-rose-500",
+	},
+	running: {
+		label: "Running",
+		icon: Loader2,
+		className: "bg-sky-500/15 text-sky-500",
+	},
+	budget_exceeded: {
+		label: "Budget exceeded",
+		icon: AlertTriangle,
+		className: "bg-amber-500/15 text-amber-500",
+	},
+} as const;
+
+function RunStatusIndicator({ status }: { status: string }) {
+	const normalized = status.toLowerCase() as keyof typeof STATUS_PRESENTATION;
+	const presentation = STATUS_PRESENTATION[normalized] ?? {
+		label: status || "Unknown",
+		icon: Clock,
+		className: "bg-muted text-muted-foreground",
+	};
+	const Icon = presentation.icon;
+
+	return (
+		<span
+			role="img"
+			aria-label={`Status: ${presentation.label}`}
+			className={cn(
+				"mt-0.5 grid h-6 w-6 shrink-0 place-items-center rounded-full",
+				presentation.className,
+			)}
+		>
+			<Icon
+				aria-hidden="true"
+				className={cn(
+					"h-3.5 w-3.5",
+					normalized === "running" && "animate-spin",
+				)}
+			/>
+		</span>
+	);
+}
+
+export function RunSummaryContent({
+	run,
+	highlight,
+	density = "comfortable",
+	titleTrailing,
+	className,
+}: RunSummaryContentProps) {
+	const query = highlight?.trim().toLowerCase() ?? "";
+	const metadataEntries = Object.entries(run.metadata ?? {});
+	const rankedMetadata = query
+		? [...metadataEntries].sort((a, b) => {
+				const aHit =
+					a[0].toLowerCase().includes(query) ||
+					a[1].toLowerCase().includes(query);
+				const bHit =
+					b[0].toLowerCase().includes(query) ||
+					b[1].toLowerCase().includes(query);
+				return Number(bHit) - Number(aHit);
+			})
+		: metadataEntries;
+	const visibleChips = rankedMetadata.slice(0, 3);
+	const overflow = metadataEntries.length - visibleChips.length;
+	const startedAt = run.started_at ?? run.created_at;
+	const bodyText = run.did ?? (run.error ? `Error: ${run.error}` : null);
+
+	return (
+		<div className={cn("flex min-w-0 flex-1 items-start gap-3", className)}>
+			<RunStatusIndicator status={run.status} />
+			<div
+				className={cn(
+					"flex min-w-0 flex-1 flex-col",
+					density === "compact" ? "gap-0.5" : "gap-1.5",
+				)}
+			>
+				<div className="flex min-w-0 items-center gap-2">
+					<div
+						className={cn(
+							"min-w-0 flex-1 truncate",
+							density === "compact" ? "text-[13px]" : "text-sm",
+						)}
+						title={run.asked ?? undefined}
+					>
+						{run.asked || (
+							<SummaryPlaceholder
+								status={run.summary_status}
+								runStatus={run.status}
+							/>
+						)}
+					</div>
+					{run.parent_run_id ? (
+						<span className="inline-flex shrink-0 items-center gap-1 rounded-full bg-violet-500/10 px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide text-violet-700 ring-1 ring-violet-500/20 dark:text-violet-300">
+							<GitBranch aria-hidden="true" className="h-2.5 w-2.5" />
+							Delegated
+						</span>
+					) : null}
+					{titleTrailing}
+				</div>
+				<div
+					className={cn(
+						"min-w-0 truncate text-muted-foreground",
+						density === "compact" ? "text-[12px]" : "text-sm",
+					)}
+					title={bodyText ?? undefined}
+				>
+					{bodyText || (
+						<SummaryPlaceholder
+							status={run.summary_status}
+							runStatus={run.status}
+							muted
+						/>
+					)}
+				</div>
+				<div className="flex min-w-0 flex-wrap items-center gap-1.5 text-xs text-muted-foreground">
+					<span className="inline-flex items-center gap-1">
+						<Clock
+							aria-hidden="true"
+							className="h-[11px] w-[11px]"
+						/>
+						{formatRelativeTime(startedAt)}
+					</span>
+					{run.duration_ms != null ? (
+						<>
+							<span aria-hidden="true">·</span>
+							<span>{formatDuration(run.duration_ms)}</span>
+						</>
+					) : null}
+					<span aria-hidden="true">·</span>
+					<span className="inline-flex items-center gap-1">
+						<Hash
+							aria-hidden="true"
+							className="h-[11px] w-[11px]"
+						/>
+						{formatNumber(run.tokens_used)}
+						<span className="sr-only">tokens</span>
+					</span>
+					{visibleChips.length > 0 ? (
+						<span aria-hidden="true">·</span>
+					) : null}
+					<div className="inline-flex min-w-0 flex-wrap gap-1">
+						{visibleChips.map(([key, value]) => {
+							const isHit =
+								query.length > 0 &&
+								(key.toLowerCase().includes(query) ||
+									value.toLowerCase().includes(query));
+							return (
+								<span
+									key={key}
+									title={`${key}=${value}`}
+									className={cn(
+										"inline-flex items-center gap-1 rounded border px-1.5 py-0.5 text-[11px]",
+										isHit
+											? "border-transparent bg-yellow-500/15 text-yellow-700 dark:text-yellow-300"
+											: "border-border bg-card text-foreground",
+									)}
+								>
+									<span className="text-muted-foreground">
+										{key}
+									</span>
+									<span className="font-mono">{value}</span>
+								</span>
+							);
+						})}
+						{overflow > 0 ? (
+							<span className="inline-flex items-center rounded border border-border bg-card px-1.5 py-0.5 text-[11px]">
+								+{overflow}
+							</span>
+						) : null}
+					</div>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/client/src/components/agents/Timeline.test.tsx
+++ b/client/src/components/agents/Timeline.test.tsx
@@ -1,103 +1,622 @@
-/**
- * Timeline tests — friendly labels per step type, expand-to-detail flow, and
- * empty state. Covers regression risk from the JSON-dump → structured view
- * rebuild.
- */
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { Route, Routes, useLocation } from "react-router-dom";
 
-import { describe, it, expect } from "vitest";
-import { fireEvent } from "@testing-library/react";
-
-import { renderWithProviders, screen } from "@/test-utils";
-import { Timeline } from "./Timeline";
 import type { components } from "@/lib/v1";
+import { renderWithProviders, screen } from "@/test-utils";
 
-type AgentRunStepResponse = components["schemas"]["AgentRunStepResponse"];
+const mockUseAgentRun = vi.hoisted(() => vi.fn());
+
+vi.mock("@/services/agentRuns", () => ({
+	useAgentRun: (runId: string | undefined, options: unknown) =>
+		mockUseAgentRun(runId, options),
+}));
+
+import { AdvancedTimeline, Timeline } from "./Timeline";
+
+type AgentRunStep = components["schemas"]["AgentRunStepResponse"];
+type AgentRunDetail = components["schemas"]["AgentRunDetailResponse"];
+type AgentRunChild = components["schemas"]["AgentRunChildResponse"];
+
+function NavigationStateProbe() {
+	const location = useLocation();
+	return (
+		<pre data-testid="navigation-state">
+			{JSON.stringify(location.state)}
+		</pre>
+	);
+}
 
 function step(
 	type: string,
 	content: Record<string, unknown>,
-	overrides: Partial<AgentRunStepResponse> = {},
-): AgentRunStepResponse {
+	stepNumber: number,
+	overrides: Partial<AgentRunStep> = {},
+): AgentRunStep {
 	return {
-		id: `s-${Math.random().toString(36).slice(2, 8)}`,
+		id: `step-${stepNumber}`,
 		run_id: "00000000-0000-0000-0000-000000000001",
-		step_number: 1,
+		step_number: stepNumber,
 		type,
 		content,
 		duration_ms: null,
-		created_at: "2026-04-24T00:00:00Z",
+		created_at: "2026-07-15T12:00:00Z",
 		...overrides,
 	};
 }
 
-describe("Timeline", () => {
-	it("shows the empty placeholder when there are no steps", () => {
+function childRun(overrides: Partial<AgentRunDetail> = {}): AgentRunDetail {
+	return {
+		id: "child-1",
+		agent_id: "agent-child",
+		agent_name: "Troubleshooting Specialist",
+		trigger_type: "delegation",
+		status: "completed",
+		iterations_used: 2,
+		tokens_used: 1200,
+		asked: "Collect endpoint evidence",
+		did: "Checked the device and found low disk space.",
+		answered: "The device is online with low disk space.",
+		input: {},
+		output: {},
+		summary_status: "completed",
+		metadata: {},
+		created_at: "2026-07-15T12:00:00Z",
+		steps: [
+			step(
+				"tool_call",
+				{ tool_name: "ninja_get_device_details", arguments: {} },
+				1,
+			),
+			step(
+				"tool_result",
+				{
+					tool_name: "ninja_get_device_details",
+					result: { device: "ELIJAH-LT", status: "online" },
+				},
+				2,
+			),
+		],
+		child_run_ids: [],
+		child_runs: [],
+		...overrides,
+	};
+}
+
+function childReference(overrides: Partial<AgentRunChild> = {}): AgentRunChild {
+	return {
+		id: "child-1",
+		agent_id: "agent-child",
+		agent_name: "Troubleshooting Specialist",
+		status: "completed",
+		asked: "Collect endpoint evidence",
+		did: "Checked the device and found low disk space.",
+		answered: "The device is online with low disk space.",
+		duration_ms: 12_000,
+		created_at: "2026-07-15T12:00:00Z",
+		...overrides,
+	};
+}
+
+describe("Timeline activity view", () => {
+	beforeEach(() => {
+		mockUseAgentRun.mockReturnValue({
+			data: undefined,
+			isLoading: false,
+			isError: false,
+		});
+	});
+
+	it("shows a helpful empty state", () => {
 		renderWithProviders(<Timeline steps={[]} />);
-		expect(screen.getByText(/no steps recorded/i)).toBeInTheDocument();
-	});
-
-	it("renders friendly labels by step type, not raw type strings", () => {
-		const steps = [
-			step("tool_call", {
-				tool_name: "send_email",
-				arguments: { to: "u@x.com" },
-			}),
-			step("tool_result", {
-				tool_name: "send_email",
-				result: "queued",
-			}),
-			step("llm_response", {
-				content: "Decision text",
-				tool_calls: [{ name: "send_email" }],
-			}),
-		];
-		renderWithProviders(<Timeline steps={steps} />);
-		expect(screen.getByText(/Called send_email/i)).toBeInTheDocument();
 		expect(
-			screen.getByText(/Result from send_email/i),
-		).toBeInTheDocument();
-		// Label names the called tool directly instead of saying "LLM
-		// decided to call tools" — saves a click of comprehension.
-		expect(
-			screen.getByText(/Decided to call send_email/i),
+			screen.getByText(/no activity to summarize/i),
 		).toBeInTheDocument();
 	});
 
-	it("expands a tool_call row to show pretty-printed args", () => {
+	it("renders one semantic operation for a decision-call-result triplet", () => {
 		const steps = [
-			step("tool_call", {
-				tool_name: "send_email",
-				arguments: { to: "u@x.com", subject: "Hi" },
+			step("llm_request", { messages_count: 2, tools_count: 17 }, 1),
+			step(
+				"llm_response",
+				{ tool_calls: [{ name: "ai_ticketing_get_ticket_details" }] },
+				2,
+			),
+			step(
+				"tool_call",
+				{
+					tool_name: "ai_ticketing_get_ticket_details",
+					arguments: { ticket_id: 428950 },
+				},
+				3,
+			),
+			step(
+				"tool_result",
+				{
+					tool_name: "ai_ticketing_get_ticket_details",
+					result: {
+						ticket_id: 428950,
+						status: "open",
+						matched: true,
+					},
+				},
+				4,
+			),
+		];
+		renderWithProviders(<Timeline steps={steps} />);
+
+		expect(
+			screen.getByText("Looked up ticket details"),
+		).toBeInTheDocument();
+		expect(
+			screen.getByText("Ticket: 428950 · Status: Open · Match found"),
+		).toBeInTheDocument();
+		expect(screen.queryByText(/decided to call/i)).not.toBeInTheDocument();
+		expect(
+			screen.queryByText(/called ai_ticketing/i),
+		).not.toBeInTheDocument();
+		expect(screen.queryByText(/\{"ticket_id"/i)).not.toBeInTheDocument();
+	});
+
+	it("highlights a referenced action and links its workflow execution", () => {
+		const { container } = renderWithProviders(
+			<Timeline
+				steps={[
+					step(
+						"tool_call",
+						{
+							tool_name: "ai_ticketing_get_ticket_details",
+							arguments: { ticket_id: 428950 },
+						},
+						1,
+					),
+					step(
+						"tool_result",
+						{
+							tool_name: "ai_ticketing_get_ticket_details",
+							result: { ticket_id: 428950 },
+							execution_id: "execution-428950",
+						},
+						2,
+					),
+				]}
+				highlightedActivityId="step-1"
+			/>,
+		);
+
+		expect(
+			container.querySelector('[data-activity-id="step-1"]'),
+		).toHaveAttribute("data-highlighted", "true");
+		expect(
+			screen.getByRole("link", { name: /execution/i }),
+		).toHaveAttribute("href", "/history/execution-428950");
+	});
+
+	it("keeps the final answer as a readable activity event", () => {
+		renderWithProviders(
+			<Timeline
+				steps={[
+					step(
+						"llm_response",
+						{ content: "Triage complete.", tool_calls: [] },
+						1,
+					),
+				]}
+			/>,
+		);
+		expect(screen.getByText("Final response")).toBeInTheDocument();
+		expect(screen.getByText("Triage complete.")).toBeInTheDocument();
+	});
+
+	it("loads and expands delegated work inline", async () => {
+		mockUseAgentRun.mockImplementation((runId: string | undefined) => ({
+			data: runId === "child-1" ? childRun() : undefined,
+			isLoading: false,
+			isError: false,
+		}));
+		const { user } = renderWithProviders(
+			<Timeline
+				steps={[
+					step(
+						"tool_call",
+						{
+							tool_name: "delegate_to_troubleshooting_agent",
+							arguments: { task: "Collect endpoint evidence" },
+						},
+						1,
+					),
+					step(
+						"tool_result",
+						{
+							tool_name: "delegate_to_troubleshooting_agent",
+							result: "Evidence collected",
+							child_run_id: "child-1",
+						},
+						2,
+					),
+				]}
+				childRunIds={["child-1"]}
+				childRuns={[childReference()]}
+			/>,
+		);
+
+		expect(
+			screen.getByText("Troubleshooting Specialist"),
+		).toBeInTheDocument();
+		expect(
+			screen.getByText("Collect endpoint evidence"),
+		).toBeInTheDocument();
+		expect(
+			screen.getByLabelText("Delegated run status: Completed"),
+		).toHaveTextContent("Completed");
+		const disclosure = screen.getByRole("button", {
+			name: /show details for troubleshooting specialist/i,
+		});
+		expect(disclosure).toHaveAccessibleDescription("Completed");
+		expect(disclosure).toContainElement(
+			screen.getByText("Troubleshooting Specialist"),
+		);
+		expect(disclosure).toContainElement(
+			screen.getByText("Collect endpoint evidence"),
+		);
+		expect(
+			screen.getByRole("link", {
+				name: /open troubleshooting specialist run/i,
 			}),
-		];
-		renderWithProviders(<Timeline steps={steps} />);
-		const btn = screen.getByRole("button", {
-			name: /toggle details for step 1/i,
+		).toHaveAttribute("href", "/agents/agent-child/runs/child-1");
+		await user.click(screen.getByText("Collect endpoint evidence"));
+		const expandedDisclosure = screen.getByRole("button", {
+			name: /hide details for troubleshooting specialist/i,
 		});
-		expect(btn).toHaveAttribute("aria-expanded", "false");
-		fireEvent.click(btn);
-		expect(btn).toHaveAttribute("aria-expanded", "true");
-		// Args should be visible as JSON in the expanded body via JsonTree —
-		// JsonTree wraps strings in quotes.
-		expect(screen.getByText(/"u@x.com"/i)).toBeInTheDocument();
+		expect(expandedDisclosure).toHaveAttribute("aria-expanded", "true");
+		expect(expandedDisclosure).toHaveAttribute(
+			"aria-controls",
+			expect.stringContaining("details"),
+		);
+		expect(
+			screen.getByText("Checked the device and found low disk space."),
+		).toBeInTheDocument();
+		expect(
+			screen.getByText("Looked up device details"),
+		).toBeInTheDocument();
 	});
 
-	it("does not render an expand affordance for steps with no detail", () => {
-		// tool_call with empty args — nothing to expand to.
+	it("carries the parent run origin when opening delegated work", async () => {
+		const { user } = renderWithProviders(
+			<Routes>
+				<Route
+					path="/"
+					element={
+						<Timeline
+							steps={[]}
+							childRunIds={["child-1"]}
+							childRuns={[childReference()]}
+							childRunOrigin={{
+								href: "/agents/agent-parent/runs/run-parent",
+								label: "Back to Service Desk Triage run",
+							}}
+						/>
+					}
+				/>
+				<Route
+					path="/agents/:agentId/runs/:runId"
+					element={<NavigationStateProbe />}
+				/>
+			</Routes>,
+		);
+
+		await user.click(
+			screen.getByRole("link", {
+				name: /open troubleshooting specialist run/i,
+			}),
+		);
+		expect(screen.getByTestId("navigation-state")).toHaveTextContent(
+			JSON.stringify({
+				agentRunOrigin: {
+					href: "/agents/agent-parent/runs/run-parent",
+					label: "Back to Service Desk Triage run",
+				},
+			}),
+		);
+	});
+
+	it("supports parent-owned delegation state and restores the source row", async () => {
+		mockUseAgentRun.mockImplementation((runId: string | undefined) => ({
+			data: runId === "child-1" ? childRun() : undefined,
+			isLoading: false,
+			isError: false,
+		}));
+		const scrollIntoView = vi.fn();
+		Object.defineProperty(HTMLElement.prototype, "scrollIntoView", {
+			configurable: true,
+			value: scrollIntoView,
+		});
+		const onExpandedChange = vi.fn();
 		const steps = [
-			step("tool_call", { tool_name: "list_workflows", arguments: {} }),
+			step(
+				"tool_call",
+				{
+					tool_name: "delegate_to_troubleshooting_agent",
+					arguments: { task: "Collect endpoint evidence" },
+				},
+				1,
+			),
+			step(
+				"tool_result",
+				{
+					tool_name: "delegate_to_troubleshooting_agent",
+					result: "Evidence collected",
+					child_run_id: "child-1",
+				},
+				2,
+			),
 		];
-		renderWithProviders(<Timeline steps={steps} />);
-		// Button is rendered but disabled (no detail = nothing to toggle).
-		const btn = screen.getByRole("button", {
-			name: /list_workflows/i,
+		const timeline = (expanded: ReadonlySet<string>, restore?: string) => (
+			<Timeline
+				steps={steps}
+				childRunIds={["child-1"]}
+				childRuns={[childReference()]}
+				expandedDelegationIds={expanded}
+				onDelegationExpandedChange={onExpandedChange}
+				restoreActivityId={restore}
+			/>
+		);
+		const { user, rerender } = renderWithProviders(
+			timeline(new Set<string>()),
+		);
+
+		await user.click(
+			screen.getByRole("button", {
+				name: /show details for troubleshooting specialist/i,
+			}),
+		);
+		expect(onExpandedChange).toHaveBeenCalledWith("step-1", true);
+
+		rerender(timeline(new Set(["step-1"]), "step-1"));
+		expect(
+			screen.getByRole("button", {
+				name: /hide details for troubleshooting specialist/i,
+			}),
+		).toHaveAttribute("aria-expanded", "true");
+		expect(
+			screen.getByText("Checked the device and found low disk space."),
+		).toBeInTheDocument();
+		expect(scrollIntoView).toHaveBeenCalledWith({
+			behavior: "auto",
+			block: "center",
 		});
-		expect(btn).toBeDisabled();
 	});
 
-	it("falls back to the raw type label for unknown step types", () => {
-		const steps = [step("custom_kind", { foo: "bar" })];
-		renderWithProviders(<Timeline steps={steps} />);
+	it("keeps delegated status copy accurate and resilient to long content", () => {
+		const agentName =
+			"EndpointTroubleshootingSpecialistWithAnExtremelyLongUnbrokenName";
+		renderWithProviders(
+			<Timeline
+				steps={[
+					step(
+						"tool_call",
+						{
+							tool_name: "delegate_to_troubleshooting_agent",
+							arguments: { task: "Collect endpoint evidence" },
+						},
+						1,
+					),
+					step(
+						"tool_result",
+						{
+							tool_name: "delegate_to_troubleshooting_agent",
+							result: "Cancellation requested",
+							child_run_id: "child-1",
+						},
+						2,
+					),
+				]}
+				childRunIds={["child-1"]}
+				childRuns={[
+					childReference({
+						agent_name: agentName,
+						status: "cancelling",
+					}),
+				]}
+			/>,
+		);
+
+		expect(screen.getByText(agentName)).toHaveClass(
+			"min-w-0",
+			"break-words",
+		);
+		const status = screen.getByLabelText(
+			"Delegated run status: Cancelling",
+		);
+		expect(status).toHaveTextContent("Cancelling");
+		expect(status).toHaveClass("shrink-0", "whitespace-nowrap");
+		expect(
+			screen.getByRole("button", {
+				name: new RegExp(`show details for ${agentName}`, "i"),
+			}),
+		).toHaveAccessibleDescription("Cancelling");
+	});
+
+	it("lazily resolves an unlinked historical child run", async () => {
+		mockUseAgentRun.mockImplementation((runId: string | undefined) => ({
+			data: runId === "child-1" ? childRun() : undefined,
+			isLoading: false,
+			isError: false,
+		}));
+		const { user } = renderWithProviders(
+			<Timeline
+				steps={[]}
+				childRunIds={["child-1"]}
+				childRuns={[childReference()]}
+			/>,
+		);
+		expect(
+			screen.getByText("Troubleshooting Specialist"),
+		).toBeInTheDocument();
+		expect(mockUseAgentRun).toHaveBeenCalledWith(
+			undefined,
+			expect.any(Object),
+		);
+		await user.click(
+			screen.getByRole("button", {
+				name: /^show details for troubleshooting specialist$/i,
+			}),
+		);
+		expect(mockUseAgentRun).toHaveBeenCalledWith(
+			"child-1",
+			expect.any(Object),
+		);
+	});
+
+	it("refreshes an expanded delegation only while the child is active", async () => {
+		mockUseAgentRun.mockImplementation((runId: string | undefined) => ({
+			data:
+				runId === "child-1"
+					? childRun({ status: "running" })
+					: undefined,
+			isLoading: false,
+			isError: false,
+		}));
+		const { user } = renderWithProviders(
+			<Timeline
+				steps={[]}
+				childRunIds={["child-1"]}
+				childRuns={[childReference({ status: "running" })]}
+			/>,
+		);
+		await user.click(
+			screen.getByRole("button", {
+				name: /^show details for troubleshooting specialist$/i,
+			}),
+		);
+
+		const options = mockUseAgentRun.mock.calls.at(-1)?.[1] as {
+			refetchInterval: (query: {
+				state: { data: AgentRunDetail | undefined };
+			}) => number | false;
+		};
+		expect(
+			options.refetchInterval({
+				state: { data: childRun({ status: "running" }) },
+			}),
+		).toBe(2_000);
+		expect(
+			options.refetchInterval({
+				state: { data: childRun({ status: "completed" }) },
+			}),
+		).toBe(false);
+	});
+
+	it("adds payload details to the same grouped actions in Advanced", async () => {
+		const steps = [
+			step(
+				"llm_response",
+				{ tool_calls: [{ name: "ai_ticketing_get_ticket_details" }] },
+				1,
+			),
+			step(
+				"tool_call",
+				{
+					tool_name: "ai_ticketing_get_ticket_details",
+					arguments: { ticket_id: 428950 },
+				},
+				2,
+			),
+			step(
+				"tool_result",
+				{
+					tool_name: "ai_ticketing_get_ticket_details",
+					result: { ticket_id: 428950, status: "open" },
+				},
+				3,
+			),
+		];
+		const { user } = renderWithProviders(
+			<Timeline steps={steps} showTechnicalDetails />,
+		);
+
+		expect(
+			screen.getByText("Looked up ticket details"),
+		).toBeInTheDocument();
+		expect(screen.queryByText(/decided to call/i)).not.toBeInTheDocument();
+		expect(
+			screen.queryByText(/called ai_ticketing/i),
+		).not.toBeInTheDocument();
+
+		await user.click(screen.getByText("Details", { exact: true }));
+		expect(
+			screen.getByText("ai_ticketing_get_ticket_details", {
+				exact: true,
+			}),
+		).toBeInTheDocument();
+		expect(screen.getAllByText("ticket_id:")).toHaveLength(2);
+		expect(screen.getByText("Steps 2–3")).toBeInTheDocument();
+	});
+});
+
+describe("AdvancedTimeline", () => {
+	it("keeps exact executor labels and shows arguments in the variable tree", async () => {
+		const { user } = renderWithProviders(
+			<AdvancedTimeline
+				steps={[
+					step(
+						"tool_call",
+						{
+							tool_name: "send_email",
+							arguments: { to: "u@x.com", subject: "Hi" },
+						},
+						1,
+					),
+				]}
+			/>,
+		);
+		expect(screen.getByText(/called send_email/i)).toBeInTheDocument();
+		await user.click(
+			screen.getByRole("button", { name: /toggle details for step 1/i }),
+		);
+		expect(screen.getByText("to:")).toBeInTheDocument();
+		expect(screen.getByText('"u@x.com"')).toBeInTheDocument();
+	});
+
+	it("expands structured results and errors without coercing them to text", async () => {
+		const { user } = renderWithProviders(
+			<AdvancedTimeline
+				steps={[
+					step(
+						"tool_result",
+						{
+							tool_name: "get_ticket",
+							result: { ticket_id: 428950, status: "open" },
+						},
+						1,
+					),
+					step(
+						"tool_error",
+						{
+							tool_name: "submit_triage",
+							error: { code: "rate_limited", retry_after: 30 },
+						},
+						2,
+					),
+				]}
+			/>,
+		);
+
+		expect(screen.queryByText(/\{"ticket_id"/)).not.toBeInTheDocument();
+		await user.click(
+			screen.getByRole("button", { name: /toggle details for step 1/i }),
+		);
+		expect(screen.getByText("ticket_id:")).toBeInTheDocument();
+		await user.click(
+			screen.getByRole("button", { name: /toggle details for step 2/i }),
+		);
+		expect(screen.getByText('"rate_limited"')).toBeInTheDocument();
+	});
+
+	it("retains unknown executor events only in Advanced", () => {
+		const custom = step("custom_kind", { foo: "bar" }, 1);
+		const { rerender } = renderWithProviders(<Timeline steps={[custom]} />);
+		expect(screen.queryByText("custom_kind")).not.toBeInTheDocument();
+		rerender(<AdvancedTimeline steps={[custom]} />);
 		expect(screen.getByText("custom_kind")).toBeInTheDocument();
 	});
 });

--- a/client/src/components/agents/Timeline.tsx
+++ b/client/src/components/agents/Timeline.tsx
@@ -1,38 +1,749 @@
 /**
- * Timeline — per-step structured view of an agent run.
+ * Timeline has two deliberately different projections of a run:
  *
- * Replaces the v2 "Raw step timeline" JSON dump. Each step renders an icon
- * by type, a friendly one-line label, and the duration on the right. Click
- * a row to expand its details (args/result for tool steps, message content
- * for LLM steps, raw JSON for everything else as the deepest layer).
- *
- * Brings back the v1 chronological-strip aesthetic so the train of thought
- * is scannable; the JSON is still there but it's one click deeper instead
- * of being the headline.
+ * - Timeline: a user-facing activity story. It groups the executor's
+ *   decision/call/result records into one operation and nests child runs.
+ * - AdvancedTimeline: the exact step sequence with raw payload disclosure.
  */
 
-import { useState } from "react";
+import { useEffect, useRef, useState, type ReactNode } from "react";
+import { Link } from "react-router-dom";
 import {
 	AlertCircle,
+	ArrowUpRight,
 	Bot,
+	Check,
 	ChevronRight,
 	CircleDot,
+	Code2,
 	Cpu,
+	GitBranch,
+	Loader2,
 	MessageSquare,
+	MessageSquareText,
+	TriangleAlert,
 	Wrench,
 } from "lucide-react";
 
 import { cn } from "@/lib/utils";
 import { formatDuration, formatNumber } from "@/lib/utils";
 import type { components } from "@/lib/v1";
+import {
+	createAgentRunNavigationState,
+	type AgentRunNavigationOrigin,
+} from "@/lib/agent-run-navigation";
+import { useAgentRun } from "@/services/agentRuns";
+import { VariablesTreeView } from "@/components/ui/variables-tree-view";
 
-import { JsonTree, isEmptyJson } from "./JsonTree";
+import { DidNarrative } from "./DidNarrative";
+import { isEmptyJson } from "./JsonTree";
+import {
+	activityDomId,
+	buildActivityReferenceIndex,
+	buildRunActivity,
+	type RunActivityItem,
+} from "./run-activity";
 
 type AgentRunStepResponse = components["schemas"]["AgentRunStepResponse"];
+type AgentRunDetailResponse = components["schemas"]["AgentRunDetailResponse"];
+type AgentRunChildResponse = components["schemas"]["AgentRunChildResponse"];
+
+const ACTIVE_RUN_STATUSES = new Set(["queued", "running", "cancelling"]);
+
+export interface TimelineProps {
+	steps: AgentRunStepResponse[] | null | undefined;
+	childRunIds?: string[] | null;
+	childRuns?: AgentRunChildResponse[] | null;
+	runStatus?: string | null;
+	showTechnicalDetails?: boolean;
+	highlightedActivityId?: string | null;
+	expandedDelegationIds?: ReadonlySet<string>;
+	onDelegationExpandedChange?: (
+		activityId: string,
+		expanded: boolean,
+	) => void;
+	restoreActivityId?: string | null;
+	onOpenChildRun?: (activityId: string) => void;
+	childRunOrigin?: AgentRunNavigationOrigin;
+	/** Used only to keep pathological/cyclic history from nesting forever. */
+	depth?: number;
+}
+
+export function Timeline({
+	steps,
+	childRunIds = [],
+	childRuns = [],
+	runStatus,
+	showTechnicalDetails = false,
+	highlightedActivityId = null,
+	expandedDelegationIds,
+	onDelegationExpandedChange,
+	restoreActivityId = null,
+	onOpenChildRun,
+	childRunOrigin,
+	depth = 0,
+}: TimelineProps) {
+	const activity = buildRunActivity(steps, childRunIds, childRuns);
+	if (!activity.length) {
+		return (
+			<div className="rounded-lg border border-dashed px-4 py-5 text-center">
+				<p className="text-sm font-medium">No activity to summarize</p>
+				<p className="mt-1 text-xs text-muted-foreground">
+					Any recorded executor steps are still available in Advanced.
+				</p>
+			</div>
+		);
+	}
+
+	return (
+		<ol
+			className="relative grid gap-3 before:absolute before:bottom-5 before:left-[15px] before:top-5 before:w-px before:bg-border"
+			aria-label="Run activity"
+		>
+			{activity.map((item) => (
+				<ActivityRow
+					key={item.id}
+					item={item}
+					depth={depth}
+					runStatus={runStatus}
+					showTechnicalDetails={showTechnicalDetails}
+					highlighted={item.id === highlightedActivityId}
+					expandedDelegationIds={expandedDelegationIds}
+					onDelegationExpandedChange={onDelegationExpandedChange}
+					restoreActivityId={restoreActivityId}
+					onOpenChildRun={onOpenChildRun}
+					childRunOrigin={childRunOrigin}
+				/>
+			))}
+		</ol>
+	);
+}
+
+function ActivityRow({
+	item,
+	depth,
+	runStatus,
+	showTechnicalDetails,
+	highlighted,
+	expandedDelegationIds,
+	onDelegationExpandedChange,
+	restoreActivityId,
+	onOpenChildRun,
+	childRunOrigin,
+}: {
+	item: RunActivityItem;
+	depth: number;
+	runStatus?: string | null;
+	showTechnicalDetails: boolean;
+	highlighted: boolean;
+	expandedDelegationIds?: ReadonlySet<string>;
+	onDelegationExpandedChange?: (
+		activityId: string,
+		expanded: boolean,
+	) => void;
+	restoreActivityId?: string | null;
+	onOpenChildRun?: (activityId: string) => void;
+	childRunOrigin?: AgentRunNavigationOrigin;
+}) {
+	if (item.kind === "delegation") {
+		return (
+			<DelegationRow
+				item={item}
+				depth={depth}
+				showTechnicalDetails={showTechnicalDetails}
+				highlighted={highlighted}
+				expandedDelegationIds={expandedDelegationIds}
+				onDelegationExpandedChange={onDelegationExpandedChange}
+				restoreActivityId={restoreActivityId}
+				onOpenChildRun={onOpenChildRun}
+				childRunOrigin={childRunOrigin}
+			/>
+		);
+	}
+
+	const isError = item.isError || item.kind === "error";
+	const isWarning = item.kind === "warning";
+	const isCancelled = item.kind === "cancelled";
+	const isResponse = item.kind === "response";
+	const pending = item.kind === "action" && !item.resultStep;
+	const runInProgress = ["queued", "running", "cancelling"].includes(
+		runStatus ?? "",
+	);
+	const Icon = isError
+		? AlertCircle
+		: isWarning || isCancelled
+			? TriangleAlert
+			: isResponse
+				? MessageSquareText
+				: pending
+					? CircleDot
+					: Check;
+	const tone = isError
+		? "border-rose-500/20 bg-rose-500/[0.06]"
+		: isWarning || isCancelled
+			? "border-amber-500/20 bg-amber-500/[0.06]"
+			: "border-border/70 bg-card";
+	const iconTone = isError
+		? "border-rose-500/25 bg-rose-500/15 text-rose-600 dark:text-rose-300"
+		: isWarning || isCancelled
+			? "border-amber-500/25 bg-amber-500/15 text-amber-600 dark:text-amber-300"
+			: isResponse
+				? "border-violet-500/25 bg-violet-500/15 text-violet-600 dark:text-violet-300"
+				: pending
+					? runInProgress
+						? "border-blue-500/25 bg-blue-500/15 text-blue-600 dark:text-blue-300"
+						: "border-border bg-muted text-muted-foreground"
+					: "border-emerald-500/25 bg-emerald-500/15 text-emerald-600 dark:text-emerald-300";
+
+	return (
+		<li
+			id={activityDomId(item.id)}
+			tabIndex={-1}
+			className="relative scroll-mt-24 rounded-xl pl-9 outline-none"
+			data-activity-id={item.id}
+			data-activity-kind={item.kind}
+			data-highlighted={highlighted ? "true" : "false"}
+		>
+			<div
+				className={cn(
+					"absolute left-0 top-4 z-10 grid h-[31px] w-[31px] place-items-center rounded-full border shadow-sm",
+					iconTone,
+				)}
+			>
+				<Icon className="h-3.5 w-3.5" />
+			</div>
+			<div
+				className={cn(
+					"rounded-xl border px-4 py-3 shadow-sm transition-[border-color,background-color,box-shadow] duration-150 motion-reduce:transition-none",
+					tone,
+					highlighted &&
+						"border-blue-500/50 ring-2 ring-blue-500/45 ring-offset-2 ring-offset-background shadow-[0_0_24px_-4px] shadow-blue-500/40",
+				)}
+			>
+				<div className="flex items-start gap-3">
+					<div className="min-w-0 flex-1">
+						<div className="text-sm font-medium leading-5">
+							{item.title}
+						</div>
+						{item.description ? (
+							<p className="mt-1 text-[13px] leading-5 text-muted-foreground">
+								{item.description}
+							</p>
+						) : pending ? (
+							<p className="mt-1 text-xs text-muted-foreground">
+								{runInProgress
+									? "In progress"
+									: "No outcome recorded"}
+							</p>
+						) : null}
+					</div>
+					<div className="flex shrink-0 items-center gap-2 pt-0.5">
+						{item.durationMs != null ? (
+							<span className="text-[11px] tabular-nums text-muted-foreground">
+								{formatDuration(item.durationMs)}
+							</span>
+						) : null}
+						{item.executionId ? (
+							<Link
+								to={`/history/${item.executionId}`}
+								className="inline-flex min-h-11 items-center gap-1 rounded-md px-2 text-[11px] font-medium text-primary transition-colors hover:bg-primary/10 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring sm:min-h-8"
+							>
+								Execution
+								<ArrowUpRight className="h-3 w-3" />
+							</Link>
+						) : null}
+					</div>
+				</div>
+				{showTechnicalDetails ? (
+					<ActivityTechnicalDetails item={item} />
+				) : null}
+			</div>
+		</li>
+	);
+}
+
+function ActivityTechnicalDetails({ item }: { item: RunActivityItem }) {
+	const callContent = (item.callStep?.content ?? {}) as Record<
+		string,
+		unknown
+	>;
+	const resultContent = (item.resultStep?.content ?? {}) as Record<
+		string,
+		unknown
+	>;
+	const inputDetail = renderDetail(callContent.arguments);
+	const resultValue =
+		item.resultStep?.type === "llm_response"
+			? resultContent.content
+			: item.isError
+				? (resultContent.error ?? resultContent.result ?? resultContent)
+				: (resultContent.result ??
+					(item.resultStep && !item.toolName ? resultContent : null));
+	const resultDetail = renderDetail(resultValue);
+	const stepNumbers = [
+		item.callStep?.step_number,
+		item.resultStep?.step_number,
+	].filter((value): value is number => value != null);
+	const tokens = [item.callStep, item.resultStep].reduce(
+		(total, step) => total + (step?.tokens_used ?? 0),
+		0,
+	);
+	const hasMetadata = !!item.toolName || stepNumbers.length > 0 || tokens > 0;
+
+	if (!hasMetadata && !inputDetail && !resultDetail) return null;
+
+	return (
+		<details className="group mt-3 border-t border-border/70 pt-2.5">
+			<summary className="flex min-h-6 cursor-pointer list-none items-center gap-1.5 text-xs font-medium text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring [&::-webkit-details-marker]:hidden">
+				<ChevronRight className="h-3 w-3 transition-transform group-open:rotate-90" />
+				<Code2 className="h-3 w-3" />
+				Details
+			</summary>
+			<div className="mt-2.5 grid gap-3 rounded-lg bg-background/65 p-3 ring-1 ring-foreground/5">
+				{hasMetadata ? (
+					<dl className="grid gap-x-4 gap-y-1.5 text-[11px] sm:grid-cols-[auto_1fr]">
+						{item.toolName ? (
+							<>
+								<dt className="text-muted-foreground">
+									Internal action
+								</dt>
+								<dd className="min-w-0 break-all font-mono">
+									{item.toolName}
+								</dd>
+							</>
+						) : null}
+						{stepNumbers.length ? (
+							<>
+								<dt className="text-muted-foreground">Trace</dt>
+								<dd>
+									{stepNumbers.length === 1 ||
+									stepNumbers[0] === stepNumbers.at(-1)
+										? `Step ${stepNumbers[0]}`
+										: `Steps ${stepNumbers[0]}–${stepNumbers.at(-1)}`}
+								</dd>
+							</>
+						) : null}
+						{tokens > 0 ? (
+							<>
+								<dt className="text-muted-foreground">
+									Tokens
+								</dt>
+								<dd>{formatNumber(tokens)}</dd>
+							</>
+						) : null}
+					</dl>
+				) : null}
+				{inputDetail ? (
+					<TechnicalDetailSection
+						label="Input"
+						detail={inputDetail}
+					/>
+				) : null}
+				{resultDetail ? (
+					<TechnicalDetailSection
+						label={item.isError ? "Error" : "Result"}
+						detail={resultDetail}
+					/>
+				) : null}
+			</div>
+		</details>
+	);
+}
+
+function TechnicalDetailSection({
+	label,
+	detail,
+}: {
+	label: string;
+	detail: DetailRender;
+}) {
+	return (
+		<section>
+			<div className="mb-1.5 text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
+				{label}
+			</div>
+			<DetailBlock detail={detail} />
+		</section>
+	);
+}
+
+function DelegationRow({
+	item,
+	depth,
+	showTechnicalDetails,
+	highlighted,
+	expandedDelegationIds,
+	onDelegationExpandedChange,
+	restoreActivityId,
+	onOpenChildRun,
+	childRunOrigin,
+}: {
+	item: RunActivityItem;
+	depth: number;
+	showTechnicalDetails: boolean;
+	highlighted: boolean;
+	expandedDelegationIds?: ReadonlySet<string>;
+	onDelegationExpandedChange?: (
+		activityId: string,
+		expanded: boolean,
+	) => void;
+	restoreActivityId?: string | null;
+	onOpenChildRun?: (activityId: string) => void;
+	childRunOrigin?: AgentRunNavigationOrigin;
+}) {
+	const [localOpen, setLocalOpen] = useState(false);
+	const rowRef = useRef<HTMLLIElement>(null);
+	const open =
+		expandedDelegationIds !== undefined
+			? expandedDelegationIds.has(item.id)
+			: localOpen;
+
+	useEffect(() => {
+		if (restoreActivityId !== item.id) return;
+		rowRef.current?.scrollIntoView({
+			behavior: "auto",
+			block: "center",
+		});
+	}, [item.id, restoreActivityId]);
+
+	function toggleOpen() {
+		const nextOpen = !open;
+		if (onDelegationExpandedChange) {
+			onDelegationExpandedChange(item.id, nextOpen);
+			return;
+		}
+		setLocalOpen(nextOpen);
+	}
+
+	const {
+		data: rawChild,
+		isLoading,
+		isError,
+	} = useAgentRun(open ? (item.childRunId ?? undefined) : undefined, {
+		refetchInterval: (query) =>
+			ACTIVE_RUN_STATUSES.has(query.state.data?.status ?? "")
+				? 2_000
+				: false,
+	});
+	const child = rawChild as unknown as AgentRunDetailResponse | undefined;
+	const agentName = child?.agent_name ?? item.agentName;
+	const childAgentId = child?.agent_id ?? item.childAgentId;
+	const title = agentName ?? "Delegated agent";
+	const expandable = !!item.childRunId;
+	const childStatus = child?.status ?? item.childStatus;
+	const childFailed = childStatus ? isFailedRunStatus(childStatus) : false;
+	const delegationFailed = item.isError || childFailed;
+	const delegationStatus = childStatus ?? (item.isError ? "failed" : null);
+	const delegationStatusId = delegationStatus
+		? `${activityDomId(item.id)}-status`
+		: undefined;
+	const detailsId = `${activityDomId(item.id)}-details`;
+	const childActivity = child
+		? buildRunActivity(child.steps, child.child_run_ids, child.child_runs)
+		: [];
+	const childActivityReferences = buildActivityReferenceIndex(childActivity);
+	const rowContent = (
+		<>
+			<div className="min-w-0 flex-1">
+				<div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+					<span className="min-w-0 break-words text-sm font-medium leading-5">
+						{title}
+					</span>
+					<span
+						className={cn(
+							"shrink-0 whitespace-nowrap rounded-full px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide",
+							delegationFailed
+								? "bg-rose-500/10 text-rose-700 dark:text-rose-300"
+								: "bg-violet-500/10 text-violet-700 dark:text-violet-300",
+						)}
+					>
+						Agent
+					</span>
+					{delegationStatus ? (
+						<DelegationStatusBadge
+							id={delegationStatusId}
+							status={delegationStatus}
+						/>
+					) : null}
+				</div>
+				{item.task ? (
+					<p className="mt-1 text-[13px] leading-5 text-muted-foreground">
+						{item.task}
+					</p>
+				) : item.description ? (
+					<p className="mt-1 text-[13px] leading-5 text-muted-foreground">
+						{item.description}
+					</p>
+				) : null}
+			</div>
+			{!delegationStatus && item.durationMs != null ? (
+				<div className="shrink-0 pt-0.5 text-[11px] text-muted-foreground">
+					<span>{formatDuration(item.durationMs)}</span>
+				</div>
+			) : null}
+		</>
+	);
+
+	return (
+		<li
+			ref={rowRef}
+			id={activityDomId(item.id)}
+			tabIndex={-1}
+			className="relative scroll-mt-24 rounded-xl pl-9 outline-none"
+			data-activity-id={item.id}
+			data-activity-kind="delegation"
+			data-highlighted={highlighted ? "true" : "false"}
+		>
+			<div
+				className={cn(
+					"absolute left-0 top-4 z-10 grid h-[31px] w-[31px] place-items-center rounded-full border shadow-sm",
+					delegationFailed
+						? "border-rose-500/25 bg-rose-500/15 text-rose-600 dark:text-rose-300"
+						: "border-violet-500/25 bg-violet-500/15 text-violet-600 dark:text-violet-300",
+				)}
+			>
+				<GitBranch className="h-3.5 w-3.5" />
+			</div>
+			<div
+				className={cn(
+					"overflow-hidden rounded-xl border shadow-sm transition-[border-color,background-color,box-shadow] duration-150 motion-reduce:transition-none",
+					delegationFailed
+						? "border-rose-500/20 bg-rose-500/[0.055]"
+						: "border-violet-500/20 bg-violet-500/[0.055]",
+					highlighted &&
+						"border-violet-500/55 ring-2 ring-violet-500/45 ring-offset-2 ring-offset-background shadow-[0_0_24px_-4px] shadow-violet-500/40",
+				)}
+			>
+				<div className="flex flex-col md:flex-row md:items-stretch">
+					{expandable ? (
+						<button
+							type="button"
+							onClick={toggleOpen}
+							aria-expanded={open}
+							aria-controls={detailsId}
+							aria-label={`${open ? "Hide" : "Show"} details for ${title}`}
+							aria-describedby={delegationStatusId}
+							className={cn(
+								"group flex min-h-11 min-w-0 flex-1 cursor-pointer items-start gap-3 px-4 py-3 text-left transition-colors hover:bg-violet-500/[0.07] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring",
+								open && "bg-violet-500/[0.045]",
+							)}
+						>
+							{rowContent}
+							{isLoading && open ? (
+								<Loader2 className="h-4 w-4 shrink-0 self-center animate-spin text-violet-600 motion-reduce:animate-none dark:text-violet-300" />
+							) : (
+								<ChevronRight
+									className={cn(
+										"h-4 w-4 shrink-0 self-center text-muted-foreground transition-transform group-hover:text-foreground motion-reduce:transition-none",
+										open && "rotate-90",
+									)}
+								/>
+							)}
+						</button>
+					) : (
+						<div className="flex min-w-0 flex-1 items-start gap-3 px-4 py-3 text-left">
+							{rowContent}
+						</div>
+					)}
+					{childAgentId && item.childRunId ? (
+						<div className="flex shrink-0 items-center justify-end border-t border-violet-500/15 p-2 md:border-l md:border-t-0">
+							<Link
+								to={`/agents/${childAgentId}/runs/${item.childRunId}`}
+								state={
+									childRunOrigin
+										? createAgentRunNavigationState(
+												childRunOrigin,
+											)
+										: undefined
+								}
+								onClick={() => onOpenChildRun?.(item.id)}
+								aria-label={`Open ${title} run`}
+								className="inline-flex min-h-11 items-center gap-1 rounded-md px-3 text-xs font-medium text-primary transition-colors hover:bg-violet-500/10 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring md:min-h-8"
+							>
+								<span>Open run</span>
+								<ArrowUpRight className="h-3.5 w-3.5" />
+							</Link>
+						</div>
+					) : null}
+				</div>
+
+				{open ? (
+					<div
+						id={detailsId}
+						className="border-t border-violet-500/15 bg-background/45 px-4 py-4"
+					>
+						{isLoading ? (
+							<div className="flex items-center gap-2 py-3 text-xs text-muted-foreground">
+								<Loader2 className="h-3.5 w-3.5 animate-spin" />
+								Loading delegated work…
+							</div>
+						) : isError || !child ? (
+							<p className="py-2 text-xs text-rose-600 dark:text-rose-300">
+								Delegated run details are not available.
+							</p>
+						) : (
+							<div className="grid gap-4">
+								<div className="grid gap-2 sm:grid-cols-2">
+									<DelegationSummary label="Task">
+										{child.asked ??
+											item.task ??
+											"No task summary recorded."}
+									</DelegationSummary>
+									<DelegationSummary label="Outcome">
+										<DidNarrative
+											text={child.did ?? child.answered}
+											activityReferences={
+												childActivityReferences
+											}
+											compact
+											fallback={
+												<>
+													No outcome summary recorded.
+												</>
+											}
+										/>
+									</DelegationSummary>
+								</div>
+
+								{depth < 3 &&
+								((child.steps?.length ?? 0) > 0 ||
+									(child.child_run_ids?.length ?? 0) > 0) ? (
+									<div className="rounded-lg border bg-background/65 p-3">
+										<div className="mb-3 text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
+											Activity
+										</div>
+										<Timeline
+											steps={child.steps}
+											childRunIds={child.child_run_ids}
+											childRuns={child.child_runs}
+											runStatus={child.status}
+											showTechnicalDetails={
+												showTechnicalDetails
+											}
+											expandedDelegationIds={
+												expandedDelegationIds
+											}
+											onDelegationExpandedChange={
+												onDelegationExpandedChange
+											}
+											restoreActivityId={
+												restoreActivityId
+											}
+											onOpenChildRun={onOpenChildRun}
+											childRunOrigin={childRunOrigin}
+											depth={depth + 1}
+										/>
+									</div>
+								) : null}
+							</div>
+						)}
+					</div>
+				) : null}
+			</div>
+		</li>
+	);
+}
+
+function DelegationStatusBadge({
+	id,
+	status,
+}: {
+	id: string | undefined;
+	status: string;
+}) {
+	const label = runStatusLabel(status);
+	const failed = isFailedRunStatus(status);
+	const active = ACTIVE_RUN_STATUSES.has(status);
+	const completed = status === "completed";
+	const StatusIcon = failed
+		? AlertCircle
+		: status === "running" || status === "cancelling"
+			? Loader2
+			: completed
+				? Check
+				: CircleDot;
+
+	return (
+		<span
+			id={id}
+			aria-label={`Delegated run status: ${label}`}
+			className={cn(
+				"inline-flex shrink-0 items-center gap-1 whitespace-nowrap rounded-full px-2 py-0.5 text-[10px] font-medium",
+				failed
+					? "bg-rose-500/10 text-rose-700 dark:text-rose-300"
+					: active
+						? "bg-blue-500/10 text-blue-700 dark:text-blue-300"
+						: completed
+							? "bg-emerald-500/10 text-emerald-700 dark:text-emerald-300"
+							: "bg-muted text-muted-foreground",
+			)}
+		>
+			<StatusIcon
+				aria-hidden="true"
+				className={cn(
+					"h-2.5 w-2.5",
+					(status === "running" || status === "cancelling") &&
+						"animate-spin motion-reduce:animate-none",
+				)}
+			/>
+			{label}
+		</span>
+	);
+}
+
+function isFailedRunStatus(status: string): boolean {
+	return [
+		"failed",
+		"budget_exceeded",
+		"cancelled",
+		"timeout",
+		"timed_out",
+	].includes(status);
+}
+
+function runStatusLabel(status: string): string {
+	switch (status) {
+		case "queued":
+			return "Queued";
+		case "running":
+			return "Running";
+		case "cancelling":
+			return "Cancelling";
+		case "cancelled":
+			return "Cancelled";
+		case "failed":
+			return "Failed";
+		case "budget_exceeded":
+			return "Budget exceeded";
+		case "timeout":
+		case "timed_out":
+			return "Timed out";
+		case "completed":
+			return "Completed";
+		default:
+			return status.replace(/_/g, " ");
+	}
+}
+
+function DelegationSummary({
+	label,
+	children,
+}: {
+	label: string;
+	children: ReactNode;
+}) {
+	return (
+		<div className="rounded-lg bg-background/70 px-3 py-2.5 ring-1 ring-foreground/5">
+			<div className="mb-1 text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
+				{label}
+			</div>
+			<div className="text-xs leading-5">{children}</div>
+		</div>
+	);
+}
 
 type DetailRender =
-	| { kind: "json"; value: unknown }
-	| { kind: "text"; value: string };
+	{ kind: "json"; value: unknown } | { kind: "text"; value: string };
 
 interface StepViewModel {
 	icon: typeof Wrench;
@@ -64,29 +775,26 @@ function buildViewModel(step: AgentRunStepResponse): StepViewModel {
 		}
 		case "tool_result": {
 			const name = (c.tool_name as string) || "tool";
-			const result = (c.result as string | undefined) ?? "";
+			const result = c.result;
 			return {
 				icon: CircleDot,
-				iconClass: "bg-emerald-500/15 text-emerald-600 dark:text-emerald-400",
+				iconClass:
+					"bg-emerald-500/15 text-emerald-600 dark:text-emerald-400",
 				label: `Result from ${name}`,
-				summary: result ? truncate(result, 100) : null,
-				primaryDetail: result
-					? { kind: "text", value: result }
-					: null,
+				summary: inlineTextPreview(result, 100),
+				primaryDetail: renderDetail(result),
 				secondaryDetail: null,
 			};
 		}
 		case "tool_error": {
 			const name = (c.tool_name as string) || "tool";
-			const result = (c.result as string | undefined) ?? "";
+			const error = c.error ?? c.result;
 			return {
 				icon: AlertCircle,
 				iconClass: "bg-rose-500/15 text-rose-600 dark:text-rose-400",
 				label: `Error from ${name}`,
-				summary: result ? truncate(result, 100) : null,
-				primaryDetail: result
-					? { kind: "text", value: result }
-					: null,
+				summary: inlineTextPreview(error, 100),
+				primaryDetail: renderDetail(error),
 				secondaryDetail: null,
 			};
 		}
@@ -109,9 +817,12 @@ function buildViewModel(step: AgentRunStepResponse): StepViewModel {
 		}
 		case "llm_response": {
 			const text = (c.content as string | undefined) ?? "";
-			const toolCalls = (c.tool_calls as Array<{
-				name?: string;
-			}> | undefined) ?? [];
+			const toolCalls =
+				(c.tool_calls as
+					| Array<{
+							name?: string;
+					  }>
+					| undefined) ?? [];
 			const callNames = toolCalls
 				.map((tc) => tc.name)
 				.filter(Boolean) as string[];
@@ -126,19 +837,14 @@ function buildViewModel(step: AgentRunStepResponse): StepViewModel {
 						: "LLM response";
 			return {
 				icon: Bot,
-				iconClass: "bg-violet-500/15 text-violet-600 dark:text-violet-400",
+				iconClass:
+					"bg-violet-500/15 text-violet-600 dark:text-violet-400",
 				label,
 				// If we put the names in the label, no summary needed; show the
 				// reasoning text as summary when it's the standalone case.
 				summary:
-					callNames.length > 0
-						? null
-						: text
-							? truncate(text, 120)
-							: null,
-				primaryDetail: text
-					? { kind: "text", value: text }
-					: null,
+					callNames.length > 0 ? null : inlineTextPreview(text, 120),
+				primaryDetail: text ? { kind: "text", value: text } : null,
 				secondaryDetail:
 					callNames.length > 0
 						? {
@@ -164,7 +870,7 @@ function buildViewModel(step: AgentRunStepResponse): StepViewModel {
 						: type === "budget_warning"
 							? "Budget warning"
 							: "Error",
-				summary: stringifyMaybeJson(c) ?? null,
+				summary: errorSummary(c),
 				primaryDetail: { kind: "json", value: c },
 				secondaryDetail: null,
 			};
@@ -174,7 +880,7 @@ function buildViewModel(step: AgentRunStepResponse): StepViewModel {
 				icon: MessageSquare,
 				iconClass: "bg-muted text-muted-foreground",
 				label: type,
-				summary: stringifyMaybeJson(c) ?? null,
+				summary: null,
 				primaryDetail: { kind: "json", value: c },
 				secondaryDetail: null,
 			};
@@ -182,15 +888,26 @@ function buildViewModel(step: AgentRunStepResponse): StepViewModel {
 	}
 }
 
-function stringifyMaybeJson(v: unknown): string | null {
-	if (v === null || v === undefined) return null;
-	if (typeof v === "string") return v;
-	try {
-		const s = JSON.stringify(v);
-		return s === "{}" ? null : s;
-	} catch {
-		return String(v);
+function renderDetail(value: unknown): DetailRender | null {
+	if (value === null || value === undefined || value === "") return null;
+	return typeof value === "string"
+		? { kind: "text", value }
+		: { kind: "json", value };
+}
+
+function inlineTextPreview(value: unknown, maxLength: number): string | null {
+	if (typeof value !== "string") return null;
+	const trimmed = value.trim();
+	if (!trimmed || looksStructured(trimmed)) return null;
+	return truncate(trimmed, maxLength);
+}
+
+function errorSummary(content: Record<string, unknown>): string | null {
+	for (const key of ["message", "error", "reason"]) {
+		const preview = inlineTextPreview(content[key], 120);
+		if (preview) return preview;
 	}
+	return null;
 }
 
 function truncate(s: string, n: number): string {
@@ -198,18 +915,18 @@ function truncate(s: string, n: number): string {
 	return s.slice(0, n - 1) + "…";
 }
 
-export interface TimelineProps {
+export interface AdvancedTimelineProps {
 	steps: AgentRunStepResponse[] | null | undefined;
 }
 
-export function Timeline({ steps }: TimelineProps) {
+export function AdvancedTimeline({ steps }: AdvancedTimelineProps) {
 	if (!steps || !steps.length) {
 		return (
 			<p className="text-xs text-muted-foreground">No steps recorded.</p>
 		);
 	}
 	return (
-		<ol className="flex flex-col gap-1.5">
+		<ol className="flex min-w-0 flex-col gap-1.5">
 			{steps.map((step, i) => (
 				<TimelineRow key={step.id ?? i} step={step} index={i + 1} />
 			))}
@@ -229,15 +946,17 @@ function TimelineRow({
 	const hasDetail = !!vm.primaryDetail || !!vm.secondaryDetail;
 	const Icon = vm.icon;
 	return (
-		<li className="overflow-hidden rounded-md bg-muted/50 ring-1 ring-foreground/5">
+		<li className="min-w-0 overflow-hidden rounded-md bg-muted/50 ring-1 ring-foreground/5">
 			<button
 				type="button"
 				onClick={() => hasDetail && setOpen((v) => !v)}
 				disabled={!hasDetail}
 				aria-expanded={open}
-				aria-label={hasDetail ? `Toggle details for step ${index}` : undefined}
+				aria-label={
+					hasDetail ? `Toggle details for step ${index}` : undefined
+				}
 				className={cn(
-					"flex w-full items-start gap-2 px-3 py-2 text-left text-xs",
+					"flex min-w-0 w-full items-start gap-2 px-3 py-2 text-left text-xs",
 					hasDetail && "hover:bg-accent/40",
 				)}
 			>
@@ -250,8 +969,13 @@ function TimelineRow({
 					<Icon className="h-3 w-3" />
 				</div>
 				<div className="min-w-0 flex-1">
-					<div className="flex items-baseline gap-2">
-						<span className="font-medium">{vm.label}</span>
+					<div className="flex min-w-0 items-baseline gap-2">
+						<span
+							className="min-w-0 truncate font-medium"
+							title={vm.label}
+						>
+							{vm.label}
+						</span>
 						{vm.summary ? (
 							<span className="truncate text-muted-foreground">
 								{vm.summary}
@@ -301,37 +1025,44 @@ function TimelineRow({
 function DetailBlock({ detail }: { detail: DetailRender }) {
 	if (detail.kind === "json") {
 		return (
-			<div className="max-h-[280px] overflow-y-auto rounded-md bg-muted ring-1 ring-foreground/5 px-2 py-1.5">
-				<JsonTree value={detail.value} />
+			<div className="max-h-[280px] overflow-y-auto rounded-md bg-muted/60 ring-1 ring-foreground/5 p-2.5">
+				<VariablesTreeView data={asVariableRecord(detail.value)} />
 			</div>
 		);
 	}
-	// Tool results / LLM response text are strings — but tool results often
-	// look like JSON. Best-effort parse so the tree view kicks in.
 	const parsed = tryParseJson(detail.value);
 	if (parsed !== UNPARSEABLE) {
 		return (
-			<div className="max-h-[280px] overflow-y-auto rounded-md bg-muted ring-1 ring-foreground/5 px-2 py-1.5">
-				<JsonTree value={parsed} />
+			<div className="max-h-[280px] overflow-y-auto rounded-md bg-muted/60 ring-1 ring-foreground/5 p-2.5">
+				<VariablesTreeView data={asVariableRecord(parsed)} />
 			</div>
 		);
 	}
 	return (
-		<pre className="max-h-[280px] overflow-y-auto rounded-md bg-muted ring-1 ring-foreground/5 px-2 py-1.5 font-mono text-[11px] whitespace-pre-wrap break-words">
+		<div className="max-h-[280px] overflow-y-auto rounded-md bg-muted/60 ring-1 ring-foreground/5 px-3 py-2 text-xs leading-5 whitespace-pre-wrap break-words">
 			{detail.value}
-		</pre>
+		</div>
+	);
+}
+
+function asVariableRecord(value: unknown): Record<string, unknown> {
+	if (value !== null && typeof value === "object" && !Array.isArray(value)) {
+		return value as Record<string, unknown>;
+	}
+	return { value };
+}
+
+function looksStructured(value: string): boolean {
+	return (
+		(value.startsWith("{") && value.endsWith("}")) ||
+		(value.startsWith("[") && value.endsWith("]"))
 	);
 }
 
 const UNPARSEABLE = Symbol("unparseable");
 function tryParseJson(value: string): unknown {
 	const trimmed = value.trim();
-	if (
-		!(
-			(trimmed.startsWith("{") && trimmed.endsWith("}")) ||
-			(trimmed.startsWith("[") && trimmed.endsWith("]"))
-		)
-	) {
+	if (!looksStructured(trimmed)) {
 		return UNPARSEABLE;
 	}
 	try {

--- a/client/src/components/agents/run-activity.test.ts
+++ b/client/src/components/agents/run-activity.test.ts
@@ -1,0 +1,444 @@
+import { describe, expect, it } from "vitest";
+
+import type { components } from "@/lib/v1";
+
+import {
+	activityDomId,
+	buildActivityReferenceIndex,
+	buildRunActivity,
+	humanizeToolAction,
+	humanizeToolReference,
+	summarizeActivityValue,
+} from "./run-activity";
+
+type AgentRunStep = components["schemas"]["AgentRunStepResponse"];
+type AgentRunChild = components["schemas"]["AgentRunChildResponse"];
+
+function step(
+	type: string,
+	content: Record<string, unknown>,
+	stepNumber: number,
+): AgentRunStep {
+	return {
+		id: `step-${stepNumber}`,
+		run_id: "00000000-0000-0000-0000-000000000001",
+		step_number: stepNumber,
+		type,
+		content,
+		duration_ms: stepNumber * 100,
+		created_at: "2026-07-15T12:00:00Z",
+	};
+}
+
+function child(
+	id: string,
+	agentName: string,
+	task: string,
+	overrides: Partial<AgentRunChild> = {},
+): AgentRunChild {
+	return {
+		id,
+		agent_id: `agent-${id}`,
+		agent_name: agentName,
+		status: "completed",
+		asked: task,
+		did: null,
+		answered: null,
+		duration_ms: 1_200,
+		created_at: "2026-07-15T12:00:00Z",
+		...overrides,
+	};
+}
+
+describe("run activity projection", () => {
+	it("groups a decision, call, and object result into one readable action", () => {
+		const activity = buildRunActivity([
+			step("llm_request", { messages_count: 2, tools_count: 17 }, 1),
+			step(
+				"llm_response",
+				{ tool_calls: [{ name: "ai_ticketing_get_ticket_details" }] },
+				2,
+			),
+			step(
+				"tool_call",
+				{
+					tool_name: "ai_ticketing_get_ticket_details",
+					arguments: { ticket_id: 428950 },
+				},
+				3,
+			),
+			step(
+				"tool_result",
+				{
+					tool_name: "ai_ticketing_get_ticket_details",
+					result: {
+						status: "open",
+						matched: true,
+						ticket_id: 428950,
+					},
+				},
+				4,
+			),
+			step(
+				"llm_response",
+				{ content: "The ticket is ready for triage.", tool_calls: [] },
+				5,
+			),
+		]);
+
+		expect(activity).toHaveLength(2);
+		expect(activity[0]).toMatchObject({
+			kind: "action",
+			title: "Looked up ticket details",
+			description: "Ticket: 428950 · Status: Open · Match found",
+		});
+		expect(activity[1]).toMatchObject({
+			kind: "response",
+			title: "Final response",
+			description: "The ticket is ready for triage.",
+		});
+	});
+
+	it("keeps a structured final response semantic and hides arbitrary fields", () => {
+		const activity = buildRunActivity([
+			step(
+				"llm_response",
+				{
+					content:
+						'{"ticket_id":428950,"status":"complete","access_token":"hidden"}',
+					tool_calls: [],
+				},
+				1,
+			),
+		]);
+
+		expect(activity[0]).toMatchObject({
+			kind: "response",
+			title: "Final response",
+			description: "Ticket: 428950 · Status: Complete",
+		});
+	});
+
+	it("pairs repeated calls with the nearest unmatched result", () => {
+		const activity = buildRunActivity([
+			step(
+				"tool_call",
+				{ tool_name: "check_status", arguments: { id: 1 } },
+				1,
+			),
+			step(
+				"tool_result",
+				{ tool_name: "check_status", result: "First" },
+				2,
+			),
+			step(
+				"tool_call",
+				{ tool_name: "check_status", arguments: { id: 2 } },
+				3,
+			),
+			step(
+				"tool_result",
+				{ tool_name: "check_status", result: "Second" },
+				4,
+			),
+		]);
+
+		expect(activity.map((item) => item.description)).toEqual([
+			"First",
+			"Second",
+		]);
+		expect(buildActivityReferenceIndex(activity)).toEqual({
+			check_status: [
+				{
+					activityId: "step-1",
+					label: "Checked status",
+				},
+				{
+					activityId: "step-3",
+					label: "Checked status",
+				},
+			],
+		});
+	});
+
+	it("preserves a workflow execution destination on its grouped action", () => {
+		const activity = buildRunActivity([
+			step(
+				"tool_call",
+				{ tool_name: "update_ticket", arguments: { ticket_id: 42 } },
+				1,
+			),
+			step(
+				"tool_result",
+				{
+					tool_name: "update_ticket",
+					result: { ticket_id: 42, status: "updated" },
+					execution_id: "execution-42",
+				},
+				2,
+			),
+		]);
+
+		expect(activity[0]).toMatchObject({
+			title: "Updated ticket",
+			executionId: "execution-42",
+		});
+		expect(activityDomId(activity[0].id)).toBe("run-activity-item-step-1");
+	});
+
+	it("keeps structured and JSON-string results semantic", () => {
+		expect(
+			summarizeActivityValue({ matched: true, device: "ELIJAH-LT" }),
+		).toBe("Device: ELIJAH-LT · Match found");
+		expect(
+			summarizeActivityValue(
+				'{"classification":"service request","routed":true}',
+			),
+		).toBe("Classification: Service request · Routed successfully");
+		expect(summarizeActivityValue([{ id: 1 }, { id: 2 }])).toBe(
+			"Returned 2 items",
+		);
+		expect(
+			summarizeActivityValue("{'raw': true, 'ticket_id': 42}"),
+		).toBeNull();
+		expect(summarizeActivityValue({ status: "in_progress" })).toBe(
+			"Status: In progress",
+		);
+		expect(
+			summarizeActivityValue({
+				status: "open",
+				access_token: "should-never-render",
+				password: "also-hidden",
+				arbitrary_field: "not-an-outcome",
+			}),
+		).toBe("Status: Open");
+	});
+
+	it("makes linked and historical unlinked child runs distinct delegations", () => {
+		const activity = buildRunActivity(
+			[
+				step(
+					"tool_call",
+					{
+						tool_name: "delegate_to_troubleshooting_agent",
+						arguments: { task: "Collect endpoint evidence" },
+					},
+					1,
+				),
+				step(
+					"tool_result",
+					{
+						tool_name: "delegate_to_troubleshooting_agent",
+						result: "Evidence collected",
+						child_run_id: "child-1",
+					},
+					2,
+				),
+			],
+			["child-1", "historic-child"],
+			[
+				child(
+					"child-1",
+					"Endpoint Evidence Collector",
+					"Collect endpoint evidence",
+				),
+				child(
+					"historic-child",
+					"Historical Specialist",
+					"Review the old run",
+				),
+			],
+		);
+
+		expect(activity).toHaveLength(2);
+		expect(activity[0]).toMatchObject({
+			kind: "delegation",
+			title: "Endpoint Evidence Collector",
+			childAgentId: "agent-child-1",
+			agentName: "Endpoint Evidence Collector",
+			task: "Collect endpoint evidence",
+			childRunId: "child-1",
+		});
+		expect(activity[1]).toMatchObject({
+			kind: "delegation",
+			title: "Historical Specialist",
+			agentName: "Historical Specialist",
+			task: "Review the old run",
+			childRunId: "historic-child",
+		});
+	});
+
+	it("keeps a failed handoff identifiable as delegated work", () => {
+		const activity = buildRunActivity([
+			step(
+				"tool_call",
+				{
+					tool_name: "delegate_to_security_agent",
+					arguments: { task: "Inspect the alert" },
+				},
+				1,
+			),
+			step(
+				"tool_error",
+				{
+					tool_name: "delegate_to_security_agent",
+					error: "Timed out",
+					child_run_id: "failed-child",
+				},
+				2,
+			),
+		]);
+
+		expect(activity[0]).toMatchObject({
+			kind: "delegation",
+			isError: true,
+			title: "Delegation failed",
+			description: "Timed out",
+			childRunId: "failed-child",
+		});
+	});
+
+	it("binds historical child IDs to delegation calls that predate child_run_id", () => {
+		const activity = buildRunActivity(
+			[
+				step(
+					"tool_call",
+					{
+						tool_name: "delegate_to_agreement_agent",
+						arguments: { task: "Check coverage" },
+					},
+					1,
+				),
+				step(
+					"tool_result",
+					{
+						tool_name: "delegate_to_agreement_agent",
+						result: "Covered",
+					},
+					2,
+				),
+			],
+			["historical-child"],
+			[child("historical-child", "Agreement Analyst", "Check coverage")],
+		);
+
+		expect(activity).toHaveLength(1);
+		expect(activity[0]).toMatchObject({
+			kind: "delegation",
+			childRunId: "historical-child",
+			title: "Agreement Analyst",
+			agentName: "Agreement Analyst",
+		});
+	});
+
+	it("does not guess which historical delegation produced a child run", () => {
+		const activity = buildRunActivity(
+			[
+				step(
+					"tool_call",
+					{
+						tool_name: "delegate_to_security_agent",
+						arguments: { task: "Inspect the alert" },
+					},
+					1,
+				),
+				step(
+					"tool_error",
+					{
+						tool_name: "delegate_to_security_agent",
+						error: "Timed out",
+					},
+					2,
+				),
+				step(
+					"tool_call",
+					{
+						tool_name: "delegate_to_agreement_agent",
+						arguments: { task: "Check coverage" },
+					},
+					3,
+				),
+				step(
+					"tool_result",
+					{
+						tool_name: "delegate_to_agreement_agent",
+						result: "Covered",
+					},
+					4,
+				),
+			],
+			["historical-child"],
+			[child("historical-child", "Agreement Analyst", "Check coverage")],
+		);
+
+		expect(activity).toHaveLength(3);
+		expect(activity[0]).toMatchObject({
+			kind: "delegation",
+			title: "Delegation failed",
+			childRunId: null,
+		});
+		expect(activity[1]).toMatchObject({
+			kind: "delegation",
+			childRunId: null,
+		});
+		expect(activity[2]).toMatchObject({
+			kind: "delegation",
+			title: "Agreement Analyst",
+			childRunId: "historical-child",
+			childAgentId: "agent-historical-child",
+		});
+	});
+
+	it("preserves errors and incomplete calls without exposing raw payloads", () => {
+		const activity = buildRunActivity([
+			step(
+				"tool_call",
+				{ tool_name: "ai_ticketing_submit_triage", arguments: {} },
+				1,
+			),
+			step(
+				"tool_error",
+				{
+					tool_name: "ai_ticketing_submit_triage",
+					error: { message: "Permission denied", code: "forbidden" },
+				},
+				2,
+			),
+			step("tool_call", { tool_name: "send_email", arguments: {} }, 3),
+		]);
+
+		expect(activity[0]).toMatchObject({
+			kind: "error",
+			title: "Could not submit triage",
+			description: "Permission denied · Code: Forbidden",
+		});
+		expect(activity[1]).toMatchObject({
+			kind: "action",
+			title: "Sent email",
+			resultStep: null,
+		});
+	});
+});
+
+describe("tool labels", () => {
+	it("drops integration prefixes and conjugates compound actions", () => {
+		expect(humanizeToolAction("halopsa_halo_update_ticket")).toBe(
+			"Updated ticket",
+		);
+		expect(
+			humanizeToolAction("supportability_resolve_and_attach_device"),
+		).toBe("Resolved and attached device");
+		expect(humanizeToolReference("ai_ticketing_get_ticket_details")).toBe(
+			"Get ticket details",
+		);
+	});
+
+	it("does not invent a label from an unknown executor identifier", () => {
+		expect(humanizeToolAction("vendor_internal_opaque_command")).toBe(
+			"Completed an action",
+		);
+		expect(humanizeToolReference("vendor_internal_opaque_command")).toBe(
+			"Agent action",
+		);
+	});
+});

--- a/client/src/components/agents/run-activity.ts
+++ b/client/src/components/agents/run-activity.ts
@@ -1,0 +1,543 @@
+import type { components } from "@/lib/v1";
+
+type AgentRunStep = components["schemas"]["AgentRunStepResponse"];
+type AgentRunChild = components["schemas"]["AgentRunChildResponse"];
+
+export type RunActivityKind =
+	"action" | "delegation" | "response" | "error" | "warning" | "cancelled";
+
+export interface RunActivityItem {
+	id: string;
+	kind: RunActivityKind;
+	title: string;
+	description: string | null;
+	toolName: string | null;
+	task: string | null;
+	childRunId: string | null;
+	childAgentId: string | null;
+	agentName: string | null;
+	childStatus: string | null;
+	executionId: string | null;
+	durationMs: number | null;
+	isError: boolean;
+	callStep: AgentRunStep | null;
+	resultStep: AgentRunStep | null;
+}
+
+export interface RunActivityReference {
+	activityId: string;
+	label: string;
+}
+
+export type RunActivityReferenceIndex = Record<string, RunActivityReference[]>;
+
+export function activityDomId(activityId: string): string {
+	return `run-activity-item-${activityId.replace(/[^a-zA-Z0-9_-]/g, "-")}`;
+}
+
+/**
+ * Index each recorded tool occurrence in activity order. A summary can mention
+ * the same tool more than once, so consumers pair the first marker with the
+ * first action, the second marker with the second action, and so on.
+ */
+export function buildActivityReferenceIndex(
+	activity: RunActivityItem[],
+): RunActivityReferenceIndex {
+	const references: RunActivityReferenceIndex = {};
+	for (const item of activity) {
+		if (!item.toolName) continue;
+		(references[item.toolName] ??= []).push({
+			activityId: item.id,
+			label: item.agentName ?? item.title,
+		});
+	}
+	return references;
+}
+
+const ACTION_VERBS: Record<string, { past: string; takesFor?: boolean }> = {
+	add: { past: "Added" },
+	approve: { past: "Approved" },
+	archive: { past: "Archived" },
+	attach: { past: "Attached" },
+	check: { past: "Checked" },
+	cancel: { past: "Cancelled" },
+	classify: { past: "Classified" },
+	close: { past: "Closed" },
+	create: { past: "Created" },
+	delete: { past: "Deleted" },
+	download: { past: "Downloaded" },
+	execute: { past: "Ran" },
+	fetch: { past: "Retrieved" },
+	find: { past: "Found" },
+	get: { past: "Looked up" },
+	link: { past: "Linked" },
+	list: { past: "Listed" },
+	lookup: { past: "Looked up" },
+	match: { past: "Matched" },
+	notify: { past: "Notified" },
+	open: { past: "Opened" },
+	read: { past: "Read" },
+	reject: { past: "Rejected" },
+	remove: { past: "Removed" },
+	resolve: { past: "Resolved" },
+	route: { past: "Routed" },
+	run: { past: "Ran" },
+	publish: { past: "Published" },
+	query: { past: "Queried" },
+	save: { past: "Saved" },
+	schedule: { past: "Scheduled" },
+	search: { past: "Searched", takesFor: true },
+	send: { past: "Sent" },
+	set: { past: "Set" },
+	submit: { past: "Submitted" },
+	update: { past: "Updated" },
+	upload: { past: "Uploaded" },
+	validate: { past: "Validated" },
+	write: { past: "Wrote" },
+};
+
+const DISPLAY_ACRONYMS: Record<string, string> = {
+	ai: "AI",
+	id: "ID",
+	ip: "IP",
+	mfa: "MFA",
+	m365: "Microsoft 365",
+	psa: "PSA",
+	rmm: "RMM",
+	sla: "SLA",
+	url: "URL",
+};
+
+const RESULT_PRIORITY = [
+	"message",
+	"summary",
+	"detail",
+	"ticket_id",
+	"device",
+	"asset_name",
+	"classification",
+	"status",
+	"matched",
+	"success",
+	"attached",
+	"routed",
+	"count",
+	"name",
+	"title",
+];
+
+const SAFE_RESULT_KEYS = new Set([...RESULT_PRIORITY, "code"]);
+
+function identifierTokens(value: string): string[] {
+	return value
+		.replace(/([a-z0-9])([A-Z])/g, "$1_$2")
+		.toLowerCase()
+		.split(/[^a-z0-9]+/)
+		.filter(Boolean);
+}
+
+function sentenceCase(words: string[]): string {
+	if (!words.length) return "";
+	const rendered = words.map((word) => DISPLAY_ACRONYMS[word] ?? word);
+	const text = rendered.join(" ");
+	return text.charAt(0).toUpperCase() + text.slice(1);
+}
+
+function lowerPhrase(words: string[]): string {
+	return words.map((word) => DISPLAY_ACRONYMS[word] ?? word).join(" ");
+}
+
+export function delegationTarget(toolName: string): string | null {
+	const match = toolName.match(/^delegate_to_(.+)$/i);
+	if (!match) return null;
+	const hasAgentSuffix = /_agent$/i.test(match[1]);
+	const target = identifierTokens(match[1].replace(/_agent$/i, ""));
+	const name = sentenceCase(target.length ? target : ["another"]);
+	return hasAgentSuffix ? `${name} Agent` : name;
+}
+
+/**
+ * Turn an executor-facing identifier into a past-tense action. Integration
+ * prefixes are discarded by starting at the first recognizable action verb.
+ */
+export function humanizeToolAction(toolName: string): string {
+	const delegatedTo = delegationTarget(toolName);
+	if (delegatedTo) return "Delegated work";
+
+	const tokens = identifierTokens(toolName);
+	const verbIndex = tokens.findIndex((token) => token in ACTION_VERBS);
+	if (verbIndex === -1) {
+		return "Completed an action";
+	}
+
+	const verb = ACTION_VERBS[tokens[verbIndex]];
+	const remainder = tokens.slice(verbIndex + 1);
+	const conjugated = remainder.map((token, index) => {
+		if (
+			index > 0 &&
+			remainder[index - 1] === "and" &&
+			ACTION_VERBS[token]
+		) {
+			return ACTION_VERBS[token].past.toLowerCase();
+		}
+		return token;
+	});
+	const object = lowerPhrase(conjugated);
+	if (!object) return verb.past;
+	return `${verb.past}${verb.takesFor ? " for" : ""} ${object}`;
+}
+
+/** Friendly noun label for a tool marker embedded in summarizer prose. */
+export function humanizeToolReference(toolName: string): string {
+	const delegatedTo = delegationTarget(toolName);
+	if (delegatedTo) return "Delegated agent";
+
+	const tokens = identifierTokens(toolName);
+	const verbIndex = tokens.findIndex((token) => token in ACTION_VERBS);
+	const meaningful = verbIndex >= 0 ? tokens.slice(verbIndex) : [];
+	return sentenceCase(meaningful.length ? meaningful : ["agent", "action"]);
+}
+
+function parseJsonish(value: unknown): unknown {
+	if (typeof value !== "string") return value;
+	const trimmed = value.trim();
+	if (!(
+		(trimmed.startsWith("{") && trimmed.endsWith("}")) ||
+		(trimmed.startsWith("[") && trimmed.endsWith("]"))
+	)) {
+		return value;
+	}
+	try {
+		return JSON.parse(trimmed);
+	} catch {
+		return value;
+	}
+}
+
+function truncate(value: string, length = 150): string {
+	const collapsed = value.replace(/\s+/g, " ").trim();
+	return collapsed.length > length
+		? `${collapsed.slice(0, length - 1)}…`
+		: collapsed;
+}
+
+function titleForKey(key: string): string {
+	const aliases: Record<string, string> = {
+		asset_name: "Device",
+		classification: "Classification",
+		ticket_id: "Ticket",
+	};
+	return aliases[key] ?? sentenceCase(identifierTokens(key));
+}
+
+function readableValue(value: string | number | boolean): string {
+	if (typeof value === "boolean") return value ? "Yes" : "No";
+	if (typeof value === "string") {
+		const clean = truncate(value, 80);
+		if (/^[a-z0-9]+(?:_[a-z0-9]+)+$/i.test(clean)) {
+			return sentenceCase(identifierTokens(clean));
+		}
+		return clean.charAt(0).toUpperCase() + clean.slice(1);
+	}
+	return value.toLocaleString();
+}
+
+function describeEntry(key: string, value: string | number | boolean): string {
+	if (key === "matched") return value ? "Match found" : "No match found";
+	if (key === "success")
+		return value ? "Completed successfully" : "Not completed";
+	if (key === "attached")
+		return value ? "Attached successfully" : "Not attached";
+	if (key === "routed") return value ? "Routed successfully" : "Not routed";
+	if (
+		["message", "summary", "detail"].includes(key) &&
+		typeof value === "string"
+	) {
+		return truncate(value);
+	}
+	if (key.endsWith("_id")) {
+		return `${titleForKey(key)}: ${String(value)}`;
+	}
+	return `${titleForKey(key)}: ${readableValue(value)}`;
+}
+
+/**
+ * Produce a compact semantic result. Objects become human-readable fields;
+ * raw keys, braces, arrays, and nested payloads stay in Advanced.
+ */
+export function summarizeActivityValue(value: unknown): string | null {
+	const parsed = parseJsonish(value);
+	if (parsed === null || parsed === undefined || parsed === "") return null;
+	if (typeof parsed === "string") {
+		const trimmed = parsed.trim();
+		// A malformed/Python-repr object is still a raw payload. Do not leak
+		// it into the normal story simply because JSON.parse rejected it.
+		if (
+			(trimmed.startsWith("{") && trimmed.endsWith("}")) ||
+			(trimmed.startsWith("[") && trimmed.endsWith("]"))
+		) {
+			return null;
+		}
+		return truncate(parsed);
+	}
+	if (typeof parsed === "number" || typeof parsed === "boolean") {
+		return readableValue(parsed);
+	}
+	if (Array.isArray(parsed)) {
+		return `Returned ${parsed.length.toLocaleString()} ${parsed.length === 1 ? "item" : "items"}`;
+	}
+	if (typeof parsed !== "object") return null;
+
+	const entries = Object.entries(parsed as Record<string, unknown>).filter(
+		([key, entryValue]) =>
+			SAFE_RESULT_KEYS.has(key) &&
+			(typeof entryValue === "string" ||
+				typeof entryValue === "number" ||
+				typeof entryValue === "boolean"),
+	);
+	entries.sort(([a], [b]) => {
+		const ai = RESULT_PRIORITY.indexOf(a);
+		const bi = RESULT_PRIORITY.indexOf(b);
+		return (ai === -1 ? 999 : ai) - (bi === -1 ? 999 : bi);
+	});
+
+	const descriptions = entries
+		.slice(0, 3)
+		.map(([key, entryValue]) =>
+			describeEntry(key, entryValue as string | number | boolean),
+		)
+		.filter(Boolean);
+	return descriptions.length ? descriptions.join(" · ") : null;
+}
+
+function stepContent(step: AgentRunStep): Record<string, unknown> {
+	return (step.content ?? {}) as Record<string, unknown>;
+}
+
+function stepId(step: AgentRunStep, fallback: string): string {
+	return step.id || fallback;
+}
+
+function stringField(value: unknown): string | null {
+	return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function toolNameFor(step: AgentRunStep): string {
+	return stringField(stepContent(step).tool_name) ?? "agent_action";
+}
+
+function newToolItem(step: AgentRunStep, index: number): RunActivityItem {
+	const content = stepContent(step);
+	const toolName = toolNameFor(step);
+	const target = delegationTarget(toolName);
+	return {
+		id: stepId(step, `action-${index}`),
+		kind: target ? "delegation" : "action",
+		title: humanizeToolAction(toolName),
+		description: null,
+		toolName,
+		task: target
+			? stringField(
+					(content.arguments as Record<string, unknown> | undefined)
+						?.task,
+				)
+			: null,
+		childRunId: null,
+		childAgentId: null,
+		agentName: null,
+		childStatus: null,
+		executionId: stringField(content.execution_id),
+		durationMs: step.duration_ms ?? null,
+		isError: false,
+		callStep: step,
+		resultStep: null,
+	};
+}
+
+function attachResult(item: RunActivityItem, step: AgentRunStep): void {
+	const content = stepContent(step);
+	const isError = step.type === "tool_error" || content.is_error === true;
+	const delegatedTo = item.toolName ? delegationTarget(item.toolName) : null;
+	item.resultStep = step;
+	item.isError = isError;
+	item.kind = isError && !delegatedTo ? "error" : item.kind;
+	item.title = isError
+		? delegatedTo
+			? "Delegation failed"
+			: `Could not ${humanizeToolReference(item.toolName ?? "action").toLowerCase()}`
+		: item.title;
+	item.description = summarizeActivityValue(
+		isError ? (content.error ?? content.result) : content.result,
+	);
+	item.childRunId = stringField(content.child_run_id) ?? item.childRunId;
+	item.executionId = stringField(content.execution_id) ?? item.executionId;
+	item.durationMs = step.duration_ms ?? item.durationMs;
+}
+
+/** Build the normal, user-facing projection of a raw executor trace. */
+export function buildRunActivity(
+	steps: AgentRunStep[] | null | undefined,
+	childRunIds: string[] | null | undefined = [],
+	childRuns: AgentRunChild[] | null | undefined = [],
+): RunActivityItem[] {
+	const ordered = [...(steps ?? [])].sort(
+		(a, b) => (a.step_number ?? 0) - (b.step_number ?? 0),
+	);
+	const activity: RunActivityItem[] = [];
+
+	for (const [index, step] of ordered.entries()) {
+		const content = stepContent(step);
+		switch (step.type) {
+			case "tool_call":
+				activity.push(newToolItem(step, index));
+				break;
+			case "tool_result":
+			case "tool_error": {
+				const toolName = toolNameFor(step);
+				const match = [...activity]
+					.reverse()
+					.find(
+						(item) =>
+							item.toolName === toolName && !item.resultStep,
+					);
+				if (match) {
+					attachResult(match, step);
+				} else {
+					const orphan = newToolItem(step, index);
+					orphan.callStep = null;
+					attachResult(orphan, step);
+					activity.push(orphan);
+				}
+				break;
+			}
+			case "llm_response": {
+				const toolCalls = Array.isArray(content.tool_calls)
+					? content.tool_calls
+					: [];
+				const response = stringField(content.content);
+				if (toolCalls.length === 0 && response) {
+					activity.push({
+						id: stepId(step, `response-${index}`),
+						kind: "response",
+						title: "Final response",
+						description: summarizeActivityValue(response),
+						toolName: null,
+						task: null,
+						childRunId: null,
+						childAgentId: null,
+						agentName: null,
+						childStatus: null,
+						executionId: null,
+						durationMs: step.duration_ms ?? null,
+						isError: false,
+						callStep: null,
+						resultStep: step,
+					});
+				}
+				break;
+			}
+			case "error":
+			case "budget_warning":
+			case "cancelled":
+				activity.push({
+					id: stepId(step, `notice-${index}`),
+					kind:
+						step.type === "error"
+							? "error"
+							: step.type === "cancelled"
+								? "cancelled"
+								: "warning",
+					title:
+						step.type === "error"
+							? "The run hit an error"
+							: step.type === "cancelled"
+								? "The run was cancelled"
+								: "The run approached its budget",
+					description: summarizeActivityValue(
+						content.error ?? content.result ?? content,
+					),
+					toolName: null,
+					task: null,
+					childRunId: null,
+					childAgentId: null,
+					agentName: null,
+					childStatus: null,
+					executionId: null,
+					durationMs: step.duration_ms ?? null,
+					isError: step.type === "error",
+					callStep: null,
+					resultStep: step,
+				});
+				break;
+			default:
+				// LLM requests, tool-planning responses, and unknown executor
+				// plumbing remain available in Advanced but do not compete with
+				// meaningful work in the normal activity story.
+				break;
+		}
+	}
+
+	const linkedChildIds = new Set(
+		activity
+			.map((item) => item.childRunId)
+			.filter((id): id is string => !!id),
+	);
+	const orderedChildIds = [
+		...(childRunIds ?? []),
+		...(childRuns ?? []).map((child) => child.id),
+	].filter((id, index, ids) => ids.indexOf(id) === index);
+	const unboundDelegations = activity.filter(
+		(item) => item.kind === "delegation" && !item.childRunId,
+	);
+	const unlinkedChildIds = orderedChildIds.filter(
+		(childRunId) => !linkedChildIds.has(childRunId),
+	);
+
+	// Older traces did not persist child_run_id on delegation results. Preserve
+	// the convenient inline binding only when there is exactly one possible
+	// pairing. With multiple handoffs, order alone is not authoritative: an
+	// earlier failed handoff may not have produced a child at all.
+	if (unboundDelegations.length === 1 && unlinkedChildIds.length === 1) {
+		unboundDelegations[0].childRunId = unlinkedChildIds[0];
+		linkedChildIds.add(unlinkedChildIds[0]);
+	}
+
+	for (const childRunId of unlinkedChildIds) {
+		if (linkedChildIds.has(childRunId)) continue;
+		activity.push({
+			id: `delegation-${childRunId}`,
+			kind: "delegation",
+			title: "Delegated work",
+			description: null,
+			toolName: null,
+			task: null,
+			childRunId,
+			childAgentId: null,
+			agentName: null,
+			childStatus: null,
+			executionId: null,
+			durationMs: null,
+			isError: false,
+			callStep: null,
+			resultStep: null,
+		});
+		linkedChildIds.add(childRunId);
+	}
+
+	const childrenById = new Map(
+		(childRuns ?? []).map((child) => [child.id, child]),
+	);
+	for (const item of activity) {
+		if (item.kind !== "delegation" || !item.childRunId) continue;
+		const child = childrenById.get(item.childRunId);
+		if (!child) continue;
+		item.childAgentId = child.agent_id;
+		item.agentName = child.agent_name ?? null;
+		item.childStatus = child.status;
+		item.task = child.asked?.trim() || item.task;
+		item.title = child.agent_name?.trim() || "Delegated agent";
+		item.durationMs = child.duration_ms ?? item.durationMs;
+	}
+
+	return activity;
+}

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -108,6 +108,76 @@
 
 /* ----------------------- end shadcn/tailwind.css ------------------- */
 
+/* Agent history surfaces are bounded workspaces on standard desktop viewports.
+ * The page context remains fixed while the repeated collection owns overflow.
+ * Runs caps expanded filters separately; Overview lets Recent activity and the
+ * sidebar scroll independently. Narrow or short viewports intentionally retain
+ * ordinary document scrolling.
+ */
+@media (min-width: 64rem) and (min-height: 45rem) {
+	.agent-overview-workspace,
+	.agent-runs-workspace {
+		height: 100%;
+		min-height: 0;
+		overflow: hidden;
+	}
+
+	.agent-overview-workspace .agent-overview-tab {
+		min-height: 0;
+		flex: 1 1 0%;
+		overflow: hidden;
+	}
+
+	.agent-overview-workspace .agent-overview-main {
+		min-height: 0;
+		overflow: hidden;
+	}
+
+	.agent-overview-workspace .agent-overview-recent {
+		display: flex;
+		min-height: 0;
+		flex: 1 1 0%;
+		flex-direction: column;
+	}
+
+	.agent-overview-workspace .agent-overview-recent-list {
+		min-height: 0;
+		flex: 1 1 0%;
+		overflow-y: auto;
+		overscroll-behavior-y: contain;
+	}
+
+	.agent-overview-workspace .agent-overview-sidebar {
+		min-height: 0;
+		overflow-y: auto;
+		overscroll-behavior-y: contain;
+		scrollbar-gutter: stable;
+		padding-inline-end: 0.25rem;
+	}
+
+	.agent-runs-workspace .agent-runs-tab {
+		min-height: 0;
+		flex: 1 1 0%;
+		overflow: hidden;
+	}
+
+	.agent-runs-workspace .agent-runs-filter-region {
+		max-height: min(12rem, 30vh);
+		overflow-y: auto;
+		overscroll-behavior-y: contain;
+		scrollbar-gutter: stable;
+		padding-inline-end: 0.25rem;
+	}
+
+	.agent-runs-workspace .agent-runs-scroll-region {
+		min-height: 0;
+		flex: 1 1 0%;
+		overflow-y: auto;
+		overscroll-behavior-y: contain;
+		padding-block-end: 0.25rem;
+	}
+}
+
 :root {
 	--radius: 0.65rem;
 	--background: oklch(1 0 0);

--- a/client/src/lib/agent-run-navigation.test.ts
+++ b/client/src/lib/agent-run-navigation.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+
+import {
+	createAgentRunNavigationState,
+	getLocationHref,
+	readAgentRunNavigationOrigin,
+} from "./agent-run-navigation";
+
+describe("agent run navigation", () => {
+	it("builds a return href from the current router location", () => {
+		expect(
+			getLocationHref({
+				pathname: "/agents/agent-1/runs/run-1",
+				search: "?view=activity",
+				hash: "#delegation",
+			}),
+		).toBe(
+			"/agents/agent-1/runs/run-1?view=activity#delegation",
+		);
+	});
+
+	it("round-trips a valid in-app origin", () => {
+		const state = createAgentRunNavigationState({
+			href: "/agents/agent-1/runs/run-1?view=activity",
+			label: "Back to Service Desk Triage run",
+		});
+
+		expect(readAgentRunNavigationOrigin(state)).toEqual(
+			state.agentRunOrigin,
+		);
+	});
+
+	it.each([
+		null,
+		{},
+		{ agentRunOrigin: null },
+		{ agentRunOrigin: { href: "/history", label: "" } },
+		{
+			agentRunOrigin: {
+				href: "https://example.com/history",
+				label: "Back",
+			},
+		},
+		{ agentRunOrigin: { href: "//example.com/history", label: "Back" } },
+		{ agentRunOrigin: { href: "/\\example.com", label: "Back" } },
+	])("rejects malformed or external navigation state", (state) => {
+		expect(readAgentRunNavigationOrigin(state)).toBeNull();
+	});
+});

--- a/client/src/lib/agent-run-navigation.ts
+++ b/client/src/lib/agent-run-navigation.ts
@@ -1,0 +1,65 @@
+export interface AgentRunNavigationOrigin {
+	href: string;
+	label: string;
+}
+
+export interface AgentRunNavigationState {
+	agentRunOrigin: AgentRunNavigationOrigin;
+}
+
+interface LocationHref {
+	pathname: string;
+	search?: string;
+	hash?: string;
+}
+
+export function getLocationHref(location: LocationHref): string {
+	return `${location.pathname}${location.search ?? ""}${location.hash ?? ""}`;
+}
+
+export function createAgentRunNavigationState(
+	origin: AgentRunNavigationOrigin,
+): AgentRunNavigationState {
+	return { agentRunOrigin: origin };
+}
+
+export function readAgentRunNavigationOrigin(
+	state: unknown,
+): AgentRunNavigationOrigin | null {
+	if (!state || typeof state !== "object") return null;
+
+	const origin = (state as { agentRunOrigin?: unknown }).agentRunOrigin;
+	if (!origin || typeof origin !== "object") return null;
+
+	const { href, label } = origin as {
+		href?: unknown;
+		label?: unknown;
+	};
+	if (
+		typeof href !== "string" ||
+		typeof label !== "string" ||
+		label.trim().length === 0 ||
+		!isSafeInternalHref(href)
+	) {
+		return null;
+	}
+
+	return { href, label: label.trim() };
+}
+
+function isSafeInternalHref(href: string): boolean {
+	if (
+		!href.startsWith("/") ||
+		href.startsWith("//") ||
+		href.includes("\\")
+	) {
+		return false;
+	}
+
+	try {
+		const base = "https://bifrost.local";
+		return new URL(href, base).origin === base;
+	} catch {
+		return false;
+	}
+}

--- a/client/src/lib/v1.d.ts
+++ b/client/src/lib/v1.d.ts
@@ -9870,6 +9870,39 @@ export interface components {
              */
             logo?: string | null;
         };
+        /**
+         * AgentRunChildResponse
+         * @description User-facing summary of a delegated child run.
+         */
+        AgentRunChildResponse: {
+            /**
+             * Id
+             * Format: uuid
+             */
+            id: string;
+            /**
+             * Agent Id
+             * Format: uuid
+             */
+            agent_id: string;
+            /** Agent Name */
+            agent_name: string;
+            /** Status */
+            status: string;
+            /** Asked */
+            asked?: string | null;
+            /** Did */
+            did?: string | null;
+            /** Answered */
+            answered?: string | null;
+            /** Duration Ms */
+            duration_ms?: number | null;
+            /**
+             * Created At
+             * Format: date-time
+             */
+            created_at: string;
+        };
         /** AgentRunCreateRequest */
         AgentRunCreateRequest: {
             /** Agent Name */
@@ -9988,6 +10021,8 @@ export interface components {
             steps?: components["schemas"]["AgentRunStepResponse"][];
             /** Child Run Ids */
             child_run_ids?: string[];
+            /** Child Runs */
+            child_runs?: components["schemas"]["AgentRunChildResponse"][];
             /** Ai Usage */
             ai_usage?: components["schemas"]["AIUsagePublicSimple"][] | null;
             ai_totals?: components["schemas"]["AIUsageTotalsSimple"] | null;

--- a/client/src/pages/ExecuteWorkflow.test.tsx
+++ b/client/src/pages/ExecuteWorkflow.test.tsx
@@ -9,6 +9,7 @@
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { renderWithProviders, screen, waitFor } from "@/test-utils";
+import { ExecuteWorkflow } from "./ExecuteWorkflow";
 
 // -----------------------------------------------------------------------------
 // Mocks
@@ -71,7 +72,6 @@ beforeEach(() => {
 });
 
 async function renderPage() {
-	const { ExecuteWorkflow } = await import("./ExecuteWorkflow");
 	return renderWithProviders(<ExecuteWorkflow />);
 }
 

--- a/client/src/pages/ExecutionHistory.test.tsx
+++ b/client/src/pages/ExecutionHistory.test.tsx
@@ -99,7 +99,7 @@ vi.mock("@/components/ui/date-range-picker", () => ({
 	DateRangePicker: () => null,
 }));
 
-const executionHistoryModule = import("./ExecutionHistory");
+import { ExecutionHistory } from "./ExecutionHistory";
 
 // -----------------------------------------------------------------------------
 // Fixtures
@@ -169,7 +169,6 @@ function LocationProbe() {
 }
 
 async function renderPage(initialEntries?: string[]) {
-	const { ExecutionHistory } = await executionHistoryModule;
 	return renderWithProviders(
 		<>
 			<ExecutionHistory />

--- a/client/src/pages/SolutionDetail.test.tsx
+++ b/client/src/pages/SolutionDetail.test.tsx
@@ -6,6 +6,7 @@
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { renderWithProviders, screen, waitFor } from "@/test-utils";
+import { SolutionDetail } from "./SolutionDetail";
 
 const mockNavigate = vi.fn();
 vi.mock("react-router-dom", async () => {
@@ -172,7 +173,6 @@ function makeEntities(statusOverride = "active") {
 }
 
 async function renderPage() {
-	const { SolutionDetail } = await import("./SolutionDetail");
 	return renderWithProviders(<SolutionDetail />);
 }
 

--- a/client/src/pages/agents/AgentDetailPage.test.tsx
+++ b/client/src/pages/agents/AgentDetailPage.test.tsx
@@ -16,9 +16,10 @@ import { renderWithProviders, screen, waitFor } from "@/test-utils";
 
 const mockUseAgent = vi.fn();
 vi.mock("@/hooks/useAgents", async () => {
-	const actual = await vi.importActual<typeof import("@/hooks/useAgents")>(
-		"@/hooks/useAgents",
-	);
+	const actual =
+		await vi.importActual<typeof import("@/hooks/useAgents")>(
+			"@/hooks/useAgents",
+		);
 	return {
 		...actual,
 		useAgent: (id: string | undefined) => mockUseAgent(id),
@@ -58,10 +59,7 @@ vi.mock("@/components/agents/AgentSettingsTab", () => ({
 		<div data-testid="settings-tab" data-mode={mode}>
 			settings-{mode}
 			{onCreated ? (
-				<button
-					type="button"
-					onClick={() => onCreated("new-agent-id")}
-				>
+				<button type="button" onClick={() => onCreated("new-agent-id")}>
 					trigger-create
 				</button>
 			) : null}
@@ -157,6 +155,25 @@ describe("AgentDetailPage — edit mode", () => {
 		expect(await screen.findByTestId("runs-tab")).toHaveTextContent(
 			"runs-agent-1",
 		);
+	});
+
+	it("uses a bounded workspace for Overview and Runs, but not Settings", async () => {
+		const { container, user } = await renderAtRoute(
+			"/agents/agent-1?tab=runs",
+		);
+
+		expect(container.querySelector(".agent-runs-workspace")).not.toBeNull();
+		expect(container.querySelector(".agent-overview-workspace")).toBeNull();
+
+		await user.click(screen.getByRole("tab", { name: /overview/i }));
+		expect(container.querySelector(".agent-runs-workspace")).toBeNull();
+		expect(
+			container.querySelector(".agent-overview-workspace"),
+		).not.toBeNull();
+
+		await user.click(screen.getByRole("tab", { name: /settings/i }));
+		expect(container.querySelector(".agent-runs-workspace")).toBeNull();
+		expect(container.querySelector(".agent-overview-workspace")).toBeNull();
 	});
 
 	it("switches to the Settings tab and renders edit mode", async () => {

--- a/client/src/pages/agents/AgentDetailPage.tsx
+++ b/client/src/pages/agents/AgentDetailPage.tsx
@@ -11,7 +11,12 @@
  */
 
 import { useState } from "react";
-import { Link, useNavigate, useParams, useSearchParams } from "react-router-dom";
+import {
+	Link,
+	useNavigate,
+	useParams,
+	useSearchParams,
+} from "react-router-dom";
 import { toast } from "sonner";
 import {
 	ArrowLeft,
@@ -133,7 +138,13 @@ export function AgentDetailPage() {
 	}
 
 	return (
-		<div className="mx-auto flex max-w-[1400px] flex-col gap-5 p-7">
+		<div
+			className={cn(
+				"mx-auto flex w-full max-w-[1400px] flex-col gap-5 p-7",
+				tab === "overview" && "agent-overview-workspace",
+				tab === "runs" && "agent-runs-workspace",
+			)}
+		>
 			{/* Breadcrumb */}
 			<div
 				className={cn(
@@ -174,7 +185,12 @@ export function AgentDetailPage() {
 						/>
 					) : null}
 					<div className="min-w-0 flex-1">
-						<h1 className={cn("flex items-center gap-2.5", TYPE_PAGE_TITLE)}>
+						<h1
+							className={cn(
+								"flex items-center gap-2.5",
+								TYPE_PAGE_TITLE,
+							)}
+						>
 							<span className="truncate">
 								{isCreate
 									? "New agent"
@@ -186,21 +202,30 @@ export function AgentDetailPage() {
 								isActive ? (
 									<span className={PILL_ACTIVE}>Active</span>
 								) : (
-									<Badge variant="secondary" className="text-[11px]">
+									<Badge
+										variant="secondary"
+										className="text-[11px]"
+									>
 										Paused
 									</Badge>
 								)
 							) : null}
 						</h1>
 						{!isCreate && agent?.description ? (
-							<p className={cn("mt-1 line-clamp-2", TYPE_BODY, TONE_MUTED)}>
+							<p
+								className={cn(
+									"mt-1 line-clamp-2",
+									TYPE_BODY,
+									TONE_MUTED,
+								)}
+							>
 								{agent.description}
 							</p>
 						) : null}
 					</div>
 				</div>
 				{!isCreate && agent ? (
-					<div className="flex items-center gap-2">
+					<div className="flex w-full flex-wrap items-center gap-2 sm:w-auto">
 						{hasChat ? (
 							<TooltipProvider>
 								<Tooltip>
@@ -238,8 +263,13 @@ export function AgentDetailPage() {
 							size="sm"
 							onClick={() =>
 								updateAgent.mutate({
-									params: { path: { agent_id: agent.id ?? "" } },
-									body: { is_active: !isActive, clear_roles: false },
+									params: {
+										path: { agent_id: agent.id ?? "" },
+									},
+									body: {
+										is_active: !isActive,
+										clear_roles: false,
+									},
 								})
 							}
 						>
@@ -249,7 +279,8 @@ export function AgentDetailPage() {
 								</>
 							) : (
 								<>
-									<PlayCircle className="h-3.5 w-3.5" /> Activate
+									<PlayCircle className="h-3.5 w-3.5" />{" "}
+									Activate
 								</>
 							)}
 						</Button>
@@ -265,7 +296,9 @@ export function AgentDetailPage() {
 							<Trash2 className="h-3.5 w-3.5" />
 						</Button>
 						{isPlatformAdmin ? (
-							<SummaryBackfillButton agentId={agent.id ?? undefined} />
+							<SummaryBackfillButton
+								agentId={agent.id ?? undefined}
+							/>
 						) : null}
 					</div>
 				) : null}

--- a/client/src/pages/agents/AgentReviewPage.test.tsx
+++ b/client/src/pages/agents/AgentReviewPage.test.tsx
@@ -123,7 +123,14 @@ async function renderPage(path = "/agents/agent-1/review") {
 	const { AgentReviewPage } = await import("./AgentReviewPage");
 	function LocationProbe() {
 		const loc = useLocation();
-		return <div data-testid="location">{loc.pathname}</div>;
+		return (
+			<div
+				data-testid="location"
+				data-navigation-state={JSON.stringify(loc.state)}
+			>
+				{loc.pathname}
+			</div>
+		);
 	}
 	return renderWithProviders(
 		<Routes>
@@ -138,6 +145,10 @@ async function renderPage(path = "/agents/agent-1/review") {
 			/>
 			<Route
 				path="/agents/:id"
+				element={<LocationProbe />}
+			/>
+			<Route
+				path="/agents/:id/runs/:runId"
 				element={<LocationProbe />}
 			/>
 		</Routes>,
@@ -176,6 +187,26 @@ describe("AgentReviewPage — basic render", () => {
 });
 
 describe("AgentReviewPage — navigation", () => {
+	it("keeps the review queue as the origin for full run details", async () => {
+		const { user } = await renderPage(
+			"/agents/agent-1/review?filter=flagged",
+		);
+
+		await user.click(screen.getByTestId("open-detail"));
+		expect(screen.getByTestId("location")).toHaveTextContent(
+			"/agents/agent-1/runs/a",
+		);
+		expect(screen.getByTestId("location")).toHaveAttribute(
+			"data-navigation-state",
+			JSON.stringify({
+				agentRunOrigin: {
+					href: "/agents/agent-1/review?filter=flagged",
+					label: "Back to Tier-1 Triage review queue",
+				},
+			}),
+		);
+	});
+
 	it("right arrow advances to the next run", async () => {
 		await renderPage();
 		expect(screen.getByTestId("review-counter")).toHaveTextContent(

--- a/client/src/pages/agents/AgentReviewPage.tsx
+++ b/client/src/pages/agents/AgentReviewPage.tsx
@@ -19,7 +19,12 @@
  */
 
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { Link, useNavigate, useParams } from "react-router-dom";
+import {
+	Link,
+	useLocation,
+	useNavigate,
+	useParams,
+} from "react-router-dom";
 import {
 	ArrowLeft,
 	CheckCircle,
@@ -57,6 +62,11 @@ import {
 	formatNumber,
 	formatRelativeTime,
 } from "@/lib/utils";
+import {
+	createAgentRunNavigationState,
+	getLocationHref,
+	type AgentRunNavigationOrigin,
+} from "@/lib/agent-run-navigation";
 import type { components } from "@/lib/v1";
 
 type AgentRun = components["schemas"]["AgentRunResponse"];
@@ -65,9 +75,14 @@ type AgentRunDetailResponse = components["schemas"]["AgentRunDetailResponse"];
 export function AgentReviewPage() {
 	const { id: agentId } = useParams<{ id: string }>();
 	const navigate = useNavigate();
+	const location = useLocation();
 	const queryClient = useQueryClient();
 
 	const { data: agent } = useAgent(agentId);
+	const runNavigationOrigin: AgentRunNavigationOrigin = {
+		href: getLocationHref(location),
+		label: `Back to ${agent?.name ?? "agent"} review queue`,
+	};
 
 	// Queue: flagged runs for this agent. Backend filter returns only the
 	// completed flagged set we want to walk through.
@@ -260,6 +275,7 @@ export function AgentReviewPage() {
 					note={note}
 					onVerdict={handleVerdict}
 					onNote={setNote}
+					runNavigationOrigin={runNavigationOrigin}
 				/>
 			) : (
 				<Skeleton className="h-96 w-full" />
@@ -327,12 +343,14 @@ function FlipbookCard({
 	note,
 	onVerdict,
 	onNote,
+	runNavigationOrigin,
 }: {
 	run: AgentRunDetailResponse;
 	verdict: Verdict;
 	note: string;
 	onVerdict: (v: Verdict) => void;
 	onNote: (n: string) => void;
+	runNavigationOrigin: AgentRunNavigationOrigin;
 }) {
 	const startedAt = run.started_at ?? run.created_at;
 	return (
@@ -358,6 +376,9 @@ function FlipbookCard({
 					<Button asChild variant="ghost" size="sm">
 						<Link
 							to={`/agents/${run.agent_id}/runs/${run.id}`}
+							state={createAgentRunNavigationState(
+								runNavigationOrigin,
+							)}
 							data-testid="open-detail"
 						>
 							Open full detail
@@ -374,6 +395,7 @@ function FlipbookCard({
 					note={note}
 					onVerdict={onVerdict}
 					onNote={onNote}
+					runNavigationOrigin={runNavigationOrigin}
 				/>
 			</CardContent>
 		</Card>

--- a/client/src/pages/agents/AgentRunDetailPage.test.tsx
+++ b/client/src/pages/agents/AgentRunDetailPage.test.tsx
@@ -6,8 +6,9 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { Routes, Route } from "react-router-dom";
+import { Link, Routes, Route } from "react-router-dom";
 import { renderWithProviders, screen, waitFor } from "@/test-utils";
+import { createAgentRunNavigationState } from "@/lib/agent-run-navigation";
 
 // -----------------------------------------------------------------------------
 // Mocks
@@ -57,14 +58,24 @@ vi.mock("@/contexts/AuthContext", () => ({
 
 // Stub heavy children
 vi.mock("@/components/agents/RunReviewPanel", () => ({
+	RunPayloads: () => (
+		<div>
+			<button type="button">Raw input</button>
+			<button type="button">Raw output</button>
+		</div>
+	),
 	RunReviewPanel: ({
 		run,
 		verdict,
 		onVerdict,
+		onActivityReferencePreview,
+		onActivityReferenceActivate,
 	}: {
 		run: { id: string };
 		verdict: string | null;
 		onVerdict: (v: string | null) => void;
+		onActivityReferencePreview?: (activityId: string | null) => void;
+		onActivityReferenceActivate?: (activityId: string) => void;
 	}) => (
 		<div data-testid="run-review-panel" data-run-id={run.id}>
 			<span data-testid="verdict-label">{verdict ?? "none"}</span>
@@ -88,6 +99,14 @@ vi.mock("@/components/agents/RunReviewPanel", () => ({
 				data-testid="clear-verdict"
 			>
 				clear
+			</button>
+			<button
+				type="button"
+				onMouseEnter={() => onActivityReferencePreview?.("step-1")}
+				onMouseLeave={() => onActivityReferencePreview?.(null)}
+				onClick={() => onActivityReferenceActivate?.("step-1")}
+			>
+				activity reference
 			</button>
 		</div>
 	),
@@ -131,6 +150,8 @@ function makeRun(overrides: Record<string, unknown> = {}) {
 		caller_email: "alice@acme.com",
 		caller_name: "Alice",
 		steps: [],
+		child_run_ids: [],
+		child_runs: [],
 		ai_usage: [],
 		ai_totals: null,
 		...overrides,
@@ -184,12 +205,116 @@ describe("AgentRunDetailPage — header + summary", () => {
 
 	it("renders the agent name in the breadcrumb", async () => {
 		await renderPage();
-		const links = screen.getAllByRole("link", { name: /tier-1 triage/i });
-		// Both breadcrumb and the sidebar Agent card link to the same URL.
+		const links = screen.getAllByRole("link", {
+			name: /back to tier-1 triage/i,
+		});
 		expect(links.length).toBeGreaterThan(0);
 		for (const link of links) {
 			expect(link).toHaveAttribute("href", "/agents/agent-1");
 		}
+	});
+
+	it("returns to the exact in-app origin from the contextual breadcrumb", async () => {
+		const { AgentRunDetailPage } = await import("./AgentRunDetailPage");
+		const { user } = renderWithProviders(
+			<Routes>
+				<Route
+					path="/parent-run"
+					element={
+						<div>
+							<h1>Parent run restored</h1>
+							<Link
+								to="/agents/agent-1/runs/run-1"
+								state={createAgentRunNavigationState({
+									href: "/parent-run",
+									label: "Back to Service Desk Triage run",
+								})}
+							>
+								Open child run
+							</Link>
+						</div>
+					}
+				/>
+				<Route
+					path="/agents/:agentId/runs/:runId"
+					element={<AgentRunDetailPage />}
+				/>
+			</Routes>,
+			{ initialEntries: ["/parent-run"] },
+		);
+
+		await user.click(
+			screen.getByRole("link", { name: "Open child run" }),
+		);
+		const back = screen.getByTestId("run-context-back");
+		expect(back).toHaveTextContent("Back to Service Desk Triage run");
+		expect(back).toHaveAttribute("href", "/parent-run");
+
+		await user.click(back);
+		expect(
+			screen.getByRole("heading", { name: "Parent run restored" }),
+		).toBeInTheDocument();
+	});
+
+	it("falls back to the parent run for a directly opened delegated run", async () => {
+		mockUseAgentRun.mockImplementation((id: string | undefined) => {
+			if (id === "parent-run") {
+				return {
+					data: makeRun({
+						id: "parent-run",
+						agent_id: "parent-agent",
+						agent_name: "Service Desk Triage",
+						parent_run_id: null,
+					}),
+					isLoading: false,
+				};
+			}
+			return {
+				data: makeRun({
+					id: "child-run",
+					agent_id: "child-agent",
+					agent_name: "Troubleshooting Specialist",
+					parent_run_id: "parent-run",
+				}),
+				isLoading: false,
+			};
+		});
+
+		await renderPage("/agents/child-agent/runs/child-run");
+		const back = screen.getByTestId("run-context-back");
+		expect(back).toHaveTextContent("Back to Service Desk Triage run");
+		expect(back).toHaveAttribute(
+			"href",
+			"/agents/parent-agent/runs/parent-run",
+		);
+	});
+
+	it("uses the run owner for a direct root-run fallback", async () => {
+		mockUseAgentRun.mockImplementation((id: string | undefined) => ({
+			data:
+				id === "run-1"
+					? makeRun({
+							agent_id: "actual-agent",
+							agent_name: "Actual Owner",
+						})
+					: undefined,
+			isLoading: false,
+		}));
+		mockUseAgent.mockImplementation((id: string | undefined) => ({
+			data: {
+				...baseAgent,
+				id,
+				name: "Actual Owner",
+			},
+			isLoading: false,
+		}));
+
+		await renderPage("/agents/stale-route-agent/runs/run-1");
+		expect(mockUseAgent).toHaveBeenCalledWith("actual-agent");
+		expect(screen.getByTestId("run-context-back")).toHaveAttribute(
+			"href",
+			"/agents/actual-agent",
+		);
 	});
 
 	it("renders the RunReviewPanel with the run id", async () => {
@@ -198,6 +323,97 @@ describe("AgentRunDetailPage — header + summary", () => {
 			"data-run-id",
 			"run-1",
 		);
+	});
+
+	it("keeps grouped work units in Advanced and nests the raw executor trace", async () => {
+		mockUseAgentRun.mockReturnValue({
+			data: makeRun({
+				steps: [
+					{
+						id: "step-1",
+						run_id: "run-1",
+						step_number: 1,
+						type: "tool_result",
+						content: {
+							tool_name: "get_ticket",
+							result: { ticket_id: 428950 },
+						},
+						created_at: "2026-04-20T12:35:00Z",
+					},
+				],
+			}),
+			isLoading: false,
+		});
+		const { user } = await renderPage();
+
+		expect(screen.getByText("Looked up ticket")).toBeInTheDocument();
+		expect(screen.getByText("Ticket: 428950")).toBeInTheDocument();
+		expect(
+			screen.queryByText(/result from get_ticket/i),
+		).not.toBeInTheDocument();
+		expect(screen.queryByText("Raw input")).not.toBeInTheDocument();
+
+		await user.click(screen.getByRole("button", { name: /advanced/i }));
+		expect(screen.getByText(/result from get_ticket/i)).not.toBeVisible();
+		expect(screen.getByText("Looked up ticket")).toBeInTheDocument();
+		expect(screen.getByText("Raw input")).toBeInTheDocument();
+		await user.click(screen.getByText("Details", { exact: true }));
+		expect(
+			screen.getByText("get_ticket", { exact: true }),
+		).toBeInTheDocument();
+		expect(screen.getByText("ticket_id:")).toBeInTheDocument();
+		expect(screen.getByText("428950")).toBeInTheDocument();
+
+		await user.click(
+			screen.getByText("Raw executor trace", { exact: true }),
+		);
+		expect(screen.getByText(/result from get_ticket/i)).toBeInTheDocument();
+	});
+
+	it("previews and scrolls to the activity referenced by summary prose", async () => {
+		const scrollIntoView = vi.fn();
+		Object.defineProperty(HTMLElement.prototype, "scrollIntoView", {
+			configurable: true,
+			value: scrollIntoView,
+		});
+		mockUseAgentRun.mockReturnValue({
+			data: makeRun({
+				steps: [
+					{
+						id: "step-1",
+						run_id: "run-1",
+						step_number: 1,
+						type: "tool_call",
+						content: {
+							tool_name: "get_ticket",
+							arguments: { ticket_id: 428950 },
+						},
+						created_at: "2026-04-20T12:35:00Z",
+					},
+				],
+			}),
+			isLoading: false,
+		});
+		const { user, container } = await renderPage();
+		const reference = screen.getByRole("button", {
+			name: "activity reference",
+		});
+		const activity = container.querySelector('[data-activity-id="step-1"]');
+		expect(activity).toHaveAttribute("data-highlighted", "false");
+
+		await user.hover(reference);
+		expect(activity).toHaveAttribute("data-highlighted", "true");
+		await user.unhover(reference);
+		expect(activity).toHaveAttribute("data-highlighted", "false");
+
+		await user.click(reference);
+		expect(scrollIntoView).toHaveBeenCalledWith({
+			behavior: "smooth",
+			block: "center",
+		});
+		await user.unhover(reference);
+		expect(activity).toHaveAttribute("data-highlighted", "false");
+		expect(activity).toHaveFocus();
 	});
 });
 
@@ -247,16 +463,18 @@ describe("AgentRunDetailPage — verdict actions", () => {
 });
 
 describe("AgentRunDetailPage — sidebar metadata", () => {
-	it("renders run id, model, caller and trigger in the sidebar", async () => {
-		await renderPage();
-		// Run ID rendered
-		expect(screen.getByText(/run-1/)).toBeInTheDocument();
-		// Model
-		expect(screen.getByText(/claude-opus-4-7/)).toBeInTheDocument();
-		// Trigger type
+	it("keeps technical metadata in Advanced while retaining operational context", async () => {
+		const { user } = await renderPage();
+		expect(screen.queryByText(/run-1/)).not.toBeInTheDocument();
+		expect(screen.queryByText(/claude-opus-4-7/)).not.toBeInTheDocument();
 		expect(screen.getByText(/test/)).toBeInTheDocument();
-		// Caller name preferred over email
 		expect(screen.getByText(/alice/i)).toBeInTheDocument();
+
+		await user.click(screen.getByRole("button", { name: /advanced/i }));
+		expect(screen.getByText(/run-1/)).toBeInTheDocument();
+		expect(screen.getByText(/claude-opus-4-7/)).toBeInTheDocument();
+		expect(screen.getByText("Iterations")).toBeInTheDocument();
+		expect(screen.getByText("Tokens")).toBeInTheDocument();
 	});
 });
 
@@ -369,14 +587,14 @@ describe("AgentRunDetailPage — AI usage card", () => {
 			}),
 			isLoading: false,
 		});
-		await renderPage();
+		const { user } = await renderPage();
+		expect(screen.queryByTestId("ai-usage-card")).not.toBeInTheDocument();
+		await user.click(screen.getByRole("button", { name: /advanced/i }));
 		expect(screen.getByTestId("ai-usage-card")).toBeInTheDocument();
 	});
 
 	it("hides the AI usage card when there is no usage data", async () => {
 		await renderPage();
-		expect(
-			screen.queryByTestId("ai-usage-card"),
-		).not.toBeInTheDocument();
+		expect(screen.queryByTestId("ai-usage-card")).not.toBeInTheDocument();
 	});
 });

--- a/client/src/pages/agents/AgentRunDetailPage.tsx
+++ b/client/src/pages/agents/AgentRunDetailPage.tsx
@@ -5,9 +5,9 @@
  *   /agents/:agentId/runs/:runId  → this page
  *
  * Layout:
- *   - Page header (breadcrumb back to agent + run summary + status badge)
- *   - Main column: <RunReviewPanel variant="page"> + Advanced collapsible
- *     for the raw step timeline
+ *   - Page header (contextual back link + run summary + status badge)
+ *   - Main column: <RunReviewPanel variant="page"> + grouped Activity with
+ *     an explicit Advanced mode for raw executor records and payloads
  *   - Sidebar: run metadata, AI usage cost breakdown, regen-summary button
  *     (admins only when summary failed), and per-flag conversation when the
  *     run's verdict is "down"
@@ -18,19 +18,29 @@
  * hooks, shadcn primitives, Tailwind. No inline styles.
  */
 
-import { useMemo, useState } from "react";
-import { Link, useNavigate, useParams } from "react-router-dom";
+import {
+	useMemo,
+	useState,
+	type MouseEvent as ReactMouseEvent,
+} from "react";
+import {
+	Link,
+	useLocation,
+	useNavigate,
+	useParams,
+} from "react-router-dom";
 import {
 	AlertCircle,
 	ArrowLeft,
 	Bot,
 	CheckCircle,
-	ChevronDown,
+	ChevronRight,
+	Code2,
 	Clock,
+	ListTree,
 	Loader2,
 	RefreshCw,
 	Sparkles,
-	Terminal,
 	XCircle,
 } from "lucide-react";
 import { useQueryClient } from "@tanstack/react-query";
@@ -40,24 +50,23 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
 	Card,
+	CardAction,
 	CardContent,
+	CardDescription,
 	CardHeader,
 	CardTitle,
 } from "@/components/ui/card";
-import {
-	Collapsible,
-	CollapsibleContent,
-	CollapsibleTrigger,
-} from "@/components/ui/collapsible";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useAuth } from "@/contexts/AuthContext";
 import { useAgent } from "@/hooks/useAgents";
 import { useAgentRunUpdates } from "@/hooks/useAgentRunUpdates";
 import {
-	formatCost,
-	formatDuration,
-	formatNumber,
-} from "@/lib/utils";
+	createAgentRunNavigationState,
+	getLocationHref,
+	readAgentRunNavigationOrigin,
+	type AgentRunNavigationOrigin,
+} from "@/lib/agent-run-navigation";
+import { formatCost, formatDuration, formatNumber } from "@/lib/utils";
 import {
 	useAgentRun,
 	useClearVerdict,
@@ -72,9 +81,11 @@ import type { components } from "@/lib/v1";
 import { FlagConversation } from "@/components/agents/FlagConversation";
 import {
 	RunReviewPanel,
+	RunPayloads,
 	type Verdict,
 } from "@/components/agents/RunReviewPanel";
-import { Timeline } from "@/components/agents/Timeline";
+import { AdvancedTimeline, Timeline } from "@/components/agents/Timeline";
+import { activityDomId } from "@/components/agents/run-activity";
 
 type AgentRunDetailResponse = components["schemas"]["AgentRunDetailResponse"];
 
@@ -85,28 +96,53 @@ export function AgentRunDetailPage() {
 	}>();
 	const queryClient = useQueryClient();
 	const { isPlatformAdmin } = useAuth();
+	const location = useLocation();
+	const navigate = useNavigate();
+	const navigationOrigin = readAgentRunNavigationOrigin(location.state);
 
 	// `useAgentRun` returns a hand-rolled `AgentRunDetail` type that predates
 	// some OpenAPI fields (asked/did/verdict/etc). Re-cast to the OpenAPI
 	// schema for full field access.
 	const { data: rawRun, isLoading } = useAgentRun(runId);
 	const run = rawRun as unknown as AgentRunDetailResponse | undefined;
-	const { data: agent } = useAgent(agentId);
+	const owningAgentId = run?.agent_id ?? agentId;
+	const { data: agent } = useAgent(owningAgentId);
+	const parentRunId = navigationOrigin
+		? undefined
+		: (run?.parent_run_id ?? undefined);
+	const { data: rawParentRun } = useAgentRun(parentRunId);
+	const parentRun = parentRunId
+		? (rawParentRun as unknown as AgentRunDetailResponse | undefined)
+		: undefined;
 
 	// Refetch this run whenever the backend broadcasts an update for it —
 	// covers summarizer transitions (pending → generating → completed) and
 	// step-writes so the page reflects live state without a manual refresh.
-	useAgentRunUpdates({ agentId });
+	useAgentRunUpdates({ agentId: owningAgentId });
 
 	const verdict = ((run?.verdict as Verdict | undefined) ?? null) as Verdict;
 	const [note, setNote] = useState<string>(run?.verdict_note ?? "");
-	const [advancedOpen, setAdvancedOpen] = useState(false);
+	const [advancedView, setAdvancedView] = useState(false);
+	const [previewedActivityId, setPreviewedActivityId] = useState<
+		string | null
+	>(null);
+	const [expandedDelegationsByRun, setExpandedDelegationsByRun] = useState<
+		Record<string, ReadonlySet<string>>
+	>({});
+	const [restoreActivityByRun, setRestoreActivityByRun] = useState<
+		Record<string, string>
+	>({});
 
 	const setVerdict = useSetVerdict();
 	const clearVerdict = useClearVerdict();
 	const regenSummary = useRegenerateSummary();
 	const rerun = useRerunAgentRun();
-	const navigate = useNavigate();
+	const currentRunOrigin: AgentRunNavigationOrigin | null = run
+		? {
+				href: getLocationHref(location),
+				label: `Back to ${run.agent_name ?? agent?.name ?? "parent"} run`,
+			}
+		: null;
 
 	const isFlagged = verdict === "down";
 	const { data: conversation } = useFlagConversation(
@@ -168,13 +204,77 @@ export function AgentRunDetailPage() {
 			{
 				onSuccess: (data) => {
 					toast.success("Rerun queued");
-					if (data.run_id) {
-						navigate(`/agents/${run.agent_id}/runs/${data.run_id}`);
+					if (data.run_id && currentRunOrigin) {
+						navigate(
+							`/agents/${run.agent_id}/runs/${data.run_id}`,
+							{
+								state: createAgentRunNavigationState(
+									currentRunOrigin,
+								),
+							},
+						);
 					}
 				},
 				onError: () => toast.error("Failed to queue rerun"),
 			},
 		);
+	}
+
+	function handleContextBackClick(
+		event: ReactMouseEvent<HTMLAnchorElement>,
+	) {
+		if (
+			!navigationOrigin ||
+			event.defaultPrevented ||
+			event.button !== 0 ||
+			event.metaKey ||
+			event.ctrlKey ||
+			event.shiftKey ||
+			event.altKey
+		) {
+			return;
+		}
+
+		event.preventDefault();
+		navigate(-1);
+	}
+
+	function handleActivityReferenceActivate(activityId: string) {
+		const target = document.getElementById(activityDomId(activityId));
+		if (!target) return;
+		const reduceMotion =
+			window.matchMedia?.("(prefers-reduced-motion: reduce)").matches ??
+			false;
+		target.scrollIntoView({
+			behavior: reduceMotion ? "auto" : "smooth",
+			block: "center",
+		});
+		target.focus({ preventScroll: true });
+	}
+
+	function handleDelegationExpandedChange(
+		activityId: string,
+		expanded: boolean,
+	) {
+		if (!runId) return;
+		setExpandedDelegationsByRun((current) => {
+			const nextForRun = new Set(current[runId] ?? []);
+			if (expanded) {
+				nextForRun.add(activityId);
+			} else {
+				nextForRun.delete(activityId);
+			}
+			return { ...current, [runId]: nextForRun };
+		});
+	}
+
+	function handleOpenChildRun(activityId: string) {
+		if (!runId) return;
+		setPreviewedActivityId(null);
+		setRestoreActivityByRun((current) => ({
+			...current,
+			[runId]: activityId,
+		}));
 	}
 
 	if (isLoading) {
@@ -195,6 +295,9 @@ export function AgentRunDetailPage() {
 	}
 
 	if (!run) {
+		const notFoundBackHref =
+			navigationOrigin?.href ??
+			(agentId ? `/agents/${agentId}` : "/agents");
 		return (
 			<div
 				className="flex flex-col items-center justify-center gap-3 py-16 text-center"
@@ -203,8 +306,11 @@ export function AgentRunDetailPage() {
 				<AlertCircle className="h-10 w-10 text-muted-foreground" />
 				<div className="text-lg font-medium">Run not found</div>
 				<Button asChild variant="outline">
-					<Link to={agentId ? `/agents/${agentId}` : "/agents"}>
-						Back to agent
+					<Link
+						to={notFoundBackHref}
+						onClick={handleContextBackClick}
+					>
+						{navigationOrigin?.label ?? "Back to agent"}
 					</Link>
 				</Button>
 			</div>
@@ -224,6 +330,18 @@ export function AgentRunDetailPage() {
 	// the summarizer prompt). `did` is a multi-sentence narrative under v3+
 	// and too long for a title; only fall back to it when `asked` is empty.
 	const headerSummary = run.asked || run.did || "Agent run";
+	const parentRunHref = parentRun
+		? `/agents/${parentRun.agent_id}/runs/${parentRun.id}`
+		: null;
+	const backHref =
+		navigationOrigin?.href ??
+		parentRunHref ??
+		`/agents/${run.agent_id}`;
+	const backLabel =
+		navigationOrigin?.label ??
+		(parentRun
+			? `Back to ${parentRun.agent_name ?? "parent"} run`
+			: `Back to ${agent?.name ?? run.agent_name ?? "agent"}`);
 
 	return (
 		<div
@@ -232,11 +350,13 @@ export function AgentRunDetailPage() {
 		>
 			{/* Breadcrumb */}
 			<Link
-				to={`/agents/${run.agent_id}`}
+				to={backHref}
+				onClick={handleContextBackClick}
+				data-testid="run-context-back"
 				className="inline-flex w-fit items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground"
 			>
 				<ArrowLeft className="h-3 w-3" />
-				{agent?.name ?? "Back to agent"}
+				{backLabel}
 			</Link>
 
 			{/* Header */}
@@ -263,11 +383,15 @@ export function AgentRunDetailPage() {
 									</span>
 								</>
 							) : null}
-							<span>·</span>
-							<span>
-								{run.iterations_used} iter ·{" "}
-								{formatNumber(run.tokens_used)} tok
-							</span>
+							{advancedView ? (
+								<>
+									<span>·</span>
+									<span>
+										{run.iterations_used} iter ·{" "}
+										{formatNumber(run.tokens_used)} tok
+									</span>
+								</>
+							) : null}
 						</div>
 					</div>
 				</div>
@@ -302,41 +426,118 @@ export function AgentRunDetailPage() {
 							note={note}
 							onVerdict={handleVerdict}
 							onNote={setNote}
+							onActivityReferencePreview={setPreviewedActivityId}
+							onActivityReferenceActivate={
+								handleActivityReferenceActivate
+							}
 						/>
 					</Card>
 
-					{/* Advanced (raw step timeline) */}
-					<Collapsible
-						open={advancedOpen}
-						onOpenChange={setAdvancedOpen}
-					>
-						<CollapsibleTrigger asChild>
-							<button
-								type="button"
-								className="flex w-full items-center gap-2 rounded-2xl bg-card px-3 py-2 text-left text-xs text-muted-foreground shadow-sm ring-1 ring-foreground/5 hover:bg-accent/40 dark:ring-foreground/10"
-							>
-								<ChevronDown
-									className={`h-3 w-3 transition-transform ${
-										advancedOpen ? "rotate-0" : "-rotate-90"
-									}`}
+					<Card data-slot="run-activity">
+						<CardHeader className="border-b pb-4">
+							<CardTitle className="flex items-center gap-2 text-sm">
+								<ListTree className="h-4 w-4 text-muted-foreground" />
+								Activity
+							</CardTitle>
+							<CardDescription className="text-xs">
+								How the agent handled this run, in order
+							</CardDescription>
+							<CardAction>
+								<div
+									role="group"
+									aria-label="Activity detail level"
+									className="flex rounded-lg bg-muted p-0.5 text-xs"
+								>
+									<button
+										type="button"
+										aria-pressed={!advancedView}
+										onClick={() => setAdvancedView(false)}
+										className={`rounded-md px-2.5 py-1.5 font-medium transition-colors ${
+											!advancedView
+												? "bg-background text-foreground shadow-sm"
+												: "text-muted-foreground hover:text-foreground"
+										}`}
+									>
+										Activity
+									</button>
+									<button
+										type="button"
+										aria-pressed={advancedView}
+										onClick={() => setAdvancedView(true)}
+										className={`inline-flex items-center gap-1.5 rounded-md px-2.5 py-1.5 font-medium transition-colors ${
+											advancedView
+												? "bg-background text-foreground shadow-sm"
+												: "text-muted-foreground hover:text-foreground"
+										}`}
+									>
+										<Code2 className="h-3 w-3" />
+										Advanced
+									</button>
+								</div>
+							</CardAction>
+						</CardHeader>
+						<CardContent>
+							<div className="grid gap-5">
+								<Timeline
+									steps={run.steps ?? []}
+									childRunIds={run.child_run_ids ?? []}
+									childRuns={run.child_runs ?? []}
+									runStatus={run.status}
+									showTechnicalDetails={advancedView}
+									highlightedActivityId={previewedActivityId}
+									expandedDelegationIds={
+										runId
+											? expandedDelegationsByRun[runId]
+											: undefined
+									}
+									onDelegationExpandedChange={
+										handleDelegationExpandedChange
+									}
+									restoreActivityId={
+										runId
+											? restoreActivityByRun[runId]
+											: null
+									}
+									onOpenChildRun={handleOpenChildRun}
+									childRunOrigin={
+										currentRunOrigin ?? undefined
+									}
 								/>
-								<Terminal className="h-3 w-3" />
-								<span>
-									Timeline ({(run.steps ?? []).length} steps)
-								</span>
-								<span className="ml-2 text-[11px]">
-									Step-by-step view of what the executor did
-								</span>
-							</button>
-						</CollapsibleTrigger>
-						<CollapsibleContent>
-							<Card className="mt-2">
-								<CardContent className="p-3">
-									<Timeline steps={run.steps ?? []} />
-								</CardContent>
-							</Card>
-						</CollapsibleContent>
-					</Collapsible>
+								{advancedView && (run.input || run.output) ? (
+									<section className="border-t pt-4">
+										<div className="mb-2 text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
+											Run payloads
+										</div>
+										<RunPayloads
+											input={run.input}
+											output={run.output}
+										/>
+									</section>
+								) : null}
+								{advancedView &&
+								(run.steps?.length ?? 0) > 0 ? (
+									<details
+										className="group border-t pt-4"
+										data-slot="raw-executor-trace"
+									>
+										<summary className="flex min-h-8 cursor-pointer list-none items-center gap-2 rounded-md px-1 text-xs font-medium text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring [&::-webkit-details-marker]:hidden">
+											<ChevronRight className="h-3.5 w-3.5 transition-transform group-open:rotate-90" />
+											<Code2 className="h-3.5 w-3.5" />
+											<span>Raw executor trace</span>
+											<span className="ml-auto font-normal tabular-nums">
+												{run.steps?.length ?? 0} events
+											</span>
+										</summary>
+										<div className="mt-2.5 rounded-lg border bg-background/50 p-3">
+											<AdvancedTimeline
+												steps={run.steps ?? []}
+											/>
+										</div>
+									</details>
+								) : null}
+							</div>
+						</CardContent>
+					</Card>
 
 					{/* Per-flag conversation (only when verdict=down) */}
 					{isFlagged ? (
@@ -365,16 +566,18 @@ export function AgentRunDetailPage() {
 					<Card>
 						<CardHeader className="pb-2">
 							<CardTitle className="text-sm">
-								Run metadata
+								Run details
 							</CardTitle>
 						</CardHeader>
 						<CardContent>
 							<dl className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-2 text-xs">
-								<MetaRow label="Run ID">
-									<span className="font-mono text-[11px] break-all">
-										{run.id}
-									</span>
-								</MetaRow>
+								{advancedView ? (
+									<MetaRow label="Run ID">
+										<span className="font-mono text-[11px] break-all">
+											{run.id}
+										</span>
+									</MetaRow>
+								) : null}
 								{run.started_at ? (
 									<MetaRow label="Started">
 										{new Date(
@@ -387,17 +590,21 @@ export function AgentRunDetailPage() {
 										? formatDuration(run.duration_ms)
 										: "—"}
 								</MetaRow>
-								<MetaRow label="Iterations">
-									{run.iterations_used}
-								</MetaRow>
-								<MetaRow label="Tokens">
-									{formatNumber(run.tokens_used)}
-								</MetaRow>
-								<MetaRow label="Model">
-									<span className="font-mono">
-										{run.llm_model ?? "default"}
-									</span>
-								</MetaRow>
+								{advancedView ? (
+									<>
+										<MetaRow label="Iterations">
+											{run.iterations_used}
+										</MetaRow>
+										<MetaRow label="Tokens">
+											{formatNumber(run.tokens_used)}
+										</MetaRow>
+										<MetaRow label="Model">
+											<span className="font-mono">
+												{run.llm_model ?? "default"}
+											</span>
+										</MetaRow>
+									</>
+								) : null}
 								<MetaRow label="Trigger">
 									{run.trigger_type}
 								</MetaRow>
@@ -411,7 +618,7 @@ export function AgentRunDetailPage() {
 					</Card>
 
 					{/* AI usage */}
-					{run.ai_usage && run.ai_usage.length > 0 ? (
+					{advancedView && run.ai_usage && run.ai_usage.length > 0 ? (
 						<AIUsageCard
 							usage={run.ai_usage}
 							totals={run.ai_totals ?? null}
@@ -423,9 +630,7 @@ export function AgentRunDetailPage() {
 						<Card>
 							<CardContent className="flex items-center justify-between gap-3 py-3 text-xs">
 								<div>
-									<div className="font-medium">
-										Summary
-									</div>
+									<div className="font-medium">Summary</div>
 									<div className="text-muted-foreground">
 										{summaryFailed
 											? "Generation failed"
@@ -615,7 +820,10 @@ function AIUsageCard({
 					</thead>
 					<tbody>
 						{grouped.map((row) => (
-							<tr key={row.model} className="border-b last:border-0">
+							<tr
+								key={row.model}
+								className="border-b last:border-0"
+							>
 								<td className="py-1.5 pr-2 font-mono text-muted-foreground">
 									{row.model.length > 20
 										? `${row.model.slice(0, 18)}…`

--- a/client/src/pages/agents/AgentRunDetailPage.tsx
+++ b/client/src/pages/agents/AgentRunDetailPage.tsx
@@ -127,11 +127,11 @@ export function AgentRunDetailPage() {
 		string | null
 	>(null);
 	const [expandedDelegationsByRun, setExpandedDelegationsByRun] = useState<
-		Record<string, ReadonlySet<string>>
-	>({});
+		ReadonlyMap<string, ReadonlySet<string>>
+	>(() => new Map());
 	const [restoreActivityByRun, setRestoreActivityByRun] = useState<
-		Record<string, string>
-	>({});
+		ReadonlyMap<string, string>
+	>(() => new Map());
 
 	const setVerdict = useSetVerdict();
 	const clearVerdict = useClearVerdict();
@@ -258,23 +258,26 @@ export function AgentRunDetailPage() {
 	) {
 		if (!runId) return;
 		setExpandedDelegationsByRun((current) => {
-			const nextForRun = new Set(current[runId] ?? []);
+			const nextForRun = new Set(current.get(runId) ?? []);
 			if (expanded) {
 				nextForRun.add(activityId);
 			} else {
 				nextForRun.delete(activityId);
 			}
-			return { ...current, [runId]: nextForRun };
+			const next = new Map(current);
+			next.set(runId, nextForRun);
+			return next;
 		});
 	}
 
 	function handleOpenChildRun(activityId: string) {
 		if (!runId) return;
 		setPreviewedActivityId(null);
-		setRestoreActivityByRun((current) => ({
-			...current,
-			[runId]: activityId,
-		}));
+		setRestoreActivityByRun((current) => {
+			const next = new Map(current);
+			next.set(runId, activityId);
+			return next;
+		});
 	}
 
 	if (isLoading) {
@@ -487,7 +490,9 @@ export function AgentRunDetailPage() {
 									highlightedActivityId={previewedActivityId}
 									expandedDelegationIds={
 										runId
-											? expandedDelegationsByRun[runId]
+											? expandedDelegationsByRun.get(
+													runId,
+												)
 											: undefined
 									}
 									onDelegationExpandedChange={
@@ -495,7 +500,7 @@ export function AgentRunDetailPage() {
 									}
 									restoreActivityId={
 										runId
-											? restoreActivityByRun[runId]
+											? restoreActivityByRun.get(runId)
 											: null
 									}
 									onOpenChildRun={handleOpenChildRun}


### PR DESCRIPTION
## Summary
- record delegated subagent runs and reconstruct historical parent-child relationships
- replace raw executor triplets with a human-readable Activity view and expandable agent work
- keep raw payloads and executor records available in Advanced
- constrain agent overview and runs scrolling while aligning run-list layouts
- preserve originating run, overview, history, review, and tuning context when opening a run

## Verification
- API quality: Pyright and Ruff passed
- Backend: 23 focused unit tests and 2 live API tests passed after rebase
- Frontend: 1,652 Vitest tests passed after rebase
- Rendered flow: all 8 agent detail/run Playwright tests passed after rebase
- Full browser matrix before the conflict-free rebase: 106 passed, 2 existing OAuth skips
- Type generation produced no diff; TypeScript and ESLint passed

Fixes #495