### PR TITLE
fix(codeql): remove useless file policy assignment

### DIFF
--- a/client/src/components/jsx-app/StandaloneV2App.test.tsx
+++ b/client/src/components/jsx-app/StandaloneV2App.test.tsx
@@ -8,9 +8,10 @@ import {
 	type StandaloneV2Module,
 } from "./StandaloneV2App";
 
-vi.mock("@/hooks/useOrgScope", () => ({
-	useOrgScope: () => ({ scope: { type: "global", orgId: null } }),
-}));
+vi.mock("@/hooks/useOrgScope", () => {
+	const scope = { type: "global" as const, orgId: null };
+	return { useOrgScope: () => ({ scope }) };
+});
 
 function props(entry: string) {
 	return {

--- a/client/src/services/filePolicies.test.ts
+++ b/client/src/services/filePolicies.test.ts
@@ -2,7 +2,11 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 
 vi.mock("@/lib/api-client", () => ({ authFetch: vi.fn() }));
 import { authFetch } from "@/lib/api-client";
-import { effectiveAccess, testAllActions } from "./filePolicies";
+import {
+	effectiveAccess,
+	saveFilePolicy,
+	testAllActions,
+} from "./filePolicies";
 
 function jsonResponse(body: unknown) {
 	return { ok: true, status: 200, json: async () => body } as Response;
@@ -52,5 +56,26 @@ describe("testAllActions", () => {
 			"read",
 			"write",
 		]);
+	});
+});
+
+describe("saveFilePolicy", () => {
+	beforeEach(() => vi.mocked(authFetch).mockReset());
+
+	it("throws the API error detail when saving fails", async () => {
+		vi.mocked(authFetch).mockResolvedValue({
+			ok: false,
+			status: 400,
+			statusText: "Bad Request",
+			json: async () => ({ detail: "Policy is invalid" }),
+		} as Response);
+
+		await expect(
+			saveFilePolicy({
+				location: "gallery",
+				path: "team/",
+				policies: { policies: [] },
+			}),
+		).rejects.toThrow("Policy is invalid");
 	});
 });

--- a/client/src/services/filePolicies.ts
+++ b/client/src/services/filePolicies.ts
@@ -52,7 +52,7 @@ async function parseResponse<T>(response: Response): Promise<T> {
 		if (response.status === 204) return undefined as T;
 		return (await response.json()) as T;
 	}
-	let detail = response.statusText;
+	let detail: string;
 	try {
 		const body = (await response.json()) as { detail?: unknown; message?: unknown };
 		const raw = body.detail ?? body.message;


### PR DESCRIPTION
## Summary
- declare the validation detail without an overwritten initial value
- add regression coverage for API validation detail propagation

## Verification
- full client suite passed: 229 files, 1,663 tests
- TypeScript passed
- ESLint passed