### PR TITLE
chore(release): refresh plugin manifests to 1.1.1-dev.22

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "bifrost",
   "description": "Bifrost — MSP automation platform. Skills for building workflows, forms, agents, apps, tables, and files with the Bifrost SDK + CLI. Includes :build (create and debug artifacts), :setup (install CLI, authenticate, configure MCP), and :copilot-cowork-package (package Bifrost agents as Microsoft 365 Copilot Cowork plugins), :migrate (move a legacy v1 inline app + its backing entities into an installable v2 Solution).",
-  "version": "1.1.1-dev.9",
+  "version": "1.1.1-dev.22",
   "author": {
     "name": "Jack Musick",
     "url": "https://github.com/gobifrost/bifrost"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "bifrost",
-  "version": "1.1.1-dev.9",
+  "version": "1.1.1-dev.22",
   "description": "Bifrost — MSP automation platform. Skills for building workflows, forms, agents, apps, tables, and files with the Bifrost SDK + CLI, setting up local Bifrost development, and packaging Bifrost agents as Microsoft 365 Copilot Cowork plugins, :migrate (move a legacy v1 inline app + its backing entities into an installable v2 Solution).",
   "author": {
     "name": "Jack Musick",

--- a/plugins/bifrost/.codex-plugin/plugin.json
+++ b/plugins/bifrost/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "bifrost",
-  "version": "1.1.1-dev.9",
+  "version": "1.1.1-dev.22",
   "description": "Bifrost — MSP automation platform. Skills for building workflows, forms, agents, apps, tables, and files with the Bifrost SDK + CLI, setting up local Bifrost development, and packaging Bifrost agents as Microsoft 365 Copilot Cowork plugins, :migrate (move a legacy v1 inline app + its backing entities into an installable v2 Solution).",
   "author": {
     "name": "Jack Musick",


### PR DESCRIPTION
## Summary

- bump the Claude Code plugin manifest from `1.1.1-dev.9` to `1.1.1-dev.22`
- bump both Codex plugin manifests to the same version
- keep this as a one-time dev refresh without changing the established tag-time release policy

## Why

Shipped plugin skill content changed after the last manifest bump. Claude Code and Codex key cached plugin content by manifest version, so users can otherwise remain on stale skill content even though the repository has newer files.

`origin/main` computed to `1.1.1-dev.21` before this change. The bump commit is commit 22, so `1.1.1-dev.22` matches `scripts/compute-dev-version.sh` on this branch after the commit.

## Impact

Installed plugin users can discover the latest shipped Bifrost skill content. There are no runtime, API, database, or UI changes.

## Validation

- `bash scripts/test-compute-dev-version.sh` — 8 passed
- `./scripts/update-plugin-version.sh 1.1.1-dev.22` — idempotent across all three manifests
- verified all manifest `.version` fields equal `1.1.1-dev.22`
- `./scripts/compute-dev-version.sh` returns `1.1.1-dev.22` after the commit
- `git diff --check`

Closes #522
