### PR TITLE
fix(llm): stream inside AnthropicClient.complete to avoid the non-streaming 10-minute guard

### DIFF
--- a/api/src/services/llm/anthropic_client.py
+++ b/api/src/services/llm/anthropic_client.py
@@ -51,7 +51,18 @@ class AnthropicClient(BaseLLMClient):
         max_tokens: int | None = None,
         model: str | None = None,
     ) -> LLMResponse:
-        """Non-streaming completion via Anthropic API."""
+        """Non-streaming completion via Anthropic API.
+
+        Uses ``messages.stream()`` + ``get_final_message()`` under the hood
+        rather than ``messages.create()``: the caller still receives one fully
+        assembled ``LLMResponse``, but streaming avoids the Anthropic SDK's
+        client-side guard that refuses a *non-streaming* request whenever
+        ``max_tokens`` is large enough to risk a >10-minute completion
+        ("Streaming is required for operations that may take longer than 10
+        minutes"). That guard fires at ``max_tokens`` above ~21k, which breaks
+        run summarization whenever the admin-configured ``LLMConfig.max_tokens``
+        is set that high, since the summarizer inherits it.
+        """
         # Extract system message and convert rest
         system_prompt, anthropic_messages = self._convert_messages(messages)
         anthropic_tools = self._convert_tools(tools) if tools else None
@@ -67,7 +78,8 @@ class AnthropicClient(BaseLLMClient):
         if anthropic_tools:
             kwargs["tools"] = anthropic_tools
 
-        response = await self.client.messages.create(**kwargs)
+        async with self.client.messages.stream(**kwargs) as stream:
+            response = await stream.get_final_message()
 
         # Extract content and tool calls
         content_parts: list[str] = []

--- a/api/tests/unit/services/test_anthropic_client_messages.py
+++ b/api/tests/unit/services/test_anthropic_client_messages.py
@@ -146,3 +146,80 @@ class TestConvertMessages:
         assert isinstance(content, list)
         assert len(content) == 3
         assert [b["tool_use_id"] for b in content] == ["c1", "c2", "c3"]
+
+
+class TestComplete:
+    """complete() must stream internally so a large max_tokens never trips the
+    Anthropic SDK's non-streaming ">10 minute" guard (which otherwise breaks run
+    summarization whenever the admin-configured max_tokens is set above ~21k)."""
+
+    @staticmethod
+    def _final_message():
+        text_block = MagicMock()
+        text_block.type = "text"
+        text_block.text = "hello world"
+        usage = MagicMock()
+        usage.input_tokens = 12
+        usage.output_tokens = 3
+        msg = MagicMock()
+        msg.content = [text_block]
+        msg.stop_reason = "end_turn"
+        msg.usage = usage
+        msg.model = "claude-sonnet-4-20250514"
+        return msg
+
+    def _mock_stream(self, client, final_message):
+        """Wire client.messages.stream to an async CM yielding final_message."""
+        from unittest.mock import AsyncMock
+
+        stream_obj = MagicMock()
+        stream_obj.get_final_message = AsyncMock(return_value=final_message)
+
+        cm = MagicMock()
+        cm.__aenter__ = AsyncMock(return_value=stream_obj)
+        cm.__aexit__ = AsyncMock(return_value=False)
+
+        client.client.messages.stream = MagicMock(return_value=cm)
+        client.client.messages.create = MagicMock(
+            side_effect=AssertionError("complete() must not call messages.create")
+        )
+        return cm
+
+    @pytest.mark.asyncio
+    async def test_complete_uses_streaming(self, client):
+        cm = self._mock_stream(client, self._final_message())
+
+        result = await client.complete(
+            [LLMMessage(role="user", content="hi")], max_tokens=64000
+        )
+
+        # Streamed, not created — this is what avoids the 10-minute guard.
+        client.client.messages.stream.assert_called_once()
+        client.client.messages.create.assert_not_called()
+        # max_tokens is forwarded verbatim; the guard would have fired on create().
+        assert client.client.messages.stream.call_args.kwargs["max_tokens"] == 64000
+        cm.__aenter__.assert_awaited_once()
+
+        # Non-streaming return contract is preserved.
+        assert result.content == "hello world"
+        assert result.finish_reason == "end_turn"
+        assert result.input_tokens == 12
+        assert result.output_tokens == 3
+
+    @pytest.mark.asyncio
+    async def test_complete_assembles_tool_calls(self, client):
+        tool_block = MagicMock()
+        tool_block.type = "tool_use"
+        tool_block.id = "toolu_1"
+        tool_block.name = "search"
+        tool_block.input = {"q": "cats"}
+        final = self._final_message()
+        final.content = [tool_block]
+        final.stop_reason = "tool_use"
+        self._mock_stream(client, final)
+
+        result = await client.complete([LLMMessage(role="user", content="hi")])
+
+        assert result.tool_calls is not None
+        assert result.tool_calls[0].name == "search"
+        assert result.tool_calls[0].arguments == {"q": "cats"}


### PR DESCRIPTION
## Problem

`AnthropicClient.complete()` calls `self.client.messages.create(**kwargs)` (non-streaming). The Anthropic SDK refuses a non-streaming request whenever `max_tokens` is large enough to risk a >10-minute completion, raising:

> Streaming is required for operations that may take longer than 10 minutes

That guard fires once `max_tokens` exceeds ~21k (`600s ÷ 3600s × 128000`).

`complete()` is used by **run summarization** (`services/execution/run_summarizer.py`), which passes no `max_tokens` and therefore inherits the admin-configured `LLMConfig.max_tokens`. When an admin sets that above ~21k (e.g. 32768 for a 128k-output model), **every run-summary generation fails** with the guard error — persisted as `summary_error = "LLM call failed: Streaming is required…"` on the run. The default (16384) is under the ceiling, so this only bites deployments that raised the limit.

## Fix

Switch `complete()` to `messages.stream()` + `get_final_message()`. The caller still gets one fully assembled `LLMResponse` (same return contract — text, tool calls, usage, stop reason, model), but the streaming path has no 10-minute ceiling, so it holds at any `max_tokens` **without capping output**. This is Anthropic's own recommended pattern for large-`max_tokens` requests.

## Tests

Two new unit tests in `test_anthropic_client_messages.py`:
- `test_complete_uses_streaming` — asserts `complete()` calls `messages.stream` and **never** `messages.create`, forwards `max_tokens` verbatim, and preserves the return contract.
- `test_complete_assembles_tool_calls` — asserts tool-use blocks are still assembled from the final message.

All anthropic-client unit tests pass; `ruff` and `pyright` clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013673rJgafX4A7TCnv1QbSa