### PR TITLE
chore(security): update Node and client dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,7 +130,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: "20"
+          node-version: "26"
           cache: npm
           cache-dependency-path: client/package-lock.json
 
@@ -162,7 +162,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: "20"
+          node-version: "26"
           cache: npm
           cache-dependency-path: client/package-lock.json
 

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -54,7 +54,7 @@
 				"cmdk": "^1.1.1",
 				"dagre": "^0.8.5",
 				"date-fns": "^4.4.0",
-				"dompurify": "^3.4.10",
+				"dompurify": "^3.4.12",
 				"framer-motion": "^12.43.0",
 				"fuse.js": "^7.5.0",
 				"lucide-react": "^1.28.0",
@@ -87,7 +87,7 @@
 				"@eslint/js": "^9.39.5",
 				"@playwright/test": "^1.62.1",
 				"@tailwindcss/typography": "^0.5.20",
-				"@testing-library/jest-dom": "^6.9.1",
+				"@testing-library/jest-dom": "^7.0.0",
 				"@testing-library/react": "^16.3.2",
 				"@testing-library/user-event": "^14.6.1",
 				"@types/babel__standalone": "^7.1.9",
@@ -104,7 +104,7 @@
 				"globals": "^17.8.0",
 				"happy-dom": "^20.11.1",
 				"js-yaml": "^5.2.2",
-				"jsdom": "^29.1.1",
+				"jsdom": "^30.0.1",
 				"openapi-typescript": "^7.9.1",
 				"playwright": "^1.56.0",
 				"prettier": "^3.9.6",
@@ -114,7 +114,7 @@
 				"vitest": "^4.1.4"
 			},
 			"engines": {
-				"node": ">=20.0.0"
+				"node": ">=26.0.0"
 			}
 		},
 		"node_modules/@adobe/css-tools": {
@@ -137,55 +137,57 @@
 			}
 		},
 		"node_modules/@asamuzakjp/css-color": {
-			"version": "5.1.11",
-			"resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
-			"integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+			"version": "6.0.5",
+			"resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-6.0.5.tgz",
+			"integrity": "sha512-mbhpPMmnw/kwW19aRNmSUl1QzLbdGo1SCuE49BT98MNwqF6zaHb3o2owssFc/PEO/4t2UjqtCNwocuDtJornzA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@asamuzakjp/generational-cache": "^1.0.1",
-				"@csstools/css-calc": "^3.2.0",
-				"@csstools/css-color-parser": "^4.1.0",
+				"@csstools/css-calc": "^3.2.1",
+				"@csstools/css-color-parser": "^4.1.9",
 				"@csstools/css-parser-algorithms": "^4.0.0",
-				"@csstools/css-tokenizer": "^4.0.0"
+				"@csstools/css-tokenizer": "^4.0.0",
+				"lru-cache": "^11.5.2"
 			},
 			"engines": {
-				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+				"node": "^22.13.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+			"version": "11.5.2",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+			"integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": "20 || >=22"
 			}
 		},
 		"node_modules/@asamuzakjp/dom-selector": {
-			"version": "7.1.1",
-			"resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
-			"integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+			"version": "8.3.2",
+			"resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-8.3.2.tgz",
+			"integrity": "sha512-93Z1N+BQNXysodoicpOIyNh2drHfz/CTf9nnT0FEx72GJcIiwgydD7tGAr78j41LsYn3hlRn+LdGPuBLn1Bl8Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@asamuzakjp/generational-cache": "^1.0.1",
-				"@asamuzakjp/nwsapi": "^2.3.9",
 				"bidi-js": "^1.0.3",
 				"css-tree": "^3.2.1",
-				"is-potential-custom-element-name": "^1.0.1"
+				"is-potential-custom-element-name": "^1.0.1",
+				"lru-cache": "^11.5.2"
 			},
 			"engines": {
-				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+				"node": "^22.13.0 || >=24.0.0"
 			}
 		},
-		"node_modules/@asamuzakjp/generational-cache": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
-			"integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+		"node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
+			"version": "11.5.2",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+			"integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
 			"dev": true,
