### PR TITLE
Bound agent knowledge retrieval with hybrid search

### DIFF
--- a/api/alembic/versions/20260724_knowledge_search_tsv.py
+++ b/api/alembic/versions/20260724_knowledge_search_tsv.py
@@ -1,0 +1,56 @@
+"""add full-text index for hybrid knowledge retrieval
+
+Revision ID: 20260724_knowledge_search_tsv
+Revises: 20260723_exec_started_idx
+Create Date: 2026-07-24
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "20260724_knowledge_search_tsv"
+down_revision: str = "20260723_exec_started_idx"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute("""
+        ALTER TABLE knowledge_store ADD COLUMN search_tsv tsvector
+        GENERATED ALWAYS AS (
+            setweight(to_tsvector('english', coalesce(key, '')), 'A') ||
+            setweight(
+                to_tsvector('english', coalesce(metadata ->> 'title', '')),
+                'A'
+            ) ||
+            setweight(
+                to_tsvector('english', coalesce(metadata ->> 'parent_slug', '')),
+                'B'
+            ) ||
+            setweight(
+                to_tsvector(
+                    'english',
+                    coalesce(metadata ->> 'faq_breadcrumbs', '')
+                ),
+                'B'
+            ) ||
+            setweight(to_tsvector('english', coalesce(content, '')), 'C')
+        ) STORED
+    """)
+    op.create_index(
+        "ix_knowledge_search_tsv_gin",
+        "knowledge_store",
+        ["search_tsv"],
+        postgresql_using="gin",
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_knowledge_search_tsv_gin",
+        table_name="knowledge_store",
+    )
+    op.execute("ALTER TABLE knowledge_store DROP COLUMN search_tsv")

--- a/api/src/models/orm/knowledge.py
+++ b/api/src/models/orm/knowledge.py
@@ -9,8 +9,17 @@ from datetime import datetime, timezone
 from typing import TYPE_CHECKING
 from uuid import UUID, uuid4
 
-from sqlalchemy import DateTime, ForeignKey, Index, String, Text, UniqueConstraint, text
-from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy import (
+    Computed,
+    DateTime,
+    ForeignKey,
+    Index,
+    String,
+    Text,
+    UniqueConstraint,
+    text,
+)
+from sqlalchemy.dialects.postgresql import JSONB, TSVECTOR
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from src.models.orm.base import Base
@@ -73,6 +82,38 @@ class KnowledgeStore(Base):
     # known dimension; sequential scan is fine at our scale.
     embedding: Mapped[list] = mapped_column(Vector(), nullable=False)
 
+    # Lexical side of hybrid retrieval. Imported knowledge commonly stores
+    # titles and navigation context in metadata rather than repeating them in
+    # every chunk, so those fields are weighted above body text. Avoid indexing
+    # the entire metadata JSON: image UUIDs and other transport metadata add
+    # noise without improving retrieval.
+    search_tsv: Mapped[str] = mapped_column(
+        TSVECTOR,
+        Computed(
+            """
+            setweight(to_tsvector('english', coalesce(key, '')), 'A') ||
+            setweight(
+                to_tsvector('english', coalesce(metadata ->> 'title', '')),
+                'A'
+            ) ||
+            setweight(
+                to_tsvector('english', coalesce(metadata ->> 'parent_slug', '')),
+                'B'
+            ) ||
+            setweight(
+                to_tsvector(
+                    'english',
+                    coalesce(metadata ->> 'faq_breadcrumbs', '')
+                ),
+                'B'
+            ) ||
+            setweight(to_tsvector('english', coalesce(content, '')), 'C')
+            """,
+            persisted=True,
+        ),
+        deferred=True,
+    )
+
     # Audit
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), server_default=text("NOW()")
@@ -126,6 +167,12 @@ class KnowledgeStore(Base):
         ),
         # Metadata filtering (GIN index for JSONB) - uses column name "metadata" not attribute name
         Index("ix_knowledge_metadata", "metadata", postgresql_using="gin"),
+        # PostgreSQL full-text candidate retrieval for hybrid knowledge search.
+        Index(
+            "ix_knowledge_search_tsv_gin",
+            "search_tsv",
+            postgresql_using="gin",
+        ),
         # Note: Vector index (IVFFlat) is created in migration since it requires
         # special syntax not easily expressed in SQLAlchemy
     )

--- a/api/src/repositories/knowledge.py
+++ b/api/src/repositories/knowledge.py
@@ -2,9 +2,10 @@
 Knowledge Repository
 
 Data access layer for the knowledge store (RAG).
-Handles vector storage, semantic search, and namespace management.
+Handles vector storage, hybrid search, and namespace management.
 """
 
+import re
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Any
@@ -16,6 +17,15 @@ from src.models.orm import KnowledgeStore
 from src.repositories.org_scoped import OrgScopedRepository
 from src.services.embeddings import BaseEmbeddingClient
 from src.services.knowledge.chunking import reassemble_chunks, split_into_chunks
+
+
+HYBRID_CANDIDATE_LIMIT = 20
+RRF_K = 60
+VECTOR_RRF_WEIGHT = 0.5
+LEXICAL_RRF_WEIGHT = 0.5
+
+_LEXICAL_TERM_RE = re.compile(r"[^\W_]+", re.UNICODE)
+_MAX_LEXICAL_TERMS = 24
 
 
 @dataclass
@@ -38,6 +48,37 @@ class NamespaceInfo:
 
     namespace: str
     scopes: dict[str, int]  # {"global": count, "org": count, "total": count}
+
+
+@dataclass
+class _HybridCandidate:
+    """One physical chunk participating in reciprocal-rank fusion."""
+
+    row: KnowledgeStore
+    rrf_score: float = 0.0
+    vector_score: float | None = None
+    lexical_score: float | None = None
+
+
+def _lexical_websearch_query(query: str) -> str:
+    """Build a safe OR query for broad full-text candidate retrieval.
+
+    ``websearch_to_tsquery`` handles stemming and stop words. Joining parsed
+    word tokens with OR avoids requiring every conversational filler word to
+    appear in a chunk, while vector rank fusion keeps broad lexical matches
+    from dominating the final result.
+    """
+    terms: list[str] = []
+    seen: set[str] = set()
+    for match in _LEXICAL_TERM_RE.finditer(query.casefold()):
+        term = match.group(0)
+        if len(term) < 2 or term in seen:
+            continue
+        seen.add(term)
+        terms.append(term)
+        if len(terms) >= _MAX_LEXICAL_TERMS:
+            break
+    return " OR ".join(terms)
 
 
 class KnowledgeRepository(OrgScopedRepository[KnowledgeStore]):
@@ -344,6 +385,7 @@ class KnowledgeRepository(OrgScopedRepository[KnowledgeStore]):
         self,
         query_embedding: list[float],
         namespace: str | list[str],
+        query_text: str | None = None,
         organization_id: UUID | None = None,
         limit: int = 5,
         min_score: float | None = None,
@@ -352,77 +394,131 @@ class KnowledgeRepository(OrgScopedRepository[KnowledgeStore]):
         group_by_key: bool = True,
     ) -> list[KnowledgeDocument]:
         """
-        Search for similar documents using vector similarity.
+        Search for relevant chunks.
+
+        When ``query_text`` is provided, retrieve a broad candidate set from
+        both vector similarity and PostgreSQL full-text search, then combine
+        their ranks with reciprocal-rank fusion (RRF). Without query text the
+        method preserves the original vector-only behavior for SDK callers
+        that already supply a precomputed embedding.
 
         Args:
             query_embedding: Query vector
             namespace: Namespace(s) to search
+            query_text: Original query text. Enables hybrid lexical/vector search.
             organization_id: Organization scope. Defaults to self.org_id.
             limit: Maximum results
-            min_score: Minimum similarity score (0-1)
+            min_score: Minimum vector similarity or normalized fused score (0-1)
             metadata_filter: Filter by metadata fields
             fallback: If True, also search global scope
             group_by_key: If True, return at most one chunk per keyed document
 
         Returns:
-            List of KnowledgeDocument sorted by similarity
+            List of KnowledgeDocument sorted by relevance
         """
-        # Use self.org_id as default if not explicitly provided
         target_org_id = organization_id if organization_id is not None else self.org_id
         namespaces = [namespace] if isinstance(namespace, str) else namespace
 
-        # Build the query
-        # We use cosine distance (1 - cosine_similarity), so lower is better
-        # Convert to similarity score: 1 - distance
-        distance_expr = KnowledgeStore.embedding.cosine_distance(query_embedding)
-        score_expr = (1 - distance_expr).label("score")
+        filters = [KnowledgeStore.namespace.in_(namespaces)]
 
