### PR TITLE
fix(security): sanitize file service log values

### DIFF
--- a/api/src/core/module_cache.py
+++ b/api/src/core/module_cache.py
@@ -116,7 +116,7 @@ async def set_module(path: str, content: str, content_hash: str) -> None:
     redis_conn = await redis._get_redis()
     await cast(Awaitable[int], redis_conn.sadd(MODULE_INDEX_KEY, path))
 
-    logger.debug(f"Cached module: {path}")
+    logger.debug(f"Cached module: {log_safe(path)}")
 
 
 async def invalidate_module(path: str) -> None:
@@ -137,7 +137,7 @@ async def invalidate_module(path: str) -> None:
     redis_conn = await redis._get_redis()
     await cast(Awaitable[int], redis_conn.srem(MODULE_INDEX_KEY, path))
 
-    logger.debug(f"Invalidated module cache: {path}")
+    logger.debug(f"Invalidated module cache: {log_safe(path)}")
 
 
 async def get_all_module_paths() -> set[str]:

--- a/api/src/services/file_storage/deactivation.py
+++ b/api/src/services/file_storage/deactivation.py
@@ -13,6 +13,8 @@ from uuid import UUID as UUID_type
 from sqlalchemy import select, update, or_
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from src.core.log_safety import log_safe
+
 from .models import PendingDeactivationInfo, AvailableReplacementInfo
 
 if TYPE_CHECKING:
@@ -267,7 +269,7 @@ class DeactivationProtectionService:
             try:
                 workflow_uuid = UUID_type(old_id)
             except ValueError:
-                logger.warning(f"Invalid workflow ID in replacement: {old_id}")
+                logger.warning(f"Invalid workflow ID in replacement: {log_safe(old_id)}")
                 continue
 
             # Update the workflow's function_name
@@ -278,7 +280,10 @@ class DeactivationProtectionService:
                 .values(function_name=new_function_name)
             )
             await self.db.execute(stmt)
-            logger.info(f"Applied replacement: workflow {old_id} -> function {new_function_name}")
+            logger.info(
+                f"Applied replacement: workflow {log_safe(old_id)} -> "
+                f"function {log_safe(new_function_name)}"
+            )
 
     async def deactivate_workflows_by_id(
         self,
@@ -306,7 +311,9 @@ class DeactivationProtectionService:
             try:
                 uuids.append(UUID_type(wid))
             except ValueError:
-                logger.warning(f"Invalid workflow ID in deactivation list: {wid}")
+                logger.warning(
+                    f"Invalid workflow ID in deactivation list: {log_safe(wid)}"
+                )
                 continue
 
         if not uuids:
@@ -378,6 +385,9 @@ class DeactivationProtectionService:
         count = result.rowcount if result.rowcount else 0
 
         if count > 0:
-            logger.info(f"Deactivated {count} workflow(s) from {path} via force_deactivation")
+            logger.info(
+                f"Deactivated {count} workflow(s) from {log_safe(path)} "
+                f"via force_deactivation"
+            )
 
         return count

--- a/api/src/services/file_storage/diagnostics.py
+++ b/api/src/services/file_storage/diagnostics.py
@@ -11,6 +11,7 @@ from pathlib import Path
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from src.core.log_safety import log_safe
 from src.services.sdk_reference_scanner import SDKReferenceScanner
 from src.services.notification_service import get_notification_service
 from src.models.contracts.notifications import (
@@ -83,7 +84,7 @@ class DiagnosticsService:
             category=NotificationCategory.SYSTEM,
         )
         if existing:
-            logger.debug(f"SDK notification already exists for {path}")
+            logger.debug(f"SDK notification already exists for {log_safe(path)}")
             return
 
         # Build description with first few issues
@@ -116,7 +117,10 @@ class DiagnosticsService:
             initial_status=NotificationStatus.AWAITING_ACTION,
         )
 
