### PR TITLE
fix(test): stabilize standalone app scope mock

### DIFF
--- a/client/src/components/jsx-app/StandaloneV2App.test.tsx
+++ b/client/src/components/jsx-app/StandaloneV2App.test.tsx
@@ -8,9 +8,10 @@ import {
 	type StandaloneV2Module,
 } from "./StandaloneV2App";
 
-vi.mock("@/hooks/useOrgScope", () => ({
-	useOrgScope: () => ({ scope: { type: "global", orgId: null } }),
-}));
+vi.mock("@/hooks/useOrgScope", () => {
+	const scope = { type: "global" as const, orgId: null };
+	return { useOrgScope: () => ({ scope }) };
+});
 
 function props(entry: string) {
 	return {


### PR DESCRIPTION
## Summary
- make the mocked organization scope referentially stable across renders
- prevent the StandaloneV2App concurrency error effect from being immediately restarted and cleared under Node 26/jsdom 30

## Verification
- affected test file: 8/8 isolated stress runs passed (9 tests each)
- TypeScript: passed
- ESLint: passed with the existing React Hook Form compiler warning
- full client suite: affected test passed; 1,657 tests passed and 5 unrelated tests hit their 5-second ceiling under concurrent local load

Follow-up to #546.