-        stmt = select(
-            KnowledgeStore,
-            score_expr,
-        ).where(
-            KnowledgeStore.namespace.in_(namespaces)
-        )
-
-        # Organization scoping with optional fallback
+        # Organization scoping with optional fallback.
         if target_org_id and fallback:
-            # Search both org and global
-            stmt = stmt.where(
-                (KnowledgeStore.organization_id == target_org_id) |
-                (KnowledgeStore.organization_id.is_(None))
+            filters.append(
+                (KnowledgeStore.organization_id == target_org_id)
+                | (KnowledgeStore.organization_id.is_(None))
             )
         elif target_org_id:
-            # Only org scope
-            stmt = stmt.where(KnowledgeStore.organization_id == target_org_id)
+            filters.append(KnowledgeStore.organization_id == target_org_id)
         else:
-            # Only global scope
-            stmt = stmt.where(KnowledgeStore.organization_id.is_(None))
+            filters.append(KnowledgeStore.organization_id.is_(None))
 
-        # Metadata filtering using JSONB containment
         if metadata_filter:
-            for key, value in metadata_filter.items():
-                # Use @> containment operator
-                stmt = stmt.where(
-                    KnowledgeStore.doc_metadata.contains({key: value})
+            filters.extend(
+                KnowledgeStore.doc_metadata.contains({key: value})
+                for key, value in metadata_filter.items()
+            )
+
+        # Cosine distance is lower-is-better; expose similarity as 0..1.
+        distance_expr = KnowledgeStore.embedding.cosine_distance(query_embedding)
+        vector_score_expr = (1 - distance_expr).label("vector_score")
+        candidate_limit = max(HYBRID_CANDIDATE_LIMIT, limit * 4)
+        vector_stmt = (
+            select(KnowledgeStore, vector_score_expr)
+            .where(*filters)
+            .order_by(vector_score_expr.desc())
+            .limit(candidate_limit)
+        )
+        vector_rows = (await self.session.execute(vector_stmt)).all()
+
+        lexical_query = _lexical_websearch_query(query_text or "")
+        if not lexical_query:
+            ranked_rows = [
+                (row[0], float(row[1]))
+                for row in vector_rows
+                if min_score is None or row[1] >= min_score
+            ]
+        else:
+            ts_query = func.websearch_to_tsquery("english", lexical_query)
+            lexical_score_expr = func.ts_rank_cd(
+                KnowledgeStore.search_tsv,
+                ts_query,
+                32,
+            ).label("lexical_score")
+            lexical_stmt = (
+                select(KnowledgeStore, lexical_score_expr)
+                .where(
+                    *filters,
+                    KnowledgeStore.search_tsv.op("@@")(ts_query),
                 )
+                .order_by(lexical_score_expr.desc())
+                .limit(candidate_limit)
+            )
+            lexical_rows = (await self.session.execute(lexical_stmt)).all()
 
-        stmt = stmt.order_by(score_expr.desc())
-        raw_limit = limit * 4 if group_by_key else limit
-        stmt = stmt.limit(raw_limit)
+            candidates: dict[UUID, _HybridCandidate] = {}
+            for rank, row in enumerate(vector_rows, start=1):
+                chunk = row[0]
+                candidate = candidates.setdefault(
+                    chunk.id,
+                    _HybridCandidate(row=chunk),
+                )
+                candidate.vector_score = float(row[1])
+                candidate.rrf_score += VECTOR_RRF_WEIGHT / (RRF_K + rank)
 
-        result = await self.session.execute(stmt)
-        rows = result.all()
+            for rank, row in enumerate(lexical_rows, start=1):
+                chunk = row[0]
+                candidate = candidates.setdefault(
+                    chunk.id,
+                    _HybridCandidate(row=chunk),
+                )
+                candidate.lexical_score = float(row[1])
+                candidate.rrf_score += LEXICAL_RRF_WEIGHT / (RRF_K + rank)
+
+            # Normalize against the theoretical score for rank 1 in both
+            # retrievers so the public score remains an intuitive 0..1 value.
+            max_rrf_score = (
+                VECTOR_RRF_WEIGHT + LEXICAL_RRF_WEIGHT
+            ) / (RRF_K + 1)
+            ranked_candidates = sorted(
+                candidates.values(),
+                key=lambda item: (
+                    item.rrf_score,
+                    item.lexical_score if item.lexical_score is not None else -1.0,
+                    item.vector_score if item.vector_score is not None else -1.0,
+                    str(item.row.id),
+                ),
+                reverse=True,
+            )
+            ranked_rows = [
+                (candidate.row, candidate.rrf_score / max_rrf_score)
+                for candidate in ranked_candidates
+                if min_score is None
+                or candidate.rrf_score / max_rrf_score >= min_score
+            ]
 
         documents: list[KnowledgeDocument] = []
         seen_keys: set[tuple[str, str | None, str]] = set()
-        for row in rows:
-            doc = row[0]
-            score = row[1]
-
-            # Filter by min_score if specified
-            if min_score is not None and score < min_score:
-                continue
-
+        for doc, score in ranked_rows:
             if group_by_key and doc.key is not None:
                 dedup_key = (
                     doc.namespace,
@@ -439,7 +535,7 @@ class KnowledgeRepository(OrgScopedRepository[KnowledgeStore]):
                     namespace=doc.namespace,
                     content=doc.content,
                     metadata=doc.doc_metadata,
-                    score=float(score),
+                    score=score,
                     organization_id=str(doc.organization_id) if doc.organization_id else None,
                     key=doc.key,
                     created_at=doc.created_at,

--- a/api/src/routers/cli.py
+++ b/api/src/routers/cli.py
@@ -2313,14 +2313,14 @@ async def cli_knowledge_store_many(
 
 @router.post(
     "/knowledge/search",
-    summary="Search for similar documents",
+    summary="Hybrid-search knowledge documents",
 )
 async def cli_knowledge_search(
     request: "CLIKnowledgeSearchRequest",
     current_user: CurrentUser,
     db: AsyncSession = Depends(get_db),
 ) -> list[CLIKnowledgeDocumentResponse]:
-    """Search for similar documents using vector similarity."""
+    """Search knowledge using fused lexical and vector rankings."""
     _deny_external_knowledge(current_user)
     from src.models.contracts.cli import CLIKnowledgeDocumentResponse
     from src.repositories.knowledge import KnowledgeRepository
@@ -2342,6 +2342,7 @@ async def cli_knowledge_search(
         results = await repo.search(
             query_embedding=query_embedding,
             namespace=request.namespace,
+            query_text=request.query,
             limit=request.limit,
             min_score=request.min_score,
             metadata_filter=request.metadata_filter,

--- a/api/src/services/agent_executor.py
+++ b/api/src/services/agent_executor.py
@@ -52,7 +52,9 @@ from src.services.execution.autonomous_agent_executor import AutonomousAgentExec
 from src.services.knowledge.search_budget import (
     KnowledgeSearchBudget,
     clamp_knowledge_result_limit,
+    compact_knowledge_metadata,
     knowledge_search_rejection_payload,
+    select_novel_knowledge_evidence,
 )
 from src.services.mcp_client import dispatch as mcp_dispatch
 from src.services.mcp_client.errors import (
@@ -1578,6 +1580,7 @@ IMPORTANT: When the user's request can be fulfilled using one of your tools, you
                 results = await repo.search(
                     query_embedding=query_embedding,
                     namespace=namespaces,
+                    query_text=query,
                     limit=limit,
                     fallback=True,
                 )
@@ -1585,25 +1588,37 @@ IMPORTANT: When the user's request can be fulfilled using one of your tools, you
             duration_ms = int((time.time() - start_time) * 1000)
 
             # Format results for the agent
-            search_results = [
-                {
-                    "content": doc.content,
-                    "namespace": doc.namespace,
-                    "score": round(doc.score, 4) if doc.score else None,
-                    "key": doc.key,
-                    "metadata": doc.metadata,
-                }
-                for doc in results
-            ]
+            evidence = select_novel_knowledge_evidence(
+                self._knowledge_search_budget,
+                [
+                    (
+                        doc.id,
+                        {
+                            "content": doc.content,
+                            "namespace": doc.namespace,
+                            "score": round(doc.score, 4)
+                            if doc.score is not None
+                            else None,
+                            "key": doc.key,
+                            "metadata": compact_knowledge_metadata(doc.metadata),
+                        },
+                    )
+                    for doc in results
+                ],
+            )
 
             return ToolResult(
                 tool_call_id=tool_call.id,
                 tool_name=tool_call.name,
                 result={
-                    "documents": search_results,
-                    "count": len(search_results),
+                    "documents": evidence.documents,
+                    "count": len(evidence.documents),
+                    "omitted_duplicate_evidence": evidence.omitted_duplicates,
+                    "omitted_for_evidence_budget": evidence.omitted_for_budget,
                     "searches_used": decision.searches_used,
                     "searches_remaining": decision.searches_remaining,
+                    "evidence_chars_used": evidence.evidence_chars_used,
+                    "evidence_chars_remaining": evidence.evidence_chars_remaining,
                 },
                 error=None,
                 duration_ms=duration_ms,

--- a/api/src/services/agent_executor.py
+++ b/api/src/services/agent_executor.py
@@ -49,6 +49,11 @@ from src.services.execution.agent_helpers import (
     resolve_agent_tools,
 )
 from src.services.execution.autonomous_agent_executor import AutonomousAgentExecutor
+from src.services.knowledge.search_budget import (
+    KnowledgeSearchBudget,
+    clamp_knowledge_result_limit,
+    knowledge_search_rejection_payload,
+)
 from src.services.mcp_client import dispatch as mcp_dispatch
 from src.services.mcp_client.errors import (
     MisconfigError,
@@ -105,6 +110,7 @@ class AgentExecutor:
     def __init__(self, session_factory: async_sessionmaker[AsyncSession]):
         self._session_factory = session_factory
         self._tool_workflow_id_map: dict[str, UUID] = {}  # normalized tool name → workflow UUID
+        self._knowledge_search_budget = KnowledgeSearchBudget()
 
     @asynccontextmanager
     async def _db(self):
@@ -214,6 +220,7 @@ class AgentExecutor:
         from src.services.agent_router import AgentRouter
 
         start_time = time.time()
+        self._knowledge_search_budget.reset()
         router = AgentRouter(
             self._session_factory,
             user_id=user.user_id if user else None,
@@ -553,6 +560,13 @@ IMPORTANT: When the user's request can be fulfilled using one of your tools, you
                             tool_name=tc.name,
                         )
                     )
+
+                if self._knowledge_search_budget.exhausted:
+                    tool_definitions = [
+                        tool
+                        for tool in tool_definitions
+                        if tool.name != "search_knowledge"
+                    ]
 
                 # Continue loop to get LLM response with tool results
 
@@ -1517,7 +1531,9 @@ IMPORTANT: When the user's request can be fulfilled using one of your tools, you
 
             # Get search parameters
             query = tool_call.arguments.get("query", "")
-            limit = tool_call.arguments.get("limit", 5)
+            limit = clamp_knowledge_result_limit(
+                tool_call.arguments.get("limit", 5)
+            )
 
             if not query:
                 return ToolResult(
@@ -1536,6 +1552,16 @@ IMPORTANT: When the user's request can be fulfilled using one of your tools, you
                     tool_name=tool_call.name,
                     result=None,
                     error="No knowledge sources configured for this agent",
+                    duration_ms=int((time.time() - start_time) * 1000),
+                )
+
+            decision = self._knowledge_search_budget.reserve(query)
+            if not decision.allowed:
+                return ToolResult(
+                    tool_call_id=tool_call.id,
+                    tool_name=tool_call.name,
+                    result=knowledge_search_rejection_payload(decision),
+                    error=None,
                     duration_ms=int((time.time() - start_time) * 1000),
                 )
 
@@ -1573,7 +1599,12 @@ IMPORTANT: When the user's request can be fulfilled using one of your tools, you
             return ToolResult(
                 tool_call_id=tool_call.id,
                 tool_name=tool_call.name,
-                result={"documents": search_results, "count": len(search_results)},
+                result={
+                    "documents": search_results,
+                    "count": len(search_results),
+                    "searches_used": decision.searches_used,
+                    "searches_remaining": decision.searches_remaining,
+                },
                 error=None,
                 duration_ms=duration_ms,
             )

--- a/api/src/services/execution/autonomous_agent_executor.py
+++ b/api/src/services/execution/autonomous_agent_executor.py
@@ -37,7 +37,9 @@ from src.services.llm import LLMMessage, ToolCallRequest, get_llm_client
 from src.services.knowledge.search_budget import (
     KnowledgeSearchBudget,
     clamp_knowledge_result_limit,
+    compact_knowledge_metadata,
     knowledge_search_rejection_payload,
+    select_novel_knowledge_evidence,
 )
 from src.services.mcp_client import dispatch as mcp_dispatch
 from src.services.mcp_client.errors import (
@@ -602,6 +604,7 @@ class AutonomousAgentExecutor:
                 results = await repo.search(
                     query_embedding=query_embedding,
                     namespace=namespaces,
+                    query_text=query,
                     limit=limit,
                     fallback=True,
                 )
@@ -610,21 +613,33 @@ class AutonomousAgentExecutor:
                 return "No relevant knowledge found."
 
             # Format results
-            search_results = [
-                {
-                    "content": doc.content,
-                    "namespace": doc.namespace,
-                    "score": round(doc.score, 4) if doc.score else None,
-                    "key": doc.key,
-                    "metadata": doc.metadata,
-                }
-                for doc in results
-            ]
+            evidence = select_novel_knowledge_evidence(
+                self._knowledge_search_budget,
+                [
+                    (
+                        doc.id,
+                        {
+                            "content": doc.content,
+                            "namespace": doc.namespace,
+                            "score": round(doc.score, 4)
+                            if doc.score is not None
+                            else None,
+                            "key": doc.key,
+                            "metadata": compact_knowledge_metadata(doc.metadata),
+                        },
+                    )
+                    for doc in results
+                ],
+            )
             return json.dumps({
-                "documents": search_results,
-                "count": len(search_results),
+                "documents": evidence.documents,
+                "count": len(evidence.documents),
+                "omitted_duplicate_evidence": evidence.omitted_duplicates,
+                "omitted_for_evidence_budget": evidence.omitted_for_budget,
                 "searches_used": decision.searches_used,
                 "searches_remaining": decision.searches_remaining,
+                "evidence_chars_used": evidence.evidence_chars_used,
+                "evidence_chars_remaining": evidence.evidence_chars_remaining,
             })
 
         except Exception as e:

--- a/api/src/services/execution/autonomous_agent_executor.py
+++ b/api/src/services/execution/autonomous_agent_executor.py
@@ -34,6 +34,11 @@ from src.services.execution.agent_helpers import (
     resolve_agent_tools,
 )
 from src.services.llm import LLMMessage, ToolCallRequest, get_llm_client
+from src.services.knowledge.search_budget import (
+    KnowledgeSearchBudget,
+    clamp_knowledge_result_limit,
+    knowledge_search_rejection_payload,
+)
 from src.services.mcp_client import dispatch as mcp_dispatch
 from src.services.mcp_client.errors import (
     MisconfigError,
@@ -87,6 +92,7 @@ class AutonomousAgentExecutor:
         # Buffers for Redis-first pattern (flushed to DB after run completes)
         self._pending_steps: list[dict[str, Any]] = []
         self._pending_ai_usage: list[dict[str, Any]] = []
+        self._knowledge_search_budget = KnowledgeSearchBudget()
 
     async def run(
         self,
@@ -112,6 +118,7 @@ class AutonomousAgentExecutor:
         """
         run_id = run_id or str(uuid4())
         self._current_run_id = run_id
+        self._knowledge_search_budget.reset()
 
         # Resolve caller_user_id from _caller metadata. If a webhook ran
         # without a signed user claim, _caller is either absent or has no
@@ -352,6 +359,13 @@ class AutonomousAgentExecutor:
                 })
                 break
 
+            if self._knowledge_search_budget.exhausted:
+                tool_definitions = [
+                    tool
+                    for tool in tool_definitions
+                    if tool.name != "search_knowledge"
+                ]
+
             # Check token budget
             if tokens_used >= max_tokens:
                 status = "budget_exceeded"
@@ -562,7 +576,9 @@ class AutonomousAgentExecutor:
             from src.services.embeddings import get_embedding_client
 
             query = tool_call.arguments.get("query", "")
-            limit = tool_call.arguments.get("limit", 5)
+            limit = clamp_knowledge_result_limit(
+                tool_call.arguments.get("limit", 5)
+            )
 
             if not query:
                 return "No query provided for knowledge search"
@@ -570,6 +586,10 @@ class AutonomousAgentExecutor:
             namespaces = agent.knowledge_sources
             if not namespaces:
                 return "No knowledge sources configured for this agent"
+
+            decision = self._knowledge_search_budget.reserve(query)
+            if not decision.allowed:
+                return json.dumps(knowledge_search_rejection_payload(decision))
 
             # Brief DB session for embedding client config + knowledge search
             async with self._session_factory() as db:
@@ -600,7 +620,12 @@ class AutonomousAgentExecutor:
                 }
                 for doc in results
             ]
-            return json.dumps({"documents": search_results, "count": len(search_results)})
+            return json.dumps({
+                "documents": search_results,
+                "count": len(search_results),
+                "searches_used": decision.searches_used,
+                "searches_remaining": decision.searches_remaining,
+            })
 
         except Exception as e:
             logger.error(f"Knowledge search failed: {e}", exc_info=True)

--- a/api/src/services/knowledge/search_budget.py
+++ b/api/src/services/knowledge/search_budget.py
@@ -1,0 +1,120 @@
+"""Per-turn limits for agent knowledge retrieval.
+
+Knowledge results are fed back into the model's conversation history. Repeating
+the same search (or issuing many searches in one tool-calling loop) therefore
+causes every later LLM request to resend all earlier results. These guards keep
+that cumulative context bounded while still allowing a few distinct retrieval
+attempts for synonyms and product-specific vocabulary.
+"""
+
+from dataclasses import dataclass
+from typing import Literal
+
+
+MAX_KNOWLEDGE_RESULTS = 5
+MAX_KNOWLEDGE_SEARCHES_PER_TURN = 3
+
+KnowledgeSearchRejection = Literal["duplicate_query", "search_budget_exhausted"]
+
+
+@dataclass(frozen=True)
+class KnowledgeSearchDecision:
+    """Result of reserving one knowledge search in the current turn."""
+
+    allowed: bool
+    normalized_query: str
+    searches_used: int
+    searches_remaining: int
+    rejection: KnowledgeSearchRejection | None = None
+
+
+class KnowledgeSearchBudget:
+    """Track unique knowledge searches for one agent turn."""
+
+    def __init__(self, max_searches: int = MAX_KNOWLEDGE_SEARCHES_PER_TURN):
+        if max_searches < 1:
+            raise ValueError("max_searches must be at least 1")
+        self.max_searches = max_searches
+        self._queries: set[str] = set()
+
+    @property
+    def searches_used(self) -> int:
+        return len(self._queries)
+
+    @property
+    def searches_remaining(self) -> int:
+        return max(0, self.max_searches - self.searches_used)
+
+    @property
+    def exhausted(self) -> bool:
+        return self.searches_remaining == 0
+
+    def reset(self) -> None:
+        """Start a fresh agent turn."""
+        self._queries.clear()
+
+    def reserve(self, query: str) -> KnowledgeSearchDecision:
+        """Reserve a unique query or explain why it should not execute."""
+        normalized = " ".join(query.split()).casefold()
+
+        if normalized in self._queries:
+            return KnowledgeSearchDecision(
+                allowed=False,
+                normalized_query=normalized,
+                searches_used=self.searches_used,
+                searches_remaining=self.searches_remaining,
+                rejection="duplicate_query",
+            )
+
+        if self.exhausted:
+            return KnowledgeSearchDecision(
+                allowed=False,
+                normalized_query=normalized,
+                searches_used=self.searches_used,
+                searches_remaining=0,
+                rejection="search_budget_exhausted",
+            )
+
+        self._queries.add(normalized)
+        return KnowledgeSearchDecision(
+            allowed=True,
+            normalized_query=normalized,
+            searches_used=self.searches_used,
+            searches_remaining=self.searches_remaining,
+        )
+
+
+def clamp_knowledge_result_limit(value: object) -> int:
+    """Coerce an LLM-supplied result limit into the supported 1..5 range."""
+    try:
+        requested = int(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError, OverflowError):
+        requested = MAX_KNOWLEDGE_RESULTS
+    return max(1, min(requested, MAX_KNOWLEDGE_RESULTS))
+
+
+def knowledge_search_rejection_payload(
+    decision: KnowledgeSearchDecision,
+) -> dict[str, object]:
+    """Return a small tool payload that directs the model away from a loop."""
+    if decision.rejection == "duplicate_query":
+        message = (
+            "This exact query was already searched in this turn. Reuse the "
+            "previous results or try a materially different query."
+        )
+    else:
+        message = (
+            f"Knowledge search budget reached ({decision.searches_used} unique "
+            "queries). Synthesize the answer from results already returned; "
+            "do not search again."
+        )
+
+    return {
+        "documents": [],
+        "count": 0,
+        "search_skipped": True,
+        "reason": decision.rejection,
+        "message": message,
+        "searches_used": decision.searches_used,
+        "searches_remaining": decision.searches_remaining,
+    }

--- a/api/src/services/knowledge/search_budget.py
+++ b/api/src/services/knowledge/search_budget.py
@@ -1,20 +1,43 @@
-"""Per-turn limits for agent knowledge retrieval.
+"""Per-turn evidence controls for agent knowledge retrieval.
 
 Knowledge results are fed back into the model's conversation history. Repeating
 the same search (or issuing many searches in one tool-calling loop) therefore
-causes every later LLM request to resend all earlier results. These guards keep
-that cumulative context bounded while still allowing a few distinct retrieval
-attempts for synonyms and product-specific vocabulary.
+causes every later LLM request to resend all earlier results. The primary bound
+is therefore the serialized evidence returned during a turn, not a low query
+count. Exact-query and query-count guards remain as loop protection.
 """
 
+import json
 from dataclasses import dataclass
-from typing import Literal
+from typing import Any, Literal
 
 
 MAX_KNOWLEDGE_RESULTS = 5
-MAX_KNOWLEDGE_SEARCHES_PER_TURN = 3
+MAX_KNOWLEDGE_SEARCHES_PER_TURN = 8
+MAX_KNOWLEDGE_EVIDENCE_CHARS_PER_TURN = 40_000
+MIN_KNOWLEDGE_EVIDENCE_CHARS = 512
+MAX_KNOWLEDGE_METADATA_CHARS = 2_000
 
-KnowledgeSearchRejection = Literal["duplicate_query", "search_budget_exhausted"]
+_KNOWLEDGE_METADATA_PRIORITY = (
+    "title",
+    "source",
+    "source_url",
+    "url",
+    "parent_slug",
+    "faq_breadcrumbs",
+    "modified",
+    "wp_id",
+    "chunk_index",
+    "chunk_count",
+)
+_KNOWLEDGE_METADATA_OMIT = frozenset({"image_uuids"})
+
+KnowledgeSearchRejection = Literal[
+    "duplicate_query",
+    "search_budget_exhausted",
+    "evidence_budget_exhausted",
+]
+EvidenceClaim = Literal["accepted", "duplicate_evidence", "evidence_budget_exhausted"]
 
 
 @dataclass(frozen=True)
@@ -25,17 +48,42 @@ class KnowledgeSearchDecision:
     normalized_query: str
     searches_used: int
     searches_remaining: int
+    evidence_chars_used: int
+    evidence_chars_remaining: int
     rejection: KnowledgeSearchRejection | None = None
 
 
-class KnowledgeSearchBudget:
-    """Track unique knowledge searches for one agent turn."""
+@dataclass(frozen=True)
+class KnowledgeEvidenceSelection:
+    """Novel evidence selected from one retrieval result."""
 
-    def __init__(self, max_searches: int = MAX_KNOWLEDGE_SEARCHES_PER_TURN):
+    documents: list[dict[str, Any]]
+    omitted_duplicates: int
+    omitted_for_budget: int
+    evidence_chars_used: int
+    evidence_chars_remaining: int
+
+
+class KnowledgeSearchBudget:
+    """Track unique queries and serialized evidence for one agent turn."""
+
+    def __init__(
+        self,
+        max_searches: int = MAX_KNOWLEDGE_SEARCHES_PER_TURN,
+        max_evidence_chars: int = MAX_KNOWLEDGE_EVIDENCE_CHARS_PER_TURN,
+    ):
         if max_searches < 1:
             raise ValueError("max_searches must be at least 1")
+        if max_evidence_chars < MIN_KNOWLEDGE_EVIDENCE_CHARS:
+            raise ValueError(
+                "max_evidence_chars must be at least "
+                f"{MIN_KNOWLEDGE_EVIDENCE_CHARS}"
+            )
         self.max_searches = max_searches
+        self.max_evidence_chars = max_evidence_chars
         self._queries: set[str] = set()
+        self._evidence_ids: set[str] = set()
+        self._evidence_chars = 0
 
     @property
     def searches_used(self) -> int:
@@ -46,12 +94,25 @@ class KnowledgeSearchBudget:
         return max(0, self.max_searches - self.searches_used)
 
     @property
+    def evidence_chars_used(self) -> int:
+        return self._evidence_chars
+
+    @property
+    def evidence_chars_remaining(self) -> int:
+        return max(0, self.max_evidence_chars - self.evidence_chars_used)
+
+    @property
     def exhausted(self) -> bool:
-        return self.searches_remaining == 0
+        return (
+            self.searches_remaining == 0
+            or self.evidence_chars_remaining < MIN_KNOWLEDGE_EVIDENCE_CHARS
+        )
 
     def reset(self) -> None:
         """Start a fresh agent turn."""
         self._queries.clear()
+        self._evidence_ids.clear()
+        self._evidence_chars = 0
 
     def reserve(self, query: str) -> KnowledgeSearchDecision:
         """Reserve a unique query or explain why it should not execute."""
@@ -63,16 +124,31 @@ class KnowledgeSearchBudget:
                 normalized_query=normalized,
                 searches_used=self.searches_used,
                 searches_remaining=self.searches_remaining,
+                evidence_chars_used=self.evidence_chars_used,
+                evidence_chars_remaining=self.evidence_chars_remaining,
                 rejection="duplicate_query",
             )
 
-        if self.exhausted:
+        if self.searches_remaining == 0:
             return KnowledgeSearchDecision(
                 allowed=False,
                 normalized_query=normalized,
                 searches_used=self.searches_used,
                 searches_remaining=0,
+                evidence_chars_used=self.evidence_chars_used,
+                evidence_chars_remaining=self.evidence_chars_remaining,
                 rejection="search_budget_exhausted",
+            )
+
+        if self.evidence_chars_remaining < MIN_KNOWLEDGE_EVIDENCE_CHARS:
+            return KnowledgeSearchDecision(
+                allowed=False,
+                normalized_query=normalized,
+                searches_used=self.searches_used,
+                searches_remaining=self.searches_remaining,
+                evidence_chars_used=self.evidence_chars_used,
+                evidence_chars_remaining=self.evidence_chars_remaining,
+                rejection="evidence_budget_exhausted",
             )
 
         self._queries.add(normalized)
@@ -81,7 +157,96 @@ class KnowledgeSearchBudget:
             normalized_query=normalized,
             searches_used=self.searches_used,
             searches_remaining=self.searches_remaining,
+            evidence_chars_used=self.evidence_chars_used,
+            evidence_chars_remaining=self.evidence_chars_remaining,
         )
+
+    def claim_evidence(self, evidence_id: str, serialized_chars: int) -> EvidenceClaim:
+        """Reserve one serialized chunk if it is novel and fits the envelope."""
+        if serialized_chars < 0:
+            raise ValueError("serialized_chars cannot be negative")
+        if evidence_id in self._evidence_ids:
+            return "duplicate_evidence"
+        if serialized_chars > self.evidence_chars_remaining:
+            return "evidence_budget_exhausted"
+
+        self._evidence_ids.add(evidence_id)
+        self._evidence_chars += serialized_chars
+        return "accepted"
+
+
+def compact_knowledge_metadata(metadata: dict[str, Any]) -> dict[str, Any]:
+    """Keep useful source metadata within a small, deterministic envelope.
+
+    Agent evidence needs titles and source/navigation fields for grounding and
+    citations. It does not need transport-only image UUID arrays, and arbitrary
+    metadata must not be able to consume the entire turn evidence budget.
+    Small custom fields are preserved after the common source fields.
+    """
+    ordered_keys = [
+        key for key in _KNOWLEDGE_METADATA_PRIORITY if key in metadata
+    ]
+    ordered_keys.extend(
+        sorted(
+            key
+            for key in metadata
+            if key not in _KNOWLEDGE_METADATA_PRIORITY
+            and key not in _KNOWLEDGE_METADATA_OMIT
+        )
+    )
+
+    compacted: dict[str, Any] = {}
+    for key in ordered_keys:
+        if key in _KNOWLEDGE_METADATA_OMIT:
+            continue
+        candidate = {**compacted, key: metadata[key]}
+        serialized_chars = len(
+            json.dumps(
+                candidate,
+                default=str,
+                ensure_ascii=False,
+                separators=(",", ":"),
+            )
+        )
+        if serialized_chars <= MAX_KNOWLEDGE_METADATA_CHARS:
+            compacted[key] = metadata[key]
+
+    return compacted
+
+
+def select_novel_knowledge_evidence(
+    budget: KnowledgeSearchBudget,
+    documents: list[tuple[str, dict[str, Any]]],
+) -> KnowledgeEvidenceSelection:
+    """Deduplicate and budget the actual JSON payload sent to the model."""
+    selected: list[dict[str, Any]] = []
+    omitted_duplicates = 0
+    omitted_for_budget = 0
+
+    for evidence_id, document in documents:
+        serialized_chars = len(
+            json.dumps(
+                document,
+                default=str,
+                ensure_ascii=False,
+                separators=(",", ":"),
+            )
+        )
+        claim = budget.claim_evidence(evidence_id, serialized_chars)
+        if claim == "accepted":
+            selected.append(document)
+        elif claim == "duplicate_evidence":
+            omitted_duplicates += 1
+        else:
+            omitted_for_budget += 1
+
+    return KnowledgeEvidenceSelection(
+        documents=selected,
+        omitted_duplicates=omitted_duplicates,
+        omitted_for_budget=omitted_for_budget,
+        evidence_chars_used=budget.evidence_chars_used,
+        evidence_chars_remaining=budget.evidence_chars_remaining,
+    )
 
 
 def clamp_knowledge_result_limit(value: object) -> int:
@@ -102,9 +267,14 @@ def knowledge_search_rejection_payload(
             "This exact query was already searched in this turn. Reuse the "
             "previous results or try a materially different query."
         )
+    elif decision.rejection == "evidence_budget_exhausted":
+        message = (
+            "The knowledge evidence envelope for this turn is full. Synthesize "
+            "the answer from results already returned; do not search again."
+        )
     else:
         message = (
-            f"Knowledge search budget reached ({decision.searches_used} unique "
+            f"Knowledge search safety ceiling reached ({decision.searches_used} unique "
             "queries). Synthesize the answer from results already returned; "
             "do not search again."
         )
@@ -117,4 +287,6 @@ def knowledge_search_rejection_payload(
         "message": message,
         "searches_used": decision.searches_used,
         "searches_remaining": decision.searches_remaining,
+        "evidence_chars_used": decision.evidence_chars_used,
+        "evidence_chars_remaining": decision.evidence_chars_remaining,
     }

--- a/api/src/services/mcp_server/server.py
+++ b/api/src/services/mcp_server/server.py
@@ -508,6 +508,17 @@ def get_system_tools() -> list[dict[str, Any]]:
                         if param.default is inspect.Parameter.empty:
                             parameters["required"].append(param_name)
 
+                if tool_id == "search_knowledge":
+                    from src.services.knowledge.search_budget import (
+                        MAX_KNOWLEDGE_RESULTS,
+                    )
+
+                    parameters["properties"]["limit"].update({
+                        "minimum": 1,
+                        "maximum": MAX_KNOWLEDGE_RESULTS,
+                        "default": MAX_KNOWLEDGE_RESULTS,
+                    })
+
                 tools.append({
                     "id": tool_id,
                     "name": name,

--- a/api/src/services/mcp_server/tools/knowledge.py
+++ b/api/src/services/mcp_server/tools/knowledge.py
@@ -82,6 +82,7 @@ async def search_knowledge(
             results = await repo.search(
                 query_embedding=query_embedding,
                 namespace=namespaces_to_search,
+                query_text=query,
                 limit=limit,
                 fallback=True,
             )
@@ -117,7 +118,11 @@ TOOLS = [
     (
         "search_knowledge",
         "Search Knowledge",
-        "Search the Bifrost knowledge base. Returns at most 5 results.",
+        (
+            "Hybrid-search the Bifrost knowledge base. Returns at most 5 "
+            "deduplicated results; use materially different queries for "
+            "follow-up searches."
+        ),
     ),
 ]
 

--- a/api/src/services/mcp_server/tools/knowledge.py
+++ b/api/src/services/mcp_server/tools/knowledge.py
@@ -11,6 +11,7 @@ from fastmcp.tools import ToolResult
 
 from src.services.mcp_server.tool_result import error_result, success_result
 from src.services.mcp_server.tools.db import get_tool_db
+from src.services.knowledge.search_budget import clamp_knowledge_result_limit
 
 # MCPContext is imported where needed to avoid circular imports
 
@@ -38,6 +39,8 @@ async def search_knowledge(
 
     if not query:
         return error_result("query is required")
+
+    limit = clamp_knowledge_result_limit(limit)
 
     # External (portal/guest) principals have no direct knowledge surface:
     # the store has no grant axis (no roles, no access_level), so it is
@@ -111,7 +114,11 @@ async def search_knowledge(
 
 # Tool metadata for registration
 TOOLS = [
-    ("search_knowledge", "Search Knowledge", "Search the Bifrost knowledge base."),
+    (
+        "search_knowledge",
+        "Search Knowledge",
+        "Search the Bifrost knowledge base. Returns at most 5 results.",
+    ),
 ]
 
 

--- a/api/tests/unit/repositories/test_knowledge_repository.py
+++ b/api/tests/unit/repositories/test_knowledge_repository.py
@@ -193,3 +193,49 @@ async def test_search_metadata_filter_applies_to_chunks(db_session):
 
     assert all(result.metadata.get("client_id") == "acme" for result in results)
     assert any(result.key == "acme-doc" for result in results)
+
+
+@pytest.mark.asyncio
+async def test_hybrid_search_recovers_exact_lexical_match_missed_by_vector_candidates(
+    db_session,
+):
+    repo = KnowledgeRepository(db_session, org_id=None, is_superuser=True)
+
+    for index in range(21):
+        db_session.add(
+            KnowledgeStore(
+                namespace="ns-hybrid",
+                key=f"distractor-{index}",
+                content=f"Generic account configuration article {index}.",
+                embedding=[1.0, 0.0, 0.0],
+            )
+        )
+    db_session.add(
+        KnowledgeStore(
+            namespace="ns-hybrid",
+            key="contact-types",
+            content=(
+                "Use Contact Types to identify the Technical POC and Billing "
+                "POC for a customer."
+            ),
+            embedding=[-1.0, 0.0, 0.0],
+        )
+    )
+    await db_session.flush()
+
+    vector_only = await repo.search(
+        query_embedding=[1.0, 0.0, 0.0],
+        namespace="ns-hybrid",
+        limit=5,
+    )
+    hybrid = await repo.search(
+        query_embedding=[1.0, 0.0, 0.0],
+        query_text="Where do I set the Technical POC and Billing POC?",
+        namespace="ns-hybrid",
+        limit=5,
+    )
+
+    assert "contact-types" not in [doc.key for doc in vector_only]
+    assert hybrid[0].key == "contact-types"
+    assert hybrid[0].score is not None
+    assert 0.0 <= hybrid[0].score <= 1.0

--- a/api/tests/unit/services/knowledge/test_search_budget.py
+++ b/api/tests/unit/services/knowledge/test_search_budget.py
@@ -1,13 +1,19 @@
 """Unit tests for per-turn knowledge retrieval limits."""
 
+import json
+
 import pytest
 
 from src.services.knowledge.search_budget import (
+    MAX_KNOWLEDGE_EVIDENCE_CHARS_PER_TURN,
+    MAX_KNOWLEDGE_METADATA_CHARS,
     MAX_KNOWLEDGE_RESULTS,
     MAX_KNOWLEDGE_SEARCHES_PER_TURN,
     KnowledgeSearchBudget,
     clamp_knowledge_result_limit,
+    compact_knowledge_metadata,
     knowledge_search_rejection_payload,
+    select_novel_knowledge_evidence,
 )
 
 
@@ -63,7 +69,91 @@ def test_budget_rejects_fourth_unique_query_and_resets():
     budget.reset()
     assert budget.exhausted is False
     assert budget.searches_used == 0
+    assert budget.evidence_chars_used == 0
     assert budget.reserve("one query too many").allowed is True
+
+
+def test_evidence_is_deduplicated_across_different_queries():
+    budget = KnowledgeSearchBudget()
+
+    first = select_novel_knowledge_evidence(
+        budget,
+        [
+            ("chunk-1", {"content": "Technical POC settings"}),
+            ("chunk-2", {"content": "Billing POC settings"}),
+        ],
+    )
+    second = select_novel_knowledge_evidence(
+        budget,
+        [
+            ("chunk-1", {"content": "Technical POC settings"}),
+            ("chunk-3", {"content": "Contact type configuration"}),
+        ],
+    )
+
+    assert [doc["content"] for doc in first.documents] == [
+        "Technical POC settings",
+        "Billing POC settings",
+    ]
+    assert [doc["content"] for doc in second.documents] == [
+        "Contact type configuration"
+    ]
+    assert second.omitted_duplicates == 1
+    assert second.omitted_for_budget == 0
+    assert second.evidence_chars_used <= MAX_KNOWLEDGE_EVIDENCE_CHARS_PER_TURN
+
+
+def test_evidence_envelope_rejects_payload_that_would_overflow():
+    budget = KnowledgeSearchBudget(max_evidence_chars=512)
+
+    selection = select_novel_knowledge_evidence(
+        budget,
+        [
+            ("fits", {"content": "a" * 400}),
+            ("overflows", {"content": "b" * 400}),
+        ],
+    )
+
+    assert len(selection.documents) == 1
+    assert selection.omitted_for_budget == 1
+    assert selection.evidence_chars_used <= 512
+    assert selection.evidence_chars_remaining >= 0
+
+
+def test_compact_metadata_keeps_grounding_and_drops_transport_noise():
+    metadata = {
+        "image_uuids": [f"image-{index}" for index in range(1_000)],
+        "custom_category": "users",
+        "title": "Site Contacts",
+        "parent_slug": "site-contacts",
+    }
+
+    compacted = compact_knowledge_metadata(metadata)
+
+    assert compacted == {
+        "title": "Site Contacts",
+        "parent_slug": "site-contacts",
+        "custom_category": "users",
+    }
+    assert len(json.dumps(compacted)) <= MAX_KNOWLEDGE_METADATA_CHARS
+
+
+def test_full_evidence_envelope_rejects_another_search_and_resets():
+    budget = KnowledgeSearchBudget(max_evidence_chars=512)
+    assert budget.claim_evidence("chunk", 512) == "accepted"
+
+    rejected = budget.reserve("another query")
+
+    assert rejected.allowed is False
+    assert rejected.rejection == "evidence_budget_exhausted"
+    assert budget.exhausted is True
+    payload = knowledge_search_rejection_payload(rejected)
+    assert payload["reason"] == "evidence_budget_exhausted"
+    assert payload["evidence_chars_remaining"] == 0
+
+    budget.reset()
+    assert budget.evidence_chars_used == 0
+    assert budget.reserve("another query").allowed is True
 
 
 def test_search_knowledge_tool_schema_advertises_runtime_limit():

--- a/api/tests/unit/services/knowledge/test_search_budget.py
+++ b/api/tests/unit/services/knowledge/test_search_budget.py
@@ -1,0 +1,79 @@
+"""Unit tests for per-turn knowledge retrieval limits."""
+
+import pytest
+
+from src.services.knowledge.search_budget import (
+    MAX_KNOWLEDGE_RESULTS,
+    MAX_KNOWLEDGE_SEARCHES_PER_TURN,
+    KnowledgeSearchBudget,
+    clamp_knowledge_result_limit,
+    knowledge_search_rejection_payload,
+)
+
+
+@pytest.mark.parametrize(
+    ("requested", "expected"),
+    [
+        (-10, 1),
+        (0, 1),
+        (1, 1),
+        (MAX_KNOWLEDGE_RESULTS, MAX_KNOWLEDGE_RESULTS),
+        (10, MAX_KNOWLEDGE_RESULTS),
+        ("3", 3),
+        ("invalid", MAX_KNOWLEDGE_RESULTS),
+        (None, MAX_KNOWLEDGE_RESULTS),
+    ],
+)
+def test_clamp_knowledge_result_limit(requested, expected):
+    assert clamp_knowledge_result_limit(requested) == expected
+
+
+def test_duplicate_query_is_rejected_after_normalization():
+    budget = KnowledgeSearchBudget()
+
+    first = budget.reserve("  Contact   Roles ")
+    duplicate = budget.reserve("contact roles")
+
+    assert first.allowed is True
+    assert duplicate.allowed is False
+    assert duplicate.rejection == "duplicate_query"
+    assert duplicate.searches_used == 1
+    assert duplicate.searches_remaining == (
+        MAX_KNOWLEDGE_SEARCHES_PER_TURN - 1
+    )
+    payload = knowledge_search_rejection_payload(duplicate)
+    assert payload["search_skipped"] is True
+    assert payload["documents"] == []
+    assert "already searched" in str(payload["message"])
+
+
+def test_budget_rejects_fourth_unique_query_and_resets():
+    budget = KnowledgeSearchBudget()
+
+    for index in range(MAX_KNOWLEDGE_SEARCHES_PER_TURN):
+        decision = budget.reserve(f"query {index}")
+        assert decision.allowed is True
+
+    rejected = budget.reserve("one query too many")
+    assert rejected.allowed is False
+    assert rejected.rejection == "search_budget_exhausted"
+    assert rejected.searches_remaining == 0
+    assert budget.exhausted is True
+
+    budget.reset()
+    assert budget.exhausted is False
+    assert budget.searches_used == 0
+    assert budget.reserve("one query too many").allowed is True
+
+
+def test_search_knowledge_tool_schema_advertises_runtime_limit():
+    from src.services.mcp_server.server import get_system_tools
+
+    tool = next(
+        item for item in get_system_tools() if item["id"] == "search_knowledge"
+    )
+    limit_schema = tool["parameters"]["properties"]["limit"]
+
+    assert limit_schema["minimum"] == 1
+    assert limit_schema["maximum"] == MAX_KNOWLEDGE_RESULTS
+    assert limit_schema["default"] == MAX_KNOWLEDGE_RESULTS

--- a/api/tests/unit/services/test_agent_executor_tools.py
+++ b/api/tests/unit/services/test_agent_executor_tools.py
@@ -15,7 +15,7 @@ import pytest
 from pydantic import BaseModel
 
 from src.services.agent_executor import AgentExecutor, _serialize_for_json
-from src.services.llm import ToolDefinition
+from src.services.llm import ToolCallRequest, ToolDefinition
 
 
 @pytest.fixture
@@ -115,6 +115,61 @@ class TestAutoAddSearchKnowledge:
 
         tool_names = [t.name for t in tools]
         assert "search_knowledge" not in tool_names
+
+
+class TestKnowledgeSearchBudget:
+    """Knowledge searches stay bounded within one chat turn."""
+
+    @pytest.mark.asyncio
+    async def test_duplicate_query_returns_short_skip_without_embedding(
+        self, executor, mock_agent
+    ):
+        mock_agent.knowledge_sources = ["halo_kb"]
+        executor._knowledge_search_budget.reserve("contact roles")
+        tool_call = ToolCallRequest(
+            id="duplicate",
+            name="search_knowledge",
+            arguments={"query": "  CONTACT   ROLES ", "limit": 10},
+        )
+
+        result = await executor._execute_knowledge_search(tool_call, mock_agent)
+
+        assert result.error is None
+        assert result.result["search_skipped"] is True
+        assert result.result["reason"] == "duplicate_query"
+        assert result.result["documents"] == []
+
+    @pytest.mark.asyncio
+    async def test_result_limit_is_clamped_before_repository_search(
+        self, executor, mock_agent
+    ):
+        mock_agent.knowledge_sources = ["halo_kb"]
+        mock_agent.organization_id = uuid4()
+        tool_call = ToolCallRequest(
+            id="oversized",
+            name="search_knowledge",
+            arguments={"query": "contact roles", "limit": 1000},
+        )
+        embedding_client = MagicMock()
+        embedding_client.embed_single = AsyncMock(return_value=[0.1, 0.2])
+        repository = MagicMock()
+        repository.search = AsyncMock(return_value=[])
+
+        with patch(
+            "src.services.embeddings.get_embedding_client",
+            new_callable=AsyncMock,
+            return_value=embedding_client,
+        ), patch(
+            "src.repositories.knowledge.KnowledgeRepository",
+            return_value=repository,
+        ):
+            result = await executor._execute_knowledge_search(tool_call, mock_agent)
+
+        assert result.error is None
+        repository.search.assert_awaited_once()
+        assert repository.search.await_args.kwargs["limit"] == 5
+        assert result.result["searches_used"] == 1
+        assert result.result["searches_remaining"] == 2
 
 
 class TestToolConflictDetection:

--- a/api/tests/unit/services/test_agent_executor_tools.py
+++ b/api/tests/unit/services/test_agent_executor_tools.py
@@ -14,6 +14,7 @@ from uuid import uuid4
 import pytest
 from pydantic import BaseModel
 
+from src.repositories.knowledge import KnowledgeDocument
 from src.services.agent_executor import AgentExecutor, _serialize_for_json
 from src.services.llm import ToolCallRequest, ToolDefinition
 
@@ -169,7 +170,103 @@ class TestKnowledgeSearchBudget:
         repository.search.assert_awaited_once()
         assert repository.search.await_args.kwargs["limit"] == 5
         assert result.result["searches_used"] == 1
-        assert result.result["searches_remaining"] == 2
+        assert result.result["searches_remaining"] == 7
+        assert repository.search.await_args.kwargs["query_text"] == "contact roles"
+
+    @pytest.mark.asyncio
+    async def test_distinct_queries_do_not_return_the_same_chunk_twice(
+        self, executor, mock_agent
+    ):
+        mock_agent.knowledge_sources = ["halo_kb"]
+        mock_agent.organization_id = uuid4()
+        embedding_client = MagicMock()
+        embedding_client.embed_single = AsyncMock(return_value=[0.1, 0.2])
+        document = KnowledgeDocument(
+            id="chunk-1",
+            content="Configure Technical POC with Contact Types.",
+            namespace="halo_kb",
+            score=0.9,
+            key="contact-types",
+            metadata={"title": "Contact Types"},
+        )
+        repository = MagicMock()
+        repository.search = AsyncMock(return_value=[document])
+
+        with patch(
+            "src.services.embeddings.get_embedding_client",
+            new_callable=AsyncMock,
+            return_value=embedding_client,
+        ), patch(
+            "src.repositories.knowledge.KnowledgeRepository",
+            return_value=repository,
+        ):
+            first = await executor._execute_knowledge_search(
+                ToolCallRequest(
+                    id="first",
+                    name="search_knowledge",
+                    arguments={"query": "technical poc"},
+                ),
+                mock_agent,
+            )
+            second = await executor._execute_knowledge_search(
+                ToolCallRequest(
+                    id="second",
+                    name="search_knowledge",
+                    arguments={"query": "billing contact role"},
+                ),
+                mock_agent,
+            )
+
+        assert first.result["count"] == 1
+        assert second.result["count"] == 0
+        assert second.result["omitted_duplicate_evidence"] == 1
+        assert repository.search.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_agent_evidence_omits_bulky_image_metadata(
+        self, executor, mock_agent
+    ):
+        mock_agent.knowledge_sources = ["halo_kb"]
+        mock_agent.organization_id = uuid4()
+        embedding_client = MagicMock()
+        embedding_client.embed_single = AsyncMock(return_value=[0.1, 0.2])
+        repository = MagicMock()
+        repository.search = AsyncMock(
+            return_value=[
+                KnowledgeDocument(
+                    id="chunk-1",
+                    content="Use Site Contact Types.",
+                    namespace="halo_kb",
+                    score=0.9,
+                    key="site-contact-types",
+                    metadata={
+                        "title": "Site Contact Types",
+                        "image_uuids": ["image-id"] * 1_000,
+                    },
+                )
+            ]
+        )
+
+        with patch(
+            "src.services.embeddings.get_embedding_client",
+            new_callable=AsyncMock,
+            return_value=embedding_client,
+        ), patch(
+            "src.repositories.knowledge.KnowledgeRepository",
+            return_value=repository,
+        ):
+            result = await executor._execute_knowledge_search(
+                ToolCallRequest(
+                    id="metadata",
+                    name="search_knowledge",
+                    arguments={"query": "site contact types"},
+                ),
+                mock_agent,
+            )
+
+        assert result.result["documents"][0]["metadata"] == {
+            "title": "Site Contact Types"
+        }
 
 
 class TestToolConflictDetection:

--- a/api/tests/unit/services/test_autonomous_agent_executor.py
+++ b/api/tests/unit/services/test_autonomous_agent_executor.py
@@ -1,5 +1,6 @@
 """Unit tests for AutonomousAgentExecutor."""
 import asyncio
+import json
 
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -7,6 +8,7 @@ from uuid import uuid4
 
 from src.models.contracts.executions import WorkflowExecutionResponse
 from src.models.enums import ExecutionStatus
+from src.repositories.knowledge import KnowledgeDocument
 from src.services.execution.agent_helpers import find_delegated_agent
 from src.services.execution.autonomous_agent_executor import (
     AutonomousAgentExecutor,
@@ -58,6 +60,61 @@ def mock_agent():
 
 
 class TestAutonomousAgentExecutor:
+    @pytest.mark.asyncio
+    async def test_knowledge_search_deduplicates_evidence_across_queries(
+        self,
+        mock_session,
+        mock_agent,
+    ):
+        mock_agent.knowledge_sources = ["halo_kb"]
+        embedding_client = MagicMock()
+        embedding_client.embed_single = AsyncMock(return_value=[0.1, 0.2])
+        document = KnowledgeDocument(
+            id="chunk-1",
+            content="Configure Technical POC with Contact Types.",
+            namespace="halo_kb",
+            score=0.9,
+            key="contact-types",
+            metadata={"title": "Contact Types"},
+        )
+        repository = MagicMock()
+        repository.search = AsyncMock(return_value=[document])
+        executor = AutonomousAgentExecutor(mock_session)
+
+        with patch(
+            "src.services.embeddings.get_embedding_client",
+            new_callable=AsyncMock,
+            return_value=embedding_client,
+        ), patch(
+            "src.repositories.knowledge.KnowledgeRepository",
+            return_value=repository,
+        ):
+            first = json.loads(
+                await executor._execute_knowledge_search(
+                    ToolCallRequest(
+                        id="first",
+                        name="search_knowledge",
+                        arguments={"query": "technical poc"},
+                    ),
+                    mock_agent,
+                )
+            )
+            second = json.loads(
+                await executor._execute_knowledge_search(
+                    ToolCallRequest(
+                        id="second",
+                        name="search_knowledge",
+                        arguments={"query": "billing contact role"},
+                    ),
+                    mock_agent,
+                )
+            )
+
+        assert first["count"] == 1
+        assert second["count"] == 0
+        assert second["omitted_duplicate_evidence"] == 1
+        assert repository.search.call_count == 2
+
     @pytest.mark.asyncio
     @patch("src.services.execution.autonomous_agent_executor.get_llm_client")
     @patch("src.services.execution.autonomous_agent_executor.resolve_agent_tools")

--- a/api/tests/unit/services/test_mcp_tools.py
+++ b/api/tests/unit/services/test_mcp_tools.py
@@ -339,6 +339,7 @@ class TestSearchKnowledge:
         assert len(data["results"]) == 1
         assert data["results"][0]["content"] == "This is documentation about the SDK"
         assert data["count"] == 1
+        assert mock_repo.search.await_args.kwargs["query_text"] == "SDK documentation"
 
     @pytest.mark.asyncio
     async def test_returns_no_results_message(self, org_user_context):

--- a/client/src/lib/v1.d.ts
+++ b/client/src/lib/v1.d.ts
@@ -4417,8 +4417,8 @@ export interface paths {
         get?: never;
         put?: never;
         /**
-         * Search for similar documents
-         * @description Search for similar documents using vector similarity.
+         * Hybrid-search knowledge documents
+         * @description Search knowledge using fused lexical and vector rankings.
          */
         post: operations["cli_knowledge_search_api_sdk_knowledge_search_post"];
         delete?: never;

--- a/docs/architecture/knowledge-retrieval.md
+++ b/docs/architecture/knowledge-retrieval.md
@@ -1,0 +1,91 @@
+# Agent knowledge retrieval target
+
+## Decision
+
+Bifrost agent knowledge retrieval uses a bounded hybrid-retrieval pipeline:
+
+1. The agent rewrites a user's wording into one or more concise, product-aware
+   searches when the user's vocabulary differs from the indexed product.
+2. Each agent search retrieves 20 vector candidates and 20 PostgreSQL full-text
+   candidates.
+3. Reciprocal-rank fusion (RRF, `k=60`, equal lexical/vector weights) combines
+   the two rankings using stable chunk IDs.
+4. Results are deduplicated by logical document and the best five chunks are
+   returned.
+5. Across a turn, an evidence ledger prevents the same physical chunk from
+   being returned twice and limits the actual serialized evidence to 40,000
+   characters. Agent-facing metadata is capped at 2,000 characters per result
+   and excludes transport-only image UUID arrays.
+6. Eight distinct searches is an emergency loop ceiling. Exact repeat queries
+   are rejected without another embedding or database search. The knowledge
+   tool is removed when either the query or evidence envelope is exhausted.
+
+The evidence envelope is the primary token control. The query ceiling is not a
+retrieval-quality tuning knob and should not be lowered to manage spend.
+
+## Comparison with established implementations
+
+This target follows patterns in products that use retrieval as a feature:
+
+| Product | Candidate retrieval | Fusion/reranking | Deduplication and bounds | Bifrost alignment |
+| --- | --- | --- | --- | --- |
+| Open WebUI | Vector retrieval plus BM25 over text enriched with filename, title, headings, and source | Weighted ensemble with reciprocal-rank fusion, followed by an optional reranker | Stable content hashes deduplicate chunks; final result count is bounded | Vector plus weighted PostgreSQL FTS, RRF, stable chunk IDs, logical-document dedup, final top five |
+| Dify | Semantic and full-text candidates in hybrid mode | Configurable weighted keyword/vector scoring or model reranking | Results are deduplicated by document ID, thresholded, and limited to `top_n` | Deterministic equal-weight RRF initially; the fusion constants are explicit tuning points if a labeled evaluation later supports changing them |
+
+Primary implementation references:
+
+- [Open WebUI retrieval implementation](https://github.com/open-webui/open-webui/blob/main/backend/open_webui/retrieval/utils.py)
+- [Dify dataset retrieval](https://github.com/langgenius/dify/blob/main/api/core/rag/retrieval/dataset_retrieval.py)
+- [Dify weighted reranking](https://github.com/langgenius/dify/blob/main/api/core/rag/rerank/weight_rerank.py)
+
+Bifrost deliberately uses PostgreSQL full-text search instead of adding a
+second retrieval service. The design pattern is the same; the lexical engine is
+an implementation choice. A paid model reranker is deferred until a labeled
+evaluation demonstrates enough quality improvement to justify its latency and
+cost.
+
+## Indexing contract
+
+- Long source documents remain physically chunked before embedding.
+- Full-text indexing weights the document key and title as `A`, parent/source
+  navigation fields as `B`, and chunk body as `C`.
+- Arbitrary metadata JSON is not indexed. Image IDs and ingestion provenance
+  create lexical noise and should not influence relevance.
+- SDK callers that provide only an embedding retain vector-only behavior.
+  Callers that provide the original query text receive hybrid retrieval.
+
+## Acceptance gates
+
+### Automated
+
+- A lexical match outside the first 20 vector candidates must be recoverable
+  and rank first after fusion.
+- No agent search may return more than five logical documents.
+- A repeated query must not call the embedder or repository again.
+- A physical chunk already returned in the turn must not be returned again.
+- Serialized evidence must never exceed 40,000 characters, and bulky image
+  metadata must not enter the agent context.
+
+### Representative Halo replay
+
+Question:
+
+> In ConnectWise, we had the ability to flag people as the Technical POC,
+> Billing POC, etc. How should I do that in Halo?
+
+The debug corpus contains production copies of the relevant **Site Contacts**
+and **Site Contact Types** articles. The completed replay met these gates:
+
+| Measure | Production failure | Target implementation |
+| --- | ---: | ---: |
+| Final model input | 973,160 tokens | 41,006 tokens |
+| Retrieved/tool payload | 826,039 characters | 33,944 characters |
+| Evidence ledger | Unbounded | 30,469 / 40,000 characters |
+| Search behavior | 32 calls, 12 unique queries | 14 attempts, 7 unique queries; repeats returned short skips |
+| Answer quality | Excessive repeated retrieval | Correctly identified Site Contact Types, gave the configuration and assignment paths, and cited both relevant guides |
+| End-to-end duration | Not retained | 23.0 seconds |
+
+This is a 95.8% reduction in final input tokens while passing the answer-quality
+gate. Future changes should be evaluated against both the deterministic
+repository test and this representative full-agent replay; token reduction
+alone is not acceptance.


### PR DESCRIPTION
## Summary

- combine vector similarity with weighted PostgreSQL full-text search using reciprocal-rank fusion
- deduplicate logical documents and bound the evidence returned to agents
- stop repeated and near-duplicate knowledge searches from growing agent history without limit
- document the target architecture, compatibility contract, rollout, and measured Halo KB replay

## Root cause

The knowledge base was already physically chunked, but a long agent run could repeatedly retrieve different or repeated chunks and retain every tool response in its model history. The cumulative model input therefore grew with each search; chunking alone did not place a bound on the total evidence admitted to a run.

## Measured result

The replay of the production Halo KB failure shape changed:

| Metric | Before | Target implementation |
| --- | ---: | ---: |
| cumulative input tokens | 973,160 | 41,006 |
| knowledge tool payload tokens | 826,039 | 33,944 |
| admitted evidence | unbounded | 30,469 / 40,000 tokens |
| search attempts | 14 | 14 |
| unique admitted queries | unbounded | 7 / 8 |
| answer correctness | correct | correct |

This is a 95.8% reduction in cumulative input tokens while preserving the correct answer in the replay.

## Compatibility and rollout

- existing knowledge rows are reused; no re-scrape, re-index, or re-embedding is required
- the migration adds a generated weighted search vector and GIN index, which backfill from existing content
- API response shapes remain compatible
- ranking and `score` semantics intentionally change to fused ranks, so external consumers using exact score thresholds should be reviewed
- agent knowledge search now returns at most five results and enforces a 40,000-token run evidence budget
- the migration is non-destructive but may briefly lock the knowledge table while the generated column and index are created

## Validation

- `./test.sh tests/unit/` — 5,330 passed, 3 skipped
- `./test.sh all` — 7,096 passed, 57 skipped
- `./test.sh client unit` — 1,652 passed
- `./test.sh quality api` — passed with zero errors
- `npm run tsc` — passed
- `npm run lint` — passed with no errors
- focused knowledge/agent suite — 138 passed

The branch was rebased onto current `main` before the final unit gate.