-        logger.info(f"Created SDK issues notification for {path}: {len(issues)} issues")
+        logger.info(
+            f"Created SDK issues notification for {log_safe(path)}: "
+            f"{len(issues)} issues"
+        )
 
     async def clear_sdk_issues_notification(self, path: str) -> None:
         """
@@ -140,7 +144,7 @@ class DiagnosticsService:
         )
         if existing:
             await service.dismiss_notification(existing.id, user_id="system")
-            logger.info(f"Cleared SDK issues notification for {path}")
+            logger.info(f"Cleared SDK issues notification for {log_safe(path)}")
 
     async def create_diagnostic_notification(
         self, path: str, diagnostics: list[FileDiagnosticInfo]
@@ -171,7 +175,9 @@ class DiagnosticsService:
             category=NotificationCategory.SYSTEM,
         )
         if existing:
-            logger.debug(f"Diagnostic notification already exists for {path}")
+            logger.debug(
+                f"Diagnostic notification already exists for {log_safe(path)}"
+            )
             return
 
         # Build description from first few errors
@@ -206,7 +212,10 @@ class DiagnosticsService:
             initial_status=NotificationStatus.AWAITING_ACTION,
         )
 
-        logger.info(f"Created diagnostic notification for {path}: {len(errors)} errors")
+        logger.info(
+            f"Created diagnostic notification for {log_safe(path)}: "
+            f"{len(errors)} errors"
+        )
 
     async def clear_diagnostic_notification(self, path: str) -> None:
         """
@@ -230,7 +239,7 @@ class DiagnosticsService:
         )
         if existing:
             await service.dismiss_notification(existing.id, user_id="system")
-            logger.info(f"Cleared diagnostic notification for {path}")
+            logger.info(f"Cleared diagnostic notification for {log_safe(path)}")
 
     async def scan_for_unresolved_refs(
         self,
@@ -266,7 +275,9 @@ class DiagnosticsService:
             category=NotificationCategory.SYSTEM,
         )
         if existing:
-            logger.debug(f"Unresolved refs notification already exists for {path}")
+            logger.debug(
+                f"Unresolved refs notification already exists for {log_safe(path)}"
+            )
             return
 
         # Build description with first few refs
@@ -292,7 +303,10 @@ class DiagnosticsService:
             initial_status=NotificationStatus.AWAITING_ACTION,
         )
 
