### PR TITLE
Fix sharing for Solution-managed forms

### DIFF
--- a/api/src/routers/forms.py
+++ b/api/src/routers/forms.py
@@ -604,6 +604,7 @@ async def publish_form(
 
     now = datetime.now(timezone.utc)
     publication = form.publication
+    publication_is_new = publication is None
     if publication is None:
         publication = FormPublicationORM(
             form_id=form.id,
@@ -617,7 +618,11 @@ async def publish_form(
             updated_at=now,
         )
         db.add(publication)
-        form.publication = publication
+        # The publication is environment-owned operational state, even when
+        # its parent form is managed by a Solution. Assigning the scalar
+        # relationship here marks the parent Form dirty and trips the
+        # solution-managed write guard during flush. Persist by foreign key,
+        # then reload the relationship without mutating the managed form.
     else:
         publication.allowed_origins = allowed_origins
         publication.approved_fingerprint = review.fingerprint
@@ -626,6 +631,8 @@ async def publish_form(
         publication.updated_at = now
 
     await db.flush()
+    if publication_is_new:
+        await db.refresh(form, attribute_names=["publication"])
     logger.info(
         "Public form publication enabled",
         extra={

--- a/api/tests/e2e/api/test_form_publication.py
+++ b/api/tests/e2e/api/test_form_publication.py
@@ -1,10 +1,15 @@
 """E2E coverage for public form publication approval and lifecycle."""
 
+import uuid
+from uuid import UUID
+
 import altcha
 import pytest
 
 from src.core.security import decode_token
+from src.services.solutions.deploy import solution_entity_id
 from tests.e2e.conftest import write_and_register
+from tests.e2e.platform.conftest import deploy_solution
 
 
 def _solve_public_captcha(e2e_client, form_id: str, headers: dict[str, str]) -> str:
@@ -204,6 +209,91 @@ async def e2e_public_form_submit(
         assert final_state.status_code == 200, final_state.text
         assert final_state.json()["status"] == "unpublished"
         assert final_state.json()["iframe_path"] is None
+
+    def test_first_publication_of_solution_managed_form(
+        self, e2e_client, platform_admin
+    ):
+        headers = platform_admin.headers
+        suffix = uuid.uuid4().hex[:8]
+        solution = e2e_client.post(
+            "/api/solutions",
+            headers=headers,
+            json={
+                "slug": f"public-form-{suffix}",
+                "name": f"Public Form {suffix}",
+                "organization_id": None,
+            },
+        )
+        assert solution.status_code in (200, 201), solution.text
+        solution_id = solution.json()["id"]
+
+        workflow_id = uuid.uuid4()
+        form_id = uuid.uuid4()
+        deployed = deploy_solution(
+            e2e_client,
+            solution_id,
+            headers,
+            {
+                "python_files": {
+                    "workflows/public_form.py": (
+                        "from bifrost import workflow\n\n"
+                        "@workflow\n"
+                        "async def public_form(email: str | None = None):\n"
+                        "    return {'received': bool(email)}\n"
+                    )
+                },
+                "workflows": [
+                    {
+                        "id": str(workflow_id),
+                        "name": f"public_form_{suffix}",
+                        "function_name": "public_form",
+                        "path": "workflows/public_form.py",
+                        "type": "workflow",
+                    }
+                ],
+                "forms": [
+                    {
+                        "id": str(form_id),
+                        "name": f"Public Form {suffix}",
+                        "workflow_id": str(workflow_id),
+                        "access_level": "authenticated",
+                        "form_schema": {
+                            "fields": [
+                                {
+                                    "name": "email",
+                                    "label": "Email",
+                                    "type": "email",
+                                    "required": True,
+                                }
+                            ]
+                        },
+                    }
+                ],
+            },
+        )
+        assert deployed.status_code in (200, 201), deployed.text
+
+        managed_form_id = solution_entity_id(UUID(solution_id), form_id)
+        review_response = e2e_client.get(
+            f"/api/forms/{managed_form_id}/publication-review",
+            headers=headers,
+        )
+        assert review_response.status_code == 200, review_response.text
+        review = review_response.json()
+        assert review["blockers"] == []
+
+        published = e2e_client.put(
+            f"/api/forms/{managed_form_id}/publication",
+            headers=headers,
+            json={
+                "reviewed_fingerprint": review["fingerprint"],
+                "allowed_origins": ["https://example.com"],
+            },
+        )
+        assert published.status_code == 200, published.text
+        body = published.json()
+        assert body["status"] == "published"
+        assert body["iframe_path"].endswith(body["public_key"])
 
     def test_public_session_is_exact_form_confirmation_only_and_revocable(
         self, e2e_client, platform_admin, publishable_form

--- a/client/e2e/solution-runtime-contract.admin.spec.ts
+++ b/client/e2e/solution-runtime-contract.admin.spec.ts
@@ -1,8 +1,8 @@
 /**
  * Golden deployed-app runtime-scope contract (Chromium, real deploy).
  *
- * Deploys a Solution workspace zip (workflow + table + file location) with a
- * standalone_v2 app whose entry module uses ONLY the transport contract —
+ * Deploys a Solution workspace zip (workflow + form + table + file location)
+ * with a standalone_v2 app whose entry module uses ONLY the transport contract —
  * Authorization + X-Bifrost-App headers, a portable path::fn workflow ref,
  * no UUIDs, no body app_id — and asserts workflow, table, and file access
  * all resolve the install's own resources in a real browser.
@@ -11,7 +11,8 @@
  * data plane (workflows, tables, files) previously derived install scope its
  * own way, so deployed apps worked for UUID workflow refs but 404'd portable
  * refs. The contract is: auth derives ctx.solution_id from the transport;
- * every resolver reads the context. See
+ * every resolver reads the context. The same deployed install also proves that
+ * read-only forms expose their environment-owned Share dialog. See
  * api/src/repositories/README.md ("How the install id is DERIVED").
  */
 
@@ -21,12 +22,13 @@ const UNIQUE = `${Date.now().toString(36)}${Math.floor(Math.random() * 1e4)}`;
 const SLUG = `runtime-contract-${UNIQUE}`;
 const APP_SLUG = `app-${SLUG}`;
 const TABLE_NAME = `runtime_items_${UNIQUE}`;
+const FORM_NAME = `Runtime Form ${UNIQUE}`;
 
 const WORKFLOW_PY = [
 	"from bifrost import tables, workflow",
 	"",
 	"@workflow",
-	"async def main():",
+	"async def main(email: str | None = None):",
 	`    await tables.upsert(${JSON.stringify(TABLE_NAME)}, id='probe-row', data={'k': 'v'})`,
 	"    return {'marker': 'golden'}",
 	"",
@@ -167,6 +169,7 @@ function workspaceZip(): Buffer {
 	const workflowId = crypto.randomUUID();
 	const tableId = crypto.randomUUID();
 	const appId = crypto.randomUUID();
+	const formId = crypto.randomUUID();
 	return buildZip([
 		{
 			path: "bifrost.solution.yaml",
@@ -209,6 +212,29 @@ function workspaceZip(): Buffer {
 			content: JSON.stringify({ locations: ["docs"] }),
 		},
 		{
+			path: ".bifrost/forms.yaml",
+			content: JSON.stringify({
+				forms: {
+					[formId]: {
+						id: formId,
+						name: FORM_NAME,
+						workflow_id: workflowId,
+						access_level: "authenticated",
+						form_schema: {
+							fields: [
+								{
+									name: "email",
+									label: "Email",
+									type: "email",
+									required: true,
+								},
+							],
+						},
+					},
+				},
+			}),
+		},
+		{
 			path: ".bifrost/apps.yaml",
 			content: JSON.stringify({
 				apps: {
@@ -247,7 +273,7 @@ test.describe("deployed solution runtime contract", () => {
 		createdSolutionId = null;
 	});
 
-	test("workflow/table/file resolve via the header contract in the browser", async ({
+	test("runtime resources resolve and solution forms expose sharing", async ({
 		page,
 		api,
 	}) => {
@@ -308,5 +334,24 @@ test.describe("deployed solution runtime contract", () => {
 		});
 		await expect(page.getByTestId("table-result")).toHaveText(/rows:[1-9]/);
 		await expect(page.getByTestId("file-result")).toHaveText("ok");
+
+		// Solution-managed forms remain read-only, but their environment-owned
+		// sharing controls are available directly from the Solution contents.
+		await page.goto(`/solutions/${sid}`);
+		await expect(page.getByTestId("solution-detail")).toBeVisible({
+			timeout: 15_000,
+		});
+		await page.getByTestId("tab-contents").click();
+		await page.getByTestId("chip-forms").click();
+		await page
+			.getByRole("button", { name: `${FORM_NAME} actions` })
+			.click();
+		await page.getByRole("menuitem", { name: "Share Form" }).click();
+		await expect(
+			page.getByRole("heading", { name: `Share ${FORM_NAME}` }),
+		).toBeVisible();
+		await expect(
+			page.getByRole("tab", { name: "Website Embed" }),
+		).toBeVisible();
 	});
 });

--- a/client/src/pages/SolutionDetail.test.tsx
+++ b/client/src/pages/SolutionDetail.test.tsx
@@ -47,6 +47,12 @@ vi.mock("@/components/files/FilesExplorer", () => ({
 	},
 }));
 
+vi.mock("@/components/forms/FormShareDialog", () => ({
+	FormShareDialog: ({ formName }: { formName: string }) => (
+		<div role="dialog">Share {formName}</div>
+	),
+}));
+
 const mockGetSolutionEntities = vi.fn();
 const mockGetSolutionSetup = vi.fn();
 const mockUpdateSolution = vi.fn();
@@ -548,6 +554,31 @@ describe("SolutionDetail", () => {
 			await user.click(screen.getByRole("button", { name: /launch/i }));
 			expect(mockNavigate).toHaveBeenCalledWith(
 				"/execute/form-1?from=solution:sol-1",
+			);
+		});
+
+		it("opens sharing for a solution-managed form without exposing edit controls", async () => {
+			const { user } = await renderPage();
+			await screen.findByTestId("solution-detail");
+
+			await user.click(screen.getByTestId("tab-contents"));
+			await user.click(screen.getByTestId("chip-forms"));
+			await user.click(
+				screen.getByRole("button", { name: "Ticket Intake actions" }),
+			);
+
+			expect(
+				screen.getByRole("menuitem", { name: "Share Form" }),
+			).toBeInTheDocument();
+			expect(
+				screen.queryByRole("menuitem", { name: "Edit Form" }),
+			).not.toBeInTheDocument();
+
+			await user.click(
+				screen.getByRole("menuitem", { name: "Share Form" }),
+			);
+			expect(screen.getByRole("dialog")).toHaveTextContent(
+				"Share Ticket Intake",
 			);
 		});
 

--- a/client/src/pages/SolutionDetail.tsx
+++ b/client/src/pages/SolutionDetail.tsx
@@ -68,6 +68,7 @@ import {
 	type FormListItem,
 	type FormValidationState,
 } from "@/components/forms/FormListSurface";
+import { FormShareDialog } from "@/components/forms/FormShareDialog";
 import {
 	WorkflowListSurface,
 	type WorkflowListItem,
@@ -900,6 +901,10 @@ function EntityTabContent({
 }) {
 	const navigate = useNavigate();
 	const [search, setSearch] = useState("");
+	const [shareForm, setShareForm] = useState<{
+		id: string;
+		name: string;
+	} | null>(null);
 	const canToggleView = GRID_TABLE_ENTITY_TABS.has(kind);
 	const [viewMode, setViewMode] = useState<"grid" | "table">(
 		canToggleView ? "grid" : "table",
@@ -1025,18 +1030,35 @@ function EntityTabContent({
 						emptySearchActive={Boolean(search.trim())}
 					/>
 				) : kind === "forms" ? (
-					<FormListSurface
-						forms={managedVisible as FormListItem[]}
-						viewMode={viewMode}
-						isPlatformAdmin={false}
-						canManageForms={true}
-						getOrgName={() => "Solution"}
-						formValidation={formValidation}
-						onLaunch={(form) =>
-							navigate(`/execute/${form.id}?from=solution:${solutionId}`)
-						}
-						emptySearchActive={Boolean(search.trim())}
-					/>
+					<>
+						<FormListSurface
+							forms={managedVisible as FormListItem[]}
+							viewMode={viewMode}
+							isPlatformAdmin={false}
+							canManageForms={true}
+							getOrgName={() => "Solution"}
+							formValidation={formValidation}
+							onLaunch={(form) =>
+								navigate(
+									`/execute/${form.id}?from=solution:${solutionId}`,
+								)
+							}
+							onShare={(form) =>
+								setShareForm({ id: form.id, name: form.name })
+							}
+							emptySearchActive={Boolean(search.trim())}
+						/>
+						{shareForm ? (
+							<FormShareDialog
+								formId={shareForm.id}
+								formName={shareForm.name}
+								open
+								onOpenChange={(open) =>
+									!open && setShareForm(null)
+								}
+							/>
+						) : null}
+					</>
 				) : viewMode === "grid" ? (
 					<SolutionEntityGrid
 						kind={kind}


### PR DESCRIPTION
## Summary

- expose Share for Solution-managed forms from Solution Contents while keeping them read-only
- allow the first publication of a Solution-managed form without tripping the managed-entity write guard
- cover the API regression, Solution detail UI, and real deployed-Solution embed journey

## Root cause

Creating a form publication assigned the new relationship object back to the managed parent form. SQLAlchemy consequently treated the parent as dirty, and the Solution-managed write guard rejected the publish request even though only the publication record should have changed.

## Validation

- API quality: Pyright and Ruff clean
- backend: 7,291 passed, 7 skipped; post-rebase unit gate 5,451 passed, 3 skipped
- frontend unit: 1,698 passed; focused Solution detail suite 34/34
- Playwright: new deployed-Solution Share → Website Embed journey passed
- TypeScript: `tsc` clean; ESLint clean apart from one existing warning

## Documentation

A focused Forms Sharing documentation PR is being prepared in parallel, covering private links, HMAC embeds, public website embeds, and Solution-managed forms.
