### PR TITLE
Adopt scoped local test verification

### DIFF
--- a/.claude/skills/bifrost-testing/SKILL.md
+++ b/.claude/skills/bifrost-testing/SKILL.md
@@ -9,11 +9,11 @@ Workflow for running and writing tests in Bifrost. Covers: stack lifecycle, whic
 
 ## Hard Rules (Non-Negotiable)
 
-1. **Never leave tests failing.** A red test means work is not done. Fix the test or fix the code under test. Never commit or claim completion with failing tests.
+1. **Never wave away a known failure.** Every test selected for the change must pass. A failure discovered by a broader local or CI run must receive a durable disposition under "Known failures outside the scoped run" below; "unrelated" and "flaky" are diagnoses to investigate, not permission to ignore it.
 
 2. **Never skip tests as a shortcut.** No `@pytest.mark.skip`, `pytest.skip()`, `test.skip()`, `test.only()`, `it.skip()`, `xfail`, or commenting a test out to silence it. A skipped test must be either **fixed** or **deleted** — and delete only if the test is genuinely no longer useful (feature removed, behavior moved, truly redundant). "I'll come back to it" is not a valid reason to skip.
 
-3. **Flaky ≠ add retries.** Per the user's memory on flaky tests (`feedback_flaky_tests.md`), E2E flakes are always state pollution from a prior test. Find the dirty state. Do not add retries, do not increase timeouts, do not re-run until green.
+3. **Flaky is a symptom, not a disposition.** Intermittent failures have previously exposed real product races as well as leaked test state. Find the cause. Do not add retries, increase timeouts, or re-run until green.
 
 4. **No silencing.** If a test is noisy, fix the source or delete the test. Don't filter output, don't swallow the failure.
 