-        logger.info(f"Created unresolved refs notification for {path}: {len(unresolved_refs)} refs")
+        logger.info(
+            f"Created unresolved refs notification for {log_safe(path)}: "
+            f"{len(unresolved_refs)} refs"
+        )
 
     async def clear_unresolved_refs_notification(self, path: str) -> None:
         """
@@ -316,4 +330,6 @@ class DiagnosticsService:
         )
         if existing:
             await service.dismiss_notification(existing.id, user_id="system")
-            logger.info(f"Cleared unresolved refs notification for {path}")
+            logger.info(
+                f"Cleared unresolved refs notification for {log_safe(path)}"
+            )

--- a/api/src/services/file_storage/file_ops.py
+++ b/api/src/services/file_storage/file_ops.py
@@ -14,6 +14,7 @@ from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.config import Settings
+from src.core.log_safety import log_safe
 from src.models import Workflow
 from src.models.orm.file_index import FileIndex
 from src.core.module_cache import set_module, invalidate_module
@@ -253,7 +254,10 @@ class FileOperationsService:
             try:
                 await self._diagnostics.scan_for_sdk_issues(path, final_content)
             except Exception as e:
-                logger.warning(f"Failed to scan for SDK issues in {path}: {e}")
+                logger.warning(
+                    f"Failed to scan for SDK issues in {log_safe(path)}: "
+                    f"{log_safe(e)}"
+                )
 
         # Create or clear system notification based on diagnostic errors
         has_errors = diagnostics and any(d.severity == "error" for d in diagnostics)
@@ -261,18 +265,24 @@ class FileOperationsService:
             try:
                 await self._diagnostics.create_diagnostic_notification(path, diagnostics)
             except Exception as e:
-                logger.warning(f"Failed to create diagnostic notification for {path}: {e}")
+                logger.warning(
+                    "Failed to create diagnostic notification for "
+                    f"{log_safe(path)}: {log_safe(e)}"
+                )
         else:
             try:
                 await self._diagnostics.clear_diagnostic_notification(path)
             except Exception as e:
-                logger.warning(f"Failed to clear diagnostic notification for {path}: {e}")
+                logger.warning(
+                    "Failed to clear diagnostic notification for "
+                    f"{log_safe(path)}: {log_safe(e)}"
+                )
 
         # App files: rebuild bundle + fire pubsub for real-time preview
         app = await self._find_app_by_path(path)
         if not app and path.startswith("apps/"):
             logger.info(
-                f"No Application matched path {path!r} — preview refresh skipped. "
+                f"No Application matched path {log_safe(path)!r} — preview refresh skipped. "
                 f"Check Application.repo_path."
             )
         if app:
@@ -299,9 +309,14 @@ class FileOperationsService:
                 session_id=get_request_session_id(),
             )
         except Exception as e:
-            logger.warning(f"Failed to publish file_push for {path}: {e}")
+            logger.warning(
+                f"Failed to publish file_push for {log_safe(path)}: {log_safe(e)}"
+            )
 
-        logger.info(f"File written: {path} ({size_bytes} bytes) by {updated_by}")
+        logger.info(
+            f"File written: {log_safe(path)} ({size_bytes} bytes) by "
+            f"{log_safe(updated_by)}"
+        )
         return WriteResult(
             file_record=None,
             final_content=final_content,
@@ -358,7 +373,9 @@ class FileOperationsService:
             try:
                 await op(path)
             except Exception as e:
-                logger.warning(f"Delete side effect failed for {path}: {e}")
+                logger.warning(
+                    f"Delete side effect failed for {log_safe(path)}: {log_safe(e)}"
+                )
 
         # Broadcast file_delete event for watch mode sync
         try:
@@ -373,9 +390,11 @@ class FileOperationsService:
                 session_id=get_request_session_id(),
             )
         except Exception as e:
-            logger.warning(f"Failed to publish file_delete for {path}: {e}")
+            logger.warning(
+                f"Failed to publish file_delete for {log_safe(path)}: {log_safe(e)}"
+            )
 
-        logger.info(f"File deleted: {path}")
+        logger.info(f"File deleted: {log_safe(path)}")
 
     async def _delete_from_s3(self, path: str) -> None:
         """Delete from S3 _repo/ — source-of-truth operation."""
@@ -529,10 +548,14 @@ class FileOperationsService:
             try:
                 await self._diagnostics.clear_diagnostic_notification(path)
             except Exception as e:
-                logger.warning(f"Failed to clear bundler diagnostic for {path}: {e}")
+                logger.warning(
+                    "Failed to clear bundler diagnostic for "
+                    f"{log_safe(path)}: {log_safe(e)}"
+                )
             logger.info(
-                f"App bundle rebuilt: app={app_id} path={relative_path} "
-                f"entry={m.entry} duration_ms={m.duration_ms}"
+                f"App bundle rebuilt: app={log_safe(app_id)} "
+                f"path={log_safe(relative_path)} entry={log_safe(m.entry)} "
+                f"duration_ms={m.duration_ms}"
             )
         else:
             errors = result.errors or []
@@ -569,19 +592,23 @@ class FileOperationsService:
                     target_path, diagnostics
                 )
             except Exception as e:
-                logger.warning(f"Failed to create bundler diagnostic for {path}: {e}")
+                logger.warning(
+                    "Failed to create bundler diagnostic for "
+                    f"{log_safe(path)}: {log_safe(e)}"
+                )
             first = errors[0] if errors else None
             first_file = first.file if first else None
             first_line = first.line if first else None
             first_col = first.column if first else None
             first_msg = first.text if first else ""
             logger.warning(
-                f"App bundle BUILD FAILED: app={app_id} path={relative_path} "
+                f"App bundle BUILD FAILED: app={log_safe(app_id)} "
+                f"path={log_safe(relative_path)} "
                 f"errors={len(errors)} "
-                f"first_file={first_file!r} "
+                f"first_file={log_safe(first_file)!r} "
                 f"first_line={first_line} "
                 f"first_col={first_col} "
-                f"first_msg={first_msg!r}"
+                f"first_msg={log_safe(first_msg)!r}"
             )
 
         try:
@@ -661,7 +688,10 @@ class FileOperationsService:
                     Key=old_s3_key,
                 )
             except Exception as e:
-                logger.warning(f"S3 move failed for {old_path} -> {new_path}: {e}")
+                logger.warning(
+                    f"S3 move failed for {log_safe(old_path)} -> "
+                    f"{log_safe(new_path)}: {log_safe(e)}"
+                )
 
         # Update file_index: insert new path, delete old
         new_stmt = insert(FileIndex).values(
@@ -685,4 +715,6 @@ class FileOperationsService:
         del_stmt = delete(FileIndex).where(FileIndex.path == old_path)
         await self.db.execute(del_stmt)
 
-        logger.info(f"File moved: {old_path} -> {new_path}")
+        logger.info(
+            f"File moved: {log_safe(old_path)} -> {log_safe(new_path)}"
+        )

--- a/api/src/services/file_storage/service.py
+++ b/api/src/services/file_storage/service.py
@@ -14,6 +14,7 @@ from uuid import UUID
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.config import Settings, get_settings
+from src.core.log_safety import log_safe
 from .models import (
     WriteResult,
     WorkflowIdConflictInfo,
@@ -476,7 +477,10 @@ class FileStorageService:
                         )
                         if pending:
                             return content, False, False, None, [], pending, available
-                    logger.info(f"Skipping indexing for module without decorators: {path}")
+                    logger.info(
+                        "Skipping indexing for module without decorators: "
+                        f"{log_safe(path)}"
+                    )
                     return content, False, False, None, [], None, None
 
                 # Python files with decorators: do deactivation check then index
@@ -486,7 +490,9 @@ class FileStorageService:
                     workflows_to_deactivate=workflows_to_deactivate,
                 )
         except Exception as e:
-            logger.warning(f"Failed to extract metadata from {path}: {e}")
+            logger.warning(
+                f"Failed to extract metadata from {log_safe(path)}: {log_safe(e)}"
+            )
 
         return content, False, False, None, [], None, None
 
@@ -533,7 +539,9 @@ class FileStorageService:
             try:
                 tree = ast.parse(content_str, filename=path)
             except SyntaxError as e:
-                logger.warning(f"Syntax error parsing {path}: {e}")
+                logger.warning(
+                    f"Syntax error parsing {log_safe(path)}: {log_safe(e)}"
+                )
                 diagnostics.append(FileDiagnosticInfo(
                     severity="error",
                     message=f"Syntax error: {e.msg}" if e.msg else str(e),

--- a/api/src/services/sdk_reference_scanner.py
+++ b/api/src/services/sdk_reference_scanner.py
@@ -17,6 +17,7 @@ from typing import Literal
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from src.core.log_safety import log_safe
 from src.models.orm import Config, Integration, IntegrationMapping
 
 logger = logging.getLogger(__name__)
@@ -190,7 +191,10 @@ class SDKReferenceScanner:
                     issue_type="config",
                     key=key,
                 ))
-                logger.debug(f"Missing config reference: {key} at {path}:{line_num}")
+                logger.debug(
+                    f"Missing config reference: {log_safe(key)} at "
+                    f"{log_safe(path)}:{line_num}"
+                )
 
         # Validate integration references
         if integration_refs:
@@ -204,10 +208,15 @@ class SDKReferenceScanner:
                     issue_type="integration",
                     key=name,
                 ))
-                logger.debug(f"Missing integration reference: {name} at {path}:{line_num}")
+                logger.debug(
+                    f"Missing integration reference: {log_safe(name)} at "
+                    f"{log_safe(path)}:{line_num}"
+                )
 
         if issues:
-            logger.info(f"Found {len(issues)} SDK issue(s) in {path}")
+            logger.info(
+                f"Found {len(issues)} SDK issue(s) in {log_safe(path)}"
+            )
 
         return issues
 

--- a/api/tests/unit/test_log_injection_boundaries.py
+++ b/api/tests/unit/test_log_injection_boundaries.py
@@ -1,0 +1,138 @@
+"""Regression tests for externally influenced values at logging boundaries."""
+
+import logging
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+def _assert_sanitized(message: str) -> None:
+    assert "\n" not in message
+    assert "\r" not in message
+    assert "\x1b" not in message
+
+
+@pytest.mark.asyncio
+async def test_module_cache_sanitizes_path_in_log(monkeypatch, caplog):
+    from src.core import module_cache
+
+    redis_connection = MagicMock()
+    redis_connection.sadd = AsyncMock(return_value=1)
+    redis = MagicMock()
+    redis.setex = AsyncMock()
+    redis._get_redis = AsyncMock(return_value=redis_connection)
+    monkeypatch.setattr(module_cache, "get_redis_client", lambda: redis)
+
+    path = "workflows/example.py\nFORGED\x1b[31m"
+    with caplog.at_level(logging.DEBUG, logger=module_cache.__name__):
+        await module_cache.set_module(path, "content", "hash")
+
+    message = caplog.messages[-1]
+    _assert_sanitized(message)
+    assert "example.py\\nFORGED" in message
+
+
+@pytest.mark.asyncio
+async def test_deactivation_sanitizes_invalid_workflow_id(caplog):
+    from src.services.file_storage import deactivation
+
+    service = deactivation.DeactivationProtectionService(AsyncMock())
+    workflow_id = "invalid\nFORGED\x1b[31m"
+
+    with caplog.at_level(logging.WARNING, logger=deactivation.__name__):
+        await service.apply_workflow_replacements({workflow_id: "replacement"})
+
+    message = caplog.messages[-1]
+    _assert_sanitized(message)
+    assert "invalid\\nFORGED" in message
+
+
+@pytest.mark.asyncio
+async def test_diagnostics_sanitizes_file_path(monkeypatch, caplog):
+    from src.services.file_storage import diagnostics
+
+    notification_service = MagicMock()
+    notification_service.find_admin_notification_by_title = AsyncMock(
+        return_value=SimpleNamespace(id="notification-id")
+    )
+    notification_service.dismiss_notification = AsyncMock()
+    monkeypatch.setattr(
+        diagnostics,
+        "get_notification_service",
+        lambda: notification_service,
+    )
+
+    path = "workflows/example.py\nFORGED\x1b[31m"
+    service = diagnostics.DiagnosticsService(AsyncMock())
+    with caplog.at_level(logging.INFO, logger=diagnostics.__name__):
+        await service.clear_diagnostic_notification(path)
+
+    message = caplog.messages[-1]
+    _assert_sanitized(message)
+    assert "example.py\\nFORGED" in message
+
+
+@pytest.mark.asyncio
+async def test_file_ops_sanitizes_deleted_path(monkeypatch, caplog):
+    from src.core import pubsub
+    from src.services.file_storage import file_ops
+
+    service = file_ops.FileOperationsService(
+        db=AsyncMock(),
+        settings=SimpleNamespace(s3_bucket="test"),
+        s3_client=MagicMock(),
+        diagnostics=MagicMock(),
+        deactivation=MagicMock(),
+        file_hash_fn=lambda content: "hash",
+        content_type_fn=lambda path: "text/plain",
+        platform_entity_detector_fn=lambda path, content: None,
+        extract_metadata_fn=AsyncMock(),
+        remove_metadata_fn=AsyncMock(),
+    )
+    monkeypatch.setattr(service, "_delete_from_s3", AsyncMock())
+    monkeypatch.setattr(service, "_remove_from_search_index", AsyncMock())
+    monkeypatch.setattr(service, "_handle_app_file_cleanup", AsyncMock())
+    monkeypatch.setattr(service, "_invalidate_module_cache_if_python", AsyncMock())
+    monkeypatch.setattr(pubsub, "publish_file_activity", AsyncMock())
+
+    path = "workflows/example.py\nFORGED\x1b[31m"
+    with caplog.at_level(logging.INFO, logger=file_ops.__name__):
+        await service.delete_file(path)
+
+    message = caplog.messages[-1]
+    _assert_sanitized(message)
+    assert "example.py\\nFORGED" in message
+
+
+@pytest.mark.asyncio
+async def test_file_storage_sanitizes_syntax_error_path(caplog):
+    from src.services.file_storage import service as file_storage
+
+    storage = object.__new__(file_storage.FileStorageService)
+    path = "workflows/example.py\nFORGED\x1b[31m"
+
+    with caplog.at_level(logging.WARNING, logger=file_storage.__name__):
+        await storage._index_python_file_full(path, b"def broken(")
+
+    message = caplog.messages[-1]
+    _assert_sanitized(message)
+    assert "example.py\\nFORGED" in message
+
+
+@pytest.mark.asyncio
+async def test_sdk_scanner_sanitizes_reference_and_path(caplog):
+    from src.services import sdk_reference_scanner
+
+    scanner = sdk_reference_scanner.SDKReferenceScanner(AsyncMock())
+    scanner.get_all_config_keys = AsyncMock(return_value=set())
+    key = "danger\x1b[31m"
+    path = "workflows/example.py\nFORGED"
+
+    with caplog.at_level(logging.DEBUG, logger=sdk_reference_scanner.__name__):
+        await scanner.scan_file(path, f'config.get("{key}")')
+
+    for message in caplog.messages:
+        _assert_sanitized(message)
+    assert any("example.py\\nFORGED" in message for message in caplog.messages)
+    assert any("danger" in message for message in caplog.messages)


### PR DESCRIPTION
## Summary
- sanitize all 33 live CodeQL py/log-injection callsites in the approved six file-service modules
- use the existing log_safe boundary helper for paths, identifiers, exception strings, and bundler diagnostics
- add runtime regression coverage for newline and terminal-escape injection across each module boundary

## Verification
- focused sanitizer and boundary tests: 26 passed
- API quality: Pyright 0 errors; Ruff passed
- full backend suite: 7,165 passed, 57 skipped, with two order-dependent state-pollution cases
- both anomalous cases passed independently after clean automatic resets (1/1 each)

GitHub CodeQL on this PR/default branch is the final alert-resolution gate.