### PR TITLE
Harden agent delegation lifecycle without changing tool schemas

### DIFF
--- a/api/src/routers/agent_runs.py
+++ b/api/src/routers/agent_runs.py
@@ -52,6 +52,7 @@ from src.models.orm.agents import Agent
 from src.models.orm.solutions import Solution
 from src.models.orm.summary_backfill_job import SummaryBackfillJob
 from src.core.redis_client import get_redis_client
+from src.services.execution.agent_run_access import agent_run_visibility_conditions
 from src.services.execution.agent_run_service import (
     enqueue_agent_run,
     wait_for_agent_run_result,
@@ -148,12 +149,12 @@ async def list_agent_runs(
     # real executions of that agent and should not disappear from its Runs tab.
     query = select(AgentRun).join(AgentRun.agent)
     if agent_id is None:
-        query = query.where(AgentRun.parent_run_id.is_(None))
+        query = query.where(
+            AgentRun.parent_run_id.is_(None),
+            AgentRun.trigger_type != "delegation",
+        )
 
-    # Org filter: non-superusers see only their org's runs
-    if not user.is_superuser:
-        if user.organization_id:
-            query = query.where(AgentRun.org_id == user.organization_id)
+    query = query.where(*agent_run_visibility_conditions(user))
 
     # Apply optional filters
     if agent_id is not None:
@@ -284,9 +285,10 @@ async def get_metadata_keys(
     extracts on this agent.
     """
     _enforce_agent_scope(agent_id, user)
-    conditions = [AgentRun.agent_id == agent_id]
-    if not user.is_superuser and user.organization_id:
-        conditions.append(AgentRun.org_id == user.organization_id)
+    conditions = [
+        AgentRun.agent_id == agent_id,
+        *agent_run_visibility_conditions(user),
+    ]
 
     # jsonb_object_keys explodes the top-level keys of each row's metadata;
     # DISTINCT + ORDER BY gives the UI a stable, deduped list.
@@ -318,9 +320,10 @@ async def get_metadata_values(
     them pick from a known-value list instead of free-typing.
     """
     _enforce_agent_scope(agent_id, user)
-    conditions = [AgentRun.agent_id == agent_id]
-    if not user.is_superuser and user.organization_id:
-        conditions.append(AgentRun.org_id == user.organization_id)
+    conditions = [
+        AgentRun.agent_id == agent_id,
+        *agent_run_visibility_conditions(user),
+    ]
 
     value_col = AgentRun.run_metadata[key].astext
     stmt = (
@@ -442,10 +445,7 @@ async def get_agent_run(
         .where(AgentRun.id == run_id)
     )
 
-    # Org filter: non-superusers see only their org's runs
-    if not user.is_superuser:
-        if user.organization_id:
-            query = query.where(AgentRun.org_id == user.organization_id)
+    query = query.where(*agent_run_visibility_conditions(user))
 
     result = await db.execute(query)
     run = result.scalar_one_or_none()
@@ -628,10 +628,7 @@ async def rerun_agent_run(
     """Rerun an agent run with the same input (async, non-blocking)."""
     query = select(AgentRun).where(AgentRun.id == run_id)
 
-    # Org filter: non-superusers see only their org's runs
-    if not user.is_superuser:
-        if user.organization_id:
-            query = query.where(AgentRun.org_id == user.organization_id)
+    query = query.where(*agent_run_visibility_conditions(user))
 
     result = await db.execute(query)
     original = result.scalar_one_or_none()
@@ -658,7 +655,14 @@ async def rerun_agent_run(
     return AgentRunRerunResponse(run_id=UUID(new_run_id))
 
 
-TERMINAL_STATUSES = {"completed", "failed", "cancelled", "budget_exceeded", "timeout"}
+TERMINAL_STATUSES = {
+    "completed",
+    "failed",
+    "cancelled",
+    "paused",
+    "budget_exceeded",
+    "timeout",
+}
 
 
 @router.post("/{run_id}/cancel")
@@ -670,10 +674,7 @@ async def cancel_agent_run(
     """Cancel a queued or running agent run."""
     query = select(AgentRun).where(AgentRun.id == run_id)
 
-    # Org filter: non-superusers see only their org's runs
-    if not user.is_superuser:
-        if user.organization_id:
-            query = query.where(AgentRun.org_id == user.organization_id)
+    query = query.where(*agent_run_visibility_conditions(user))
 
     result = await db.execute(query)
     agent_run = result.scalar_one_or_none()
@@ -742,10 +743,7 @@ async def set_verdict(
     """Set a verdict on a completed run. Records an audit row."""
     query = select(AgentRun).where(AgentRun.id == run_id)
 
-    # Org filter: non-superusers see only their org's runs
-    if not user.is_superuser:
-        if user.organization_id:
-            query = query.where(AgentRun.org_id == user.organization_id)
+    query = query.where(*agent_run_visibility_conditions(user))
 
     result = await db.execute(query)
     run = result.scalar_one_or_none()
@@ -798,10 +796,7 @@ async def clear_verdict(
     """Clear the verdict on a run. Records an audit row."""
     query = select(AgentRun).where(AgentRun.id == run_id)
 
-    # Org filter: non-superusers see only their org's runs
-    if not user.is_superuser:
-        if user.organization_id:
-            query = query.where(AgentRun.org_id == user.organization_id)
+    query = query.where(*agent_run_visibility_conditions(user))
 
     result = await db.execute(query)
     run = result.scalar_one_or_none()
@@ -855,8 +850,7 @@ async def get_flag_conversation(
     stream messages into a stable ``id``.
     """
     query = select(AgentRun).where(AgentRun.id == run_id)
-    if not user.is_superuser and user.organization_id:
-        query = query.where(AgentRun.org_id == user.organization_id)
+    query = query.where(*agent_run_visibility_conditions(user))
     run = (await db.execute(query)).scalar_one_or_none()
     if not run:
         raise HTTPException(
@@ -888,8 +882,7 @@ async def send_flag_message(
 ) -> FlagConversationResponse:
     """Append a user turn and synchronously get the tuning-model reply."""
     query = select(AgentRun).where(AgentRun.id == run_id)
-    if not user.is_superuser and user.organization_id:
-        query = query.where(AgentRun.org_id == user.organization_id)
+    query = query.where(*agent_run_visibility_conditions(user))
     run = (await db.execute(query)).scalar_one_or_none()
     if not run:
         raise HTTPException(
@@ -961,8 +954,7 @@ async def dry_run_agent_run(
     tracking (``sequence=8000``).
     """
     query = select(AgentRun).where(AgentRun.id == run_id)
-    if not user.is_superuser and user.organization_id:
-        query = query.where(AgentRun.org_id == user.organization_id)
+    query = query.where(*agent_run_visibility_conditions(user))
 
     run = (await db.execute(query)).scalar_one_or_none()
     if not run:

--- a/api/src/routers/agent_tuning.py
+++ b/api/src/routers/agent_tuning.py
@@ -89,7 +89,7 @@ async def create_tuning_session(
     await _load_agent_with_access(agent_id, db, user)
 
     try:
-        proposal = await propose_consolidated_tuning(agent_id, db)
+        proposal = await propose_consolidated_tuning(agent_id, db, user)
     except LookupError as exc:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)
@@ -124,6 +124,7 @@ async def dry_run_tuning_session(
         proposed_prompt=request.proposed_prompt,
         db=db,
         session_factory=session_factory,
+        user=user,
     )
     return ConsolidatedDryRunResponse(
         results=[
@@ -158,6 +159,7 @@ async def apply_tuning_session(
             reason=request.reason,
             user_id=user.user_id,
             db=db,
+            user=user,
         )
     except LookupError as exc:
         raise HTTPException(

--- a/api/src/services/agent_executor.py
+++ b/api/src/services/agent_executor.py
@@ -11,7 +11,6 @@ Handles the chat completion loop for AI agents, including:
 - Agent delegation
 """
 
-import asyncio
 import json
 import logging
 import time
@@ -48,7 +47,10 @@ from src.services.execution.agent_helpers import (
     parse_mcp_tool_name,
     resolve_agent_tools,
 )
-from src.services.execution.autonomous_agent_executor import AutonomousAgentExecutor
+from src.services.execution.autonomous_agent_executor import (
+    AutonomousAgentExecutor,
+    ToolError,
+)
 from src.services.knowledge.search_budget import (
     KnowledgeSearchBudget,
     clamp_knowledge_result_limit,
@@ -79,6 +81,13 @@ def _serialize_for_json(value: Any) -> str:
     import pydantic_core
 
     return pydantic_core.to_json(value, fallback=str).decode()
+
+
+def _serialize_tool_result_for_history(tool_result: ToolResult) -> str:
+    """Serialize what the parent model sees, with failures taking precedence."""
+    if tool_result.error:
+        return tool_result.error
+    return _serialize_for_json(tool_result.result)
 
 
 # Maximum tool call iterations to prevent infinite loops
@@ -295,6 +304,25 @@ class AgentExecutor:
             # auth-resolution layer makes the user-vs-service decision
             # exactly once per call.
             caller_user_id: UUID | None = conversation.user_id
+            caller = (
+                {
+                    "user_id": str(user.user_id),
+                    "email": user.email,
+                    "name": user.name,
+                    "organization_id": (
+                        str(user.organization_id)
+                        if user.organization_id
+                        else None
+                    ),
+                    "is_platform_admin": user.is_superuser,
+                }
+                if user
+                else (
+                    {"user_id": str(caller_user_id)}
+                    if caller_user_id
+                    else None
+                )
+            )
             tool_definitions = (
                 await self._get_agent_tools(agent, caller_user_id=caller_user_id)
                 if agent
@@ -525,13 +553,22 @@ IMPORTANT: When the user's request can be fulfilled using one of your tools, you
                         conversation,
                         execution_id=execution_id,
                         caller_user_id=caller_user_id,
+                        caller=caller,
                     )
 
                     # Update TOOL_CALL message with result and state
+                    persisted_tool_result = (
+                        tool_result.result
+                        if not tool_result.error
+                        else {
+                            "error": tool_result.error,
+                            **(tool_result.metadata or {}),
+                        }
+                    )
                     await self._update_tool_call_message(
                         message_id=tool_call_msg.id,
                         tool_state="completed" if not tool_result.error else "error",
-                        tool_result=tool_result.result if not tool_result.error else {"error": tool_result.error},
+                        tool_result=persisted_tool_result,
                         duration_ms=tool_result.duration_ms,
                     )
 
@@ -542,11 +579,17 @@ IMPORTANT: When the user's request can be fulfilled using one of your tools, you
                             message_id=str(tool_call_msg.id),
                         )
 
+                    # Errors take precedence when a tool happens to return both
+                    # a partial result and an error.
+                    tool_history_content = _serialize_tool_result_for_history(
+                        tool_result
+                    )
+
                     # Still save TOOL message for Anthropic API compatibility (history reconstruction)
                     await self._save_message(
                         conversation_id=conversation.id,
                         role=MessageRole.TOOL,
-                        content=_serialize_for_json(tool_result.result) if tool_result.result else tool_result.error,
+                        content=tool_history_content,
                         tool_call_id=tc.id,
                         tool_name=tc.name,
                         execution_id=execution_id,
@@ -557,7 +600,7 @@ IMPORTANT: When the user's request can be fulfilled using one of your tools, you
                     messages.append(
                         LLMMessage(
                             role="tool",
-                            content=_serialize_for_json(tool_result.result) if tool_result.result else tool_result.error,
+                            content=tool_history_content,
                             tool_call_id=tc.id,
                             tool_name=tc.name,
                         )
@@ -1239,6 +1282,7 @@ IMPORTANT: When the user's request can be fulfilled using one of your tools, you
         execution_id: str | None = None,
         *,
         caller_user_id: UUID | None = None,
+        caller: dict[str, Any] | None = None,
     ) -> ToolResult:
         """
         Execute a tool (workflow, delegation, system tool, knowledge search,
@@ -1256,7 +1300,12 @@ IMPORTANT: When the user's request can be fulfilled using one of your tools, you
 
         # Check if this is a delegation tool call
         if tool_call.name.startswith("delegate_to_") and agent:
-            return await self._execute_delegation(tool_call, agent)
+            return await self._execute_delegation(
+                tool_call,
+                agent,
+                conversation=conversation,
+                caller=caller,
+            )
 
         # Check if this is a system tool call
         if agent and tool_call.name in (agent.system_tools or []):
@@ -1638,6 +1687,9 @@ IMPORTANT: When the user's request can be fulfilled using one of your tools, you
         self,
         tool_call: ToolCallRequest,
         agent: Agent,
+        *,
+        conversation: Conversation | None = None,
+        caller: dict[str, Any] | None = None,
     ) -> ToolResult:
         """Execute a delegation to another agent via AutonomousAgentExecutor."""
         start_time = time.time()
@@ -1664,57 +1716,66 @@ IMPORTANT: When the user's request can be fulfilled using one of your tools, you
 
         try:
             from src.core.cache import get_shared_redis
-            from src.services.execution.autonomous_agent_executor import DELEGATION_TIMEOUT_SECONDS
 
             logger.info(f"Agent '{agent.name}' delegating to '{delegated_agent.name}' via chat")
 
-            # Re-fetch with relationships loaded — the parent's selectinload
-            # doesn't transitively load the child agent's own relationships
-            async with self._db() as session:
-                result = await session.execute(
-                    select(Agent)
-                    .options(selectinload(Agent.tools), selectinload(Agent.delegated_agents))
-                    .where(Agent.id == delegated_agent.id)
-                )
-                delegated_agent = result.scalar_one()
-
             redis_client = await get_shared_redis()
-            sub_executor = AutonomousAgentExecutor(self._session_factory, redis_client=redis_client)
-            try:
-                sub_result = await asyncio.wait_for(
-                    sub_executor.run(
-                        agent=delegated_agent,
-                        input_data={"task": task, "_delegated_from": agent.name},
-                    ),
-                    timeout=DELEGATION_TIMEOUT_SECONDS,
-                )
-            except asyncio.TimeoutError:
-                logger.error(
-                    f"Delegation to '{delegated_agent.name}' timed out after {DELEGATION_TIMEOUT_SECONDS}s"
-                )
+            delegation_executor = AutonomousAgentExecutor(
+                self._session_factory,
+                redis_client=redis_client,
+            )
+            outcome = await delegation_executor.run_delegation(
+                parent_agent=agent,
+                tool_call=tool_call,
+                conversation_id=conversation.id if conversation else None,
+                caller=caller,
+            )
+            metadata = {
+                "child_run_id": str(outcome.child_run_id),
+                "agent": outcome.agent_name,
+                "status": outcome.status,
+            }
+
+            logger.info(
+                f"Delegation to '{outcome.agent_name}' completed with "
+                f"status={outcome.status}"
+            )
+
+            if not outcome.succeeded:
                 return ToolResult(
                     tool_call_id=tool_call.id,
                     tool_name=tool_call.name,
                     result=None,
-                    error=f"Delegation to {delegated_agent.name} timed out after {DELEGATION_TIMEOUT_SECONDS}s",
-                    duration_ms=int((time.time() - start_time) * 1000),
+                    error=(
+                        outcome.error
+                        or f"Delegation ended with status {outcome.status}"
+                    ),
+                    duration_ms=outcome.duration_ms,
+                    metadata=metadata,
                 )
-
-            duration_ms = int((time.time() - start_time) * 1000)
-            output = sub_result.get("output", "Delegation completed with no output.")
-
-            logger.info(
-                f"Delegation to '{delegated_agent.name}' completed with status={sub_result.get('status')}"
-            )
 
             return ToolResult(
                 tool_call_id=tool_call.id,
                 tool_name=tool_call.name,
-                result={"response": str(output), "agent": delegated_agent.name},
-                error=None if sub_result.get("status") != "failed" else sub_result.get("error"),
-                duration_ms=duration_ms,
+                result={
+                    "response": str(outcome.output),
+                    "agent": outcome.agent_name,
+                    "status": outcome.status,
+                    "child_run_id": str(outcome.child_run_id),
+                },
+                error=None,
+                duration_ms=outcome.duration_ms,
+                metadata=metadata,
             )
 
+        except ToolError as e:
+            return ToolResult(
+                tool_call_id=tool_call.id,
+                tool_name=tool_call.name,
+                result=None,
+                error=str(e),
+                duration_ms=int((time.time() - start_time) * 1000),
+            )
         except Exception as e:
             logger.error(f"Delegation error for {tool_call.name}: {e}", exc_info=True)
             return ToolResult(

--- a/api/src/services/execution/agent_run_access.py
+++ b/api/src/services/execution/agent_run_access.py
@@ -1,0 +1,33 @@
+"""Shared visibility policy for agent-run records."""
+
+from sqlalchemy import or_
+from sqlalchemy.sql.elements import ColumnElement
+
+from src.core.principal import UserPrincipal
+from src.models.orm.agent_runs import AgentRun
+
+
+def agent_run_visibility_conditions(
+    user: UserPrincipal,
+) -> tuple[ColumnElement[bool], ...]:
+    """Return SQL conditions limiting runs to those visible to ``user``.
+
+    Autonomous delegations have a parent run and remain visible anywhere
+    their parent orchestration is visible. Chat has no parent ``AgentRun``, so
+    its delegated child is a root delegation row. Those rows inherit the
+    private conversation's owner boundary through ``caller_user_id``.
+    """
+    if user.is_superuser:
+        return ()
+
+    conditions: list[ColumnElement[bool]] = []
+    if user.organization_id is not None:
+        conditions.append(AgentRun.org_id == user.organization_id)
+    conditions.append(
+        or_(
+            AgentRun.trigger_type != "delegation",
+            AgentRun.parent_run_id.is_not(None),
+            AgentRun.caller_user_id == str(user.user_id),
+        )
+    )
+    return tuple(conditions)

--- a/api/src/services/execution/agent_run_service.py
+++ b/api/src/services/execution/agent_run_service.py
@@ -45,6 +45,7 @@ async def enqueue_agent_run(
             "user_id": caller_user_id,
             "email": caller_email,
             "name": caller_name,
+            "organization_id": org_id,
         },
         "event_delivery_id": event_delivery_id,
         "sync": sync,

--- a/api/src/services/execution/autonomous_agent_executor.py
+++ b/api/src/services/execution/autonomous_agent_executor.py
@@ -13,16 +13,17 @@ import asyncio
 import json
 import logging
 import time
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any
 from uuid import UUID, uuid4
 
 import redis.asyncio as aioredis
-from sqlalchemy import select
+from sqlalchemy import or_, select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 from sqlalchemy.orm import selectinload
 
-from src.models.orm.agents import Agent
+from src.models.orm.agents import Agent, AgentDelegation
 from src.models.orm.agent_runs import AgentRun, AgentRunStep
 from src.core.constants import SYSTEM_USER_ID, SYSTEM_USER_EMAIL
 from src.core.cache.keys import agent_run_steps_stream_key
@@ -60,6 +61,22 @@ class ToolError(Exception):
     pass
 
 
+@dataclass(frozen=True)
+class DelegationOutcome:
+    """Canonical internal result for a delegated child run."""
+
+    child_run_id: UUID
+    agent_name: str
+    status: str
+    output: str | dict | None
+    error: str | None
+    duration_ms: int
+
+    @property
+    def succeeded(self) -> bool:
+        return self.status == "completed"
+
+
 class AutonomousAgentExecutor:
     """Execute an agent autonomously (no streaming, no chat session).
 
@@ -77,10 +94,12 @@ class AutonomousAgentExecutor:
         redis_client: aioredis.Redis | None = None,
         *,
         _delegation_depth: int = 0,
+        _ancestor_run_ids: tuple[str, ...] = (),
     ):
         self._session_factory = session_factory
         self.redis_client = redis_client
         self._delegation_depth = _delegation_depth
+        self._ancestor_run_ids = _ancestor_run_ids
         self._tool_workflow_id_map: dict[str, UUID] = {}
         self._current_run_id: str = ""
         self._last_delegation_run_id: str | None = None
@@ -91,6 +110,7 @@ class AutonomousAgentExecutor:
         # event-trigger), in which case dispatch resolves to the
         # service token only.
         self._caller_user_id: UUID | None = None
+        self._caller: dict[str, Any] | None = None
         # Buffers for Redis-first pattern (flushed to DB after run completes)
         self._pending_steps: list[dict[str, Any]] = []
         self._pending_ai_usage: list[dict[str, Any]] = []
@@ -140,6 +160,7 @@ class AutonomousAgentExecutor:
                 )
                 caller_user_id = None
         self._caller_user_id = caller_user_id
+        self._caller = dict(_caller) if _caller else None
 
         # Short-circuit if agent is paused. Runs already past this point continue
         # normally — this check only gates new runs at entry.
@@ -312,6 +333,8 @@ class AutonomousAgentExecutor:
                     # previous workflow's execution ID.
                     self._last_workflow_execution_id = None
                     self._last_workflow_execution_is_error = False
+                    if tc.name.startswith("delegate_to_"):
+                        self._last_delegation_run_id = None
                     result = await self._execute_tool(tc, agent)
                     tool_duration = int((time.time() - tool_start) * 1000)
 
@@ -337,12 +360,21 @@ class AutonomousAgentExecutor:
                     ))
                 except Exception as e:
                     tool_duration = int((time.time() - tool_start) * 1000)
-                    step_number += 1
-                    await self._record_step(run_id, step_number, "tool_error", {
+                    step_content = {
                         "tool_name": tc.name,
                         "error": str(e),
                         "is_error": True,
-                    }, duration_ms=tool_duration)
+                    }
+                    if tc.name.startswith("delegate_to_") and self._last_delegation_run_id:
+                        step_content["child_run_id"] = self._last_delegation_run_id
+                    step_number += 1
+                    await self._record_step(
+                        run_id,
+                        step_number,
+                        "tool_error",
+                        step_content,
+                        duration_ms=tool_duration,
+                    )
 
                     messages.append(LLMMessage(
                         role="tool",
@@ -482,11 +514,31 @@ class AutonomousAgentExecutor:
             workflow_id=str(workflow_id),
             workflow_name=tool_call.name,
             parameters=tool_call.arguments or {},
-            user_id=SYSTEM_USER_ID,
-            user_email=SYSTEM_USER_EMAIL,
-            user_name=agent.name,
+            user_id=(
+                str(self._caller_user_id)
+                if self._caller_user_id
+                else SYSTEM_USER_ID
+            ),
+            user_email=(
+                str(self._caller.get("email"))
+                if self._caller_user_id
+                and self._caller
+                and self._caller.get("email")
+                else SYSTEM_USER_EMAIL
+            ),
+            user_name=(
+                str(self._caller.get("name"))
+                if self._caller_user_id
+                and self._caller
+                and self._caller.get("name")
+                else agent.name
+            ),
             org_id=str(agent.organization_id) if agent.organization_id else None,
-            is_platform_admin=False,
+            is_platform_admin=(
+                bool(self._caller.get("is_platform_admin", False))
+                if self._caller_user_id and self._caller
+                else False
+            ),
             is_agent=True,
         )
         self._last_workflow_execution_id = response.execution_id
@@ -646,47 +698,111 @@ class AutonomousAgentExecutor:
             logger.error(f"Knowledge search failed: {e}", exc_info=True)
             raise ToolError(f"Knowledge search error: {e}") from e
 
-    async def _execute_delegation(self, tool_call: ToolCallRequest, agent: Agent) -> str:
-        """Execute delegation to another agent (recursive autonomous run)."""
-        # Check cancellation before starting potentially long delegation
-        if await self._check_cancelled(self._current_run_id):
+    async def run_delegation(
+        self,
+        *,
+        parent_agent: Agent,
+        tool_call: ToolCallRequest,
+        parent_run_id: str | None = None,
+        conversation_id: UUID | None = None,
+        caller: dict[str, Any] | None = None,
+    ) -> DelegationOutcome:
+        """Run one delegated child with a durable, caller-neutral lifecycle."""
+        if parent_run_id and await self._check_cancelled(parent_run_id):
             raise ToolError("Agent run was cancelled")
-
         if self._delegation_depth >= MAX_DELEGATION_DEPTH:
-            logger.warning(f"Delegation depth limit ({MAX_DELEGATION_DEPTH}) exceeded for {tool_call.name}")
-            raise ToolError(f"Delegation depth limit ({MAX_DELEGATION_DEPTH}) exceeded — cannot delegate further.")
+            logger.warning(
+                f"Delegation depth limit ({MAX_DELEGATION_DEPTH}) exceeded for {tool_call.name}"
+            )
+            raise ToolError(
+                f"Delegation depth limit ({MAX_DELEGATION_DEPTH}) exceeded — "
+                "cannot delegate further."
+            )
 
         task = tool_call.arguments.get("task", "")
+        if not task:
+            raise ToolError("No task provided for delegation")
 
-        target_agent = find_delegated_agent(agent, tool_call.name)
+        target_agent = find_delegated_agent(parent_agent, tool_call.name)
         if not target_agent:
             raise ToolError(f"Delegation target for '{tool_call.name}' not found.")
+        if (
+            target_agent.organization_id is not None
+            and target_agent.organization_id != parent_agent.organization_id
+        ):
+            raise ToolError(
+                f"Delegation target '{target_agent.name}' is outside the "
+                "parent agent's organization."
+            )
 
         logger.info(
-            f"Agent '{agent.name}' delegating to '{target_agent.name}' "
+            f"Agent '{parent_agent.name}' delegating to '{target_agent.name}' "
             f"(depth={self._delegation_depth + 1}/{MAX_DELEGATION_DEPTH})"
         )
 
-        # Brief DB session: re-fetch child agent with relationships + create sub-run record
-        sub_run_id = str(uuid4())
+        sub_run_id = uuid4()
+        delegation_org_id = parent_agent.organization_id
+        if (
+            delegation_org_id is None
+            and caller
+            and caller.get("organization_id")
+        ):
+            try:
+                delegation_org_id = UUID(str(caller["organization_id"]))
+            except (TypeError, ValueError):
+                logger.warning(
+                    "Delegation from agent %s received invalid caller "
+                    "organization_id %r; retaining global run scope",
+                    parent_agent.id,
+                    caller.get("organization_id"),
+                )
+
         async with self._session_factory() as db:
             result = await db.execute(
                 select(Agent)
-                .options(selectinload(Agent.tools), selectinload(Agent.delegated_agents))
-                .where(Agent.id == target_agent.id)
+                .join(
+                    AgentDelegation,
+                    AgentDelegation.child_agent_id == Agent.id,
+                )
+                .options(
+                    selectinload(Agent.tools),
+                    selectinload(Agent.delegated_agents),
+                )
+                .where(
+                    Agent.id == target_agent.id,
+                    Agent.is_active.is_(True),
+                    AgentDelegation.parent_agent_id == parent_agent.id,
+                    or_(
+                        Agent.organization_id.is_(None),
+                        Agent.organization_id == parent_agent.organization_id,
+                    ),
+                )
+                .with_for_update()
             )
-            target_agent = result.scalar_one()
+            target_agent = result.scalar_one_or_none()
+            if target_agent is None:
+                raise ToolError(
+                    f"Delegation target for '{tool_call.name}' is no longer "
+                    "active, authorized, or in scope."
+                )
 
-            # Create a child AgentRun so steps and AI usage are properly tracked
             sub_run = AgentRun(
-                id=UUID(sub_run_id),
+                id=sub_run_id,
                 agent_id=target_agent.id,
                 trigger_type="delegation",
-                trigger_source=f"agent:{agent.name}",
-                input={"task": task, "_delegated_from": agent.name},
+                trigger_source=(
+                    f"conversation:{conversation_id}"
+                    if conversation_id
+                    else f"agent:{parent_agent.name}"
+                ),
+                conversation_id=conversation_id,
+                input={"task": task, "_delegated_from": parent_agent.name},
                 status="running",
-                org_id=agent.organization_id,
-                parent_run_id=UUID(self._current_run_id),
+                org_id=delegation_org_id,
+                caller_user_id=caller.get("user_id") if caller else None,
+                caller_email=caller.get("email") if caller else None,
+                caller_name=caller.get("name") if caller else None,
+                parent_run_id=UUID(parent_run_id) if parent_run_id else None,
                 budget_max_iterations=target_agent.max_iterations,
                 budget_max_tokens=target_agent.max_token_budget,
                 started_at=datetime.now(timezone.utc),
@@ -694,65 +810,195 @@ class AutonomousAgentExecutor:
             db.add(sub_run)
             await db.commit()
 
-        # Store for the caller to include in the tool_result step
-        self._last_delegation_run_id = sub_run_id
+        self._last_delegation_run_id = str(sub_run_id)
 
-        # Recursive run with the delegated agent (child gets its own session factory)
+        ancestor_run_ids = self._ancestor_run_ids
+        if parent_run_id and parent_run_id not in ancestor_run_ids:
+            ancestor_run_ids = (*ancestor_run_ids, parent_run_id)
         sub_executor = AutonomousAgentExecutor(
             self._session_factory,
             redis_client=self.redis_client,
             _delegation_depth=self._delegation_depth + 1,
+            _ancestor_run_ids=ancestor_run_ids,
         )
+
         sub_start = time.time()
+        cancellation: asyncio.CancelledError | None = None
         try:
             sub_result = await asyncio.wait_for(
                 sub_executor.run(
                     agent=target_agent,
-                    input_data={"task": task, "_delegated_from": agent.name},
-                    run_id=sub_run_id,
+                    input_data={
+                        "task": task,
+                        "_delegated_from": parent_agent.name,
+                    },
+                    run_id=str(sub_run_id),
+                    _caller=caller,
                 ),
                 timeout=DELEGATION_TIMEOUT_SECONDS,
             )
         except asyncio.TimeoutError:
-            duration_ms = int((time.time() - sub_start) * 1000)
-            async with self._session_factory() as db:
-                sub_run_obj = await db.get(AgentRun, UUID(sub_run_id))
-                if sub_run_obj:
-                    sub_run_obj.status = "failed"
-                    sub_run_obj.error = f"Timed out after {DELEGATION_TIMEOUT_SECONDS}s"
-                    sub_run_obj.duration_ms = duration_ms
-                    sub_run_obj.completed_at = datetime.now(timezone.utc)
-                    await db.commit()
             logger.error(
-                f"Delegation to '{target_agent.name}' timed out after {DELEGATION_TIMEOUT_SECONDS}s"
+                f"Delegation to '{target_agent.name}' timed out after "
+                f"{DELEGATION_TIMEOUT_SECONDS}s"
             )
-            raise ToolError(f"Delegation to {target_agent.name} timed out after {DELEGATION_TIMEOUT_SECONDS}s")
+            sub_result = {
+                "output": None,
+                "iterations_used": 0,
+                "tokens_used": 0,
+                "status": "timeout",
+                "llm_model": target_agent.llm_model,
+                "error": (
+                    f"Delegation to {target_agent.name} timed out after "
+                    f"{DELEGATION_TIMEOUT_SECONDS}s"
+                ),
+            }
+        except asyncio.CancelledError as exc:
+            cancellation = exc
+            sub_result = {
+                "output": None,
+                "iterations_used": 0,
+                "tokens_used": 0,
+                "status": "cancelled",
+                "llm_model": target_agent.llm_model,
+                "error": f"Delegation to {target_agent.name} was cancelled",
+            }
+        except Exception as exc:
+            logger.error(
+                f"Delegation to '{target_agent.name}' failed: {exc}",
+                exc_info=True,
+            )
+            sub_result = {
+                "output": None,
+                "iterations_used": 0,
+                "tokens_used": 0,
+                "status": "failed",
+                "llm_model": target_agent.llm_model,
+                "error": str(exc),
+            }
 
-        # Update sub-run record with results (brief DB session)
         duration_ms = int((time.time() - sub_start) * 1000)
-        async with self._session_factory() as db:
-            sub_run_obj = await db.get(AgentRun, UUID(sub_run_id))
-            if sub_run_obj:
-                sub_run_obj.status = sub_result.get("status", "completed")
-                output = sub_result.get("output")
-                sub_run_obj.output = output if isinstance(output, dict) else {"text": output}
-                sub_run_obj.iterations_used = sub_result.get("iterations_used", 0)
-                sub_run_obj.tokens_used = sub_result.get("tokens_used", 0)
-                sub_run_obj.llm_model = sub_result.get("llm_model")
-                sub_run_obj.duration_ms = duration_ms
-                sub_run_obj.completed_at = datetime.now(timezone.utc)
-                if sub_result.get("error"):
-                    sub_run_obj.error = sub_result["error"]
+        status = str(sub_result.get("status") or "completed")
+        if status not in {
+            "completed",
+            "failed",
+            "cancelled",
+            "paused",
+            "budget_exceeded",
+            "timeout",
+        }:
+            sub_result = {
+                **sub_result,
+                "status": "failed",
+                "error": f"Delegation returned unsupported status '{status}'",
+            }
+            status = "failed"
 
-                # Flush child executor's buffered steps in the same transaction
-                await sub_executor.flush_to_db(db)
-                await db.commit()
-
-        logger.info(
-            f"Delegation to '{target_agent.name}' completed with status={sub_result.get('status')}"
+        error = self._delegation_error(target_agent.name, status, sub_result)
+        outcome = DelegationOutcome(
+            child_run_id=sub_run_id,
+            agent_name=target_agent.name,
+            status=status,
+            output=sub_result.get("output"),
+            error=error,
+            duration_ms=duration_ms,
         )
 
-        return str(sub_result.get("output", "Delegation completed with no output."))
+        async with self._session_factory() as db:
+            sub_run_obj = await db.get(AgentRun, sub_run_id)
+            if sub_run_obj is None:
+                raise RuntimeError(
+                    f"Delegated AgentRun {sub_run_id} disappeared before finalization"
+                )
+            sub_run_obj.status = status
+            output = sub_result.get("output")
+            sub_run_obj.output = (
+                output if isinstance(output, dict) else {"text": output}
+            )
+            sub_run_obj.iterations_used = sub_result.get("iterations_used", 0)
+            sub_run_obj.tokens_used = sub_result.get("tokens_used", 0)
+            sub_run_obj.llm_model = sub_result.get("llm_model")
+            sub_run_obj.duration_ms = duration_ms
+            sub_run_obj.completed_at = datetime.now(timezone.utc)
+            sub_run_obj.error = error
+
+            await sub_executor.flush_to_db(db)
+            await db.commit()
+
+        if status == "completed":
+            try:
+                from src.services.execution.run_summarizer import enqueue_summarize
+
+                await enqueue_summarize(sub_run_id)
+            except Exception:
+                logger.exception(
+                    "Failed to enqueue summarizer for delegated run %s",
+                    sub_run_id,
+                )
+
+        if self.redis_client:
+            try:
+                await self.redis_client.delete(
+                    agent_run_steps_stream_key(str(sub_run_id))
+                )
+            except Exception:
+                logger.debug(
+                    "Failed to clean delegated run stream %s",
+                    sub_run_id,
+                    exc_info=True,
+                )
+
+        logger.info(
+            f"Delegation to '{target_agent.name}' completed with status={status}"
+        )
+
+        if cancellation is not None:
+            raise cancellation
+        return outcome
+
+    @staticmethod
+    def _delegation_error(
+        agent_name: str,
+        status: str,
+        sub_result: dict[str, Any],
+    ) -> str | None:
+        if status == "completed":
+            return None
+        if sub_result.get("error"):
+            return str(sub_result["error"])
+        if status == "paused" and sub_result.get("message"):
+            return str(sub_result["message"])
+        if status == "cancelled":
+            return f"Delegation to {agent_name} was cancelled"
+        if status == "paused":
+            return f"Delegated agent {agent_name} is paused"
+        if status == "budget_exceeded":
+            return f"Delegated agent {agent_name} exceeded its budget"
+        if status == "timeout":
+            return f"Delegation to {agent_name} timed out"
+        return f"Delegation to {agent_name} failed"
+
+    async def _execute_delegation(
+        self,
+        tool_call: ToolCallRequest,
+        agent: Agent,
+    ) -> str:
+        """Execute delegation for an autonomous parent run."""
+        outcome = await self.run_delegation(
+            parent_agent=agent,
+            tool_call=tool_call,
+            parent_run_id=self._current_run_id,
+            caller=self._caller,
+        )
+        if not outcome.succeeded:
+            raise ToolError(
+                outcome.error or f"Delegation ended with status {outcome.status}"
+            )
+        if isinstance(outcome.output, dict):
+            return json.dumps(outcome.output)
+        if outcome.output is None:
+            return "Delegation completed with no output."
+        return str(outcome.output)
 
     async def _execute_system_tool(self, tool_call: ToolCallRequest, agent: Agent) -> str:
         """Execute a system tool."""
@@ -766,11 +1012,31 @@ class AutonomousAgentExecutor:
             # Brief DB session scoped to the tool call
             async with self._session_factory() as db:
                 context = MCPContext(
-                    user_id=SYSTEM_USER_ID,
+                    user_id=(
+                        str(self._caller_user_id)
+                        if self._caller_user_id
+                        else SYSTEM_USER_ID
+                    ),
                     org_id=str(agent.organization_id) if agent.organization_id else None,
-                    is_platform_admin=False,
-                    user_email=SYSTEM_USER_EMAIL,
-                    user_name=agent.name,
+                    is_platform_admin=(
+                        bool(self._caller.get("is_platform_admin", False))
+                        if self._caller_user_id and self._caller
+                        else False
+                    ),
+                    user_email=(
+                        str(self._caller.get("email"))
+                        if self._caller_user_id
+                        and self._caller
+                        and self._caller.get("email")
+                        else SYSTEM_USER_EMAIL
+                    ),
+                    user_name=(
+                        str(self._caller.get("name"))
+                        if self._caller_user_id
+                        and self._caller
+                        and self._caller.get("name")
+                        else agent.name
+                    ),
                     session=db,
                 )
 
@@ -801,13 +1067,15 @@ class AutonomousAgentExecutor:
     # ------------------------------------------------------------------
 
     async def _check_cancelled(self, run_id: str) -> bool:
-        """Check if this agent run has been flagged for cancellation via Redis."""
+        """Check this run and every ancestor for a Redis cancellation flag."""
         if not self.redis_client:
             return False
         try:
-            key = f"bifrost:agent_run:{run_id}:cancel"
-            result = await self.redis_client.get(key)
-            return result is not None
+            for candidate_run_id in dict.fromkeys((run_id, *self._ancestor_run_ids)):
+                key = f"bifrost:agent_run:{candidate_run_id}:cancel"
+                if await self.redis_client.get(key) is not None:
+                    return True
+            return False
         except Exception:
             return False
 

--- a/api/src/services/execution/tuning_service.py
+++ b/api/src/services/execution/tuning_service.py
@@ -37,12 +37,14 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from src.core.log_safety import log_safe
+from src.core.principal import UserPrincipal
 from src.jobs.rabbitmq import publish_message
 from src.models.orm.agent_prompt_history import AgentPromptHistory
 from src.models.orm.agent_run_flag_conversations import AgentRunFlagConversation
 from src.models.orm.agent_runs import AgentRun
 from src.models.orm.agents import Agent
 from src.models.orm.ai_usage import AIUsage
+from src.services.execution.agent_run_access import agent_run_visibility_conditions
 from src.services.execution.dry_run import evaluate_against_prompt
 from src.services.execution.model_selection import get_tuning_client
 from src.services.llm import LLMMessage
@@ -210,7 +212,9 @@ class AppliedTuning:
 
 
 async def _load_flagged_runs_with_conversations(
-    agent_id: UUID, db: AsyncSession
+    agent_id: UUID,
+    db: AsyncSession,
+    user: UserPrincipal,
 ) -> list[tuple[AgentRun, AgentRunFlagConversation | None]]:
     """Load all completed thumbs-down runs for ``agent_id`` and their conversations."""
     runs = (
@@ -220,6 +224,7 @@ async def _load_flagged_runs_with_conversations(
                 .where(AgentRun.agent_id == agent_id)
                 .where(AgentRun.verdict == "down")
                 .where(AgentRun.status == "completed")
+                .where(*agent_run_visibility_conditions(user))
                 .order_by(AgentRun.created_at)
             )
         )
@@ -246,7 +251,9 @@ async def _load_flagged_runs_with_conversations(
 
 
 async def propose_consolidated_tuning(
-    agent_id: UUID, db: AsyncSession
+    agent_id: UUID,
+    db: AsyncSession,
+    user: UserPrincipal,
 ) -> ConsolidatedProposal:
     """Single LLM call across all flagged runs; returns one consolidated proposal.
 
@@ -258,7 +265,7 @@ async def propose_consolidated_tuning(
     if agent is None:
         raise LookupError(f"Agent {agent_id} not found")
 
-    pairs = await _load_flagged_runs_with_conversations(agent_id, db)
+    pairs = await _load_flagged_runs_with_conversations(agent_id, db, user)
     if not pairs:
         raise LookupError(
             f"Agent {agent_id} has no flagged (thumbs-down) runs to tune"
@@ -324,13 +331,14 @@ async def dry_run_consolidated(
     proposed_prompt: str,
     db: AsyncSession,
     session_factory: async_sessionmaker[AsyncSession],
+    user: UserPrincipal,
 ) -> list[tuple[UUID, bool, str, float]]:
     """Run :func:`evaluate_against_prompt` for each flagged run (capped).
 
     Returns a list of ``(run_id, would_still_decide_same, reasoning, confidence)``
     tuples, capped at :data:`CONSOLIDATED_DRY_RUN_LIMIT` runs to bound cost.
     """
-    pairs = await _load_flagged_runs_with_conversations(agent_id, db)
+    pairs = await _load_flagged_runs_with_conversations(agent_id, db, user)
     capped = pairs[:CONSOLIDATED_DRY_RUN_LIMIT]
     results: list[tuple[UUID, bool, str, float]] = []
     for run, _conv in capped:
@@ -356,6 +364,7 @@ async def apply_consolidated_tuning(
     reason: str | None,
     user_id: UUID | None,
     db: AsyncSession,
+    user: UserPrincipal,
 ) -> AppliedTuning:
     """Apply a consolidated tuning proposal.
 
@@ -369,7 +378,7 @@ async def apply_consolidated_tuning(
     if agent is None:
         raise LookupError(f"Agent {agent_id} not found")
 
-    pairs = await _load_flagged_runs_with_conversations(agent_id, db)
+    pairs = await _load_flagged_runs_with_conversations(agent_id, db, user)
     affected_ids = [r.id for r, _ in pairs]
 
     previous_prompt = agent.system_prompt

--- a/api/tests/e2e/api/test_agent_delegation_lifecycle.py
+++ b/api/tests/e2e/api/test_agent_delegation_lifecycle.py
@@ -1,0 +1,384 @@
+"""Durable delegation lifecycle coverage across chat and autonomous surfaces."""
+
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, patch
+from uuid import UUID, uuid4
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.orm import selectinload
+
+from src.core.principal import UserPrincipal
+from src.models.orm.agents import Agent, AgentDelegation, Conversation
+from src.models.orm.agent_runs import AgentRun
+from src.services.agent_executor import AgentExecutor
+from src.services.execution.agent_helpers import agent_delegation_slug
+from src.services.execution.autonomous_agent_executor import AutonomousAgentExecutor
+from src.services.llm.base import LLMResponse, LLMStreamChunk, ToolCallRequest
+
+
+pytestmark = pytest.mark.asyncio
+
+
+def _session_factory_for(session):
+    @asynccontextmanager
+    async def session_factory():
+        yield session
+
+    return session_factory
+
+
+def _create_agent(e2e_client, platform_admin, name: str) -> dict:
+    response = e2e_client.post(
+        "/api/agents",
+        json={
+            "name": name,
+            "description": "Delegation lifecycle E2E agent",
+            "system_prompt": "Complete delegated work.",
+            "channels": ["chat"],
+            "access_level": "authenticated",
+            "organization_id": None,
+        },
+        headers=platform_admin.headers,
+    )
+    assert response.status_code == 201, response.text
+    return response.json()
+
+
+async def test_chat_delegation_creates_terminal_run_with_conversation_and_caller(
+    e2e_client,
+    platform_admin,
+    alice_user,
+    bob_user,
+    db_session,
+):
+    child = _create_agent(
+        e2e_client,
+        platform_admin,
+        f"Chat Lifecycle Child {uuid4().hex[:8]}",
+    )
+    parent = _create_agent(
+        e2e_client,
+        platform_admin,
+        f"Chat Lifecycle Parent {uuid4().hex[:8]}",
+    )
+    conversation_response = e2e_client.post(
+        "/api/chat/conversations",
+        json={
+            "agent_id": parent["id"],
+            "channel": "chat",
+            "title": "Delegation lifecycle",
+        },
+        headers=alice_user.headers,
+    )
+    assert conversation_response.status_code == 201, conversation_response.text
+    conversation_id = UUID(conversation_response.json()["id"])
+
+    db_session.add(
+        AgentDelegation(
+            parent_agent_id=UUID(parent["id"]),
+            child_agent_id=UUID(child["id"]),
+        )
+    )
+    await db_session.commit()
+
+    session_factory = _session_factory_for(db_session)
+    try:
+        async with session_factory() as session:
+            parent_result = await session.execute(
+                select(Agent)
+                .options(
+                    selectinload(Agent.tools),
+                    selectinload(Agent.delegated_agents),
+                )
+                .where(Agent.id == UUID(parent["id"]))
+            )
+            parent_agent = parent_result.scalar_one()
+
+        executor = AutonomousAgentExecutor(session_factory)
+        caller = {
+            "user_id": str(alice_user.user_id),
+            "email": alice_user.email,
+            "name": alice_user.name,
+            "organization_id": str(alice_user.organization_id),
+        }
+        with (
+            patch.object(
+                AutonomousAgentExecutor,
+                "run",
+                new_callable=AsyncMock,
+                return_value={
+                    "output": "Durable answer",
+                    "status": "completed",
+                    "iterations_used": 2,
+                    "tokens_used": 42,
+                    "llm_model": "cheap-model",
+                },
+            ),
+            patch(
+                "src.services.execution.run_summarizer.enqueue_summarize",
+                new_callable=AsyncMock,
+            ),
+        ):
+            outcome = await executor.run_delegation(
+                parent_agent=parent_agent,
+                tool_call=ToolCallRequest(
+                    id="tc1",
+                    name=f"delegate_to_{child['name'].lower().replace(' ', '_')}",
+                    arguments={"task": "Return a durable answer"},
+                ),
+                conversation_id=conversation_id,
+                caller=caller,
+            )
+
+        async with session_factory() as session:
+            persisted = await session.get(AgentRun, outcome.child_run_id)
+            assert persisted is not None
+            assert persisted.status == "completed"
+            assert persisted.completed_at is not None
+            assert persisted.parent_run_id is None
+            assert persisted.conversation_id == conversation_id
+            assert persisted.org_id == alice_user.organization_id
+            assert persisted.caller_user_id == caller["user_id"]
+            assert persisted.caller_email == caller["email"]
+            assert persisted.caller_name == caller["name"]
+            assert persisted.output == {"text": "Durable answer"}
+            assert persisted.iterations_used == 2
+            assert persisted.tokens_used == 42
+
+        scoped_response = e2e_client.get(
+            "/api/agent-runs",
+            params={"agent_id": child["id"]},
+            headers=alice_user.headers,
+        )
+        assert scoped_response.status_code == 200, scoped_response.text
+        assert str(outcome.child_run_id) in {
+            item["id"] for item in scoped_response.json()["items"]
+        }
+
+        other_user_list = e2e_client.get(
+            "/api/agent-runs",
+            params={"agent_id": child["id"]},
+            headers=bob_user.headers,
+        )
+        assert other_user_list.status_code == 200, other_user_list.text
+        assert str(outcome.child_run_id) not in {
+            item["id"] for item in other_user_list.json()["items"]
+        }
+
+        owner_detail = e2e_client.get(
+            f"/api/agent-runs/{outcome.child_run_id}",
+            headers=alice_user.headers,
+        )
+        assert owner_detail.status_code == 200, owner_detail.text
+
+        other_user_detail = e2e_client.get(
+            f"/api/agent-runs/{outcome.child_run_id}",
+            headers=bob_user.headers,
+        )
+        assert other_user_detail.status_code == 404, other_user_detail.text
+
+        admin_detail = e2e_client.get(
+            f"/api/agent-runs/{outcome.child_run_id}",
+            headers=platform_admin.headers,
+        )
+        assert admin_detail.status_code == 200, admin_detail.text
+
+        global_response = e2e_client.get(
+            "/api/agent-runs",
+            headers=alice_user.headers,
+        )
+        assert global_response.status_code == 200, global_response.text
+        assert str(outcome.child_run_id) not in {
+            item["id"] for item in global_response.json()["items"]
+        }
+    finally:
+        e2e_client.delete(
+            f"/api/chat/conversations/{conversation_id}",
+            headers=alice_user.headers,
+        )
+        for agent in (parent, child):
+            e2e_client.delete(
+                f"/api/agents/{agent['id']}",
+                headers=platform_admin.headers,
+            )
+
+
+async def test_chat_executor_receives_durable_child_callback(
+    e2e_client,
+    platform_admin,
+    db_session,
+):
+    child = _create_agent(
+        e2e_client,
+        platform_admin,
+        f"Chat Callback Child {uuid4().hex[:8]}",
+    )
+    parent = _create_agent(
+        e2e_client,
+        platform_admin,
+        f"Chat Callback Parent {uuid4().hex[:8]}",
+    )
+    conversation_response = e2e_client.post(
+        "/api/chat/conversations",
+        json={
+            "agent_id": parent["id"],
+            "channel": "chat",
+            "title": "Delegation callback",
+        },
+        headers=platform_admin.headers,
+    )
+    assert conversation_response.status_code == 201, conversation_response.text
+    conversation_id = UUID(conversation_response.json()["id"])
+
+    db_session.add(
+        AgentDelegation(
+            parent_agent_id=UUID(parent["id"]),
+            child_agent_id=UUID(child["id"]),
+        )
+    )
+    await db_session.commit()
+
+    parent_llm = AsyncMock()
+    parent_llm.provider_name = "openai"
+    parent_llm.model_name = "test-parent"
+    parent_stream_calls = 0
+
+    async def parent_stream(**_kwargs):
+        nonlocal parent_stream_calls
+        parent_stream_calls += 1
+        if parent_stream_calls == 1:
+            yield LLMStreamChunk(
+                type="tool_call",
+                tool_call=ToolCallRequest(
+                    id="parent-delegation-call",
+                    name=agent_delegation_slug(child["name"]),
+                    arguments={"task": "Return the durable callback"},
+                ),
+            )
+            yield LLMStreamChunk(
+                type="done",
+                finish_reason="tool_calls",
+                input_tokens=10,
+                output_tokens=5,
+            )
+            return
+
+        yield LLMStreamChunk(
+            type="delta",
+            content="Parent received the durable callback.",
+        )
+        yield LLMStreamChunk(
+            type="done",
+            finish_reason="stop",
+            input_tokens=12,
+            output_tokens=6,
+        )
+
+    parent_llm.stream = parent_stream
+    child_llm = AsyncMock()
+    child_llm.provider_name = "openai"
+    child_llm.complete = AsyncMock(
+        return_value=LLMResponse(
+            content="Durable child answer",
+            finish_reason="stop",
+            input_tokens=8,
+            output_tokens=4,
+            model="test-child",
+        )
+    )
+
+    try:
+        with (
+            patch(
+                "src.services.agent_executor.get_llm_client",
+                new_callable=AsyncMock,
+                return_value=parent_llm,
+            ),
+            patch(
+                "src.services.execution.autonomous_agent_executor.get_llm_client",
+                new_callable=AsyncMock,
+                return_value=child_llm,
+            ),
+            patch(
+                "src.services.execution.run_summarizer.enqueue_summarize",
+                new_callable=AsyncMock,
+            ),
+        ):
+            session_factory = _session_factory_for(db_session)
+            conversation_result = await db_session.execute(
+                select(Conversation)
+                .options(
+                    selectinload(Conversation.agent).selectinload(Agent.tools),
+                    selectinload(Conversation.agent).selectinload(
+                        Agent.delegated_agents
+                    ),
+                )
+                .where(Conversation.id == conversation_id)
+            )
+            conversation = conversation_result.scalar_one()
+
+            assert platform_admin.user_id is not None
+            principal = UserPrincipal(
+                user_id=platform_admin.user_id,
+                email=platform_admin.email,
+                name=platform_admin.name,
+                organization_id=platform_admin.organization_id,
+                is_superuser=platform_admin.is_superuser,
+            )
+            executor = AgentExecutor(session_factory)
+            final_content = ""
+            async for chunk in executor.chat(
+                agent=conversation.agent,
+                conversation=conversation,
+                user_message="Delegate this request.",
+                stream=False,
+                enable_routing=False,
+                user=principal,
+            ):
+                if chunk.type == "done":
+                    final_content = chunk.content or ""
+
+        assert final_content == "Parent received the durable callback."
+
+        result = await db_session.execute(
+            select(AgentRun).where(
+                AgentRun.conversation_id == conversation_id,
+                AgentRun.trigger_type == "delegation",
+            )
+        )
+        child_run = result.scalar_one()
+        assert child_run.status == "completed"
+        assert child_run.output == {"text": "Durable child answer"}
+        assert child_run.caller_user_id == str(platform_admin.user_id)
+
+        messages_response = e2e_client.get(
+            f"/api/chat/conversations/{conversation_id}/messages",
+            headers=platform_admin.headers,
+        )
+        assert messages_response.status_code == 200, messages_response.text
+        tool_call_messages = [
+            message
+            for message in messages_response.json()
+            if message["role"] == "tool_call"
+        ]
+        assert len(tool_call_messages) == 1
+        assert tool_call_messages[0]["tool_state"] == "completed"
+        assert tool_call_messages[0]["tool_result"]["child_run_id"] == str(
+            child_run.id
+        )
+        assert tool_call_messages[0]["tool_result"]["response"] == (
+            "Durable child answer"
+        )
+        assert parent_stream_calls == 2
+        child_llm.complete.assert_awaited_once()
+    finally:
+        e2e_client.delete(
+            f"/api/chat/conversations/{conversation_id}",
+            headers=platform_admin.headers,
+        )
+        for agent in (parent, child):
+            e2e_client.delete(
+                f"/api/agents/{agent['id']}",
+                headers=platform_admin.headers,
+            )

--- a/api/tests/unit/services/test_agent_executor_session.py
+++ b/api/tests/unit/services/test_agent_executor_session.py
@@ -233,6 +233,7 @@ class TestDelegationUsesFactory:
         child_agent = _make_mock_agent()
         child_agent.name = "child agent"  # agent_delegation_slug("child agent") -> "delegate_to_child_agent"
         child_agent.is_active = True
+        child_agent.organization_id = agent.organization_id
         agent.delegated_agents = [child_agent]
 
         # Mock the select query for re-fetching child agent

--- a/api/tests/unit/services/test_agent_executor_tools.py
+++ b/api/tests/unit/services/test_agent_executor_tools.py
@@ -14,8 +14,14 @@ from uuid import uuid4
 import pytest
 from pydantic import BaseModel
 
+from src.models.contracts.agents import ToolResult
 from src.repositories.knowledge import KnowledgeDocument
-from src.services.agent_executor import AgentExecutor, _serialize_for_json
+from src.services.agent_executor import (
+    AgentExecutor,
+    _serialize_for_json,
+    _serialize_tool_result_for_history,
+)
+from src.services.execution.autonomous_agent_executor import DelegationOutcome
 from src.services.llm import ToolCallRequest, ToolDefinition
 
 
@@ -575,7 +581,7 @@ class TestChatDelegation:
 
     @pytest.mark.asyncio
     async def test_delegation_calls_autonomous_executor(self, executor, mock_session):
-        """Chat delegation dispatches to AutonomousAgentExecutor.run()."""
+        """Chat delegation dispatches through the shared durable runner."""
         from src.services.llm.base import ToolCallRequest
 
         delegated = MagicMock()
@@ -584,21 +590,22 @@ class TestChatDelegation:
         delegated.is_active = True
 
         agent = MagicMock()
+        agent.name = "Coordinator"
         agent.delegated_agents = [delegated]
+        conversation = MagicMock()
+        conversation.id = uuid4()
+        caller = {
+            "user_id": str(uuid4()),
+            "email": "person@example.com",
+            "name": "Person",
+        }
 
         tool_call = ToolCallRequest(
             id="tc1",
             name="delegate_to_data_analyst",
             arguments={"task": "Analyze revenue trends"},
         )
-
-        # Mock the re-fetch query that loads the delegated agent with relationships
-        refetched = MagicMock()
-        refetched.id = delegated.id
-        refetched.name = "Data Analyst"
-        mock_refetch_result = MagicMock()
-        mock_refetch_result.scalar_one.return_value = refetched
-        mock_session.execute = AsyncMock(return_value=mock_refetch_result)
+        child_run_id = uuid4()
 
         with patch(
             "src.services.agent_executor.AutonomousAgentExecutor"
@@ -607,32 +614,59 @@ class TestChatDelegation:
         ) as mock_get_redis:
             mock_get_redis.return_value = MagicMock()
             mock_sub = AsyncMock()
-            mock_sub.run = AsyncMock(return_value={
-                "output": "Revenue is up 15%",
-                "status": "completed",
-                "iterations_used": 3,
-                "tokens_used": 500,
-            })
+            mock_sub.run_delegation = AsyncMock(
+                return_value=DelegationOutcome(
+                    child_run_id=child_run_id,
+                    agent_name="Data Analyst",
+                    status="completed",
+                    output="Revenue is up 15%",
+                    error=None,
+                    duration_ms=15,
+                )
+            )
             MockExecutorClass.return_value = mock_sub
 
-            result = await executor._execute_delegation(tool_call, agent)
+            result = await executor._execute_delegation(
+                tool_call,
+                agent,
+                conversation=conversation,
+                caller=caller,
+            )
 
         assert result.error is None
         assert result.result["response"] == "Revenue is up 15%"
         assert result.result["agent"] == "Data Analyst"
-        # The sub-executor receives the re-fetched agent, not the original
-        mock_sub.run.assert_awaited_once_with(
-            agent=refetched,
-            input_data={"task": "Analyze revenue trends", "_delegated_from": agent.name},
+        assert result.result["status"] == "completed"
+        assert result.result["child_run_id"] == str(child_run_id)
+        assert result.metadata == {
+            "child_run_id": str(child_run_id),
+            "agent": "Data Analyst",
+            "status": "completed",
+        }
+        mock_sub.run_delegation.assert_awaited_once_with(
+            parent_agent=agent,
+            tool_call=tool_call,
+            conversation_id=conversation.id,
+            caller=caller,
+        )
+
+    def test_parent_history_prefers_error_over_partial_result(self):
+        """A failed child must not look successful merely because it returned data."""
+        tool_result = ToolResult(
+            tool_call_id="tc1",
+            tool_name="delegate_to_specialist",
+            result={"response": "partial answer"},
+            error="Specialist failed after producing a partial answer",
+        )
+
+        assert _serialize_tool_result_for_history(tool_result) == (
+            "Specialist failed after producing a partial answer"
         )
 
     @pytest.mark.asyncio
-    async def test_delegation_refetches_agent_with_relationships(self, executor, mock_session):
-        """Delegation re-fetches the target agent to ensure relationships are loaded.
-
-        Without this re-fetch, accessing agent.tools or agent.delegated_agents
-        on a child loaded via selectinload causes greenlet_spawn errors in async.
-        """
+    async def test_delegation_without_conversation_still_uses_shared_runner(
+        self, executor
+    ):
         from src.services.llm.base import ToolCallRequest
 
         delegated = MagicMock()
@@ -649,13 +683,6 @@ class TestChatDelegation:
             arguments={"task": "Fix the issue"},
         )
 
-        refetched = MagicMock()
-        refetched.id = delegated.id
-        refetched.name = "Troubleshooting Agent"
-        mock_refetch_result = MagicMock()
-        mock_refetch_result.scalar_one.return_value = refetched
-        mock_session.execute = AsyncMock(return_value=mock_refetch_result)
-
         with patch(
             "src.services.agent_executor.AutonomousAgentExecutor"
         ) as MockExecutorClass, patch(
@@ -663,22 +690,25 @@ class TestChatDelegation:
         ) as mock_get_redis:
             mock_get_redis.return_value = MagicMock()
             mock_sub = AsyncMock()
-            mock_sub.run = AsyncMock(return_value={
-                "output": "Fixed",
-                "status": "completed",
-                "iterations_used": 1,
-                "tokens_used": 100,
-            })
+            mock_sub.run_delegation = AsyncMock(
+                return_value=DelegationOutcome(
+                    child_run_id=uuid4(),
+                    agent_name="Troubleshooting Agent",
+                    status="completed",
+                    output="Fixed",
+                    error=None,
+                    duration_ms=10,
+                )
+            )
             MockExecutorClass.return_value = mock_sub
 
             result = await executor._execute_delegation(tool_call, agent)
 
-        # Verify session.execute was called (the re-fetch query)
-        mock_session.execute.assert_awaited()
-        # Verify the sub-executor got the re-fetched agent
-        mock_sub.run.assert_awaited_once_with(
-            agent=refetched,
-            input_data={"task": "Fix the issue", "_delegated_from": agent.name},
+        mock_sub.run_delegation.assert_awaited_once_with(
+            parent_agent=agent,
+            tool_call=tool_call,
+            conversation_id=None,
+            caller=None,
         )
         assert result.error is None
 
@@ -741,9 +771,58 @@ class TestChatDelegation:
             arguments={"task": "Do something"},
         )
 
-        mock_refetch_result = MagicMock()
-        mock_refetch_result.scalar_one.return_value = delegated
-        mock_session.execute = AsyncMock(return_value=mock_refetch_result)
+        with patch(
+            "src.services.agent_executor.AutonomousAgentExecutor"
+        ) as MockExecutorClass, patch(
+            "src.core.cache.get_shared_redis", new_callable=AsyncMock
+        ) as mock_get_redis:
+            mock_get_redis.return_value = MagicMock()
+            mock_sub = AsyncMock()
+            child_run_id = uuid4()
+            mock_sub.run_delegation = AsyncMock(
+                return_value=DelegationOutcome(
+                    child_run_id=child_run_id,
+                    agent_name="Broken Agent",
+                    status="failed",
+                    output=None,
+                    error="LLM call failed",
+                    duration_ms=10,
+                )
+            )
+            MockExecutorClass.return_value = mock_sub
+
+            result = await executor._execute_delegation(tool_call, agent)
+
+        assert result.error == "LLM call failed"
+        assert result.result is None
+        assert result.metadata == {
+            "child_run_id": str(child_run_id),
+            "agent": "Broken Agent",
+            "status": "failed",
+        }
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("status", "error"),
+        [
+            ("cancelled", "Delegation was cancelled"),
+            ("paused", "Delegated agent is paused"),
+            ("budget_exceeded", "Delegated agent exceeded its budget"),
+            ("timeout", "Delegation timed out"),
+        ],
+    )
+    async def test_delegation_propagates_every_non_success_status(
+        self, executor, status, error
+    ):
+        from src.services.llm.base import ToolCallRequest
+
+        delegated = MagicMock()
+        delegated.id = uuid4()
+        delegated.name = "Lifecycle Agent"
+        delegated.is_active = True
+        agent = MagicMock()
+        agent.delegated_agents = [delegated]
+        child_run_id = uuid4()
 
         with patch(
             "src.services.agent_executor.AutonomousAgentExecutor"
@@ -752,18 +831,34 @@ class TestChatDelegation:
         ) as mock_get_redis:
             mock_get_redis.return_value = MagicMock()
             mock_sub = AsyncMock()
-            mock_sub.run = AsyncMock(return_value={
-                "output": None,
-                "status": "failed",
-                "error": "LLM call failed",
-                "iterations_used": 0,
-                "tokens_used": 0,
-            })
+            mock_sub.run_delegation = AsyncMock(
+                return_value=DelegationOutcome(
+                    child_run_id=child_run_id,
+                    agent_name="Lifecycle Agent",
+                    status=status,
+                    output=None,
+                    error=error,
+                    duration_ms=10,
+                )
+            )
             MockExecutorClass.return_value = mock_sub
 
-            result = await executor._execute_delegation(tool_call, agent)
+            result = await executor._execute_delegation(
+                ToolCallRequest(
+                    id="tc1",
+                    name="delegate_to_lifecycle_agent",
+                    arguments={"task": "Exercise lifecycle"},
+                ),
+                agent,
+            )
 
-        assert result.error == "LLM call failed"
+        assert result.result is None
+        assert result.error == error
+        assert result.metadata == {
+            "child_run_id": str(child_run_id),
+            "agent": "Lifecycle Agent",
+            "status": status,
+        }
 
     @pytest.mark.asyncio
     async def test_delegation_handles_exception(self, executor, mock_session):
@@ -784,10 +879,6 @@ class TestChatDelegation:
             arguments={"task": "Crash please"},
         )
 
-        mock_refetch_result = MagicMock()
-        mock_refetch_result.scalar_one.return_value = delegated
-        mock_session.execute = AsyncMock(return_value=mock_refetch_result)
-
         with patch(
             "src.services.agent_executor.AutonomousAgentExecutor"
         ) as MockExecutorClass, patch(
@@ -795,7 +886,9 @@ class TestChatDelegation:
         ) as mock_get_redis:
             mock_get_redis.return_value = MagicMock()
             mock_sub = AsyncMock()
-            mock_sub.run = AsyncMock(side_effect=RuntimeError("Connection lost"))
+            mock_sub.run_delegation = AsyncMock(
+                side_effect=RuntimeError("Connection lost")
+            )
             MockExecutorClass.return_value = mock_sub
 
             result = await executor._execute_delegation(tool_call, agent)
@@ -806,7 +899,6 @@ class TestChatDelegation:
     @pytest.mark.asyncio
     async def test_delegation_timeout_returns_error(self, executor, mock_session):
         """Delegation returns timeout error when sub-executor takes too long."""
-        import asyncio
         from src.services.llm.base import ToolCallRequest
 
         delegated = MagicMock()
@@ -823,20 +915,25 @@ class TestChatDelegation:
             arguments={"task": "Take forever"},
         )
 
-        mock_refetch_result = MagicMock()
-        mock_refetch_result.scalar_one.return_value = delegated
-        mock_session.execute = AsyncMock(return_value=mock_refetch_result)
-
         with patch(
             "src.services.agent_executor.AutonomousAgentExecutor"
         ) as MockExecutorClass, patch(
             "src.core.cache.get_shared_redis", new_callable=AsyncMock
-        ) as mock_get_redis, patch(
-            "src.services.agent_executor.asyncio.wait_for",
-            side_effect=asyncio.TimeoutError(),
-        ):
+        ) as mock_get_redis:
             mock_get_redis.return_value = MagicMock()
-            MockExecutorClass.return_value = AsyncMock()
+            child_run_id = uuid4()
+            mock_sub = AsyncMock()
+            mock_sub.run_delegation = AsyncMock(
+                return_value=DelegationOutcome(
+                    child_run_id=child_run_id,
+                    agent_name="Slow Agent",
+                    status="timeout",
+                    output=None,
+                    error="Delegation to Slow Agent timed out after 600s",
+                    duration_ms=600_000,
+                )
+            )
+            MockExecutorClass.return_value = mock_sub
 
             result = await executor._execute_delegation(tool_call, agent)
 

--- a/api/tests/unit/services/test_agent_helpers.py
+++ b/api/tests/unit/services/test_agent_helpers.py
@@ -85,6 +85,45 @@ class TestResolveAgentTools:
         assert tools == []
         assert id_map == {}
 
+    @pytest.mark.asyncio
+    @patch("src.services.mcp_server.server.get_system_tools", return_value=[])
+    async def test_delegation_tool_contract_remains_task_only(
+        self, _mock_get_system_tools
+    ):
+        """Delegation hardening must not change the model-facing tool contract."""
+        delegated = MagicMock()
+        delegated.name = "Echo Specialist"
+        delegated.description = "Returns a concise specialist answer."
+        delegated.is_active = True
+
+        parent = MagicMock()
+        parent.id = uuid4()
+        parent.organization_id = None
+        parent.tools = []
+        parent.system_tools = []
+        parent.knowledge_sources = []
+        parent.delegated_agents = [delegated]
+
+        tools, id_map = await resolve_agent_tools(parent, MagicMock())
+
+        assert id_map == {}
+        assert len(tools) == 1
+        assert tools[0].name == "delegate_to_echo_specialist"
+        assert tools[0].description == (
+            "Delegate a task to Echo Specialist. "
+            "Returns a concise specialist answer."
+        )
+        assert tools[0].parameters == {
+            "type": "object",
+            "properties": {
+                "task": {
+                    "type": "string",
+                    "description": "The task or question to delegate to this agent",
+                },
+            },
+            "required": ["task"],
+        }
+
 
 class TestBuildAgentSystemPrompt:
     def test_uses_agent_system_prompt(self):

--- a/api/tests/unit/services/test_agent_run_service.py
+++ b/api/tests/unit/services/test_agent_run_service.py
@@ -1,6 +1,8 @@
-import pytest
+import json
 from unittest.mock import AsyncMock, patch
 from uuid import uuid4
+
+import pytest
 
 from src.services.execution.agent_run_service import enqueue_agent_run
 
@@ -39,14 +41,19 @@ class TestEnqueueAgentRun:
         mock_ctx.__aexit__ = AsyncMock(return_value=False)
         mock_get_redis.return_value = mock_ctx
 
+        org_id = str(uuid4())
         await enqueue_agent_run(
             agent_id=str(uuid4()),
             trigger_type="sdk",
             input_data={"task": "analyze"},
             output_schema={"action": {"type": "string"}},
+            org_id=org_id,
+            caller_user_id=str(uuid4()),
         )
 
         mock_redis.set.assert_called_once()
+        context = json.loads(mock_redis.set.call_args.args[1])
+        assert context["caller"]["organization_id"] == org_id
 
     @pytest.mark.asyncio
     @patch("src.services.execution.agent_run_service.publish_message")

--- a/api/tests/unit/services/test_autonomous_agent_executor.py
+++ b/api/tests/unit/services/test_autonomous_agent_executor.py
@@ -6,13 +6,17 @@ import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
+from src.core.constants import SYSTEM_USER_EMAIL, SYSTEM_USER_ID
 from src.models.contracts.executions import WorkflowExecutionResponse
 from src.models.enums import ExecutionStatus
+from src.models.orm.agent_runs import AgentRun
 from src.repositories.knowledge import KnowledgeDocument
 from src.services.execution.agent_helpers import find_delegated_agent
 from src.services.execution.autonomous_agent_executor import (
     AutonomousAgentExecutor,
+    DelegationOutcome,
     MAX_DELEGATION_DEPTH,
+    ToolError,
 )
 from src.services.llm.base import LLMResponse, ToolCallRequest
 
@@ -143,6 +147,557 @@ class TestAutonomousAgentExecutor:
         assert result["output"] == "Hello world"
         assert result["iterations_used"] == 1
         assert result["tokens_used"] == 150
+
+    @pytest.mark.asyncio
+    async def test_run_delegation_persists_chat_child_and_caller(
+        self, mock_session, mock_agent
+    ):
+        delegated = MagicMock()
+        delegated.id = uuid4()
+        delegated.name = "Chat Specialist"
+        delegated.description = "Handles chat work"
+        delegated.is_active = True
+        delegated.system_prompt = "Do specialist work."
+        delegated.tools = []
+        delegated.system_tools = []
+        delegated.knowledge_sources = []
+        delegated.delegated_agents = []
+        delegated.max_iterations = 5
+        delegated.max_token_budget = 1000
+        delegated.llm_model = "cheap-model"
+        delegated.llm_max_tokens = 200
+        # Global specialists remain valid delegates for an org-scoped parent.
+        delegated.organization_id = None
+        mock_agent.delegated_agents = [delegated]
+
+        query_result = MagicMock()
+        query_result.scalar_one_or_none.return_value = delegated
+        mock_session._mock_session.execute = AsyncMock(return_value=query_result)
+
+        created_runs: list[AgentRun] = []
+
+        def capture_add(value):
+            if isinstance(value, AgentRun):
+                created_runs.append(value)
+
+        mock_session._mock_session.add.side_effect = capture_add
+
+        async def get_created(model, run_id):
+            if model is AgentRun and created_runs and created_runs[0].id == run_id:
+                return created_runs[0]
+            return None
+
+        mock_session._mock_session.get.side_effect = get_created
+
+        conversation_id = uuid4()
+        caller = {
+            "user_id": str(uuid4()),
+            "email": "person@example.com",
+            "name": "Person",
+        }
+        tool_call = ToolCallRequest(
+            id="tc1",
+            name="delegate_to_chat_specialist",
+            arguments={"task": "Investigate the request"},
+        )
+        executor = AutonomousAgentExecutor(mock_session)
+
+        with (
+            patch.object(
+                AutonomousAgentExecutor,
+                "run",
+                new_callable=AsyncMock,
+                return_value={
+                    "output": "Investigation complete",
+                    "status": "completed",
+                    "iterations_used": 2,
+                    "tokens_used": 123,
+                    "llm_model": "cheap-model",
+                },
+            ) as mock_child_run,
+            patch(
+                "src.services.execution.run_summarizer.enqueue_summarize",
+                new_callable=AsyncMock,
+            ) as mock_enqueue_summarize,
+        ):
+            outcome = await executor.run_delegation(
+                parent_agent=mock_agent,
+                tool_call=tool_call,
+                conversation_id=conversation_id,
+                caller=caller,
+            )
+
+        assert outcome.status == "completed"
+        assert outcome.output == "Investigation complete"
+        assert len(created_runs) == 1
+        child_run = created_runs[0]
+        assert child_run.trigger_type == "delegation"
+        assert child_run.parent_run_id is None
+        assert child_run.conversation_id == conversation_id
+        assert child_run.caller_user_id == caller["user_id"]
+        assert child_run.caller_email == caller["email"]
+        assert child_run.caller_name == caller["name"]
+        assert child_run.status == "completed"
+        assert child_run.completed_at is not None
+        mock_enqueue_summarize.assert_awaited_once_with(child_run.id)
+        mock_child_run.assert_awaited_once_with(
+            agent=delegated,
+            input_data={
+                "task": "Investigate the request",
+                "_delegated_from": mock_agent.name,
+            },
+            run_id=str(child_run.id),
+            _caller=caller,
+        )
+
+    @pytest.mark.asyncio
+    async def test_delegated_workflow_inherits_caller_identity(
+        self,
+        mock_session,
+        mock_agent,
+    ):
+        workflow_id = uuid4()
+        caller_user_id = uuid4()
+        executor = AutonomousAgentExecutor(mock_session)
+        executor._tool_workflow_id_map = {"specialist_tool": workflow_id}
+        executor._caller_user_id = caller_user_id
+        executor._caller = {
+            "user_id": str(caller_user_id),
+            "email": "person@example.com",
+            "name": "Person",
+            "is_platform_admin": True,
+        }
+
+        with patch(
+            "src.services.execution.service.execute_tool",
+            new_callable=AsyncMock,
+            return_value=MagicMock(
+                execution_id=str(uuid4()),
+                status=ExecutionStatus.SUCCESS,
+                result={"ok": True},
+            ),
+        ) as mock_execute_tool:
+            result = await executor._execute_tool(
+                ToolCallRequest(
+                    id="tc1",
+                    name="specialist_tool",
+                    arguments={"value": 1},
+                ),
+                mock_agent,
+            )
+
+        assert result == '{"ok": true}'
+        mock_execute_tool.assert_awaited_once_with(
+            workflow_id=str(workflow_id),
+            workflow_name="specialist_tool",
+            parameters={"value": 1},
+            user_id=str(caller_user_id),
+            user_email="person@example.com",
+            user_name="Person",
+            org_id=str(mock_agent.organization_id),
+            is_platform_admin=True,
+            is_agent=True,
+        )
+
+    @pytest.mark.asyncio
+    async def test_autonomous_workflow_without_caller_uses_system_identity(
+        self,
+        mock_session,
+        mock_agent,
+    ):
+        workflow_id = uuid4()
+        executor = AutonomousAgentExecutor(mock_session)
+        executor._tool_workflow_id_map = {"scheduled_tool": workflow_id}
+
+        with patch(
+            "src.services.execution.service.execute_tool",
+            new_callable=AsyncMock,
+            return_value=MagicMock(
+                execution_id=str(uuid4()),
+                status=ExecutionStatus.SUCCESS,
+                result={"ok": True},
+            ),
+        ) as mock_execute_tool:
+            result = await executor._execute_tool(
+                ToolCallRequest(
+                    id="tc1",
+                    name="scheduled_tool",
+                    arguments={"value": 1},
+                ),
+                mock_agent,
+            )
+
+        assert result == '{"ok": true}'
+        mock_execute_tool.assert_awaited_once_with(
+            workflow_id=str(workflow_id),
+            workflow_name="scheduled_tool",
+            parameters={"value": 1},
+            user_id=SYSTEM_USER_ID,
+            user_email=SYSTEM_USER_EMAIL,
+            user_name=mock_agent.name,
+            org_id=str(mock_agent.organization_id),
+            is_platform_admin=False,
+            is_agent=True,
+        )
+
+    @pytest.mark.asyncio
+    async def test_delegated_system_tool_inherits_caller_identity(
+        self,
+        mock_session,
+        mock_agent,
+    ):
+        caller_user_id = uuid4()
+        captured_context = None
+
+        async def system_tool(context, **_arguments):
+            nonlocal captured_context
+            captured_context = context
+            return "ok"
+
+        executor = AutonomousAgentExecutor(mock_session)
+        executor._caller_user_id = caller_user_id
+        executor._caller = {
+            "user_id": str(caller_user_id),
+            "email": "person@example.com",
+            "name": "Person",
+            "is_platform_admin": True,
+        }
+
+        with patch(
+            "src.services.mcp_server.server.get_system_tool_function",
+            return_value=system_tool,
+        ):
+            await executor._execute_system_tool(
+                ToolCallRequest(
+                    id="tc1",
+                    name="specialist_system_tool",
+                    arguments={},
+                ),
+                mock_agent,
+            )
+
+        assert captured_context is not None
+        assert captured_context.user_id == caller_user_id
+        assert captured_context.user_email == "person@example.com"
+        assert captured_context.user_name == "Person"
+        assert captured_context.is_platform_admin is True
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("child_result", "expected_status", "expected_error"),
+        [
+            (
+                {
+                    "output": None,
+                    "status": "failed",
+                    "error": "Provider unavailable",
+                },
+                "failed",
+                "Provider unavailable",
+            ),
+            (
+                {
+                    "output": None,
+                    "status": "cancelled",
+                },
+                "cancelled",
+                "was cancelled",
+            ),
+            (
+                {
+                    "output": None,
+                    "status": "paused",
+                    "message": "Specialist is paused",
+                },
+                "paused",
+                "Specialist is paused",
+            ),
+            (
+                {
+                    "output": None,
+                    "status": "budget_exceeded",
+                },
+                "budget_exceeded",
+                "exceeded its budget",
+            ),
+        ],
+    )
+    async def test_run_delegation_terminalizes_non_success_statuses(
+        self,
+        mock_session,
+        mock_agent,
+        child_result,
+        expected_status,
+        expected_error,
+    ):
+        delegated = MagicMock()
+        delegated.id = uuid4()
+        delegated.name = "Lifecycle Specialist"
+        delegated.is_active = True
+        delegated.tools = []
+        delegated.delegated_agents = []
+        delegated.max_iterations = 5
+        delegated.max_token_budget = 1000
+        delegated.organization_id = mock_agent.organization_id
+        mock_agent.delegated_agents = [delegated]
+
+        query_result = MagicMock()
+        query_result.scalar_one_or_none.return_value = delegated
+        mock_session._mock_session.execute = AsyncMock(return_value=query_result)
+
+        created_runs: list[AgentRun] = []
+        mock_session._mock_session.add.side_effect = (
+            lambda value: created_runs.append(value)
+            if isinstance(value, AgentRun)
+            else None
+        )
+        mock_session._mock_session.get.side_effect = (
+            lambda model, _run_id: created_runs[0]
+            if model is AgentRun and created_runs
+            else None
+        )
+
+        executor = AutonomousAgentExecutor(mock_session)
+        tool_call = ToolCallRequest(
+            id="tc1",
+            name="delegate_to_lifecycle_specialist",
+            arguments={"task": "Exercise lifecycle"},
+        )
+
+        with patch.object(
+            AutonomousAgentExecutor,
+            "run",
+            new_callable=AsyncMock,
+            return_value={
+                **child_result,
+                "iterations_used": 1,
+                "tokens_used": 10,
+                "llm_model": "cheap-model",
+            },
+        ):
+            outcome = await executor.run_delegation(
+                parent_agent=mock_agent,
+                tool_call=tool_call,
+                parent_run_id=str(uuid4()),
+            )
+
+        assert outcome.status == expected_status
+        assert expected_error in (outcome.error or "")
+        assert created_runs[0].status == expected_status
+        assert expected_error in (created_runs[0].error or "")
+        assert created_runs[0].completed_at is not None
+
+    @pytest.mark.asyncio
+    async def test_run_delegation_terminalizes_unexpected_exception(
+        self, mock_session, mock_agent
+    ):
+        delegated = MagicMock()
+        delegated.id = uuid4()
+        delegated.name = "Crasher"
+        delegated.is_active = True
+        delegated.tools = []
+        delegated.delegated_agents = []
+        delegated.max_iterations = 5
+        delegated.max_token_budget = 1000
+        delegated.organization_id = mock_agent.organization_id
+        mock_agent.delegated_agents = [delegated]
+
+        query_result = MagicMock()
+        query_result.scalar_one_or_none.return_value = delegated
+        mock_session._mock_session.execute = AsyncMock(return_value=query_result)
+        created_runs: list[AgentRun] = []
+        mock_session._mock_session.add.side_effect = (
+            lambda value: created_runs.append(value)
+            if isinstance(value, AgentRun)
+            else None
+        )
+        mock_session._mock_session.get.side_effect = (
+            lambda model, _run_id: created_runs[0]
+            if model is AgentRun and created_runs
+            else None
+        )
+
+        executor = AutonomousAgentExecutor(mock_session)
+        with patch.object(
+            AutonomousAgentExecutor,
+            "run",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("Connection lost"),
+        ):
+            outcome = await executor.run_delegation(
+                parent_agent=mock_agent,
+                tool_call=ToolCallRequest(
+                    id="tc1",
+                    name="delegate_to_crasher",
+                    arguments={"task": "Crash"},
+                ),
+                parent_run_id=str(uuid4()),
+            )
+
+        assert outcome.status == "failed"
+        assert outcome.error == "Connection lost"
+        assert created_runs[0].status == "failed"
+        assert created_runs[0].error == "Connection lost"
+        assert created_runs[0].completed_at is not None
+
+    @pytest.mark.asyncio
+    async def test_run_delegation_rejects_cross_org_target(
+        self, mock_session, mock_agent
+    ):
+        delegated = MagicMock()
+        delegated.id = uuid4()
+        delegated.name = "Other Org Specialist"
+        delegated.is_active = True
+        delegated.organization_id = uuid4()
+        mock_agent.delegated_agents = [delegated]
+
+        executor = AutonomousAgentExecutor(mock_session)
+        with pytest.raises(ToolError, match="outside the parent agent's organization"):
+            await executor.run_delegation(
+                parent_agent=mock_agent,
+                tool_call=ToolCallRequest(
+                    id="tc1",
+                    name="delegate_to_other_org_specialist",
+                    arguments={"task": "Cross a boundary"},
+                ),
+                parent_run_id=str(uuid4()),
+            )
+
+        mock_session._mock_session.add.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_run_delegation_revalidates_current_link_and_scope(
+        self,
+        mock_session,
+        mock_agent,
+    ):
+        delegated = MagicMock()
+        delegated.id = uuid4()
+        delegated.name = "Former Specialist"
+        delegated.is_active = True
+        delegated.organization_id = mock_agent.organization_id
+        mock_agent.delegated_agents = [delegated]
+
+        query_result = MagicMock()
+        query_result.scalar_one_or_none.return_value = None
+        mock_session._mock_session.execute = AsyncMock(return_value=query_result)
+
+        executor = AutonomousAgentExecutor(mock_session)
+        with pytest.raises(
+            ToolError,
+            match="no longer active, authorized, or in scope",
+        ):
+            await executor.run_delegation(
+                parent_agent=mock_agent,
+                tool_call=ToolCallRequest(
+                    id="tc1",
+                    name="delegate_to_former_specialist",
+                    arguments={"task": "Use a stale parent relationship"},
+                ),
+                parent_run_id=str(uuid4()),
+            )
+
+        statement = mock_session._mock_session.execute.await_args.args[0]
+        compiled = str(statement)
+        assert "JOIN agent_delegations" in compiled
+        assert "agent_delegations.parent_agent_id" in compiled
+        assert "FOR UPDATE" in compiled
+        mock_session._mock_session.add.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_run_delegation_terminalizes_then_reraises_parent_cancellation(
+        self, mock_session, mock_agent
+    ):
+        delegated = MagicMock()
+        delegated.id = uuid4()
+        delegated.name = "Cancelled Specialist"
+        delegated.is_active = True
+        delegated.tools = []
+        delegated.delegated_agents = []
+        delegated.max_iterations = 5
+        delegated.max_token_budget = 1000
+        delegated.organization_id = mock_agent.organization_id
+        mock_agent.delegated_agents = [delegated]
+
+        query_result = MagicMock()
+        query_result.scalar_one_or_none.return_value = delegated
+        mock_session._mock_session.execute = AsyncMock(return_value=query_result)
+        created_runs: list[AgentRun] = []
+        mock_session._mock_session.add.side_effect = (
+            lambda value: created_runs.append(value)
+            if isinstance(value, AgentRun)
+            else None
+        )
+        mock_session._mock_session.get.side_effect = (
+            lambda model, _run_id: created_runs[0]
+            if model is AgentRun and created_runs
+            else None
+        )
+
+        executor = AutonomousAgentExecutor(mock_session)
+        with patch.object(
+            AutonomousAgentExecutor,
+            "run",
+            new_callable=AsyncMock,
+            side_effect=asyncio.CancelledError(),
+        ), pytest.raises(asyncio.CancelledError):
+            await executor.run_delegation(
+                parent_agent=mock_agent,
+                tool_call=ToolCallRequest(
+                    id="tc1",
+                    name="delegate_to_cancelled_specialist",
+                    arguments={"task": "Wait"},
+                ),
+                parent_run_id=str(uuid4()),
+            )
+
+        assert created_runs[0].status == "cancelled"
+        assert created_runs[0].completed_at is not None
+
+    @pytest.mark.asyncio
+    async def test_child_checks_ancestor_cancel_flags(self, mock_session):
+        child_run_id = str(uuid4())
+        root_run_id = str(uuid4())
+        redis = AsyncMock()
+        redis.get = AsyncMock(side_effect=[None, b"1"])
+        executor = AutonomousAgentExecutor(
+            mock_session,
+            redis_client=redis,
+            _ancestor_run_ids=(root_run_id,),
+        )
+
+        assert await executor._check_cancelled(child_run_id) is True
+        assert redis.get.await_args_list == [
+            ((f"bifrost:agent_run:{child_run_id}:cancel",),),
+            ((f"bifrost:agent_run:{root_run_id}:cancel",),),
+        ]
+
+    @pytest.mark.asyncio
+    async def test_autonomous_delegation_raises_tool_error_for_failed_child(
+        self, mock_session, mock_agent
+    ):
+        executor = AutonomousAgentExecutor(mock_session)
+        executor._current_run_id = str(uuid4())
+        executor._caller = {"user_id": str(uuid4())}
+        failed = DelegationOutcome(
+            child_run_id=uuid4(),
+            agent_name="Broken Specialist",
+            status="failed",
+            output=None,
+            error="Provider unavailable",
+            duration_ms=12,
+        )
+        executor.run_delegation = AsyncMock(return_value=failed)
+
+        with pytest.raises(ToolError, match="Provider unavailable"):
+            await executor._execute_delegation(
+                ToolCallRequest(
+                    id="tc1",
+                    name="delegate_to_broken_specialist",
+                    arguments={"task": "Do work"},
+                ),
+                mock_agent,
+            )
 
     @pytest.mark.asyncio
     @patch("src.services.execution.autonomous_agent_executor.get_llm_client")
@@ -479,7 +1034,7 @@ class TestAutonomousAgentExecutor:
 
         # Mock session.execute to return the re-fetched delegated agent
         mock_result = MagicMock()
-        mock_result.scalar_one.return_value = delegated
+        mock_result.scalar_one_or_none.return_value = delegated
         mock_session._mock_session.execute = AsyncMock(return_value=mock_result)
 
         mock_llm = AsyncMock()
@@ -651,7 +1206,7 @@ class TestAutonomousAgentExecutor:
         )
 
         mock_result = MagicMock()
-        mock_result.scalar_one.return_value = delegated
+        mock_result.scalar_one_or_none.return_value = delegated
         mock_session._mock_session.execute = AsyncMock(return_value=mock_result)
 
         mock_llm = AsyncMock()
@@ -789,7 +1344,7 @@ class TestAutonomousAgentExecutor:
         )
 
         mock_result = MagicMock()
-        mock_result.scalar_one.return_value = delegated
+        mock_result.scalar_one_or_none.return_value = delegated
         mock_session._mock_session.execute = AsyncMock(return_value=mock_result)
 
         mock_llm = AsyncMock()
@@ -910,7 +1465,7 @@ class TestAutonomousAgentExecutor:
         )
 
         mock_result = MagicMock()
-        mock_result.scalar_one.return_value = delegated
+        mock_result.scalar_one_or_none.return_value = delegated
         mock_session._mock_session.execute = AsyncMock(return_value=mock_result)
 
         mock_llm = AsyncMock()

--- a/api/tests/unit/test_consolidated_tuning.py
+++ b/api/tests/unit/test_consolidated_tuning.py
@@ -18,6 +18,7 @@ import pytest
 import pytest_asyncio
 from sqlalchemy import delete, select
 
+from src.core.principal import UserPrincipal
 from src.models.orm.agent_prompt_history import AgentPromptHistory
 from src.models.orm.agent_run_flag_conversations import AgentRunFlagConversation
 from src.models.orm.agent_runs import AgentRun
@@ -46,6 +47,16 @@ def _build_mock_client(response):
     client.complete = AsyncMock(return_value=response)
     client.provider_name = "anthropic"
     return client
+
+
+def _superuser_principal(user) -> UserPrincipal:  # type: ignore[no-untyped-def]
+    return UserPrincipal(
+        user_id=user.id,
+        email=user.email,
+        name=user.name or "",
+        organization_id=user.organization_id,
+        is_superuser=True,
+    )
 
 
 @pytest_asyncio.fixture
@@ -92,7 +103,7 @@ async def seed_agent_with_flagged_runs(db_session, seed_agent):
 
 @pytest.mark.asyncio
 async def test_propose_returns_proposal_with_flagged_runs(
-    db_session, seed_agent_with_flagged_runs
+    db_session, seed_agent_with_flagged_runs, seed_user
 ):
     """LLM is called once; response parsed into proposal containing all flagged runs."""
     from src.services.execution import tuning_service as mod
@@ -110,7 +121,11 @@ async def test_propose_returns_proposal_with_flagged_runs(
         "get_tuning_client",
         new=AsyncMock(return_value=(mock_client, "claude-sonnet-4-6")),
     ):
-        proposal = await propose_consolidated_tuning(agent.id, db_session)
+        proposal = await propose_consolidated_tuning(
+            agent.id,
+            db_session,
+            _superuser_principal(seed_user),
+        )
 
     assert proposal.summary == "Routing is too eager."
     assert "careful agent" in proposal.proposed_prompt
@@ -119,10 +134,14 @@ async def test_propose_returns_proposal_with_flagged_runs(
 
 
 @pytest.mark.asyncio
-async def test_propose_no_flagged_runs_raises(db_session, seed_agent):
+async def test_propose_no_flagged_runs_raises(db_session, seed_agent, seed_user):
     """No flagged runs -> LookupError (router maps to 404)."""
     with pytest.raises(LookupError):
-        await propose_consolidated_tuning(seed_agent.id, db_session)
+        await propose_consolidated_tuning(
+            seed_agent.id,
+            db_session,
+            _superuser_principal(seed_user),
+        )
 
 
 @pytest.mark.asyncio
@@ -140,6 +159,7 @@ async def test_apply_updates_prompt_creates_history_resets_verdicts(
         reason="Consolidated tuning from 3 flagged runs.",
         user_id=seed_user.id,
         db=db_session,
+        user=_superuser_principal(seed_user),
     )
     await db_session.commit()
 
@@ -185,7 +205,7 @@ async def test_apply_updates_prompt_creates_history_resets_verdicts(
 
 
 @pytest.mark.asyncio
-async def test_dry_run_caps_at_limit(db_session, seed_agent):
+async def test_dry_run_caps_at_limit(db_session, seed_agent, seed_user):
     """Even with 12 flagged runs, dry-run only evaluates the cap."""
     from src.services.execution import tuning_service as mod
 
@@ -226,6 +246,7 @@ async def test_dry_run_caps_at_limit(db_session, seed_agent):
                 proposed_prompt="Stricter prompt.",
                 db=db_session,
                 session_factory=MagicMock(),
+                user=_superuser_principal(seed_user),
             )
 
         assert len(results) == CONSOLIDATED_DRY_RUN_LIMIT


### PR DESCRIPTION
## Summary

- unify chat and autonomous agent delegation behind one durable child-run lifecycle
- preserve caller and organization context while retaining the normal minted workflow engine token
- terminalize delegated runs across success, failure, timeout, cancellation, pause, budget exhaustion, and unexpected exceptions
- propagate ancestor cancellation, persist child links/steps/usage, and enqueue child summaries
- keep private chat delegation runs owner-visible while preserving org-level autonomous run visibility

## Compatibility

- existing `delegate_to_<agent>` tool names and `{ "task": string }` schemas are unchanged
- no database migration or public CLI, MCP, DTO, or OpenAPI contract change
- global run history remains root-oriented; delegated runs remain available in per-agent history

## Verification

- API Pyright and Ruff passed
- 5,412 backend unit tests passed
- backend E2E coverage passed in segmented runs, including the new chat delegation lifecycle and privacy tests
- generated OpenAPI types were unchanged; TypeScript and ESLint passed
- 225 frontend test files / 1,657 tests passed
- post-rebase delegation + MCP gateway intersection suite: 142 passed
- live OpenRouter acceptance passed for chat and autonomous delegation, including terminal child records, summaries, caller/org propagation, durable parent links, and parent callbacks

The monolithic local E2E invocation outlived its session bearer-token TTL, so the remaining coverage was rerun in fresh-token segments. All resulting failures were isolated to stale test-stack state and passed after a clean stack rebuild.

Fixes #518