-			"license": "MIT",
+			"license": "BlueOak-1.0.0",
 			"engines": {
-				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+				"node": "20 || >=22"
 			}
-		},
-		"node_modules/@asamuzakjp/nwsapi": {
-			"version": "2.3.9",
-			"resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
-			"integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/@atlaskit/pragmatic-drag-and-drop": {
 			"version": "2.0.1",
@@ -243,18 +245,18 @@
 			}
 		},
 		"node_modules/@babel/core": {
-			"version": "7.29.0",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
-			"integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+			"version": "7.29.6",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.6.tgz",
+			"integrity": "sha512-QdxmAo/ikZqqRGA8s43ww8lcql6naWRvEz0FFrl6MIlc7Gi6TroXnSdWa5U/kq6fzcpqpHesicQxFZIieZbyIA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@babel/code-frame": "^7.29.0",
-				"@babel/generator": "^7.29.0",
+				"@babel/generator": "^7.29.6",
 				"@babel/helper-compilation-targets": "^7.28.6",
 				"@babel/helper-module-transforms": "^7.28.6",
-				"@babel/helpers": "^7.28.6",
-				"@babel/parser": "^7.29.0",
+				"@babel/helpers": "^7.29.2",
+				"@babel/parser": "^7.29.3",
 				"@babel/template": "^7.28.6",
 				"@babel/traverse": "^7.29.0",
 				"@babel/types": "^7.29.0",
@@ -274,13 +276,13 @@
 			}
 		},
 		"node_modules/@babel/generator": {
-			"version": "7.29.1",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
-			"integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+			"version": "7.29.8",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.8.tgz",
+			"integrity": "sha512-gZbepsdh3WDtgZKWL+vTPh71LSBrm/Y4/QDZBVCcYfmeTEEuoOYwlSy+G1StfJg+/Zy550u/3TATbm7qDbbMtg==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/parser": "^7.29.0",
-				"@babel/types": "^7.29.0",
+				"@babel/parser": "^7.29.8",
+				"@babel/types": "^7.29.8",
 				"@jridgewell/gen-mapping": "^0.3.12",
 				"@jridgewell/trace-mapping": "^0.3.28",
 				"jsesc": "^3.0.2"
@@ -347,18 +349,18 @@
 			}
 		},
 		"node_modules/@babel/helper-string-parser": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-			"integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+			"integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-validator-identifier": {
-			"version": "7.28.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-			"integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+			"integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=6.9.0"
@@ -389,12 +391,12 @@
 			}
 		},
 		"node_modules/@babel/parser": {
-			"version": "7.29.2",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
-			"integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+			"version": "7.29.8",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+			"integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/types": "^7.29.0"
+				"@babel/types": "^7.29.8"
 			},
 			"bin": {
 				"parser": "bin/babel-parser.js"
@@ -454,13 +456,13 @@
 			}
 		},
 		"node_modules/@babel/types": {
-			"version": "7.29.0",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-			"integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+			"version": "7.29.8",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+			"integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-string-parser": "^7.27.1",
-				"@babel/helper-validator-identifier": "^7.28.5"
+				"@babel/helper-string-parser": "^7.29.7",
+				"@babel/helper-validator-identifier": "^7.29.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -480,9 +482,9 @@
 			}
 		},
 		"node_modules/@csstools/color-helpers": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
-			"integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.0.tgz",
+			"integrity": "sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==",
 			"dev": true,
 			"funding": [
 				{
@@ -500,9 +502,9 @@
 			}
 		},
 		"node_modules/@csstools/css-calc": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.1.tgz",
