### PR TITLE
fix(codeql): normalize Python import styles

### DIFF
--- a/api/bifrost/cli.py
+++ b/api/bifrost/cli.py
@@ -328,8 +328,7 @@ async def login_flow(api_url: str | None = None, auto_open: bool = True) -> bool
     api_url = api_url.rstrip("/")
 
     # Surface keyring fallback here — login is the user's chance to fix it.
-    from bifrost.credentials import warn_if_keyring_fallback
-    warn_if_keyring_fallback()
+    credentials.warn_if_keyring_fallback()
 
     try:
         async with httpx.AsyncClient(base_url=api_url, timeout=30.0) as client:

--- a/api/tests/unit/test_sdk_package_fingerprint.py
+++ b/api/tests/unit/test_sdk_package_fingerprint.py
@@ -16,50 +16,39 @@ import json
 import tarfile
 
 import pytest
+import src.services.sdk_package as sdkpkg
 
 
 def test_tarball_package_json_carries_fingerprint():
-    from src.services.sdk_package import build_sdk_tarball, sdk_fingerprint
-
-    data = build_sdk_tarball("v1.2.3")
+    data = sdkpkg.build_sdk_tarball("v1.2.3")
     with tarfile.open(fileobj=io.BytesIO(data), mode="r:gz") as tar:
         pkg = json.load(tar.extractfile("package/package.json"))
 
-    assert pkg["bifrost"]["fingerprint"] == sdk_fingerprint("v1.2.3")
+    assert pkg["bifrost"]["fingerprint"] == sdkpkg.sdk_fingerprint("v1.2.3")
     assert len(pkg["bifrost"]["fingerprint"]) == 16
 
 
 def test_fingerprint_is_stable_across_calls():
-    from src.services.sdk_package import sdk_fingerprint
-
-    assert sdk_fingerprint("v1.2.3") == sdk_fingerprint("v1.2.3")
+    assert sdkpkg.sdk_fingerprint("v1.2.3") == sdkpkg.sdk_fingerprint("v1.2.3")
 
 
 def test_sdk_contract_version_is_positive_int():
-    from src.services.sdk_package import sdk_contract_version
-
-    version = sdk_contract_version()
+    version = sdkpkg.sdk_contract_version()
     assert isinstance(version, int)
     assert version > 0
 
 
 def test_sdk_contract_version_matches_json_file():
-    import json as _json
-
-    from src.services.sdk_package import _SDK_SRC, sdk_contract_version
-
-    contract = _json.loads((_SDK_SRC / "sdk-contract.json").read_text())
-    assert sdk_contract_version() == contract["version"]
+    contract = json.loads((sdkpkg._SDK_SRC / "sdk-contract.json").read_text())
+    assert sdkpkg.sdk_contract_version() == contract["version"]
 
 
 def test_tarball_package_json_carries_contract_version():
-    from src.services.sdk_package import build_sdk_tarball, sdk_contract_version
-
-    data = build_sdk_tarball("v1.2.3")
+    data = sdkpkg.build_sdk_tarball("v1.2.3")
     with tarfile.open(fileobj=io.BytesIO(data), mode="r:gz") as tar:
         pkg = json.load(tar.extractfile("package/package.json"))
 
-    assert pkg["bifrost"]["contract"] == sdk_contract_version()
+    assert pkg["bifrost"]["contract"] == sdkpkg.sdk_contract_version()
 
 
 def test_version_endpoint_reports_sdk_fingerprint_and_contract(monkeypatch):
@@ -128,8 +117,6 @@ def test_version_endpoint_tolerates_fingerprint_failure(monkeypatch):
 def test_sdk_fingerprint_does_not_cache_failures(monkeypatch):
     """A transient node hiccup must be retryable on the next call, not
     permanently cached as a failure."""
-    import src.services.sdk_package as sdkpkg
-
     calls = {"n": 0}
 
     def _flaky(_version: str) -> bytes:

--- a/client/src/components/jsx-app/StandaloneV2App.test.tsx
+++ b/client/src/components/jsx-app/StandaloneV2App.test.tsx
@@ -8,9 +8,10 @@ import {
 	type StandaloneV2Module,
 } from "./StandaloneV2App";
 
-vi.mock("@/hooks/useOrgScope", () => ({
-	useOrgScope: () => ({ scope: { type: "global", orgId: null } }),
-}));
+vi.mock("@/hooks/useOrgScope", () => {
+	const scope = { type: "global" as const, orgId: null };
+	return { useOrgScope: () => ({ scope }) };
+});
 
 function props(entry: string) {
 	return {


### PR DESCRIPTION
## Summary
- replace mixed module/member imports with a single import style
- preserve SDK package fingerprint behavior

## Verification
- 82 focused tests passed
- API typecheck and lint passed