### PR TITLE
Fix public form execution attribution

### DIFF
--- a/api/src/core/security.py
+++ b/api/src/core/security.py
@@ -248,6 +248,7 @@ def create_embed_access_token(
     grant: Literal["hmac", "public"],
     resource_id: str,
     org_id: str | None,
+    display_name: str | None = None,
     verified_context: dict[str, str] | None = None,
     capability_fingerprint: str | None = None,
     expires_delta: timedelta = timedelta(hours=8),
@@ -270,6 +271,8 @@ def create_embed_access_token(
         "roles": ["EmbedUser"],
     }
     data[f"{embed_kind}_id"] = resource_id
+    if display_name is not None:
+        data["name"] = display_name
     if verified_context:
         data["verified_context"] = verified_context
         if embed_kind == "app":

--- a/api/src/routers/embed.py
+++ b/api/src/routers/embed.py
@@ -200,6 +200,7 @@ async def embed_public_form(request: Request, public_key: str = Path(...)):
             if publication.form.organization_id
             else None
         ),
+        display_name=f"Public Form · {publication.form.name}",
         verified_context={},
         capability_fingerprint=fingerprint,
         expires_delta=timedelta(minutes=30),

--- a/api/tests/e2e/api/test_form_publication.py
+++ b/api/tests/e2e/api/test_form_publication.py
@@ -4,7 +4,7 @@ import altcha
 import pytest
 
 from src.core.security import decode_token
-from tests.e2e.conftest import write_and_register
+from tests.e2e.conftest import poll_until, write_and_register
 
 
 def _solve_public_captcha(e2e_client, form_id: str, headers: dict[str, str]) -> str:
@@ -234,6 +234,7 @@ async def e2e_public_form_submit(
         assert claims["embed_kind"] == "form"
         assert claims["grant"] == "public"
         assert claims["form_id"] == form_id
+        assert claims["name"] == "Public Form · Public form lifecycle"
         assert claims["capability_fingerprint"] == review["fingerprint"]
         headers = {"Authorization": f"Bearer {token}"}
 
@@ -328,6 +329,33 @@ async def e2e_public_form_submit(
             "status": "accepted",
             "confirmation_markdown": "## All set\n\nWe received it.",
         }
+
+        def find_history_execution():
+            response = e2e_client.get(
+                "/api/executions",
+                params={"workflowId": publishable_form["workflow_id"]},
+                headers=platform_admin.headers,
+            )
+            assert response.status_code == 200, response.text
+            return next(
+                (
+                    execution
+                    for execution in response.json()["executions"]
+                    if execution["form_id"] == form_id
+                ),
+                None,
+            )
+
+        history_execution = poll_until(
+            find_history_execution,
+            max_wait=30.0,
+            interval=0.2,
+        )
+        assert history_execution is not None
+        assert history_execution["executed_by_name"] == (
+            "Public Form · Public form lifecycle"
+        )
+
         duplicate = e2e_client.post(
             f"/api/forms/{form_id}/submissions",
             headers=headers,

--- a/api/tests/unit/core/test_embed_token.py
+++ b/api/tests/unit/core/test_embed_token.py
@@ -56,6 +56,7 @@ class TestEmbedAccessToken:
             grant="public",
             resource_id=str(uuid4()),
             org_id=str(uuid4()),
+            display_name="Public Form · Contact us",
             verified_context={},
             capability_fingerprint=fingerprint,
         )
@@ -63,4 +64,5 @@ class TestEmbedAccessToken:
         payload = decode_token(token, expected_type="access")
         assert payload is not None
         assert payload["grant"] == "public"
+        assert payload["name"] == "Public Form · Contact us"
         assert payload["capability_fingerprint"] == fingerprint


### PR DESCRIPTION
## Summary
- give anonymous public-form capability tokens a meaningful display identity
- persist `Public Form · <form name>` through the existing execution pipeline
- verify the public submission appears with that attribution in History

## Testing
- `./test.sh tests/unit/core/test_embed_token.py -vv` (3 passed)
- `./test.sh tests/e2e/api/test_form_publication.py::TestFormPublication::test_public_session_is_exact_form_confirmation_only_and_revocable -vv` (1 passed)
- `./test.sh quality api`
- `npm run generate:types`
- `npm run tsc`
- `npm run lint` (0 errors; 1 existing warning)
- isolated full-suite failures: backend 3/3 passed after clean reset; client 23/23 passed in isolation

## Full-suite note
`./test.sh all` completed with 7,291 passed, 7 skipped, and three unrelated suite-order state-pollution failures in chat, knowledge, and OAuth tests. Each failing backend test passed together after a clean reset. `./test.sh client unit` completed with 1,695 passed and three unrelated timeout failures; both affected files passed in isolation (23/23).

Fixes #561