-			"integrity": "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==",
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.3.0.tgz",
+			"integrity": "sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -524,9 +526,9 @@
 			}
 		},
 		"node_modules/@csstools/css-color-parser": {
-			"version": "4.1.8",
-			"resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.8.tgz",
-			"integrity": "sha512-3chWb7PRLijpJpPIKkDxdu6IBeO5MrFACND57On0j8OPpc0wZibcGc3xAHrSEbOx/KDRyMHoIxGn0w1PhXMYHw==",
+			"version": "4.1.10",
+			"resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.10.tgz",
+			"integrity": "sha512-UZhQLIUyJaaMepqehrCODwCg2KW25vFvLWBmqYFaPclYvvxzj/sG8LBOhBFCp11i9uE7t1EyS+RAoV9tztPFyw==",
 			"dev": true,
 			"funding": [
 				{
@@ -540,8 +542,8 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"@csstools/color-helpers": "^6.0.2",
-				"@csstools/css-calc": "^3.2.1"
+				"@csstools/color-helpers": "^6.1.0",
+				"@csstools/css-calc": "^3.3.0"
 			},
 			"engines": {
 				"node": ">=20.19.0"
@@ -575,9 +577,9 @@
 			}
 		},
 		"node_modules/@csstools/css-syntax-patches-for-csstree": {
-			"version": "1.1.5",
-			"resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.5.tgz",
-			"integrity": "sha512-oNjBvzLq2GPZtJphCjLqXow/cHySHSgtxvKZb7OqSZ/xHgw6NWNhfad+6AB9cLeVm6eA9d/qMll3JdEHjy6M+A==",
+			"version": "1.1.7",
+			"resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.7.tgz",
+			"integrity": "sha512-fQ+05118eQS1cofO3aJpB5efgpBZMvIzwr/sbC8kDLVA5XLG8q1kJV5yzrUAI1f7lvhPnm8fgIjzFB8/O/5Dig==",
 			"dev": true,
 			"funding": [
 				{
@@ -2837,9 +2839,9 @@
 			}
 		},
 		"node_modules/@redocly/openapi-core/node_modules/brace-expansion": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-			"integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.3.tgz",
+			"integrity": "sha512-DRdx5neNsG/QXbniLFWi2YmC/68oeOOmKz6zOjVk6ZS1ZLXgLIKqVEc6hWsmkjBbgii0SwaBTcJ5XKj5gzY/4A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2847,10 +2849,20 @@
 			}
 		},
 		"node_modules/@redocly/openapi-core/node_modules/js-yaml": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-			"integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+			"integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
 			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/puzrin"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/nodeca"
+				}
+			],
 			"license": "MIT",
 			"dependencies": {
 				"argparse": "^2.0.1"
@@ -2985,9 +2997,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3003,9 +3012,6 @@
 			"integrity": "sha512-B5G/zJdHaoJn9vD50eGHWkiWfmq8Uhi3IiLPJTzmZTrAalk1bztUikSXo0qga18ibE0IXboyeMUnhPjhAJ45wQ==",
 			"cpu": [
 				"arm64"
-			],
-			"libc": [
-				"musl"
 			],
 			"license": "MIT",
 			"optional": true,
@@ -3023,9 +3029,6 @@
 			"cpu": [
 				"ppc64"
 			],
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3041,9 +3044,6 @@
 			"integrity": "sha512-412MX9fJLdA1IK28EZnc8jYv2HRTleOZgfLQumJ5zy7OeJLZlg/CETwFaXjNmGVxG51cFHpKLqb5LKvBC+HsHA==",
 			"cpu": [
 				"s390x"
-			],
-			"libc": [
-				"glibc"
 			],
 			"license": "MIT",
 			"optional": true,
@@ -3061,9 +3061,6 @@
 			"cpu": [
 				"x64"
 			],
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3079,9 +3076,6 @@
 			"integrity": "sha512-ZKp/w41n6wCvxzxQHtQSbuphfX3Y4cCvbjkKHusrLx4lh+JWLTU7StSltO/DKARISzbj368d+qUaCjI8K2wzXw==",
 			"cpu": [
 				"x64"
-			],
-			"libc": [
-				"musl"
 			],
 			"license": "MIT",
 			"optional": true,
@@ -3289,9 +3283,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3307,9 +3298,6 @@
 			"integrity": "sha512-Md44bD6veX/PC5iyF8cDVnw4HBIANZepRZZ7a8DQOvkfo5WUBwcp6iAuCUz23u+4SUkhJlD3eL7hNdW8ezd/kA==",
 			"cpu": [
 				"arm64"
-			],
-			"libc": [
-				"musl"
 			],
 			"license": "MIT",
 			"optional": true,
@@ -3327,9 +3315,6 @@
 			"cpu": [
 				"x64"
 			],
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3345,9 +3330,6 @@
 			"integrity": "sha512-SJxX60smvHgasZoBy11dX6YRjXJFovwWBoedhbQPOBzgFWBHGB+TVPWB9BxzR7TTxU8FQZAI2AyiNCMzFm8Img==",
 			"cpu": [
 				"x64"
-			],
-			"libc": [
-				"musl"
 			],
 			"license": "MIT",
 			"optional": true,
@@ -3567,9 +3549,9 @@
 			}
 		},
 		"node_modules/@testing-library/jest-dom": {
-			"version": "6.9.1",
-			"resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
-			"integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-7.0.0.tgz",
+			"integrity": "sha512-HKAH9C6mBo5yBG6yRO5i43L2iisencAo5z+o5P/saHUoY+miC5ivXRxHBJcFyB5ypPNxHJdK3BoF/3O4DIptMg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -3581,9 +3563,12 @@
 				"redent": "^3.0.0"
 			},
 			"engines": {
-				"node": ">=14",
+				"node": ">=22",
 				"npm": ">=6",
 				"yarn": ">=1"
+			},
+			"peerDependencies": {
+				"@testing-library/dom": ">=10 <11"
 			}
 		},
 		"node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
