### PR TITLE
fix(security): patch brace-expansion advisory

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -2839,9 +2839,9 @@
 			}
 		},
 		"node_modules/@redocly/openapi-core/node_modules/brace-expansion": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.3.tgz",
-			"integrity": "sha512-DRdx5neNsG/QXbniLFWi2YmC/68oeOOmKz6zOjVk6ZS1ZLXgLIKqVEc6hWsmkjBbgii0SwaBTcJ5XKj5gzY/4A==",
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+			"integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -4636,9 +4636,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-			"version": "5.0.8",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-			"integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+			"version": "5.0.9",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+			"integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -5171,9 +5171,9 @@
 			"license": "MIT"
 		},
 		"node_modules/brace-expansion": {
-			"version": "1.1.17",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.17.tgz",
-			"integrity": "sha512-w+aeW/mkgM4PyRMOJCgi3fOrTm5Q8QY1OSfn2TO2iuDj3ezIHqejmuxbjfPrqUkgqRew1iqkyAn0tr0ZwHD9+w==",
+			"version": "1.1.18",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+			"integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {

--- a/client/package.json
+++ b/client/package.json
@@ -135,8 +135,9 @@
 	},
 	"overrides": {
 		"@babel/core@<7.29.6": "7.29.6",
-		"brace-expansion@<1.1.17": "1.1.17",
-		"brace-expansion@>=2 <2.1.3": "2.1.3",
+		"brace-expansion@<1.1.18": "1.1.18",
+		"brace-expansion@>=2 <2.1.4": "2.1.4",
+		"brace-expansion@>=4 <5.0.9": "5.0.9",
 		"dompurify": "^3.4.12",
 		"js-yaml@>=4 <4.3.0": "4.3.0"
 	}


### PR DESCRIPTION
## Summary
- update brace-expansion 1.x to 1.1.18
- update brace-expansion 2.x to 2.1.4
- add an override for the vulnerable 4.x/5.x range at 5.0.9
- remediate GHSA-rgw5-rvv9-x895, which Scorecard detected before Dependabot/npm indexed it

## Verification
- clean Node 26 npm install passed
- npm ls confirms every installed brace-expansion line is patched
- full client suite: 229 files, 1,663 tests passed
- TypeScript passed
- ESLint passed
- npm audit now reports only the reviewed React Router RSC-only advisory