### PR TITLE
fix(solutions): enforce and document shared resource access

### DIFF
--- a/.claude/skills/bifrost-build/SKILL.md
+++ b/.claude/skills/bifrost-build/SKILL.md
@@ -141,6 +141,7 @@ When workflows are exposed as MCP tools (via agents), their `name` becomes the M
 | I need to… | Read |
 |---|---|
 | Build in a Solution workspace | `references/solutions.md` |
+| Understand Solution access to shared/global resources | `references/solution-resource-access.md` |
 | Build in the global `_repo` workspace | `references/repo.md` |
 | Build or modify an app (TSX/React) | `references/apps.md` · `references/web-sdk-v2.md` |
 | Write or debug a Python workflow | `references/workflows-python.md` · `references/python-sdk.md` |

--- a/.claude/skills/bifrost-build/references/solution-resource-access.md
+++ b/.claude/skills/bifrost-build/references/solution-resource-access.md
@@ -1,0 +1,170 @@
+# Solution Runtime Resource Access
+
+Use this reference when Solution code needs anything outside its own install.
+The `global_repo_access` name is historical and narrower than "all global
+resources", but broader than "only the global `_repo`":
+
+- It is **not** the install scope. Org install versus global install is chosen
+  separately with `--org` / `--global`.
+- It gates shared fallback for resource types that have a Solution-owned tier:
+  `_repo` modules, loose workflows, tables, and files.
+- For an org install, an allowed fallback searches the install org and then
+  global. It is therefore not literally "global only".
+- Config values, integrations/OAuth, and knowledge have no Solution-owned
+  runtime value tier. They are shared instance resources and do not consult
+  this flag.
+
+The flag defaults to `false`.
+
+## Runtime access matrix
+
+| Resource | Standalone app / web SDK | Solution workflow | `global_repo_access: false` | `global_repo_access: true` |
+|---|---|---|---|---|
+| Python modules | Not applicable | Imports under the install first | No shared `_repo` import fallback | Shared `_repo` import fallback |
+| Workflows | `useWorkflow` sends the app id | Nested/direct execute carries Solution scope | Own install only | Own install, then loose install-org/global workflow |
+| Tables | `tables` / `useTable` send `X-Bifrost-App` | Python SDK appends Solution scope | Own Solution table only | Own table, then install-org, then global by **name** |
+| Files | `files` / `useFiles` send `X-Bifrost-App` | Python SDK appends Solution scope | Own declared location only | Own, then install-org, then global reads in a declared location |
+| Config values/secrets | No web-SDK surface | `config` SDK | Shared install-org/global cascade | Same; flag is not consulted |
+| Integrations/OAuth | No web-SDK surface | `integrations` SDK | Shared org mapping, then integration/global defaults | Same; flag is not consulted |
+| Knowledge | No web-SDK surface | `knowledge` SDK | Shared org/global namespace | Same; flag is not consulted |
+
+Forms, agents, apps, event sources, and custom claims are installed entities,
+not general shared-resource SDK lookups. Their `solution_id`, org scope,
+`access_level`, roles, and resource-specific rules remain authoritative. Do not
+infer access to them from `global_repo_access`.
+
+## How Solution scope reaches the server
+
+The app and workflow paths converge on the same request context:
+
+- A deployed standalone app's `BifrostProvider` adds `X-Bifrost-App` to table,
+  file, and workflow calls. Auth resolves that app to its active Solution.
+- A Solution workflow's Python SDK carries its execution `solution_id` on
+  table/file calls.
+- Workflow execution derives scope from the authenticated request context,
+  then the request's Solution/form/app identity for older SDK calls.
+- A mismatched app header and `?solution=` signal is rejected; inactive installs
+  are not executable.
+
+This context selects the install. It does not bypass org scope, RBAC, row/file
+policies, or external-user restrictions.
+
+## Per-resource boundaries
+
+### Modules and workflows
+
+Module imports resolve the install's `_solutions/{id}/` source first. A sealed
+Solution does not fall through to shared `_repo` modules.
+
+Workflow refs follow the same ownership boundary:
+
+1. Resolve the caller's own install by path, name, or UUID.
+2. If shared fallback is disabled, stop.
+3. If enabled, resolve a loose install-org/global workflow subject to normal
+   workflow visibility and access rules.
+
+A scoped caller never resolves a sibling Solution's workflow, including by
+UUID. Prefer portable `path::function` refs in source; UUIDs are
+environment-specific.
+
+When an open Solution resolves a loose workflow, that workflow executes as the
+loose row (`solution_id` is null), not as borrowed Solution-owned code. Its own
+imports and SDK calls therefore use the ordinary org/global runtime. Treat
+allowing loose-workflow fallback as a strong trust boundary, not a harmless
+function alias.
+
+### Tables
+
+Own table names win. With shared fallback enabled, a miss searches loose
+install-org then global tables by name. External table UUIDs stay hidden from
+Solution context.
+
+Shared fallback tables are read-only from the Solution. The flag does not allow
+table creation or row mutation outside the install. Table policies still filter
+or deny rows after the table resolves.
+
+Denied/missing behavior differs slightly by SDK surface:
+
+- The web transport receives the server's 404.
+- Python `tables.query()` deliberately converts a 404 into an empty
+  `DocumentList`; write/get operations keep their documented error/`None`
+  behavior.
+
+### Files
+
+The location must be declared in `.bifrost/files.yaml`; `workspace` is never a
+Solution runtime location. With shared fallback enabled, read/list/exists and
+signed-read operations search own, install-org, then global tiers. File policies
+apply independently at each tier.
+
+Writes and deletes always target the Solution-owned tier. Enabling fallback does
+not let an app or workflow modify loose org/global files.
+
+### Config values and secrets
+
+The manifest carries config **declarations** (key, type, required/default
+metadata), not an isolated value store. Runtime `config.get()` reads the
+instance's org/global config cascade regardless of `global_repo_access`.
+
+`config.set()` and `config.delete()` mutate that shared instance namespace when
+the caller's execution scope permits it. Treat those calls as changes to shared
+environment state, not install-local state.
+
+For an org install, setup status can require an org-specific value while runtime
+lookup can still find a global fallback. If setup says "unset" but execution
+works, inspect both tiers rather than assuming the SDK is unavailable.
+
+### Integrations and OAuth
+
+A Solution can declare that a connection is required, but the installed
+environment supplies the Integration row, org mapping, OAuth provider/token,
+and secret config. `integrations.get()` resolves the caller's org mapping first,
+then integration/global defaults. This behavior is independent of
+`global_repo_access`.
+
+Integrations are intentionally server-side only in a standalone app: call them
+from a Python workflow so OAuth tokens and decrypted secrets never enter browser
+JavaScript. Mapping mutation APIs change shared instance state and require the
+same care as config writes.
+
+### Knowledge
+
+Knowledge is also an org/global shared namespace with its own access rules. A
+Solution declaration or install does not create a private knowledge tier, and
+the flag does not seal knowledge access.
+
+## Security and portability rules
+
+- Shared fallback is an additional lookup tier, **not** an authorization
+  bypass. Org boundaries, role checks, table/file policies, and external-user
+  restrictions still apply.
+- `global_repo_access: true` weakens self-containment. A package can depend on
+  loose workflows, code, tables, or files that another environment does not
+  have.
+- Config values, integration mappings, OAuth tokens, knowledge content, table
+  rows, and runtime files are environment state. Normal shareable packages
+  carry declarations/schema, not those values.
+- Config and integration names are shared keys. Two Solutions using the same
+  key/name intentionally consume the same instance value.
+- Keep secrets behind Python workflows. The web SDK exposes workflows, tables,
+  and files; it does not expose config, integrations/OAuth, or knowledge.
+
+## `bifrost solution start`
+
+Local preview is connected to the selected live instance; it is not a data
+sandbox.
+
+- The generic `/api/*` proxy adds the bound Solution context and app/org auth
+  headers. Table and file routes are handled by the normal upstream routers;
+  the proxy does not implement a separate table namespace.
+- Workflow execute is special: local functions resolve first and return a
+  transient terminal response. If a ref is absent locally, a sealed Solution
+  stops there; an open Solution may delegate the loose ref upstream.
+- Remote table/file/config/integration writes are real instance changes.
+- The access token is injected at runtime for preview/deployed mounts; it is not
+  bundled into application source or build output.
+
+Validate boundary-sensitive changes against both `solution start` and a
+deployed install. They must agree on whether a loose workflow/resource fallback
+is permitted even though local workflow executions are transient and deployed
+executions are durable.