@@ -5186,9 +5171,9 @@
 			"license": "MIT"
 		},
 		"node_modules/brace-expansion": {
-			"version": "1.1.14",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-			"integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+			"version": "1.1.17",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.17.tgz",
+			"integrity": "sha512-w+aeW/mkgM4PyRMOJCgi3fOrTm5Q8QY1OSfn2TO2iuDj3ezIHqejmuxbjfPrqUkgqRew1iqkyAn0tr0ZwHD9+w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -5935,9 +5920,9 @@
 			"peer": true
 		},
 		"node_modules/dompurify": {
-			"version": "3.4.11",
-			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
-			"integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
+			"version": "3.4.13",
+			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.13.tgz",
+			"integrity": "sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==",
 			"license": "(MPL-2.0 OR Apache-2.0)",
 			"optionalDependencies": {
 				"@types/trusted-types": "^2.0.7"
@@ -7090,39 +7075,39 @@
 			}
 		},
 		"node_modules/jsdom": {
-			"version": "29.1.1",
-			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
-			"integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
+			"version": "30.0.1",
+			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-30.0.1.tgz",
+			"integrity": "sha512-52v7mUVUfNQVYYqE1lcdaymWL0njO7lTLUog6ZvW2U5KsbiLk/GnZlVJ+qx0xfNJZ6Gn+KSpPNE52vurbxZwrA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@asamuzakjp/css-color": "^5.1.11",
-				"@asamuzakjp/dom-selector": "^7.1.1",
+				"@asamuzakjp/css-color": "^6.0.5",
+				"@asamuzakjp/dom-selector": "^8.3.0",
 				"@bramus/specificity": "^2.4.2",
-				"@csstools/css-syntax-patches-for-csstree": "^1.1.3",
-				"@exodus/bytes": "^1.15.0",
+				"@csstools/css-syntax-patches-for-csstree": "^1.1.7",
+				"@exodus/bytes": "^1.15.1",
 				"css-tree": "^3.2.1",
 				"data-urls": "^7.0.0",
 				"decimal.js": "^10.6.0",
 				"html-encoding-sniffer": "^6.0.0",
 				"is-potential-custom-element-name": "^1.0.1",
-				"lru-cache": "^11.3.5",
+				"lru-cache": "^11.5.2",
 				"parse5": "^8.0.1",
 				"saxes": "^6.0.0",
 				"symbol-tree": "^3.2.4",
-				"tough-cookie": "^6.0.1",
-				"undici": "^7.25.0",
+				"tough-cookie": "^6.0.2",
+				"undici": "^8.9.0",
 				"w3c-xmlserializer": "^5.0.0",
 				"webidl-conversions": "^8.0.1",
 				"whatwg-mimetype": "^5.0.0",
-				"whatwg-url": "^16.0.1",
+				"whatwg-url": "^17.1.0",
 				"xml-name-validator": "^5.0.0"
 			},
 			"engines": {
-				"node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+				"node": "^22.22.2 || ^24.15.0 || >=26.0.0"
 			},
 			"peerDependencies": {
-				"canvas": "^3.0.0"
+				"canvas": "^3.2.3"
 			},
 			"peerDependenciesMeta": {
 				"canvas": {
@@ -7144,9 +7129,9 @@
 			}
 		},
 		"node_modules/jsdom/node_modules/lru-cache": {
-			"version": "11.5.1",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
-			"integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+			"version": "11.5.2",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+			"integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
 			"dev": true,
 			"license": "BlueOak-1.0.0",
 			"engines": {
@@ -7174,6 +7159,21 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=20"
+			}
+		},
+		"node_modules/jsdom/node_modules/whatwg-url": {
+			"version": "17.1.0",
+			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-17.1.0.tgz",
+			"integrity": "sha512-3GeworPmc2ZfEEHP7lEbUfBX/L75wdEsi0rLNhXcXxnoN5jyq0SL5gCy06SGW2cyTIZdTvWIDQNQoza++vKeaw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@exodus/bytes": "^1.15.1",
+				"tr46": "^6.0.0",
+				"webidl-conversions": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.14.0 || >=24.0.0"
 			}
 		},
 		"node_modules/jsesc": {
@@ -9370,9 +9370,9 @@
 			}
 		},
 		"node_modules/react-diff-viewer-continued/node_modules/js-yaml": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-			"integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+			"integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
 			"funding": [
 				{
 					"type": "github",
@@ -10203,22 +10203,22 @@
 			}
 		},
 		"node_modules/tldts": {
-			"version": "7.4.3",
-			"resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.3.tgz",
-			"integrity": "sha512-A3BDQBeeukYPzB4QdQ1DtdlUmp4x2OCH8n5UVhEWbyANxNep8GavottKzd1xYKFJKjUgMyPT7EzOfnBO55s8Sg==",
+			"version": "7.4.10",
+			"resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.10.tgz",
+			"integrity": "sha512-GgouD1B+sWwvkaEq8vXC15DjQitxbvs12oIXELpconwm+Tg3zfcEv4jgzq3vtKverDXsg3VI8aRgNL2Nra0Iog==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"tldts-core": "^7.4.3"
+				"tldts-core": "^7.4.10"
 			},
 			"bin": {
 				"tldts": "bin/cli.js"
 			}
 		},
 		"node_modules/tldts-core": {
-			"version": "7.4.3",
-			"resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.3.tgz",
-			"integrity": "sha512-27ep5H9PzdBrNd5OFM/j3WCU8F3kPwM9D0BOaOf7uYfxMJfyr0K5Tjj69Gri+sZlh2WXd5buIm47NuPF29CDiw==",
+			"version": "7.4.10",
+			"resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.10.tgz",
+			"integrity": "sha512-KnQjp53ZekKgm/r3l+u8kJGGzYgrWdP8+Mql7a4vijh2WE0IrZWspQj/TpTxDho/YxO+AnOZnIjQcCD+q6iJsw==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -10233,9 +10233,9 @@
 			}
 		},
 		"node_modules/tough-cookie": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