@@ -62,16 +62,20 @@ If `DOWN` → `./test.sh stack up`. Each worktree runs its own isolated stack (C
 - Backend with live services → `./test.sh e2e` (or `./test.sh tests/e2e/test_foo.py -v`)
 - React component behavior → `./test.sh client unit` (vitest on host, no stack needed)
 - Full user flow through UI → `./test.sh client e2e`
-- Everything (like CI) → `./test.sh all` (backend) + `./test.sh client unit` + `./test.sh client e2e`
+- All available suites (manual broad run) → `./test.sh all` (backend) + `./test.sh client unit` + `./test.sh client e2e`
 
 State is auto-reset before every test subcommand. If migrations changed, run `./test.sh stack reset` once — that rebuilds the template DB.
 
-### 3. Before declaring done
+### 3. Before declaring done: scoped verification
 
-Run the broader suite to catch regressions outside your targeted area:
+Run the smallest test set that gives direct evidence for the change:
 
-- Backend change → `./test.sh all`
-- UI change → `./test.sh client unit && ./test.sh client e2e`
+- The tests added or changed with the implementation.
+- Existing tests for the changed behavior and its known consumers or contracts.
+- The relevant contract tripwires when DTOs, CLI/MCP surfaces, manifests, permissions, storage, scheduling, or other shared boundaries change.
+- One targeted live-service or Playwright happy path when the behavior crosses that boundary.
+
+The full backend, Vitest, and Playwright suites are **not** a default local completion requirement. They are broad integration-gate checks unless the user explicitly requests them or the change is so cross-cutting that no honest bounded selection exists. Until every broad suite is wired into that gate, targeted coverage for changed behavior remains mandatory; never assume an unrun suite is covered elsewhere. In the handoff, list the exact commands run and any broader suites not run. Never imply unrun suites are green.
 
 Verify the authoring rules above are satisfied for any new code.
 
@@ -87,20 +91,32 @@ Verify the authoring rules above are satisfied for any new code.
 
 **Skip when:** bugfixes, backend changes, routine pre-merge sanity checks. Most runs do not need a UX review.
 
-### 5. Flaky / failing tests
+### 5. Known failures outside the scoped run
 
-Before anything else, read the user's memory on this: flaky E2E tests are always **state pollution** from a prior test, not resource saturation. Do not add retries or raise timeouts.
+A scoped change may be complete without running every suite. If a broader local run or CI later finds another failure, however, the failure becomes owned work and must be classified from evidence:
+
+1. Capture the exact failure, logs, and test order or concurrency conditions. Do not start with blind reruns.
+2. Run the failing test alone, then reproduce the condition that exposed it (for example, after a suspected neighbor or under the relevant concurrency). A pass in isolation does not prove the failure is harmless.
+3. Choose a permanent outcome:
+   - **Regression caused by the change:** fix the product and add or strengthen the scoped regression test.
+   - **Real product race or nondeterminism:** fix the product boundary and preserve a deterministic regression test.
+   - **Leaked test state or harness defect:** make the test own its cleanup or fix isolation at the narrowest safe layer.
+   - **Overcomplicated or duplicated test:** simplify it to one stable contract, move edge cases to unit/component tests, and retain at most the useful end-to-end happy path.
+   - **Obsolete or redundant signal:** delete the test and document which remaining test covers the behavior, or why the behavior no longer matters.
+4. Validate the fix under the condition that previously failed. Repetition is acceptable after a hypothesized fix to demonstrate stability; it is not acceptable as a way to fish for a green run.
+
+If the repair is bounded, make it in the current change. If it is substantial and unrelated, split it into a dedicated blocking repair change rather than expanding the feature indefinitely. The scoped feature can be reported as implemented, but it must not be merged through a red required gate and the failure must not be left as an unowned follow-up.
 
 Diagnostics:
 - Logs per service: `/tmp/bifrost-<project-name>/*.log` (per-worktree).
 - JUnit: `/tmp/bifrost/test-results.xml`.
 - To isolate a test, run it alone: `./test.sh tests/e2e/path/test_foo.py::TestClass::test_method -v`.
 
-If a test is genuinely broken:
-- Fix it, or
-- Delete it (and document why in the commit message).
+### 6. Prefer simple tests
 
-No third option.
+Test complexity is a liability, not evidence of rigor. Prefer one observable contract, minimal fixtures, deterministic state, explicit cleanup, and the lowest test layer that can catch the regression. An end-to-end test should prove the primary integration or user journey, not reproduce every validation rule and edge case already covered below it.
+
+When simplifying or deleting a test, preserve its unique behavioral signal. Do not preserve incidental implementation assertions merely because they already exist.
 
 ## Definition-of-Done Checklist
 
@@ -111,7 +127,8 @@ Before declaring work complete, every box must be checked:
 - [ ] Backend logic has a unit test; endpoint/workflow changes have an e2e test
 - [ ] No new `skip`, `xfail`, `.only`, or commented-out tests introduced
 - [ ] Targeted suite green
-- [ ] Broader suite green (`./test.sh all` for backend, `./test.sh client e2e` for UI)
+- [ ] Exact test commands and unrun broader suites reported honestly
+- [ ] Every known out-of-scope failure has a durable fix or a dedicated blocking repair change
 - [ ] UX review done if new UI was built
 
 If any box is unchecked, keep working. Do not declare done.

--- a/.claude/skills/bifrost-testing/authoring-rules.md
+++ b/.claude/skills/bifrost-testing/authoring-rules.md
@@ -91,4 +91,6 @@ All via `./test.sh`. Never `pytest` or `npx vitest` / `npx playwright` directly 
 
 - Logs: `/tmp/bifrost-<project>/*.log` per service, per worktree.
 - JUnit XML: `/tmp/bifrost/test-results.xml`.
-- For flaky E2E: the answer is always state pollution from a prior test. Do not add retries. Run the failing test in isolation, then run it after a suspected neighbor, and find the dirty state the neighbor left behind.
+- For an intermittent E2E failure, do not assume the test is harmless or that state pollution is the only cause. Prior Bifrost flakes have exposed both leaked state and real product races. Capture the exposing order/load, run the test alone, then recreate the exposing condition and classify the cause from evidence.
+- Do not add retries, raise timeouts, skip the test, or rerun until green. After fixing a concrete cause, repetition is useful only to validate that fix under the previously failing condition.
+- If the E2E test is trying to prove many edge cases or implementation details, simplify it to the one stable integration or user contract and move the remaining assertions to unit/component tests. Delete obsolete or duplicate coverage when another named test preserves its only useful signal.

--- a/.codex/skills/bifrost-testing/SKILL.md
+++ b/.codex/skills/bifrost-testing/SKILL.md
@@ -9,11 +9,11 @@ Workflow for running and writing tests in Bifrost. Covers: stack lifecycle, whic
 
 ## Hard Rules (Non-Negotiable)
 
-1. **Never leave tests failing.** A red test means work is not done. Fix the test or fix the code under test. Never commit or claim completion with failing tests.
+1. **Never wave away a known failure.** Every test selected for the change must pass. A failure discovered by a broader local or CI run must receive a durable disposition under "Known failures outside the scoped run" below; "unrelated" and "flaky" are diagnoses to investigate, not permission to ignore it.
 
 2. **Never skip tests as a shortcut.** No `@pytest.mark.skip`, `pytest.skip()`, `test.skip()`, `test.only()`, `it.skip()`, `xfail`, or commenting a test out to silence it. A skipped test must be either **fixed** or **deleted** — and delete only if the test is genuinely no longer useful (feature removed, behavior moved, truly redundant). "I'll come back to it" is not a valid reason to skip.
 
-3. **Flaky ≠ add retries.** Per the user's memory on flaky tests (`feedback_flaky_tests.md`), E2E flakes are always state pollution from a prior test. Find the dirty state. Do not add retries, do not increase timeouts, do not re-run until green.
+3. **Flaky is a symptom, not a disposition.** Intermittent failures have previously exposed real product races as well as leaked test state. Find the cause. Do not add retries, increase timeouts, or re-run until green.
 
 4. **No silencing.** If a test is noisy, fix the source or delete the test. Don't filter output, don't swallow the failure.
 
@@ -62,16 +62,20 @@ If `DOWN` → `./test.sh stack up`. Each worktree runs its own isolated stack (C
 - Backend with live services → `./test.sh e2e` (or `./test.sh tests/e2e/test_foo.py -v`)
 - React component behavior → `./test.sh client unit` (vitest on host, no stack needed)
 - Full user flow through UI → `./test.sh client e2e`
-- Everything (like CI) → `./test.sh all` (backend) + `./test.sh client unit` + `./test.sh client e2e`
+- All available suites (manual broad run) → `./test.sh all` (backend) + `./test.sh client unit` + `./test.sh client e2e`
 
 State is auto-reset before every test subcommand. If migrations changed, run `./test.sh stack reset` once — that rebuilds the template DB.
 
-### 3. Before declaring done
+### 3. Before declaring done: scoped verification
 
-Run the broader suite to catch regressions outside your targeted area:
+Run the smallest test set that gives direct evidence for the change:
 
-- Backend change → `./test.sh all`
-- UI change → `./test.sh client unit && ./test.sh client e2e`
+- The tests added or changed with the implementation.
+- Existing tests for the changed behavior and its known consumers or contracts.
+- The relevant contract tripwires when DTOs, CLI/MCP surfaces, manifests, permissions, storage, scheduling, or other shared boundaries change.
+- One targeted live-service or Playwright happy path when the behavior crosses that boundary.
+
+The full backend, Vitest, and Playwright suites are **not** a default local completion requirement. They are broad integration-gate checks unless the user explicitly requests them or the change is so cross-cutting that no honest bounded selection exists. Until every broad suite is wired into that gate, targeted coverage for changed behavior remains mandatory; never assume an unrun suite is covered elsewhere. In the handoff, list the exact commands run and any broader suites not run. Never imply unrun suites are green.
 
 Verify the authoring rules above are satisfied for any new code.
 
@@ -87,20 +91,32 @@ Verify the authoring rules above are satisfied for any new code.
 
 **Skip when:** bugfixes, backend changes, routine pre-merge sanity checks. Most runs do not need a UX review.
 
-### 5. Flaky / failing tests
+### 5. Known failures outside the scoped run
 
-Before anything else, read the user's memory on this: flaky E2E tests are always **state pollution** from a prior test, not resource saturation. Do not add retries or raise timeouts.
+A scoped change may be complete without running every suite. If a broader local run or CI later finds another failure, however, the failure becomes owned work and must be classified from evidence:
+
+1. Capture the exact failure, logs, and test order or concurrency conditions. Do not start with blind reruns.
+2. Run the failing test alone, then reproduce the condition that exposed it (for example, after a suspected neighbor or under the relevant concurrency). A pass in isolation does not prove the failure is harmless.
+3. Choose a permanent outcome:
+   - **Regression caused by the change:** fix the product and add or strengthen the scoped regression test.
+   - **Real product race or nondeterminism:** fix the product boundary and preserve a deterministic regression test.
+   - **Leaked test state or harness defect:** make the test own its cleanup or fix isolation at the narrowest safe layer.
+   - **Overcomplicated or duplicated test:** simplify it to one stable contract, move edge cases to unit/component tests, and retain at most the useful end-to-end happy path.
+   - **Obsolete or redundant signal:** delete the test and document which remaining test covers the behavior, or why the behavior no longer matters.
+4. Validate the fix under the condition that previously failed. Repetition is acceptable after a hypothesized fix to demonstrate stability; it is not acceptable as a way to fish for a green run.
+
+If the repair is bounded, make it in the current change. If it is substantial and unrelated, split it into a dedicated blocking repair change rather than expanding the feature indefinitely. The scoped feature can be reported as implemented, but it must not be merged through a red required gate and the failure must not be left as an unowned follow-up.
 
 Diagnostics:
 - Logs per service: `/tmp/bifrost-<project-name>/*.log` (per-worktree).
 - JUnit: `/tmp/bifrost/test-results.xml`.
 - To isolate a test, run it alone: `./test.sh tests/e2e/path/test_foo.py::TestClass::test_method -v`.
 
-If a test is genuinely broken:
-- Fix it, or
-- Delete it (and document why in the commit message).
+### 6. Prefer simple tests
 
-No third option.
+Test complexity is a liability, not evidence of rigor. Prefer one observable contract, minimal fixtures, deterministic state, explicit cleanup, and the lowest test layer that can catch the regression. An end-to-end test should prove the primary integration or user journey, not reproduce every validation rule and edge case already covered below it.
+
+When simplifying or deleting a test, preserve its unique behavioral signal. Do not preserve incidental implementation assertions merely because they already exist.
 
 ## Definition-of-Done Checklist
 
@@ -111,7 +127,8 @@ Before declaring work complete, every box must be checked:
 - [ ] Backend logic has a unit test; endpoint/workflow changes have an e2e test
 - [ ] No new `skip`, `xfail`, `.only`, or commented-out tests introduced
 - [ ] Targeted suite green
-- [ ] Broader suite green (`./test.sh all` for backend, `./test.sh client e2e` for UI)
+- [ ] Exact test commands and unrun broader suites reported honestly
+- [ ] Every known out-of-scope failure has a durable fix or a dedicated blocking repair change
 - [ ] UX review done if new UI was built
 
 If any box is unchecked, keep working. Do not declare done.

--- a/.codex/skills/bifrost-testing/authoring-rules.md
+++ b/.codex/skills/bifrost-testing/authoring-rules.md
@@ -91,4 +91,6 @@ All via `./test.sh`. Never `pytest` or `npx vitest` / `npx playwright` directly 
 
 - Logs: `/tmp/bifrost-<project>/*.log` per service, per worktree.
 - JUnit XML: `/tmp/bifrost/test-results.xml`.
-- For flaky E2E: the answer is always state pollution from a prior test. Do not add retries. Run the failing test in isolation, then run it after a suspected neighbor, and find the dirty state the neighbor left behind.
+- For an intermittent E2E failure, do not assume the test is harmless or that state pollution is the only cause. Prior Bifrost flakes have exposed both leaked state and real product races. Capture the exposing order/load, run the test alone, then recreate the exposing condition and classify the cause from evidence.
+- Do not add retries, raise timeouts, skip the test, or rerun until green. After fixing a concrete cause, repetition is useful only to validate that fix under the previously failing condition.
+- If the E2E test is trying to prove many edge cases or implementation details, simplify it to the one stable integration or user contract and move the remaining assertions to unit/component tests. Delete obsolete or duplicate coverage when another named test preserves its only useful signal.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -286,6 +286,10 @@ export async function getDataProviders() {
 
 -   **Tests**: All work requires tests. Backend logic → unit tests in `api/tests/unit/`. Endpoint/workflow/integration changes → e2e tests in `api/tests/e2e/`. React components → sibling `*.test.tsx` (vitest). User-facing features → happy-path spec in `client/e2e/` (Playwright).
     -   **Functional frontend modules require vitest coverage.** New or modified `.ts` files under `client/src/lib/**` and `client/src/services/**` that export functions (auth helpers, storage adapters, API wrappers, formatters, etc.) need a sibling `*.test.ts` covering the public API. Pure type/constant re-export files and files that only import and re-configure third-party SDKs are exempt. If the module has a cross-tab, cross-window, or storage-boundary concern (like `auth-token.ts`), the test MUST exercise that boundary — a regression that only reproduces with two tabs open is one a future refactor will silently re-introduce otherwise.
+    -   **Scoped verification is the local default.** Run the tests that directly exercise the changed behavior, its known consumers, and any affected contract boundaries. Full backend, Vitest, and Playwright suites are broad integration-gate checks, not a routine local completion requirement. Until every suite is wired into that gate, targeted coverage for changed behavior remains mandatory; never assume an unrun suite is covered elsewhere. Report exactly what ran and which broader suites did not run.
+    -   **A known failure must receive a durable disposition.** If a broader local or CI run finds a failure outside the scoped set, determine whether it is a regression, product race, leaked state, harness defect, overcomplicated test, or obsolete coverage. Fix the cause, simplify the test, or delete genuinely redundant coverage with a documented replacement. "Unrelated" or "flaky" alone is not a disposition.
+    -   **Never rerun until green or mask instability.** Do not add retries, longer timeouts, `skip`, or `xfail`. Reproduce the exposing condition, fix the hypothesized cause, then use repetition only to validate the fix. See `.claude/skills/bifrost-testing/SKILL.md` for the full protocol.
+    -   **Prefer simple, durable tests.** Keep one observable contract per test, minimal fixtures, deterministic state, explicit cleanup, and only one useful end-to-end happy path. Move edge cases down to unit/component tests; complexity is not evidence of rigor.
     -   **IMPORTANT**: Always use `./test.sh` — it manages the Dockerized test stack (PostgreSQL, Redis, RabbitMQ, SeaweedFS, API, worker). Running pytest directly on the host will FAIL for anything touching DB/queue/cache.
     -   **Stack lifecycle is separate from test execution.** Boot once per worktree, run tests many times. See the Commands section below.
     -   **Test results**: `./test.sh` writes JUnit XML to `/tmp/bifrost/test-results.xml` — parse this for pass/fail details instead of grepping stdout.
@@ -374,33 +378,24 @@ export async function getDataProviders() {
 
 ## Pre-Completion Verification (REQUIRED)
 
-Before marking any significant work complete, run this verification sequence:
+Before marking work complete, select verification from the actual change surface. The examples below are choices, not a command list to run wholesale:
 
 ```bash
-# 1. Ensure debug stack is running for THIS worktree
+# Backend source changed
+./test.sh quality api
+./test.sh tests/unit/test_relevant_behavior.py -v
+./test.sh tests/e2e/path/test_relevant_boundary.py -v  # when a live boundary changed
+
+# Client source changed
+(cd client && npm run tsc && npm run lint)
+./test.sh client unit src/path/RelevantComponent.test.tsx
+./test.sh client e2e e2e/relevant-flow.admin.spec.ts  # when a user journey changed
+
+# API contract changed: regenerate types against this worktree's running debug stack
 ./debug.sh status | grep -q "Status:   UP" || ./debug.sh up
-
-# 2. Backend checks
-./test.sh quality api       # Dockerized pyright + ruff; must pass with 0 errors
-
-# 3. Regenerate frontend types (from client/ directory)
-cd client
-npm run generate:types     # Requires debug stack up. If client is bound to a non-default port,
-                           # set OPENAPI_URL=http://localhost:<port>/openapi.json (see ./debug.sh status).
-
-# 4. Frontend checks
-npm run tsc                # Type checking - must pass
-npm run lint               # Linting - must pass
-
-# 5. Run tests
-cd ..
-./test.sh stack up         # boot if not already up (per-worktree)
-./test.sh all              # backend unit + e2e
-./test.sh client unit      # vitest component tests
-./test.sh client e2e       # Playwright E2E (skip if no UI changes)
+(cd client && npm run generate:types)
 ```
 
-**This is mandatory for any changes that touch:**
-- Backend API endpoints or models
-- Frontend components or hooks
-- Database schema or migrations
+The selected tests must cover the changed behavior, known consumers, and contract tripwires. Do not run `./test.sh all`, the full Vitest suite, or the full Playwright suite by default; use them when explicitly requested, when reproducing a broad CI failure, or when no honest bounded selection exists for a cross-cutting change.
+
+In the final handoff, list the exact checks and tests run, state which broader suites were not run, and disclose any known failure. A known out-of-scope failure must be permanently fixed in the current change or split into a dedicated blocking repair change; it cannot be waived as flaky or left as an unowned follow-up.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -288,6 +288,10 @@ export async function getDataProviders() {
 
 -   **Tests**: All work requires tests. Backend logic → unit tests in `api/tests/unit/`. Endpoint/workflow/integration changes → e2e tests in `api/tests/e2e/`. React components → sibling `*.test.tsx` (vitest). User-facing features → happy-path spec in `client/e2e/` (Playwright).
     -   **Functional frontend modules require vitest coverage.** New or modified `.ts` files under `client/src/lib/**` and `client/src/services/**` that export functions (auth helpers, storage adapters, API wrappers, formatters, etc.) need a sibling `*.test.ts` covering the public API. Pure type/constant re-export files and files that only import and re-configure third-party SDKs are exempt. If the module has a cross-tab, cross-window, or storage-boundary concern (like `auth-token.ts`), the test MUST exercise that boundary — a regression that only reproduces with two tabs open is one a future refactor will silently re-introduce otherwise.
+    -   **Scoped verification is the local default.** Run the tests that directly exercise the changed behavior, its known consumers, and any affected contract boundaries. Full backend, Vitest, and Playwright suites are broad integration-gate checks, not a routine local completion requirement. Until every suite is wired into that gate, targeted coverage for changed behavior remains mandatory; never assume an unrun suite is covered elsewhere. Report exactly what ran and which broader suites did not run.
+    -   **A known failure must receive a durable disposition.** If a broader local or CI run finds a failure outside the scoped set, determine whether it is a regression, product race, leaked state, harness defect, overcomplicated test, or obsolete coverage. Fix the cause, simplify the test, or delete genuinely redundant coverage with a documented replacement. "Unrelated" or "flaky" alone is not a disposition.
+    -   **Never rerun until green or mask instability.** Do not add retries, longer timeouts, `skip`, or `xfail`. Reproduce the exposing condition, fix the hypothesized cause, then use repetition only to validate the fix. See `.claude/skills/bifrost-testing/SKILL.md` for the full protocol.
+    -   **Prefer simple, durable tests.** Keep one observable contract per test, minimal fixtures, deterministic state, explicit cleanup, and only one useful end-to-end happy path. Move edge cases down to unit/component tests; complexity is not evidence of rigor.
     -   **IMPORTANT**: Always use `./test.sh` — it manages the Dockerized test stack (PostgreSQL, Redis, RabbitMQ, SeaweedFS, API, worker). Running pytest directly on the host will FAIL for anything touching DB/queue/cache.
     -   **Stack lifecycle is separate from test execution.** Boot once per worktree, run tests many times. See the Commands section below.
     -   **Test results**: `./test.sh` writes JUnit XML to `/tmp/bifrost/test-results.xml` — parse this for pass/fail details instead of grepping stdout.
@@ -376,33 +380,24 @@ export async function getDataProviders() {
 
 ## Pre-Completion Verification (REQUIRED)
 
-Before marking any significant work complete, run this verification sequence:
+Before marking work complete, select verification from the actual change surface. The examples below are choices, not a command list to run wholesale:
 
 ```bash
-# 1. Ensure debug stack is running for THIS worktree
+# Backend source changed
+./test.sh quality api
+./test.sh tests/unit/test_relevant_behavior.py -v
+./test.sh tests/e2e/path/test_relevant_boundary.py -v  # when a live boundary changed
+
+# Client source changed
+(cd client && npm run tsc && npm run lint)
+./test.sh client unit src/path/RelevantComponent.test.tsx
+./test.sh client e2e e2e/relevant-flow.admin.spec.ts  # when a user journey changed
+
+# API contract changed: regenerate types against this worktree's running debug stack
 ./debug.sh status | grep -q "Status:   UP" || ./debug.sh up
-
-# 2. Backend checks
-./test.sh quality api       # Dockerized pyright + ruff; must pass with 0 errors
-
-# 3. Regenerate frontend types (from client/ directory)
-cd client
-npm run generate:types     # Requires debug stack up. If client is bound to a non-default port,
-                           # set OPENAPI_URL=http://localhost:<port>/openapi.json (see ./debug.sh status).
-
-# 4. Frontend checks
-npm run tsc                # Type checking - must pass
-npm run lint               # Linting - must pass
-
-# 5. Run tests
-cd ..
-./test.sh stack up         # boot if not already up (per-worktree)
-./test.sh all              # backend unit + e2e
-./test.sh client unit      # vitest component tests
-./test.sh client e2e       # Playwright E2E (skip if no UI changes)
+(cd client && npm run generate:types)
 ```
 
-**This is mandatory for any changes that touch:**
-- Backend API endpoints or models
-- Frontend components or hooks
-- Database schema or migrations
+The selected tests must cover the changed behavior, known consumers, and contract tripwires. Do not run `./test.sh all`, the full Vitest suite, or the full Playwright suite by default; use them when explicitly requested, when reproducing a broad CI failure, or when no honest bounded selection exists for a cross-cutting change.
+
+In the final handoff, list the exact checks and tests run, state which broader suites were not run, and disclose any known failure. A known out-of-scope failure must be permanently fixed in the current change or split into a dedicated blocking repair change; it cannot be waived as flaky or left as an unowned follow-up.

--- a/api/tests/e2e/api/test_form_embed.py
+++ b/api/tests/e2e/api/test_form_embed.py
@@ -7,6 +7,7 @@ import uuid
 import pytest
 
 from src.core.security import decode_token
+from tests.helpers.polling import poll_until
 
 
 def _compute_hmac(params: dict, secret: str) -> str:
@@ -265,10 +266,17 @@ class TestFormEmbed:
         assert accepted_body["execution_id"]
         assert "confirmation_markdown" not in accepted_body
 
-        own_execution = e2e_client.get(
-            f"/api/executions/{accepted_body['execution_id']}",
-            headers=first_headers,
-        )
+        # Async submissions return while the execution is still pending in Redis;
+        # the worker creates the queryable PostgreSQL record afterward.
+        def get_own_execution():
+            response = e2e_client.get(
+                f"/api/executions/{accepted_body['execution_id']}",
+                headers=first_headers,
+            )
+            return None if response.status_code == 404 else response
+
+        own_execution = poll_until(get_own_execution, max_wait=30.0, interval=0.2)
+        assert own_execution is not None, "Queued execution never became visible"
         assert own_execution.status_code == 200, own_execution.text
         assert own_execution.json()["execution_id"] == accepted_body["execution_id"]
 


### PR DESCRIPTION
## What changed

- make scoped tests the default local completion requirement
- require agents to report exact checks run and broader suites not run
- define permanent dispositions for failures discovered outside the scoped run
- explicitly allow simplifying or deleting overcomplicated, redundant tests while preserving unique behavioral coverage
- forbid retries, timeout inflation, skips, `xfail`, and rerun-until-green handling
- keep Claude and Codex testing guidance synchronized
- restore a bounded condition wait for an asynchronously queued form execution to become queryable

## Why

Bifrost's broad suites are now large enough that running them repeatedly during a scoped change creates substantial feedback delay. The previous guidance required full backend and client suites locally before completion, duplicating integration checks and encouraging work to become entangled with unrelated intermittent failures.

The new policy separates scoped implementation evidence from broad integration evidence without permitting known failures to be ignored. A failure found later must be fixed, simplified, deleted as redundant, or split into a dedicated blocking repair.

The first merge-queue run demonstrated that policy. It exposed a form E2E test that assumed a queued execution was immediately present in PostgreSQL, although the execution service intentionally returns while the execution is pending in Redis and the worker creates the database record afterward. The test now waits for that documented state transition with a fixed deadline instead of relying on worker timing or rerunning the suite.

## Validation

- `./scripts/sync-codex-skills.sh`
- `git diff --check`
- canonical and generated Codex testing skill mirrors compared byte-for-byte
- `./test.sh tests/e2e/api/test_form_embed.py::TestFormEmbed::test_startup_handle_is_authoritative_bound_and_consumed -v` — 1 passed

Broader local suites were not run. The documentation changes have no application runtime, and the only executable change was validated with its exact E2E test. The merge queue remains the broad integration gate.