--- a/.claude/skills/bifrost-build/references/solutions.md
+++ b/.claude/skills/bifrost-build/references/solutions.md
@@ -187,6 +187,13 @@ This applies to install-creating or install-selecting Solution commands (`create
 
 `bifrost.solution.yaml` is the **definition** descriptor — `slug`, `name`, `version`, `global_repo_access`, and git-source fields (`git_connected`, `git_repo_url`, `repo_subpath`, `git_ref`, `logo`). It intentionally carries **no install id** and **no install scope**. The concrete install binding lives in `.env` (`BIFROST_SOLUTION_ID`, slug, org id, scope), which is local environment state and should not be committed. The descriptor also doubles as the workspace mode marker (its presence is what switches tooling into solution mode).
 
+`global_repo_access` is not a blanket global-resource switch and is not limited
+to module imports. It gates shared fallback for `_repo` modules, loose
+org/global workflows, tables, and files. Config values, integrations/OAuth, and
+knowledge are shared instance resources regardless of the flag. Read the full
+matrix and its security/portability boundaries in
+`references/solution-resource-access.md`.
+
 The install id lives **server-side** (`Solution.id` — the `solution_id` stamped on every managed entity *at deploy time*) and in the local uncommitted `.env` binding. The repo is the **definition**; `solution create` or `solution bind` chooses which concrete install this checkout is working against. Deploy/pull then operate on that install (or an explicit `--solution` override).
 
 **Instance vs fork — the `slug` is the dividing line:**
@@ -281,6 +288,7 @@ There is no React, shadcn, or router injection from the SDK — import those fro
 ## Key constraints
 
 - Workflows must use portable `path::function` refs (e.g. `functions/hello.py::main`), not UUIDs or bare names — UUIDs are environment-specific and break portability.
+- Before depending on loose org/global resources, read `references/solution-resource-access.md`; shared fallback and shared-by-design instance state have different portability/security boundaries.
 - Solution file locations live in `.bifrost/files.yaml`; runtime file bytes are user data and only travel in encrypted full backups.
 - `_solutions/` and `_solution_artifacts/` are platform internals. Never create those folders in a Solution workspace.
 - The `bifrost:migrate` skill covers the v1→v2 migration path (slug swap, import rewrite, entity capture, etc.).

--- a/.claude/skills/bifrost-build/references/sources.yaml
+++ b/.claude/skills/bifrost-build/references/sources.yaml
@@ -58,13 +58,33 @@ references:
 
   - file: references/solutions.md
     source_globs:
+      - api/bifrost/solution_descriptor.py
       - api/bifrost/commands/solution.py
       - api/bifrost/commands/files.py
       - api/bifrost/manifest.py
       - api/src/models/contracts/solutions.py
       - api/src/services/solution_files.py
       - api/src/services/solutions/*.py
-    verified_at_sha: 44fed5904f8b36b2f8ace25c17e144a8fb89dc87
+    verified_at_sha: ea2714bd66c640d1b7b3bf1a21ccbd7dcb462773
+
+  - file: references/solution-resource-access.md
+    source_globs:
+      - api/bifrost/config.py
+      - api/bifrost/integrations.py
+      - api/bifrost/solution_descriptor.py
+      - api/bifrost/solution_dev/proxy.py
+      - api/bifrost/tables.py
+      - api/src/core/auth.py
+      - api/src/repositories/workflows.py
+      - api/src/routers/cli.py
+      - api/src/routers/files.py
+      - api/src/routers/forms.py
+      - api/src/routers/tables.py
+      - api/src/routers/workflows.py
+      - api/src/services/solution_scope.py
+      - client/src/lib/app-sdk/*.ts
+      - client/src/lib/app-sdk/*.tsx
+    verified_at_sha: ea2714bd66c640d1b7b3bf1a21ccbd7dcb462773
 
   - file: references/tables.md
     source_globs:

--- a/api/bifrost/solution_descriptor.py
+++ b/api/bifrost/solution_descriptor.py
@@ -34,8 +34,11 @@ class SolutionDescriptor(BaseModel):
     descriptors that still carry a ``scope:`` key load fine — it is ignored
     (``extra="ignore"``).
 
-    ``global_repo_access`` is unrelated to install scope: it controls whether
-    the Solution's code may import shared modules from ``_repo/`` (§3.3/§3.5).
+    ``global_repo_access`` is unrelated to install scope. It controls shared
+    fallback for Solution-scope-capable resources: ``_repo/`` module imports,
+    loose org/global workflows, tables, and files. Config values, integrations,
+    OAuth, and knowledge are shared instance resources without a Solution-owned
+    value tier, so this flag does not govern them.
     """
 
     # Ignore unknown/legacy keys (e.g. a pre-standard ``scope:``) so old

--- a/api/src/models/orm/solutions.py
+++ b/api/src/models/orm/solutions.py
@@ -79,8 +79,10 @@ class Solution(Base):
         index=True,
     )
 
-    # Whether this Solution's code may import shared modules from _repo/ (§3.5).
-    # Orthogonal to scope. Off by default — Solutions are self-contained worlds.
+    # Whether this Solution may fall back to shared _repo modules and loose
+    # org/global workflows, tables, and files. Orthogonal to install scope and
+    # off by default. Configs/integrations/OAuth/knowledge are shared instance
+    # resources and are not governed by this flag.
     global_repo_access: Mapped[bool] = mapped_column(
         Boolean, default=False, server_default=text("false")
     )

--- a/api/src/repositories/README.md
+++ b/api/src/repositories/README.md
@@ -45,12 +45,15 @@ flowchart TD
 
     E --> F{"Solution context active?<br/><i>module_cache_sync.get_solution_context</i>"}
     F -->|"yes — solution-managed run"| G["FIRST STOP: resolve under<br/>_solutions/{id}/ (modules) /<br/>solution_id-owned row (entities)<br/><i>own-first; ctx.solution_id / X-Bifrost-App</i>"]
-    G --> H{"global_repo_access?<br/>(CODE fallback only —<br/>data fallback is ungated today)<br/><i>Solution.global_repo_access</i>"}
-    H -->|"no (code)"| HFINAL["FINAL STOP for code<br/>(no _repo/ module fallthrough —<br/>a bare _repo/ import does NOT resolve)"]
-    H -->|yes| I
+    G --> H{"Solution-owned resource tier?<br/>module · workflow · table · file"}
+    H -->|yes| GA{"global_repo_access?<br/><i>Solution.global_repo_access</i>"}
+    GA -->|no| HFINAL["FINAL STOP<br/>(no loose org/global fallback)"]
+    GA -->|yes| I
+    H -->|no| SHARED["Shared instance namespace<br/>config · integration/OAuth · knowledge<br/>(normal org/global rules)"]
     F -->|"no — plain _repo/ run"| I["Cascade: org-specific row<br/>then global (solution_id IS NULL world)"]
 
     HFINAL --> J
+    SHARED --> J
     I --> J
     J{"GATE 3 — RBAC / access_level<br/>role-table match: FormRole, AppRole,<br/>AgentRole, WorkflowRole<br/><i>org_scoped.py role filter</i>"}
     J -->|"no matching role<br/>(role_based entity)<br/>or external on authenticated tier"| DENY2["403 / not visible"]
@@ -65,12 +68,11 @@ flowchart TD
 the caller's `ExecutionContext` (gate 0a) is *whose authority it travels
 under*. They are deliberately separate. A leak of the sentinel collapses
 only the transport trust — the per-call C2 gate (gate 1) still runs against
-the caller's real flags. Solutions are a **first stop at gate 2**. For
-**code** resolution they are the **final stop unless `global_repo_access`
-is on** (the diamond above). For **data** (tables/configs/storage) the
-flag does **not** apply today — data fallback to `_repo/` is currently
-ungated; whether it should be gated is an open question (see the Solutions
-section). Table policies (gate 4) gate individual *rows* after the *table*
+the caller's real flags. Solutions are a **first stop at gate 2**.
+`global_repo_access` controls loose org/global fallback for resource types
+with a Solution-owned tier: modules, workflows, tables, and files. Config
+values, integrations/OAuth, and knowledge use shared instance namespaces
+instead. Table policies (gate 4) gate individual *rows* after the *table*
 itself has been resolved and RBAC-checked.
 
 ### External users live at gate 3 only
@@ -421,16 +423,18 @@ For entities that have it:
 
 ---
 
-## Solutions: first-stop resolution and the global-repo-access gate
+## Solutions: first-stop resolution and the shared-fallback gate
 
 A **Solution** is an installable bundle of workflows, apps, tables, configs,
 forms, and agents. Its entities live in a parallel namespace keyed by
 `solution_id`, and its code lives under `_solutions/{solution_id}/` in S3.
 A Solution inserts itself at **gate 2 (entity resolution)** as a **first
-stop**, and is the **final stop unless the install's `global_repo_access`
-flag is on**.
+stop**.
 
-There are two parallel mechanisms — same rule, different layer:
+`global_repo_access` is orthogonal to the install's org/global scope. It
+controls shared fallback for resource types with a Solution-owned tier. For
+an org install, an allowed fallback searches the install org and then global,
+so the historical field name does not mean "only the global `_repo`".
 
 ### 1. Module loads (the code side)
 
@@ -442,14 +446,11 @@ There are two parallel mechanisms — same rule, different layer:
   is on**. With it off, a bare `_repo/` import does **not** silently
   resolve — the solution is sealed **for code**.
 
-`global_repo_access` governs **code only**. See the open question at the end
-of this section for why data (gate 2's entity reads) is currently ungated.
-
 The context is per-execution and thread-local: `set_solution_context` /
 `clear_solution_context` / `get_solution_context`. No active context ==
 unchanged plain `_repo/` behavior, so non-solution runs are unaffected.
 
-### 2. Entity reads (the data side)
+### 2. Solution-scope-capable entity reads
 
 `OrgScopedRepository` (`org_scoped.py`) treats solution-managed rows
 (`solution_id IS NOT NULL`) as a **separate world resolved by id**, not by
@@ -471,6 +472,33 @@ the name cascade:
     `Application.solution_id` and routers consume it via
     `services/solution_scope.py` (e.g. `resolve_solution_table_by_name`
     used by `routers/tables.py`).
+
+After an own-install miss:
+
+- **Workflows** fall back to loose install-org/global rows only when
+  `global_repo_access` is on. The gate applies to path, name, and UUID
+  resolution; a caller never reaches a sibling Solution.
+- **Tables** fall back by name to loose install-org/global rows only when the
+  flag is on. Fallback tables are read-only from Solution context and table
+  policies still apply.
+- **Files** fall back for reads/list/exists/signed reads only when the flag is
+  on and the location is declared. Writes/deletes always target the install.
+
+### 3. Shared-by-design instance resources
+
+Configs, integrations/OAuth, and knowledge do not have a Solution-owned
+runtime value tier, so `global_repo_access` does not apply:
+
+- Config declarations ship with the bundle; values resolve through the
+  ordinary org/global config cascade.
+- Connection declarations ship with the bundle; Integration rows, mappings,
+  OAuth providers/tokens, and secret values belong to the installed instance.
+- Knowledge remains an org/global namespace with its own access rules.
+
+The Python SDK can mutate config and integration mappings, so those writes
+change shared environment state rather than install-local state. The web SDK
+does not expose configs, integrations/OAuth, or knowledge; apps must call a
+server-side workflow so decrypted secrets do not enter browser JavaScript.
 
 ### How the install id is DERIVED (the request side)
 
@@ -501,7 +529,9 @@ The install's `global_repo_access` flag is read once at dispatch in
 `jobs/consumers/workflow_execution.py` (from `Solution.global_repo_access`),
 passed to the worker as `solution_global_repo_access`, and applied via
 `set_solution_context` in `services/execution/worker.py` /
-`simple_worker.py`. It is cleared after the run.
+`simple_worker.py` for module imports. Request-time workflow/table/file
+resolvers read the same flag through `services/solution_scope.py`. The worker
+context is cleared after the run.
 
 ### Uninstall and lifecycle states
 
@@ -526,21 +556,6 @@ path: FK cascade removes all owned rows and an S3 sweep cleans the file tree.
 
 **Reinstall-over-inactive** (`POST /api/solutions/{id}/install` on a solution with
 `status == "inactive"`) reactivates the install after prompting for conflict resolution.
-
-### Open question: should data fallback be gated?
-
-`global_repo_access` gates **code** fallback (the module loader). **Data
-fallback is currently ungated**: a solution-managed run reads a `_repo/`
-table or config by name regardless of the flag. This is an asymmetry — a
-"sealed" install can't import `_repo/` code but *can* read `_repo/` data.
-
-Whether to close it is undecided. Options under consideration: reuse
-`global_repo_access` for data too (one "touch `_repo/` at all" flag), add a
-separate data-fallback flag (independent code/data sharing), or leave data
-ungated. See
-`docs/superpowers/specs/2026-06-08-solution-workflow-resolution-chokepoint-design.md`.
-Until that resolves, the current behavior — **code gated, data ungated** —
-is the truth.
 
 ---
 

--- a/api/src/repositories/workflows.py
+++ b/api/src/repositories/workflows.py
@@ -63,17 +63,24 @@ class WorkflowRepository(OrgScopedRepository[Workflow]):
     # ==========================================================================
 
     async def resolve(
-        self, identifier: str, *, solution_scope: UUID | None = None
+        self,
+        identifier: str,
+        *,
+        solution_scope: UUID | None = None,
+        allow_shared_fallback: bool = False,
     ) -> Workflow | None:
         """Resolve a workflow by UUID, path::function_name, or scoped name.
 
         Resolution order:
-        1. If identifier parses as a UUID, look up by id.
+        1. If identifier parses as a UUID, look up by id. A Solution-scoped
+           caller may resolve its own workflow, or a loose org/global workflow
+           only when ``allow_shared_fallback`` is true. It never resolves a
+           sibling Solution's workflow.
         2. If identifier contains '::', treat as path::function_name lookup.
         3. Otherwise, treat it as a workflow name. With ``solution_scope``, look
-           in the caller's own install first, then fall back to the normal
-           non-solution org/global cascade. Without ``solution_scope``, use only
-           the non-solution cascade.
+           in the caller's own install first. Fall back to the normal
+           non-solution org/global cascade only when ``allow_shared_fallback``
+           is true. Without ``solution_scope``, use the non-solution cascade.
 
         Args:
             identifier: A workflow UUID string or "path::function_name" ref
@@ -81,27 +88,50 @@ class WorkflowRepository(OrgScopedRepository[Workflow]):
                 a Solution app/form. A v2 app's ``path::fn`` ref carries no
                 install id (it can't know the per-install uuid5), so path-ref
                 resolution disambiguates to THIS install's own workflow first,
-                falling back to the global ``_repo/`` row. Without it, two
-                same-org installs sharing a path would resolve non-deterministically
-                (Codex #8 P1). Ignored for UUID lookups (already unambiguous).
+                optionally falling back to a loose org/global workflow. Without
+                it, two same-org installs sharing a path would resolve
+                non-deterministically (Codex #8 P1).
+            allow_shared_fallback: Whether a Solution-scoped miss may resolve a
+                loose org/global workflow. Callers derive this from the
+                Solution's ``global_repo_access`` setting. Ignored for unscoped
+                callers.
 
         Returns:
             Workflow if found and accessible, None otherwise
         """
         try:
             workflow_uuid = UUID(identifier)
-            return await self.get(id=workflow_uuid)
+            workflow = await self.get(id=workflow_uuid)
+            if workflow is None or solution_scope is None:
+                return workflow
+            if workflow.solution_id == solution_scope:
+                return workflow
+            if workflow.solution_id is not None:
+                return None
+            return workflow if allow_shared_fallback else None
         except ValueError:
             pass
 
         # path::function_name format (portable ref used by app code)
         if "::" in identifier:
-            return await self._resolve_by_path_ref(identifier, solution_scope=solution_scope)
+            return await self._resolve_by_path_ref(
+                identifier,
+                solution_scope=solution_scope,
+                allow_shared_fallback=allow_shared_fallback,
+            )
 
-        return await self._resolve_by_name(identifier, solution_scope=solution_scope)
+        return await self._resolve_by_name(
+            identifier,
+            solution_scope=solution_scope,
+            allow_shared_fallback=allow_shared_fallback,
+        )
 
     async def _resolve_by_name(
-        self, name: str, *, solution_scope: UUID | None = None
+        self,
+        name: str,
+        *,
+        solution_scope: UUID | None = None,
+        allow_shared_fallback: bool = False,
     ) -> Workflow | None:
         """Resolve a bare workflow name using solution-own-first semantics.
 
@@ -138,11 +168,17 @@ class WorkflowRepository(OrgScopedRepository[Workflow]):
             own = result.scalar_one_or_none()
             if own is not None:
                 return own
+            if not allow_shared_fallback:
+                return None
 
         return await self.get(name=name, is_active=True)
 
     async def _resolve_by_path_ref(
-        self, ref: str, *, solution_scope: UUID | None = None
+        self,
+        ref: str,
+        *,
+        solution_scope: UUID | None = None,
+        allow_shared_fallback: bool = False,
     ) -> Workflow | None:
         """Resolve a path::function_name reference to a workflow.
 
@@ -177,6 +213,8 @@ class WorkflowRepository(OrgScopedRepository[Workflow]):
             own_row = (await self.session.execute(own_stmt)).scalars().first()
             if own_row is not None:
                 return own_row
+            if not allow_shared_fallback:
+                return None
 
         stmt = (
             select(Workflow)
@@ -202,10 +240,11 @@ class WorkflowRepository(OrgScopedRepository[Workflow]):
         # a lone SIBLING-install row by the count==1 shortcut.
         if solution_scope is not None:
             # A Solution app/form caller: resolve THIS install's own workflow
-            # first (no guesswork), else the global _repo/ row (the app
-            # referenced a shared-library path). NEVER a SIBLING install's row —
-            # a stale/typo'd ref in app A must not execute app B's workflow just
-            # because they share a path. Absent both → None (the caller 404s).
+            # first (no guesswork), else a loose org/global workflow only when
+            # the caller explicitly allowed that shared fallback. NEVER a
+            # SIBLING install's row — a stale/typo'd ref in app A must not
+            # execute app B's workflow just because they share a path. Absent
+            # both → None (the caller 404s).
             own = [w for w in rows if w.solution_id == solution_scope]
             if own:
                 return own[0]

--- a/api/src/routers/forms.py
+++ b/api/src/routers/forms.py
@@ -875,8 +875,18 @@ async def execute_form(
     # form's org. Caller identity was already used for AUTHORIZATION above.
     anchor_org_id = form.organization_id if form.organization_id is not None else ctx.org_id
 
+    from src.services.solution_scope import solution_allows_global
+
     _wf_repo = WorkflowRepository(db, org_id=anchor_org_id, is_superuser=True)
-    _resolved_wf = await _wf_repo.resolve(form.workflow_id, solution_scope=form.solution_id)
+    allow_shared_workflow = (
+        form.solution_id is None
+        or await solution_allows_global(db, form.solution_id)
+    )
+    _resolved_wf = await _wf_repo.resolve(
+        form.workflow_id,
+        solution_scope=form.solution_id,
+        allow_shared_fallback=allow_shared_workflow,
+    )
     if _resolved_wf is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,

--- a/api/src/routers/workflows.py
+++ b/api/src/routers/workflows.py
@@ -62,7 +62,10 @@ from src.models.orm.applications import Application
 from src.models.orm.agents import Agent, AgentTool
 from src.models.orm.users import Role
 from src.services.workflow_validation import _extract_relative_path
-from src.services.solution_scope import derive_execution_solution_scope
+from src.services.solution_scope import (
+    derive_execution_solution_scope,
+    solution_allows_global,
+)
 from src.services.solutions.guard import (
     assert_entity_id_not_solution_managed,
     assert_not_solution_managed,
@@ -765,12 +768,18 @@ async def execute_workflow(
         form_id=request.form_id,
         app_id=request.app_id,
     )
+    allow_shared_workflow = (
+        solution_scope is None
+        or await solution_allows_global(db, solution_scope)
+    )
 
     # Look up workflow metadata for type checking (needed for data provider handling)
     workflow = None
     if request.workflow_id:
         workflow = await workflow_repo.resolve(
-            request.workflow_id, solution_scope=solution_scope
+            request.workflow_id,
+            solution_scope=solution_scope,
+            allow_shared_fallback=allow_shared_workflow,
         )
         if not workflow:
             # A resolution miss must identify its scope inputs: a dropped or

--- a/api/tests/e2e/platform/test_solution_shared_resource_access.py
+++ b/api/tests/e2e/platform/test_solution_shared_resource_access.py
@@ -1,0 +1,350 @@
+"""Live runtime coverage for Solution access to shared instance resources."""
+from __future__ import annotations
+
+import io
+import json
+import uuid
+import zipfile
+from uuid import UUID
+
+import pytest
+
+from src.services.solutions.deploy import solution_entity_id
+from tests.e2e.platform.conftest import wait_for_deploy
+
+pytestmark = pytest.mark.e2e
+
+
+def _create_solution(
+    e2e_client,
+    headers: dict[str, str],
+    *,
+    slug: str,
+    global_repo_access: bool,
+) -> str:
+    response = e2e_client.post(
+        "/api/solutions",
+        headers=headers,
+        json={
+            "slug": slug,
+            "name": slug.upper(),
+            "organization_id": None,
+            "global_repo_access": global_repo_access,
+        },
+    )
+    assert response.status_code in (200, 201), response.text
+    return response.json()["id"]
+
+
+def _probe_workspace_zip(
+    *,
+    slug: str,
+    global_repo_access: bool,
+    table_name: str,
+    config_key: str,
+    integration_name: str,
+    app_manifest_id: str,
+    workflow_manifest_id: str,
+) -> bytes:
+    source = (
+        "from bifrost import config, integrations, tables, workflow\n\n"
+        "@workflow\n"
+        "async def probe():\n"
+        f"    docs = await tables.query({table_name!r}, limit=10)\n"
+        f"    config_value = await config.get({config_key!r})\n"
+        f"    integration = await integrations.get({integration_name!r})\n"
+        "    return {\n"
+        "        'rows': [doc.data for doc in docs.documents],\n"
+        "        'config': config_value,\n"
+        "        'integration_entity': integration.entity_id if integration else None,\n"
+        "    }\n"
+    )
+    workflows = {
+        "workflows": {
+            workflow_manifest_id: {
+                "id": workflow_manifest_id,
+                "name": f"probe_{slug}",
+                "function_name": "probe",
+                "path": "workflows/probe.py",
+                "type": "workflow",
+                "access_level": "authenticated",
+            }
+        }
+    }
+    apps = {
+        "apps": {
+            app_manifest_id: {
+                "id": app_manifest_id,
+                "slug": f"app-{slug}",
+                "name": f"App {slug}",
+                "path": f"apps/{slug}",
+                "app_model": "standalone_v2",
+                "access_level": "authenticated",
+                "dependencies": {},
+                "dist_files": {
+                    "index.html": "<!doctype html><div id=\"root\"></div>"
+                },
+            }
+        }
+    }
+
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w") as archive:
+        archive.writestr(
+            "bifrost.solution.yaml",
+            (
+                f"slug: {slug}\n"
+                f"name: {slug.upper()}\n"
+                "scope: global\n"
+                f"global_repo_access: {str(global_repo_access).lower()}\n"
+            ),
+        )
+        archive.writestr(
+            ".bifrost/workflows.yaml",
+            json.dumps(workflows),
+        )
+        archive.writestr(".bifrost/apps.yaml", json.dumps(apps))
+        archive.writestr("workflows/probe.py", source)
+    return buffer.getvalue()
+
+
+def _deploy_workspace(
+    e2e_client,
+    headers: dict[str, str],
+    *,
+    solution_id: str,
+    slug: str,
+    workspace_zip: bytes,
+) -> None:
+    upload_headers = {
+        key: value
+        for key, value in headers.items()
+        if key.lower() != "content-type"
+    }
+    response = e2e_client.post(
+        f"/api/solutions/{solution_id}/deploy",
+        headers=upload_headers,
+        files={
+            "file": (
+                f"{slug}.zip",
+                workspace_zip,
+                "application/zip",
+            )
+        },
+    )
+    result = wait_for_deploy(e2e_client, response, headers)
+    assert result.status_code == 200, result.text
+
+
+def _create_shared_resources(
+    e2e_client,
+    headers: dict[str, str],
+    *,
+    table_name: str,
+    config_key: str,
+    integration_name: str,
+) -> None:
+    table = e2e_client.post(
+        "/api/tables?scope=global",
+        headers=headers,
+        json={
+            "name": table_name,
+            "schema": {"columns": [{"name": "marker", "type": "string"}]},
+            "policies": {
+                "policies": [
+                    {
+                        "name": "admin_bypass",
+                        "actions": ["read", "create", "update", "delete"],
+                        "when": {"user": "is_platform_admin"},
+                    },
+                    {
+                        "name": "authenticated_read",
+                        "actions": ["read"],
+                        "when": None,
+                    },
+                ]
+            },
+        },
+    )
+    assert table.status_code == 201, table.text
+    row = e2e_client.post(
+        f"/api/tables/{table.json()['id']}/documents",
+        headers=headers,
+        json={"id": "shared-row", "data": {"marker": "table-ok"}},
+    )
+    assert row.status_code == 201, row.text
+
+    config = e2e_client.post(
+        "/api/config",
+        headers=headers,
+        json={
+            "key": config_key,
+            "value": "config-ok",
+            "type": "string",
+            "organization_id": None,
+        },
+    )
+    assert config.status_code == 201, config.text
+
+    integration = e2e_client.post(
+        "/api/integrations",
+        headers=headers,
+        json={
+            "name": integration_name,
+            "default_entity_id": "integration-ok",
+        },
+    )
+    assert integration.status_code == 201, integration.text
+
+
+@pytest.mark.parametrize(
+    ("global_repo_access", "expected_app_status", "expected_rows"),
+    [
+        (True, 200, [{"marker": "table-ok"}]),
+        (False, 404, []),
+    ],
+)
+def test_solution_app_and_workflow_shared_resource_matrix(
+    e2e_client,
+    platform_admin,
+    alice_user,
+    global_repo_access: bool,
+    expected_app_status: int,
+    expected_rows: list[dict[str, str]],
+) -> None:
+    """Exercise the real web-SDK transport and a deployed Python workflow.
+
+    Tables are Solution-scope-capable, so the flag gates their shared fallback.
+    Config and integration values have no Solution-owned value tier and remain
+    shared instance state regardless of the flag.
+    """
+    token = uuid.uuid4().hex[:8]
+    slug = f"shared-access-{token}"
+    table_name = f"shared_table_{token}"
+    config_key = f"shared_config_{token}"
+    integration_name = f"shared_integration_{token}"
+    app_manifest_id = str(uuid.uuid4())
+    workflow_manifest_id = str(uuid.uuid4())
+
+    _create_shared_resources(
+        e2e_client,
+        platform_admin.headers,
+        table_name=table_name,
+        config_key=config_key,
+        integration_name=integration_name,
+    )
+    solution_id = _create_solution(
+        e2e_client,
+        platform_admin.headers,
+        slug=slug,
+        global_repo_access=global_repo_access,
+    )
+    _deploy_workspace(
+        e2e_client,
+        platform_admin.headers,
+        solution_id=solution_id,
+        slug=slug,
+        workspace_zip=_probe_workspace_zip(
+            slug=slug,
+            global_repo_access=global_repo_access,
+            table_name=table_name,
+            config_key=config_key,
+            integration_name=integration_name,
+            app_manifest_id=app_manifest_id,
+            workflow_manifest_id=workflow_manifest_id,
+        ),
+    )
+
+    app_id = str(
+        solution_entity_id(UUID(solution_id), UUID(app_manifest_id))
+    )
+    # BifrostProvider's data transport attaches X-Bifrost-App to this exact
+    # request. Use a non-admin plus an unconditional read policy so a 200 proves
+    # both Solution resolution and ordinary row-policy authorization.
+    app_query = e2e_client.post(
+        f"/api/tables/{table_name}/documents/query",
+        headers={**alice_user.headers, "X-Bifrost-App": app_id},
+        json={"where": {}, "limit": 10},
+    )
+    assert app_query.status_code == expected_app_status, app_query.text
+    if expected_app_status == 200:
+        assert [doc["data"] for doc in app_query.json()["documents"]] == expected_rows
+
+    workflow = e2e_client.post(
+        "/api/workflows/execute",
+        headers=alice_user.headers,
+        json={
+            "workflow_id": "workflows/probe.py::probe",
+            "solution_id": solution_id,
+            "sync": True,
+        },
+    )
+    assert workflow.status_code == 200, workflow.text
+    execution = workflow.json()
+    assert execution["status"] == "Success", execution
+    assert execution["result"] == {
+        "rows": expected_rows,
+        "config": "config-ok",
+        "integration_entity": "integration-ok",
+    }
+
+
+@pytest.mark.parametrize(
+    ("global_repo_access", "expected_status"),
+    [(True, 200), (False, 404)],
+)
+def test_solution_shared_workflow_fallback_obeys_global_repo_access(
+    e2e_client,
+    platform_admin,
+    alice_user,
+    global_repo_access: bool,
+    expected_status: int,
+) -> None:
+    """A scoped caller may execute a loose workflow only from an open Solution."""
+    token = uuid.uuid4().hex[:8]
+    path = f"workflows/shared_{token}.py"
+    function_name = f"shared_{token}"
+    source = (
+        "from bifrost import workflow\n\n"
+        "@workflow\n"
+        f"async def {function_name}():\n"
+        "    return {'shared_workflow': 'executed'}\n"
+    )
+    write = e2e_client.put(
+        "/api/files/editor/content",
+        headers=platform_admin.headers,
+        json={"path": path, "content": source, "encoding": "utf-8"},
+    )
+    assert write.status_code in (200, 201), write.text
+    register = e2e_client.post(
+        "/api/workflows/register",
+        headers=platform_admin.headers,
+        json={
+            "path": path,
+            "function_name": function_name,
+            "organization_id": None,
+            "access_level": "authenticated",
+        },
+    )
+    assert register.status_code in (200, 201), register.text
+
+    solution_id = _create_solution(
+        e2e_client,
+        platform_admin.headers,
+        slug=f"shared-workflow-{token}",
+        global_repo_access=global_repo_access,
+    )
+    response = e2e_client.post(
+        "/api/workflows/execute",
+        headers=alice_user.headers,
+        json={
+            "workflow_id": f"{path}::{function_name}",
+            "solution_id": solution_id,
+            "sync": True,
+        },
+    )
+    assert response.status_code == expected_status, response.text
+    if expected_status == 200:
+        execution = response.json()
+        assert execution["status"] == "Success", execution
+        assert execution["result"] == {"shared_workflow": "executed"}

--- a/api/tests/unit/repositories/test_workflow_pathref_solution_scope.py
+++ b/api/tests/unit/repositories/test_workflow_pathref_solution_scope.py
@@ -143,9 +143,9 @@ class TestPathRefSolutionScope:
         assert got_a is not None and got_a.id == wf_a.id
         assert got_b is not None and got_b.id == wf_b.id
 
-    async def test_install_scope_falls_back_to_repo_when_own_absent(self, db_session) -> None:
-        """An install whose bundle does NOT ship a given path resolves the global
-        _repo/ workflow at that path (the app referenced a shared-library path)."""
+    async def test_install_scope_falls_back_to_repo_when_allowed(self, db_session) -> None:
+        """An open install whose bundle does not ship a path may resolve the
+        loose global workflow at that path."""
         db = db_session
         org = (await _add_org(db)).id
         sol = await _add_solution(db, org)
@@ -157,8 +157,35 @@ class TestPathRefSolutionScope:
         await _add_workflow(db, org_id=org, solution_id=sol.id, path="workflows/own.py")
 
         repo = WorkflowRepository(db, org_id=org, is_superuser=True)
-        got = await repo.resolve("workflows/shared.py::main", solution_scope=sol.id)
+        got = await repo.resolve(
+            "workflows/shared.py::main",
+            solution_scope=sol.id,
+            allow_shared_fallback=True,
+        )
         assert got is not None and got.id == repo_wf.id
+
+    async def test_install_scope_blocks_repo_when_shared_fallback_disabled(
+        self, db_session
+    ) -> None:
+        """A sealed install cannot resolve a loose workflow at a missing path."""
+        db = db_session
+        org = (await _add_org(db)).id
+        sol = await _add_solution(db, org)
+        await _add_workflow(
+            db,
+            org_id=None,
+            solution_id=None,
+            path="workflows/shared.py",
+            name="repo",
+        )
+
+        repo = WorkflowRepository(db, org_id=org, is_superuser=True)
+        got = await repo.resolve(
+            "workflows/shared.py::main",
+            solution_scope=sol.id,
+            allow_shared_fallback=False,
+        )
+        assert got is None
 
     async def test_install_scope_prefers_own_over_repo_on_shared_path(self, db_session) -> None:
         """When a _repo/ row and the caller's OWN solution row share a path, the
@@ -256,9 +283,10 @@ class TestBareNameSolutionScope:
         assert got is not None
         assert got.id == own.id
 
-    async def test_install_scope_falls_back_to_repo_name_when_own_absent(self, db_session) -> None:
-        """A solution caller can still execute a shared _repo workflow by name
-        when its own install does not ship that workflow."""
+    async def test_install_scope_falls_back_to_repo_name_when_allowed(
+        self, db_session
+    ) -> None:
+        """An open Solution caller can execute a loose workflow by name."""
         db = db_session
         org = (await _add_org(db)).id
         sol = await _add_solution(db, org)
@@ -278,9 +306,36 @@ class TestBareNameSolutionScope:
         )
 
         repo = WorkflowRepository(db, org_id=org, is_superuser=True)
-        got = await repo.resolve("shared", solution_scope=sol.id)
+        got = await repo.resolve(
+            "shared",
+            solution_scope=sol.id,
+            allow_shared_fallback=True,
+        )
         assert got is not None
         assert got.id == repo_wf.id
+
+    async def test_install_scope_blocks_repo_name_when_shared_fallback_disabled(
+        self, db_session
+    ) -> None:
+        """A sealed Solution caller cannot execute a loose workflow by name."""
+        db = db_session
+        org = (await _add_org(db)).id
+        sol = await _add_solution(db, org)
+        await _add_workflow(
+            db,
+            org_id=org,
+            solution_id=None,
+            path="workflows/repo.py",
+            name="shared",
+        )
+
+        repo = WorkflowRepository(db, org_id=org, is_superuser=True)
+        got = await repo.resolve(
+            "shared",
+            solution_scope=sol.id,
+            allow_shared_fallback=False,
+        )
+        assert got is None
 
     async def test_two_solution_installs_can_share_name_and_resolve_own(self, db_session) -> None:
         """Two installs in the same org can both ship a workflow named 'hello';
@@ -345,4 +400,69 @@ class TestBareNameSolutionScope:
 
         repo = WorkflowRepository(db, org_id=org, is_superuser=True)
         got = await repo.resolve("hello", solution_scope=sol_a.id)
+        assert got is None
+
+
+@pytest.mark.e2e
+class TestUuidSolutionScope:
+    async def test_scoped_uuid_resolves_own_workflow(self, db_session) -> None:
+        db = db_session
+        org = (await _add_org(db)).id
+        sol = await _add_solution(db, org)
+        own = await _add_workflow(
+            db,
+            org_id=org,
+            solution_id=sol.id,
+            path="workflows/own.py",
+        )
+
+        repo = WorkflowRepository(db, org_id=org, is_superuser=True)
+        got = await repo.resolve(str(own.id), solution_scope=sol.id)
+        assert got is not None and got.id == own.id
+
+    async def test_scoped_uuid_gates_loose_workflow_fallback(self, db_session) -> None:
+        db = db_session
+        org = (await _add_org(db)).id
+        sol = await _add_solution(db, org)
+        shared = await _add_workflow(
+            db,
+            org_id=None,
+            solution_id=None,
+            path="workflows/shared.py",
+        )
+
+        repo = WorkflowRepository(db, org_id=org, is_superuser=True)
+        denied = await repo.resolve(
+            str(shared.id),
+            solution_scope=sol.id,
+            allow_shared_fallback=False,
+        )
+        allowed = await repo.resolve(
+            str(shared.id),
+            solution_scope=sol.id,
+            allow_shared_fallback=True,
+        )
+        assert denied is None
+        assert allowed is not None and allowed.id == shared.id
+
+    async def test_scoped_uuid_never_resolves_sibling_solution(
+        self, db_session
+    ) -> None:
+        db = db_session
+        org = (await _add_org(db)).id
+        sol_a = await _add_solution(db, org)
+        sol_b = await _add_solution(db, org)
+        sibling = await _add_workflow(
+            db,
+            org_id=org,
+            solution_id=sol_b.id,
+            path="workflows/sibling.py",
+        )
+
+        repo = WorkflowRepository(db, org_id=org, is_superuser=True)
+        got = await repo.resolve(
+            str(sibling.id),
+            solution_scope=sol_a.id,
+            allow_shared_fallback=True,
+        )
         assert got is None

--- a/api/tests/unit/repositories/test_workflow_repository.py
+++ b/api/tests/unit/repositories/test_workflow_repository.py
@@ -83,7 +83,9 @@ class TestWorkflowRepository:
 
         assert result == mock_workflow
         mock_resolve.assert_called_once_with(
-            "workflows/customers.py::list_customers", solution_scope=None
+            "workflows/customers.py::list_customers",
+            solution_scope=None,
+            allow_shared_fallback=False,
         )
 
     async def test_resolve_by_path_ref_with_feature_prefix(self, repository, mock_workflow):
@@ -93,7 +95,11 @@ class TestWorkflowRepository:
             result = await repository.resolve(ref)
 
         assert result == mock_workflow
-        mock_resolve.assert_called_once_with(ref, solution_scope=None)
+        mock_resolve.assert_called_once_with(
+            ref,
+            solution_scope=None,
+            allow_shared_fallback=False,
+        )
 
     async def test_resolve_by_path_ref_not_found(self, repository, mock_session):
         """Test resolve() returns None when path::function_name not found."""

--- a/client/src/components/solutions/CreateEditSolution.test.tsx
+++ b/client/src/components/solutions/CreateEditSolution.test.tsx
@@ -83,6 +83,11 @@ describe("CreateEditSolution — edit mode", () => {
 
 		const dialog = await screen.findByTestId("solution-dialog");
 		expect(within(dialog).getByText("Organization")).toBeInTheDocument();
+		expect(
+			within(dialog).getByText(
+				/allow shared module imports and read fallback to loose/i,
+			),
+		).toBeInTheDocument();
 		// The old manual toggle is gone — connection is derived from the URL.
 		expect(within(dialog).queryByLabelText(/git connected/i)).toBeNull();
 		expect(within(dialog).getByTestId("git-section")).toBeInTheDocument();

--- a/client/src/components/solutions/CreateEditSolution.tsx
+++ b/client/src/components/solutions/CreateEditSolution.tsx
@@ -1545,7 +1545,8 @@ function EditBody({
 					<div className="space-y-0.5">
 						<Label htmlFor="edit-global-repo">Global repo access</Label>
 						<p className="text-xs text-muted-foreground">
-							Allow this install to read the global repository.
+							Allow shared module imports and read fallback to loose
+							org/global workflows, tables, and files.
 						</p>
 					</div>
 					<Switch

--- a/plugins/bifrost/skills/bifrost-build/SKILL.md
+++ b/plugins/bifrost/skills/bifrost-build/SKILL.md
@@ -141,6 +141,7 @@ When workflows are exposed as MCP tools (via agents), their `name` becomes the M
 | I need to… | Read |
 |---|---|
 | Build in a Solution workspace | `references/solutions.md` |
+| Understand Solution access to shared/global resources | `references/solution-resource-access.md` |
 | Build in the global `_repo` workspace | `references/repo.md` |
 | Build or modify an app (TSX/React) | `references/apps.md` · `references/web-sdk-v2.md` |
 | Write or debug a Python workflow | `references/workflows-python.md` · `references/python-sdk.md` |

--- a/plugins/bifrost/skills/bifrost-build/references/solution-resource-access.md
+++ b/plugins/bifrost/skills/bifrost-build/references/solution-resource-access.md
@@ -1,0 +1,170 @@
+# Solution Runtime Resource Access
+
+Use this reference when Solution code needs anything outside its own install.
+The `global_repo_access` name is historical and narrower than "all global
+resources", but broader than "only the global `_repo`":
+
+- It is **not** the install scope. Org install versus global install is chosen
+  separately with `--org` / `--global`.
+- It gates shared fallback for resource types that have a Solution-owned tier:
+  `_repo` modules, loose workflows, tables, and files.
+- For an org install, an allowed fallback searches the install org and then
+  global. It is therefore not literally "global only".
+- Config values, integrations/OAuth, and knowledge have no Solution-owned
+  runtime value tier. They are shared instance resources and do not consult
+  this flag.
+
+The flag defaults to `false`.
+
+## Runtime access matrix
+
+| Resource | Standalone app / web SDK | Solution workflow | `global_repo_access: false` | `global_repo_access: true` |
+|---|---|---|---|---|
+| Python modules | Not applicable | Imports under the install first | No shared `_repo` import fallback | Shared `_repo` import fallback |
+| Workflows | `useWorkflow` sends the app id | Nested/direct execute carries Solution scope | Own install only | Own install, then loose install-org/global workflow |
+| Tables | `tables` / `useTable` send `X-Bifrost-App` | Python SDK appends Solution scope | Own Solution table only | Own table, then install-org, then global by **name** |
+| Files | `files` / `useFiles` send `X-Bifrost-App` | Python SDK appends Solution scope | Own declared location only | Own, then install-org, then global reads in a declared location |
+| Config values/secrets | No web-SDK surface | `config` SDK | Shared install-org/global cascade | Same; flag is not consulted |
+| Integrations/OAuth | No web-SDK surface | `integrations` SDK | Shared org mapping, then integration/global defaults | Same; flag is not consulted |
+| Knowledge | No web-SDK surface | `knowledge` SDK | Shared org/global namespace | Same; flag is not consulted |
+
+Forms, agents, apps, event sources, and custom claims are installed entities,
+not general shared-resource SDK lookups. Their `solution_id`, org scope,
+`access_level`, roles, and resource-specific rules remain authoritative. Do not
+infer access to them from `global_repo_access`.
+
+## How Solution scope reaches the server
+
+The app and workflow paths converge on the same request context:
+
+- A deployed standalone app's `BifrostProvider` adds `X-Bifrost-App` to table,
+  file, and workflow calls. Auth resolves that app to its active Solution.
+- A Solution workflow's Python SDK carries its execution `solution_id` on
+  table/file calls.
+- Workflow execution derives scope from the authenticated request context,
+  then the request's Solution/form/app identity for older SDK calls.
+- A mismatched app header and `?solution=` signal is rejected; inactive installs
+  are not executable.
+
+This context selects the install. It does not bypass org scope, RBAC, row/file
+policies, or external-user restrictions.
+
+## Per-resource boundaries
+
+### Modules and workflows
+
+Module imports resolve the install's `_solutions/{id}/` source first. A sealed
+Solution does not fall through to shared `_repo` modules.
+
+Workflow refs follow the same ownership boundary:
+
+1. Resolve the caller's own install by path, name, or UUID.
+2. If shared fallback is disabled, stop.
+3. If enabled, resolve a loose install-org/global workflow subject to normal
+   workflow visibility and access rules.
+
+A scoped caller never resolves a sibling Solution's workflow, including by
+UUID. Prefer portable `path::function` refs in source; UUIDs are
+environment-specific.
+
+When an open Solution resolves a loose workflow, that workflow executes as the
+loose row (`solution_id` is null), not as borrowed Solution-owned code. Its own
+imports and SDK calls therefore use the ordinary org/global runtime. Treat
+allowing loose-workflow fallback as a strong trust boundary, not a harmless
+function alias.
+
+### Tables
+
+Own table names win. With shared fallback enabled, a miss searches loose
+install-org then global tables by name. External table UUIDs stay hidden from
+Solution context.
+
+Shared fallback tables are read-only from the Solution. The flag does not allow
+table creation or row mutation outside the install. Table policies still filter
+or deny rows after the table resolves.
+
+Denied/missing behavior differs slightly by SDK surface:
+
+- The web transport receives the server's 404.
+- Python `tables.query()` deliberately converts a 404 into an empty
+  `DocumentList`; write/get operations keep their documented error/`None`
+  behavior.
+
+### Files
+
+The location must be declared in `.bifrost/files.yaml`; `workspace` is never a
+Solution runtime location. With shared fallback enabled, read/list/exists and
+signed-read operations search own, install-org, then global tiers. File policies
+apply independently at each tier.
+
+Writes and deletes always target the Solution-owned tier. Enabling fallback does
+not let an app or workflow modify loose org/global files.
+
+### Config values and secrets
+
+The manifest carries config **declarations** (key, type, required/default
+metadata), not an isolated value store. Runtime `config.get()` reads the
+instance's org/global config cascade regardless of `global_repo_access`.
+
+`config.set()` and `config.delete()` mutate that shared instance namespace when
+the caller's execution scope permits it. Treat those calls as changes to shared
+environment state, not install-local state.
+
+For an org install, setup status can require an org-specific value while runtime
+lookup can still find a global fallback. If setup says "unset" but execution
+works, inspect both tiers rather than assuming the SDK is unavailable.
+
+### Integrations and OAuth
+
+A Solution can declare that a connection is required, but the installed
+environment supplies the Integration row, org mapping, OAuth provider/token,
+and secret config. `integrations.get()` resolves the caller's org mapping first,
+then integration/global defaults. This behavior is independent of
+`global_repo_access`.
+
+Integrations are intentionally server-side only in a standalone app: call them
+from a Python workflow so OAuth tokens and decrypted secrets never enter browser
+JavaScript. Mapping mutation APIs change shared instance state and require the
+same care as config writes.
+
+### Knowledge
+
+Knowledge is also an org/global shared namespace with its own access rules. A
+Solution declaration or install does not create a private knowledge tier, and
+the flag does not seal knowledge access.
+
+## Security and portability rules
+
+- Shared fallback is an additional lookup tier, **not** an authorization
+  bypass. Org boundaries, role checks, table/file policies, and external-user
+  restrictions still apply.
+- `global_repo_access: true` weakens self-containment. A package can depend on
+  loose workflows, code, tables, or files that another environment does not
+  have.
+- Config values, integration mappings, OAuth tokens, knowledge content, table
+  rows, and runtime files are environment state. Normal shareable packages
+  carry declarations/schema, not those values.
+- Config and integration names are shared keys. Two Solutions using the same
+  key/name intentionally consume the same instance value.
+- Keep secrets behind Python workflows. The web SDK exposes workflows, tables,
+  and files; it does not expose config, integrations/OAuth, or knowledge.
+
+## `bifrost solution start`
+
+Local preview is connected to the selected live instance; it is not a data
+sandbox.
+
+- The generic `/api/*` proxy adds the bound Solution context and app/org auth
+  headers. Table and file routes are handled by the normal upstream routers;
+  the proxy does not implement a separate table namespace.
+- Workflow execute is special: local functions resolve first and return a
+  transient terminal response. If a ref is absent locally, a sealed Solution
+  stops there; an open Solution may delegate the loose ref upstream.
+- Remote table/file/config/integration writes are real instance changes.
+- The access token is injected at runtime for preview/deployed mounts; it is not
+  bundled into application source or build output.
+
+Validate boundary-sensitive changes against both `solution start` and a
+deployed install. They must agree on whether a loose workflow/resource fallback
+is permitted even though local workflow executions are transient and deployed
+executions are durable.

--- a/plugins/bifrost/skills/bifrost-build/references/solutions.md
+++ b/plugins/bifrost/skills/bifrost-build/references/solutions.md
@@ -187,6 +187,13 @@ This applies to install-creating or install-selecting Solution commands (`create
 
 `bifrost.solution.yaml` is the **definition** descriptor — `slug`, `name`, `version`, `global_repo_access`, and git-source fields (`git_connected`, `git_repo_url`, `repo_subpath`, `git_ref`, `logo`). It intentionally carries **no install id** and **no install scope**. The concrete install binding lives in `.env` (`BIFROST_SOLUTION_ID`, slug, org id, scope), which is local environment state and should not be committed. The descriptor also doubles as the workspace mode marker (its presence is what switches tooling into solution mode).
 
+`global_repo_access` is not a blanket global-resource switch and is not limited
+to module imports. It gates shared fallback for `_repo` modules, loose
+org/global workflows, tables, and files. Config values, integrations/OAuth, and
+knowledge are shared instance resources regardless of the flag. Read the full
+matrix and its security/portability boundaries in
+`references/solution-resource-access.md`.
+
 The install id lives **server-side** (`Solution.id` — the `solution_id` stamped on every managed entity *at deploy time*) and in the local uncommitted `.env` binding. The repo is the **definition**; `solution create` or `solution bind` chooses which concrete install this checkout is working against. Deploy/pull then operate on that install (or an explicit `--solution` override).
 
 **Instance vs fork — the `slug` is the dividing line:**
@@ -281,6 +288,7 @@ There is no React, shadcn, or router injection from the SDK — import those fro
 ## Key constraints
 
 - Workflows must use portable `path::function` refs (e.g. `functions/hello.py::main`), not UUIDs or bare names — UUIDs are environment-specific and break portability.
+- Before depending on loose org/global resources, read `references/solution-resource-access.md`; shared fallback and shared-by-design instance state have different portability/security boundaries.
 - Solution file locations live in `.bifrost/files.yaml`; runtime file bytes are user data and only travel in encrypted full backups.
 - `_solutions/` and `_solution_artifacts/` are platform internals. Never create those folders in a Solution workspace.
 - The `bifrost:migrate` skill covers the v1→v2 migration path (slug swap, import rewrite, entity capture, etc.).

--- a/plugins/bifrost/skills/bifrost-build/references/sources.yaml
+++ b/plugins/bifrost/skills/bifrost-build/references/sources.yaml
@@ -58,13 +58,33 @@ references:
 
   - file: references/solutions.md
     source_globs:
+      - api/bifrost/solution_descriptor.py
       - api/bifrost/commands/solution.py
       - api/bifrost/commands/files.py
       - api/bifrost/manifest.py
       - api/src/models/contracts/solutions.py
       - api/src/services/solution_files.py
       - api/src/services/solutions/*.py
-    verified_at_sha: 44fed5904f8b36b2f8ace25c17e144a8fb89dc87
+    verified_at_sha: ea2714bd66c640d1b7b3bf1a21ccbd7dcb462773
+
+  - file: references/solution-resource-access.md
+    source_globs:
+      - api/bifrost/config.py
+      - api/bifrost/integrations.py
+      - api/bifrost/solution_descriptor.py
+      - api/bifrost/solution_dev/proxy.py
+      - api/bifrost/tables.py
+      - api/src/core/auth.py
+      - api/src/repositories/workflows.py
+      - api/src/routers/cli.py
+      - api/src/routers/files.py
+      - api/src/routers/forms.py
+      - api/src/routers/tables.py
+      - api/src/routers/workflows.py
+      - api/src/services/solution_scope.py
+      - client/src/lib/app-sdk/*.ts
+      - client/src/lib/app-sdk/*.tsx
+    verified_at_sha: ea2714bd66c640d1b7b3bf1a21ccbd7dcb462773
 
   - file: references/tables.md
     source_globs:


### PR DESCRIPTION
Fixes #525

## Summary

- enforce `allow_global_repo_access` when a Solution-bound workflow or form resolves a loose organization/global workflow
- preserve own-Solution workflow resolution and prevent sibling-Solution UUID/name/path access
- add deploy-level E2E coverage for a standalone v2 app and Solution workflow reading a global table in allowed and denied modes
- verify and document that configs, integrations, OAuth mappings, and knowledge are shared services governed by their existing org/global authorization, not by the Solution flag
- publish the complete shared-resource matrix in the public `bifrost-build` skill and update the Solution UI copy

## Verified behavior

| Resource | Flag off | Flag on | Additional boundary |
|---|---|---|---|
| modules | own Solution only | own then shared `_repo` | import/read only |
| workflows | own Solution only | own then loose org/global | sibling Solutions never resolve |
| tables | own Solution only | own then org/global by name | fallback is read-only and table policies still apply |
| files | own Solution only | own then org/global read cascade | writes/deletes stay own-Solution; file policies still apply |
| configs/integrations/OAuth/knowledge | shared service behavior unchanged | shared service behavior unchanged | existing org/global and external-user authorization applies |

## Test evidence

- affected repository + deploy-level access matrix after merging current main: 48 passed
- full backend unit suite: 5,371 passed, 3 skipped, 20 deselected
- Solution editor component: 20 passed
- API quality: pyright 0 errors/0 warnings; ruff clean
- TypeScript: `tsc` clean; lint 0 errors (one pre-existing warning)
- skill validation: 8 passed, 3 host-only skips; mirror diff clean
- full Vitest: 1,647 passed and 5 host-parallel timeouts; all five affected files pass serially (86/86)
- Playwright: 102 passed, including deployed Solution runtime workflow/table/file browser contract; isolated Solutions spec 3/3. The local full suite also surfaced three unrelated existing tests (Agent Detail scroll timeout, order-dependent Solutions empty state, workflow execute navigation).
- GitHub CI on current main: full unit, client unit, lint/type-check, CodeQL, and both E2E shards pass

## Related PR

#524 contains useful local-dev/no-sandbox and portability guidance, but its claim that the flag is workflow-code-only conflicts with `solution_scope.py`, existing tests, and live validation. This PR does not modify or overwrite that contributor branch; it supplies the enforcement fix, executable matrix, and canonical documentation separately.