-			"integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.2.tgz",
+			"integrity": "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==",
 			"dev": true,
 			"license": "BSD-3-Clause",
 			"dependencies": {
@@ -10371,13 +10371,13 @@
 			}
 		},
 		"node_modules/undici": {
-			"version": "7.28.0",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-			"integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+			"version": "8.10.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-8.10.0.tgz",
+			"integrity": "sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
-				"node": ">=20.18.1"
+				"node": ">=22.19.0"
 			}
 		},
 		"node_modules/undici-types": {
@@ -10871,9 +10871,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"libc": [
-				"glibc"
-			],
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -10893,9 +10890,6 @@
 			"integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
 			"cpu": [
 				"arm64"
-			],
-			"libc": [
-				"musl"
 			],
 			"license": "MPL-2.0",
 			"optional": true,
@@ -10917,9 +10911,6 @@
 			"cpu": [
 				"x64"
 			],
-			"libc": [
-				"glibc"
-			],
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -10939,9 +10930,6 @@
 			"integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
 			"cpu": [
 				"x64"
-			],
-			"libc": [
-				"musl"
 			],
 			"license": "MPL-2.0",
 			"optional": true,

--- a/client/package.json
+++ b/client/package.json
@@ -6,7 +6,7 @@
 	"author": "Jack Musick <jack@gocovi.com>",
 	"private": true,
 	"engines": {
-		"node": ">=20.0.0"
+		"node": ">=26.0.0"
 	},
 	"scripts": {
 		"dev": "vite",
@@ -18,9 +18,9 @@
 		"format": "prettier --write .",
 		"generate:types": "npx openapi-typescript ${OPENAPI_URL:-http://localhost:3000/openapi.json} -o src/lib/v1.d.ts",
 		"generate:types:docker": "npx openapi-typescript http://localhost/openapi.json -o src/lib/v1.d.ts",
-		"test": "vitest run",
-		"test:watch": "vitest",
-		"test:ui": "vitest --ui",
+		"test": "NODE_OPTIONS=--no-experimental-webstorage vitest run",
+		"test:watch": "NODE_OPTIONS=--no-experimental-webstorage vitest",
+		"test:ui": "NODE_OPTIONS=--no-experimental-webstorage vitest --ui",
 		"test:e2e": "playwright test",
 		"test:e2e:ui": "playwright test --ui",
 		"test:e2e:headed": "playwright test --headed",
@@ -74,7 +74,7 @@
 		"cmdk": "^1.1.1",
 		"dagre": "^0.8.5",
 		"date-fns": "^4.4.0",
-		"dompurify": "^3.4.10",
+		"dompurify": "^3.4.12",
 		"framer-motion": "^12.43.0",
 		"fuse.js": "^7.5.0",
 		"lucide-react": "^1.28.0",
@@ -107,7 +107,7 @@
 		"@eslint/js": "^9.39.5",
 		"@playwright/test": "^1.62.1",
 		"@tailwindcss/typography": "^0.5.20",
-		"@testing-library/jest-dom": "^6.9.1",
+		"@testing-library/jest-dom": "^7.0.0",
 		"@testing-library/react": "^16.3.2",
 		"@testing-library/user-event": "^14.6.1",
 		"@types/babel__standalone": "^7.1.9",
@@ -124,7 +124,7 @@
 		"globals": "^17.8.0",
 		"happy-dom": "^20.11.1",
 		"js-yaml": "^5.2.2",
-		"jsdom": "^29.1.1",
+		"jsdom": "^30.0.1",
 		"openapi-typescript": "^7.9.1",
 		"playwright": "^1.56.0",
 		"prettier": "^3.9.6",
@@ -134,6 +134,10 @@
 		"vitest": "^4.1.4"
 	},
 	"overrides": {
-		"dompurify": "^3.4.10"
+		"@babel/core@<7.29.6": "7.29.6",
+		"brace-expansion@<1.1.17": "1.1.17",
+		"brace-expansion@>=2 <2.1.3": "2.1.3",
+		"dompurify": "^3.4.12",
+		"js-yaml@>=4 <4.3.0": "4.3.0"
 	}
 }


### PR DESCRIPTION
## Summary
- align client development and CI with Node 26, matching the existing client container runtime
- update jsdom and jest-dom together, superseding Dependabot PRs #541 and #542
- patch DOMPurify, Babel, js-yaml, and brace-expansion advisories through direct updates and targeted overrides
- disable Node 26 native experimental web storage for Vitest so jsdom remains the test storage implementation

## Verification
- npm ci under Node 26
- npm run tsc
- npm run lint (0 errors; 1 existing warning)
- npm test: 229 files, 1,662 tests passed

The remaining npm audit finding is React Router's RSC-only advisory. Bifrost is a Vite SPA and does not use React Server Components or unstable RSC action APIs, so that alert will be documented as not affected rather than forcing an unrelated framework-major upgrade.