### PR TITLE
Add preferred SSO redirect before login

### DIFF
--- a/.claude/skills/bifrost-build/generated/openapi-digest.md
+++ b/.claude/skills/bifrost-build/generated/openapi-digest.md
@@ -421,6 +421,7 @@
 | PUT | `/api/settings/ai/pricing/{pricing_id}` |
 | GET | `/api/settings/oauth` |
 | PUT | `/api/settings/oauth/google` |
+| PUT | `/api/settings/oauth/login-preference` |
 | PUT | `/api/settings/oauth/microsoft` |
 | PUT | `/api/settings/oauth/oidc` |
 | DELETE | `/api/settings/oauth/{provider}` |

--- a/api/src/models/contracts/auth.py
+++ b/api/src/models/contracts/auth.py
@@ -2,7 +2,7 @@
 Authentication and MFA contract models for Bifrost.
 """
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 from pydantic import BaseModel, EmailStr
 
@@ -34,6 +34,8 @@ class AuthStatusResponse(BaseModel):
     password_login_enabled: bool
     mfa_required_for_password: bool
     oauth_providers: list[OAuthProviderInfo]
+    auto_redirect_to_sso: bool = False
+    default_sso_provider: Literal["microsoft", "google", "oidc"] | None = None
 
 
 class MFARequiredResponse(BaseModel):

--- a/api/src/models/contracts/oauth_config.py
+++ b/api/src/models/contracts/oauth_config.py
@@ -7,13 +7,14 @@ These are stored in the system_configs table with category='oauth_sso'.
 
 from typing import Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 # Supported OAuth SSO providers
 OAuthSSOProvider = Literal["microsoft", "google", "oidc"]
 
 # Config key constants for each provider
 OAUTH_CONFIG_CATEGORY = "oauth_sso"
+OAUTH_LOGIN_PREFERENCE = "login_preference"
 
 # Microsoft config keys
 OAUTH_MICROSOFT_CLIENT_ID = "microsoft_client_id"
@@ -29,6 +30,27 @@ OAUTH_OIDC_DISCOVERY_URL = "oidc_discovery_url"
 OAUTH_OIDC_CLIENT_ID = "oidc_client_id"
 OAUTH_OIDC_CLIENT_SECRET = "oidc_client_secret"
 OAUTH_OIDC_DISPLAY_NAME = "oidc_display_name"
+
+
+class OAuthLoginPreference(BaseModel):
+    """Preferred SSO behavior before the full login screen is shown."""
+
+    auto_redirect_to_sso: bool = Field(
+        default=False,
+        description="Whether login should first redirect to the preferred SSO provider",
+    )
+    default_sso_provider: OAuthSSOProvider | None = Field(
+        default=None,
+        description="Configured SSO provider used for the preferred redirect",
+    )
+
+    @model_validator(mode="after")
+    def require_provider_when_enabled(self) -> "OAuthLoginPreference":
+        if self.auto_redirect_to_sso and self.default_sso_provider is None:
+            raise ValueError(
+                "default_sso_provider is required when auto_redirect_to_sso is enabled"
+            )
+        return self
 
 
 class MicrosoftOAuthConfigRequest(BaseModel):
@@ -140,6 +162,10 @@ class OAuthConfigListResponse(BaseModel):
     callback_url: str = Field(
         ...,
         description="OAuth callback URL to configure in each provider"
+    )
+    login_preference: OAuthLoginPreference = Field(
+        ...,
+        description="Preferred SSO behavior before the full login screen",
     )
 
 

--- a/api/src/routers/auth.py
+++ b/api/src/routers/auth.py
@@ -1311,6 +1311,7 @@ async def get_auth_status(db: DbSession = None) -> AuthStatusResponse:
     # Get available OAuth providers from database config
     oauth_config_service = OAuthConfigService(db)
     available_providers = await oauth_config_service.get_available_providers()
+    login_preference = await oauth_config_service.get_login_preference()
 
     # Get OIDC display name if configured
     oidc_display_name = "SSO"
@@ -1340,6 +1341,8 @@ async def get_auth_status(db: DbSession = None) -> AuthStatusResponse:
         password_login_enabled=True,  # Always enabled for now
         mfa_required_for_password=settings.mfa_enabled,
         oauth_providers=oauth_providers,
+        auto_redirect_to_sso=login_preference.auto_redirect_to_sso,
+        default_sso_provider=login_preference.default_sso_provider,
     )
 
 

--- a/api/src/routers/oauth_config.py
+++ b/api/src/routers/oauth_config.py
@@ -17,13 +17,18 @@ from src.models.contracts.oauth_config import (
     GoogleOAuthConfigRequest,
     MicrosoftOAuthConfigRequest,
     OAuthConfigListResponse,
+    OAuthLoginPreference,
     OAuthConfigTestRequest,
     OAuthConfigTestResponse,
     OAuthProviderConfigResponse,
     OAuthSSOProvider,
     OIDCConfigRequest,
 )
-from src.services.oauth_config_service import OAuthConfigService
+from src.services.oauth_config_service import (
+    OAuthConfigService,
+    OAuthLoginPreferenceError,
+    OAuthProviderPreferenceConflict,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -58,12 +63,43 @@ async def list_oauth_configs(
     """
     service = OAuthConfigService(db)
     providers = await service.get_all_provider_configs()
+    login_preference = await service.get_login_preference()
     callback_url = _get_callback_url(request)
 
     return OAuthConfigListResponse(
         providers=providers,
         callback_url=callback_url,
+        login_preference=login_preference,
     )
+
+
+@router.put(
+    "/login-preference",
+    response_model=OAuthLoginPreference,
+    summary="Configure preferred SSO redirect",
+    description="Choose whether login should first redirect to a configured SSO provider",
+)
+async def set_oauth_login_preference(
+    preference: OAuthLoginPreference,
+    ctx: Context,
+    user: CurrentSuperuser,
+    db: AsyncSession = Depends(get_db),
+) -> OAuthLoginPreference:
+    """Update the platform-wide preferred SSO behavior."""
+    service = OAuthConfigService(db)
+    try:
+        result = await service.set_login_preference(
+            preference,
+            updated_by=user.email,
+        )
+    except OAuthLoginPreferenceError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(exc),
+        ) from exc
+
+    await db.commit()
+    return result
 
 
 @router.get(
@@ -244,7 +280,16 @@ async def delete_oauth_config(
 ) -> None:
     """Delete all configuration for a specific OAuth provider."""
     service = OAuthConfigService(db)
-    deleted = await service.delete_provider_config(provider)
+    try:
+        deleted = await service.delete_provider_config(
+            provider,
+            updated_by=user.email,
+        )
+    except OAuthProviderPreferenceConflict as exc:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=str(exc),
+        ) from exc
     await db.commit()
 
     if not deleted:

--- a/api/src/services/oauth_config_service.py
+++ b/api/src/services/oauth_config_service.py
@@ -23,6 +23,7 @@ from src.models.contracts.oauth_config import (
     OAUTH_MICROSOFT_CLIENT_ID,
     OAUTH_MICROSOFT_CLIENT_SECRET,
     OAUTH_MICROSOFT_TENANT_ID,
+    OAUTH_LOGIN_PREFERENCE,
     OAUTH_OIDC_CLIENT_ID,
     OAUTH_OIDC_CLIENT_SECRET,
     OAUTH_OIDC_DISCOVERY_URL,
@@ -30,6 +31,7 @@ from src.models.contracts.oauth_config import (
     GoogleOAuthConfigRequest,
     MicrosoftOAuthConfigRequest,
     OAuthConfigTestResponse,
+    OAuthLoginPreference,
     OAuthProviderConfigResponse,
     OAuthSSOProvider,
     OIDCConfigRequest,
@@ -37,6 +39,14 @@ from src.models.contracts.oauth_config import (
 from src.models.orm.config import SystemConfig
 
 logger = logging.getLogger(__name__)
+
+
+class OAuthLoginPreferenceError(ValueError):
+    """Raised when a preferred SSO provider cannot be used."""
+
+
+class OAuthProviderPreferenceConflict(ValueError):
+    """Raised when deleting the provider used by an active preference."""
 
 
 @dataclass
@@ -143,6 +153,64 @@ class OAuthConfigService:
             )
         )
         await self.db.flush()
+
+    async def get_login_preference(self) -> OAuthLoginPreference:
+        """Return the platform-wide preferred SSO behavior."""
+        result = await self.db.execute(
+            select(SystemConfig).where(
+                SystemConfig.category == OAUTH_CONFIG_CATEGORY,
+                SystemConfig.key == OAUTH_LOGIN_PREFERENCE,
+                SystemConfig.organization_id.is_(None),
+            )
+        )
+        config = result.scalar_one_or_none()
+        if not config or not config.value_json:
+            return OAuthLoginPreference()
+        return OAuthLoginPreference.model_validate(config.value_json)
+
+    async def set_login_preference(
+        self,
+        preference: OAuthLoginPreference,
+        updated_by: str = "system",
+    ) -> OAuthLoginPreference:
+        """Persist a preferred provider after verifying it is configured."""
+        if preference.default_sso_provider is not None:
+            provider_config = await self.get_provider_config(
+                preference.default_sso_provider
+            )
+            if not provider_config or not provider_config.is_complete:
+                raise OAuthLoginPreferenceError(
+                    f"{preference.default_sso_provider.title()} SSO must be configured "
+                    "before it can be preferred"
+                )
+
+        result = await self.db.execute(
+            select(SystemConfig).where(
+                SystemConfig.category == OAUTH_CONFIG_CATEGORY,
+                SystemConfig.key == OAUTH_LOGIN_PREFERENCE,
+                SystemConfig.organization_id.is_(None),
+            )
+        )
+        existing = result.scalar_one_or_none()
+        value_json = preference.model_dump(mode="json")
+
+        if existing:
+            existing.value_json = value_json
+            existing.updated_by = updated_by
+        else:
+            self.db.add(
+                SystemConfig(
+                    category=OAUTH_CONFIG_CATEGORY,
+                    key=OAUTH_LOGIN_PREFERENCE,
+                    value_json=value_json,
+                    organization_id=None,
+                    created_by=updated_by,
+                    updated_by=updated_by,
+                )
+            )
+
+        await self.db.flush()
+        return preference
 
     # =========================================================================
     # Provider Configuration CRUD
@@ -263,8 +331,21 @@ class OAuthConfigService:
         )
         logger.info(f"OIDC config updated by {updated_by}")
 
-    async def delete_provider_config(self, provider: OAuthSSOProvider) -> bool:
+    async def delete_provider_config(
+        self,
+        provider: OAuthSSOProvider,
+        updated_by: str = "system",
+    ) -> bool:
         """Delete all configuration for a provider."""
+        preference = await self.get_login_preference()
+        if (
+            preference.auto_redirect_to_sso
+            and preference.default_sso_provider == provider
+        ):
+            raise OAuthProviderPreferenceConflict(
+                f"Disable preferred SSO redirect before removing {provider.title()}"
+            )
+
         if provider == "microsoft":
             keys = [
                 OAUTH_MICROSOFT_CLIENT_ID,
@@ -287,6 +368,11 @@ class OAuthConfigService:
             return False
 
         await self._delete_config_keys(keys)
+        if preference.default_sso_provider == provider:
+            await self.set_login_preference(
+                OAuthLoginPreference(),
+                updated_by=updated_by,
+            )
         logger.info(f"OAuth config deleted for provider: {log_safe(provider)}")
         return True
 

--- a/api/tests/e2e/api/test_oauth_config.py
+++ b/api/tests/e2e/api/test_oauth_config.py
@@ -1,0 +1,106 @@
+"""Live API coverage for platform OAuth login preferences."""
+
+import pytest
+
+
+@pytest.mark.e2e
+class TestOAuthLoginPreference:
+    def test_preferred_provider_lifecycle(
+        self,
+        e2e_client,
+        platform_admin,
+    ) -> None:
+        headers = platform_admin.headers
+
+        try:
+            response = e2e_client.put(
+                "/api/settings/oauth/microsoft",
+                headers=headers,
+                json={
+                    "client_id": "preferred-login-client",
+                    "client_secret": "preferred-login-secret",
+                    "tenant_id": "organizations",
+                },
+            )
+            assert response.status_code == 200
+
+            response = e2e_client.put(
+                "/api/settings/oauth/login-preference",
+                headers=headers,
+                json={
+                    "auto_redirect_to_sso": True,
+                    "default_sso_provider": "microsoft",
+                },
+            )
+            assert response.status_code == 200
+
+            response = e2e_client.get("/api/settings/oauth", headers=headers)
+            assert response.status_code == 200
+            assert response.json()["login_preference"] == {
+                "auto_redirect_to_sso": True,
+                "default_sso_provider": "microsoft",
+            }
+
+            response = e2e_client.get("/auth/status")
+            assert response.status_code == 200
+            assert response.json()["auto_redirect_to_sso"] is True
+            assert response.json()["default_sso_provider"] == "microsoft"
+
+            response = e2e_client.delete(
+                "/api/settings/oauth/microsoft",
+                headers=headers,
+            )
+            assert response.status_code == 409
+            assert "Disable preferred SSO redirect" in response.json()["detail"]
+
+            response = e2e_client.put(
+                "/api/settings/oauth/login-preference",
+                headers=headers,
+                json={
+                    "auto_redirect_to_sso": False,
+                    "default_sso_provider": "microsoft",
+                },
+            )
+            assert response.status_code == 200
+
+            response = e2e_client.delete(
+                "/api/settings/oauth/microsoft",
+                headers=headers,
+            )
+            assert response.status_code == 204
+
+            response = e2e_client.get("/api/settings/oauth", headers=headers)
+            assert response.status_code == 200
+            assert response.json()["login_preference"] == {
+                "auto_redirect_to_sso": False,
+                "default_sso_provider": None,
+            }
+        finally:
+            e2e_client.put(
+                "/api/settings/oauth/login-preference",
+                headers=headers,
+                json={
+                    "auto_redirect_to_sso": False,
+                    "default_sso_provider": None,
+                },
+            )
+            e2e_client.delete(
+                "/api/settings/oauth/microsoft",
+                headers=headers,
+            )
+
+    def test_non_admin_cannot_update_login_preference(
+        self,
+        e2e_client,
+        org1_user,
+    ) -> None:
+        response = e2e_client.put(
+            "/api/settings/oauth/login-preference",
+            headers=org1_user.headers,
+            json={
+                "auto_redirect_to_sso": False,
+                "default_sso_provider": None,
+            },
+        )
+
+        assert response.status_code == 403

--- a/api/tests/unit/services/test_oauth_config_service.py
+++ b/api/tests/unit/services/test_oauth_config_service.py
@@ -1,0 +1,96 @@
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from pydantic import ValidationError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.models.contracts.oauth_config import OAuthLoginPreference
+from src.services.oauth_config_service import (
+    OAuthConfigService,
+    OAuthLoginPreferenceError,
+    OAuthProviderConfig,
+    OAuthProviderPreferenceConflict,
+)
+
+
+def make_db() -> MagicMock:
+    db = MagicMock(spec=AsyncSession)
+    db.execute = AsyncMock()
+    db.flush = AsyncMock()
+    return db
+
+
+def test_enabled_login_preference_requires_provider() -> None:
+    with pytest.raises(ValidationError, match="default_sso_provider is required"):
+        OAuthLoginPreference(auto_redirect_to_sso=True)
+
+
+@pytest.mark.asyncio
+async def test_login_preference_defaults_to_disabled() -> None:
+    db = make_db()
+    result = MagicMock()
+    result.scalar_one_or_none.return_value = None
+    db.execute.return_value = result
+
+    preference = await OAuthConfigService(db).get_login_preference()
+
+    assert preference == OAuthLoginPreference()
+
+
+@pytest.mark.asyncio
+async def test_login_preference_requires_configured_provider() -> None:
+    service = OAuthConfigService(make_db())
+    service.get_provider_config = AsyncMock(return_value=None)
+
+    with pytest.raises(OAuthLoginPreferenceError, match="must be configured"):
+        await service.set_login_preference(
+            OAuthLoginPreference(
+                auto_redirect_to_sso=True,
+                default_sso_provider="microsoft",
+            )
+        )
+
+
+@pytest.mark.asyncio
+async def test_login_preference_is_persisted_for_configured_provider() -> None:
+    db = make_db()
+    result = MagicMock()
+    result.scalar_one_or_none.return_value = None
+    db.execute.return_value = result
+    service = OAuthConfigService(db)
+    service.get_provider_config = AsyncMock(
+        return_value=OAuthProviderConfig(
+            provider="microsoft",
+            client_id="client-id",
+            client_secret="client-secret",
+        )
+    )
+    preference = OAuthLoginPreference(
+        auto_redirect_to_sso=True,
+        default_sso_provider="microsoft",
+    )
+
+    assert await service.set_login_preference(preference) == preference
+    added = db.add.call_args.args[0]
+    assert added.value_json == preference.model_dump(mode="json")
+    db.flush.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_active_preferred_provider_cannot_be_deleted() -> None:
+    service = OAuthConfigService(make_db())
+    service.get_login_preference = AsyncMock(
+        return_value=OAuthLoginPreference(
+            auto_redirect_to_sso=True,
+            default_sso_provider="microsoft",
+        )
+    )
+    service._delete_config_keys = AsyncMock()
+
+    with pytest.raises(
+        OAuthProviderPreferenceConflict,
+        match="Disable preferred SSO redirect",
+    ):
+        await service.delete_provider_config("microsoft")
+
+    service._delete_config_keys.assert_not_awaited()

--- a/client/e2e/preferred-sso.admin.spec.ts
+++ b/client/e2e/preferred-sso.admin.spec.ts
@@ -1,0 +1,123 @@
+import { expect, request as playwrightRequest, test } from "@playwright/test";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+
+const API_URL = process.env.TEST_API_URL || "http://api:8000";
+
+test.describe.serial("Preferred SSO redirect", () => {
+	let api: Awaited<ReturnType<typeof playwrightRequest.newContext>>;
+
+	test.beforeAll(async () => {
+		const credentials = JSON.parse(
+			readFileSync(resolve("e2e/.auth/credentials.json"), "utf8"),
+		) as { platform_admin: { accessToken: string } };
+		api = await playwrightRequest.newContext({
+			baseURL: API_URL,
+			extraHTTPHeaders: {
+				Authorization: `Bearer ${credentials.platform_admin.accessToken}`,
+			},
+		});
+
+		const response = await api.put("/api/settings/oauth/microsoft", {
+			data: {
+				client_id: "playwright-preferred-login",
+				client_secret: "playwright-secret",
+				tenant_id: "organizations",
+			},
+		});
+		expect(response.ok(), await response.text()).toBe(true);
+	});
+
+	test.afterAll(async () => {
+		if (!api) return;
+		await api.put("/api/settings/oauth/login-preference", {
+			data: {
+				auto_redirect_to_sso: false,
+				default_sso_provider: null,
+			},
+		});
+		await api.delete("/api/settings/oauth/microsoft");
+		await api.dispose();
+	});
+
+	test("tries Microsoft once, then Back shows every login option", async ({
+		browser,
+	}) => {
+		const context = await browser.newContext({
+			storageState: { cookies: [], origins: [] },
+		});
+		// OAuth runs in HTTPS/localhost secure contexts in production. The
+		// container-only http://client origin needs a minimal Web Crypto boundary.
+		await context.addInitScript(() => {
+			Object.defineProperty(window.crypto, "subtle", {
+				value: {
+					digest: async () => new Uint8Array(32).buffer,
+				},
+			});
+		});
+		const page = await context.newPage();
+		let oauthInitRequests = 0;
+
+		page.on("request", (request) => {
+			if (request.url().includes("/auth/oauth/init/microsoft")) {
+				oauthInitRequests += 1;
+			}
+		});
+
+		await page.route("**/auth/status", async (route) => {
+			const response = await route.fetch();
+			const status = await response.json();
+			await route.fulfill({
+				response,
+				json: {
+					...status,
+					auto_redirect_to_sso: true,
+					default_sso_provider: "microsoft",
+					oauth_providers: [
+						{
+							name: "microsoft",
+							display_name: "Microsoft",
+							icon: "microsoft",
+						},
+					],
+				},
+			});
+		});
+
+		await page.route("https://login.microsoftonline.com/**", async (route) => {
+			await route.fulfill({
+				contentType: "text/html",
+				body: "<main><h1>Microsoft sign-in test boundary</h1></main>",
+			});
+		});
+
+		await page.goto("/login?returnTo=/workflows");
+		await expect(
+			page.getByRole("heading", {
+				name: "Microsoft sign-in test boundary",
+			}),
+		).toBeVisible();
+		expect(oauthInitRequests).toBe(1);
+
+		const providerUrl = new URL(page.url());
+		expect(providerUrl.hostname).toBe("login.microsoftonline.com");
+		expect(providerUrl.searchParams.get("redirect_uri")).toMatch(
+			/\/auth\/callback\/microsoft$/,
+		);
+
+		await page.goBack();
+		await expect(page.getByLabel("Email")).toBeVisible();
+		await expect(page.getByLabel("Password")).toBeVisible();
+		await expect(
+			page.getByRole("button", { name: "Microsoft" }),
+		).toBeVisible();
+		expect(oauthInitRequests).toBe(1);
+		expect(
+			await page.evaluate(() =>
+				sessionStorage.getItem("oauth_redirect_from"),
+			),
+		).toBe("/workflows");
+
+		await context.close();
+	});
+});

--- a/client/src/contexts/AuthContext.tsx
+++ b/client/src/contexts/AuthContext.tsx
@@ -23,6 +23,7 @@ import {
 	getActiveToken,
 	isEmbedSession,
 } from "@/lib/auth-token";
+import { clearPreferredSsoRedirectAttempt } from "@/services/auth";
 
 // Consume the fragment before AuthProvider performs its initial auth check.
 // api-client does the same defensively before requests; this keeps auth state
@@ -155,6 +156,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
 
 	const completeLoginWithToken = useCallback((accessToken: string): void => {
 		clearEmbedToken();
+		clearPreferredSsoRedirectAttempt();
 		localStorage.setItem(ACCESS_TOKEN_KEY, accessToken);
 
 		const payload = parseJwt(accessToken);

--- a/client/src/lib/v1.d.ts
+++ b/client/src/lib/v1.d.ts
@@ -6646,6 +6646,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/settings/oauth/login-preference": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        /**
+         * Configure preferred SSO redirect
+         * @description Choose whether login should first redirect to a configured SSO provider
+         */
+        put: operations["set_oauth_login_preference_api_settings_oauth_login_preference_put"];
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/settings/oauth/{provider}": {
         parameters: {
             query?: never;
@@ -11267,6 +11287,13 @@ export interface components {
             mfa_required_for_password: boolean;
             /** Oauth Providers */
             oauth_providers: components["schemas"]["src__models__contracts__auth__OAuthProviderInfo"][];
+            /**
+             * Auto Redirect To Sso
+             * @default false
+             */
+            auto_redirect_to_sso: boolean;
+            /** Default Sso Provider */
+            default_sso_provider?: ("microsoft" | "google" | "oidc") | null;
         };
         /**
          * AuthorizeResponse
@@ -18946,6 +18973,8 @@ export interface components {
              * @description OAuth callback URL to configure in each provider
              */
             callback_url: string;
+            /** @description Preferred SSO behavior before the full login screen */
+            login_preference: components["schemas"]["OAuthLoginPreference"];
         };
         /**
          * OAuthConfigResponse
@@ -19289,6 +19318,23 @@ export interface components {
             authorization_url: string;
             /** State */
             state: string;
+        };
+        /**
+         * OAuthLoginPreference
+         * @description Preferred SSO behavior before the full login screen is shown.
+         */
+        OAuthLoginPreference: {
+            /**
+             * Auto Redirect To Sso
+             * @description Whether login should first redirect to the preferred SSO provider
+             * @default false
+             */
+            auto_redirect_to_sso: boolean;
+            /**
+             * Default Sso Provider
+             * @description Configured SSO provider used for the preferred redirect
+             */
+            default_sso_provider?: ("microsoft" | "google" | "oidc") | null;
         };
         /**
          * OAuthProviderConfigResponse
@@ -36876,6 +36922,39 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["OAuthConfigListResponse"];
+                };
+            };
+        };
+    };
+    set_oauth_login_preference_api_settings_oauth_login_preference_put: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["OAuthLoginPreference"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["OAuthLoginPreference"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
                 };
             };
         };

--- a/client/src/pages/Login.test.tsx
+++ b/client/src/pages/Login.test.tsx
@@ -1,0 +1,103 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { renderWithProviders, screen, waitFor } from "@/test-utils";
+import { Login } from "./Login";
+import {
+	getAuthStatus,
+	initOAuth,
+	PREFERRED_SSO_REDIRECT_ATTEMPTED_KEY,
+} from "@/services/auth";
+
+const loginWithPasskey = vi.fn();
+
+vi.mock("@/contexts/AuthContext", () => ({
+	useAuth: () => ({
+		login: vi.fn(),
+		loginWithMfa: vi.fn(),
+		loginWithPasskey,
+		isAuthenticated: false,
+		isLoading: false,
+	}),
+}));
+
+vi.mock("@/services/auth", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("@/services/auth")>();
+	return {
+		...actual,
+		getAuthStatus: vi.fn(),
+		hashOAuthState: vi.fn(),
+		initOAuth: vi.fn(),
+	};
+});
+
+vi.mock("@/services/passkeys", () => ({
+	supportsPasskeys: () => true,
+}));
+
+vi.mock("@/components/branding/Logo", () => ({
+	Logo: () => null,
+}));
+
+vi.mock("@/lib/applicationName", () => ({
+	useApplicationName: () => "Bifrost",
+}));
+
+const preferredStatus = {
+	needs_setup: false,
+	password_login_enabled: true,
+	mfa_required_for_password: false,
+	oauth_providers: [
+		{
+			name: "microsoft",
+			display_name: "Microsoft",
+			icon: "microsoft",
+		},
+	],
+	auto_redirect_to_sso: true,
+	default_sso_provider: "microsoft" as const,
+};
+
+describe("Login preferred SSO redirect", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		sessionStorage.clear();
+		vi.mocked(getAuthStatus).mockResolvedValue(preferredStatus);
+		vi.mocked(initOAuth).mockImplementation(
+			() => new Promise(() => undefined),
+		);
+	});
+
+	it("tries the preferred provider once before passkey or credentials", async () => {
+		renderWithProviders(<Login />, {
+			initialEntries: ["/login?returnTo=/workflows"],
+		});
+
+		await waitFor(() => {
+			expect(initOAuth).toHaveBeenCalledWith(
+				"microsoft",
+				`${window.location.origin}/auth/callback/microsoft`,
+			);
+		});
+		expect(
+			sessionStorage.getItem(PREFERRED_SSO_REDIRECT_ATTEMPTED_KEY),
+		).toBe("true");
+		expect(sessionStorage.getItem("oauth_redirect_from")).toBe("/workflows");
+		expect(loginWithPasskey).not.toHaveBeenCalled();
+	});
+
+	it("shows the full login screen after the preferred attempt", async () => {
+		sessionStorage.setItem(PREFERRED_SSO_REDIRECT_ATTEMPTED_KEY, "true");
+
+		renderWithProviders(<Login />, { initialEntries: ["/login"] });
+
+		expect(await screen.findByLabelText("Email")).toBeInTheDocument();
+		expect(screen.getByLabelText("Password")).toBeInTheDocument();
+		expect(
+			screen.getByRole("button", { name: "Microsoft" }),
+		).toBeInTheDocument();
+		expect(
+			screen.getByRole("button", { name: /sign in with passkey/i }),
+		).toBeInTheDocument();
+		expect(initOAuth).not.toHaveBeenCalled();
+		expect(loginWithPasskey).not.toHaveBeenCalled();
+	});
+});

--- a/client/src/pages/Login.tsx
+++ b/client/src/pages/Login.tsx
@@ -7,7 +7,12 @@
 import { useState, useEffect, useCallback, useMemo } from "react";
 import { useNavigate, useLocation } from "react-router-dom";
 import { useAuth } from "@/contexts/AuthContext";
-import { getOAuthProviders, hashOAuthState, initOAuth } from "@/services/auth";
+import {
+	getAuthStatus,
+	hashOAuthState,
+	initOAuth,
+	PREFERRED_SSO_REDIRECT_ATTEMPTED_KEY,
+} from "@/services/auth";
 import { supportsPasskeys } from "@/services/passkeys";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -69,6 +74,11 @@ export function Login() {
 	const [finalizing, setFinalizing] = useState<string | null>(null);
 	const [error, setError] = useState<string | null>(null);
 	const [oauthProviders, setOAuthProviders] = useState<OAuthProvider[]>([]);
+	const [authStatusLoaded, setAuthStatusLoaded] = useState(false);
+	const [autoRedirectToSso, setAutoRedirectToSso] = useState(false);
+	const [defaultSsoProvider, setDefaultSsoProvider] = useState<string | null>(
+		null,
+	);
 	// Derived synchronously — `supportsPasskeys()` is a pure feature check on
 	// `window` that returns the same value across renders for the lifetime of
 	// the page, so it does not need to live in state.
@@ -139,13 +149,106 @@ export function Login() {
 		}
 	}, [email, loginWithPasskey, redirectToFrom]);
 
-	// Load OAuth providers
+	const handleOAuthLogin = useCallback(
+		async (provider: string) => {
+			setError(null);
+			setIsLoading(true);
+
+			try {
+				// Store redirect info for callback
+				// Note: PKCE (code_verifier) is now handled server-side
+				sessionStorage.setItem("oauth_redirect_from", from);
+
+				// Build callback URL
+				const callbackUrl = `${window.location.origin}/auth/callback/${provider}`;
+
+				// Get authorization URL (server generates and stores PKCE verifier)
+				const { authorization_url, state } = await initOAuth(
+					provider,
+					callbackUrl,
+				);
+
+				// Store only a digest of the state for the callback CSRF check —
+				// never the raw token (see hashOAuthState).
+				sessionStorage.setItem(
+					"oauth_state",
+					await hashOAuthState(state),
+				);
+
+				// Redirect to OAuth provider
+				setFinalizing("Redirecting to sign-in…");
+				window.location.assign(authorization_url);
+			} catch (err) {
+				setError(
+					err instanceof Error
+						? err.message
+						: "OAuth initialization failed",
+				);
+				setFinalizing(null);
+				setIsLoading(false);
+			}
+		},
+		[from],
+	);
+
+	// Load the full login policy before presenting or starting an auth method.
 	useEffect(() => {
-		getOAuthProviders()
-			.then(setOAuthProviders)
+		getAuthStatus()
+			.then((status) => {
+				setOAuthProviders(status.oauth_providers);
+				setAutoRedirectToSso(
+					status.auto_redirect_to_sso && !status.needs_setup,
+				);
+				setDefaultSsoProvider(status.default_sso_provider ?? null);
+			})
 			.catch(() => {
-				// OAuth not configured, that's fine
-			});
+				// If status cannot load, leave all optional methods disabled and
+				// present the standard login screen.
+			})
+			.finally(() => setAuthStatusLoaded(true));
+	}, []);
+
+	// The preference is one attempt, not an enforcement loop. Set the guard
+	// before leaving so browser Back and provider cancellation show the full
+	// login screen on return.
+	useEffect(() => {
+		if (
+			!authStatusLoaded ||
+			authLoading ||
+			isAuthenticated ||
+			step !== "credentials" ||
+			!autoRedirectToSso ||
+			!defaultSsoProvider ||
+			sessionStorage.getItem(PREFERRED_SSO_REDIRECT_ATTEMPTED_KEY)
+		) {
+			return;
+		}
+
+		sessionStorage.setItem(PREFERRED_SSO_REDIRECT_ATTEMPTED_KEY, "true");
+		queueMicrotask(() => void handleOAuthLogin(defaultSsoProvider));
+	}, [
+		authLoading,
+		authStatusLoaded,
+		autoRedirectToSso,
+		defaultSsoProvider,
+		handleOAuthLogin,
+		isAuthenticated,
+		step,
+	]);
+
+	// Browsers may restore the pre-redirect page from the back-forward cache.
+	// Clear its transient loading state while keeping the attempt guard.
+	useEffect(() => {
+		const handlePageShow = () => {
+			if (
+				sessionStorage.getItem(PREFERRED_SSO_REDIRECT_ATTEMPTED_KEY)
+			) {
+				setFinalizing(null);
+				setIsLoading(false);
+			}
+		};
+		window.addEventListener("pageshow", handlePageShow);
+		return () => window.removeEventListener("pageshow", handlePageShow);
 	}, []);
 
 	// Auto-trigger passkey authentication if:
@@ -160,6 +263,8 @@ export function Login() {
 		const hasAttempted = sessionStorage.getItem("passkey_auto_attempted");
 		if (
 			supported &&
+			authStatusLoaded &&
+			!autoRedirectToSso &&
 			!authLoading &&
 			!isAuthenticated &&
 			!hasAttempted &&
@@ -173,7 +278,15 @@ export function Login() {
 			return () => clearTimeout(timer);
 		}
 		return undefined;
-	}, [authLoading, isAuthenticated, step, handlePasskeyLogin, passkeySupported]);
+	}, [
+		authLoading,
+		authStatusLoaded,
+		autoRedirectToSso,
+		isAuthenticated,
+		step,
+		handlePasskeyLogin,
+		passkeySupported,
+	]);
 
 	// Clear the auto-attempt flag when user logs out and returns
 	useEffect(() => {
@@ -251,42 +364,6 @@ export function Login() {
 		}
 	};
 
-	const handleOAuthLogin = async (provider: string) => {
-		setError(null);
-		setIsLoading(true);
-
-		try {
-			// Store redirect info for callback
-			// Note: PKCE (code_verifier) is now handled server-side
-			sessionStorage.setItem("oauth_redirect_from", from);
-
-			// Build callback URL
-			const callbackUrl = `${window.location.origin}/auth/callback/${provider}`;
-
-			// Get authorization URL (server generates and stores PKCE verifier)
-			const { authorization_url, state } = await initOAuth(
-				provider,
-				callbackUrl,
-			);
-
-			// Store only a digest of the state for the callback CSRF check —
-			// never the raw token (see hashOAuthState).
-			sessionStorage.setItem("oauth_state", await hashOAuthState(state));
-
-			// Redirect to OAuth provider
-			setFinalizing("Redirecting to sign-in…");
-			window.location.assign(authorization_url);
-		} catch (err) {
-			setError(
-				err instanceof Error
-					? err.message
-					: "OAuth initialization failed",
-			);
-			setFinalizing(null);
-			setIsLoading(false);
-		}
-	};
-
 	const getProviderIcon = (provider: string) => {
 		switch (provider) {
 			case "microsoft":
@@ -346,7 +423,7 @@ export function Login() {
 		return <AuthTransition message={finalizing} />;
 	}
 
-	if (authLoading) {
+	if (authLoading || !authStatusLoaded) {
 		return (
 			<div className="min-h-screen flex items-center justify-center bg-background">
 				<Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />

--- a/client/src/pages/Settings.test.tsx
+++ b/client/src/pages/Settings.test.tsx
@@ -1,0 +1,23 @@
+import { describe, expect, it, vi } from "vitest";
+import { renderWithProviders, screen } from "@/test-utils";
+import { Settings } from "./Settings";
+
+vi.mock("@/pages/settings/WorkflowKeys", () => ({ WorkflowKeys: () => null }));
+vi.mock("@/pages/settings/Branding", () => ({ Branding: () => null }));
+vi.mock("@/pages/settings/OAuth", () => ({ OAuth: () => null }));
+vi.mock("@/pages/settings/GitHub", () => ({ GitHub: () => null }));
+vi.mock("@/pages/settings/LLMConfig", () => ({ LLMConfig: () => null }));
+vi.mock("@/pages/settings/MCP", () => ({ MCP: () => null }));
+vi.mock("@/pages/settings/Maintenance", () => ({ Maintenance: () => null }));
+
+describe("Settings", () => {
+	it("labels the SSO configuration surface as Authentication", () => {
+		renderWithProviders(<Settings />, {
+			initialEntries: ["/settings/sso"],
+		});
+
+		expect(
+			screen.getByRole("tab", { name: /authentication/i }),
+		).toBeVisible();
+	});
+});

--- a/client/src/pages/Settings.tsx
+++ b/client/src/pages/Settings.tsx
@@ -61,7 +61,7 @@ export function Settings() {
 						</TabsTrigger>
 						<TabsTrigger value="sso">
 							<Shield className="h-4 w-4 mr-1" />
-							SSO
+							Authentication
 						</TabsTrigger>
 						<TabsTrigger value="github">
 							<Github className="h-4 w-4 mr-1" />

--- a/client/src/pages/settings/OAuth.test.tsx
+++ b/client/src/pages/settings/OAuth.test.tsx
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { renderWithProviders, screen, waitFor } from "@/test-utils";
+import { OAuth } from "./OAuth";
+
+const refetch = vi.fn();
+const updateLoginPreference = vi.fn();
+const configData = {
+	providers: [
+		{
+			provider: "microsoft",
+			configured: true,
+			client_id: "client-id",
+			client_secret_set: true,
+			tenant_id: "organizations",
+		},
+		{
+			provider: "google",
+			configured: false,
+			client_secret_set: false,
+		},
+		{
+			provider: "oidc",
+			configured: false,
+			client_secret_set: false,
+		},
+	],
+	callback_url: "http://localhost/auth/oauth/callback",
+	login_preference: {
+		auto_redirect_to_sso: false,
+		default_sso_provider: null,
+	},
+};
+
+vi.mock("@/services/oauth-config", () => ({
+	useOAuthConfigs: () => ({
+		data: configData,
+		isLoading: false,
+		refetch,
+	}),
+	useUpdateOAuthLoginPreference: () => ({
+		mutateAsync: updateLoginPreference,
+		isPending: false,
+	}),
+	useUpdateMicrosoftConfig: () => ({ mutateAsync: vi.fn() }),
+	useUpdateGoogleConfig: () => ({ mutateAsync: vi.fn() }),
+	useUpdateOIDCConfig: () => ({ mutateAsync: vi.fn() }),
+	useDeleteOAuthConfig: () => ({ mutateAsync: vi.fn() }),
+	useTestOAuthConfig: () => ({ mutateAsync: vi.fn() }),
+}));
+
+describe("OAuth settings", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		updateLoginPreference.mockResolvedValue({});
+		refetch.mockResolvedValue({});
+	});
+
+	it("saves a configured provider as the preferred first attempt", async () => {
+		const { user } = renderWithProviders(<OAuth />);
+
+		const preferenceSwitch = screen.getByRole("switch", {
+			name: /prefer sso on login/i,
+		});
+		await user.click(preferenceSwitch);
+		expect(preferenceSwitch).toHaveAttribute("aria-checked", "true");
+		await user.click(
+			screen.getByRole("button", { name: /save preference/i }),
+		);
+
+		await waitFor(() => {
+			expect(updateLoginPreference).toHaveBeenCalledWith({
+				body: {
+					auto_redirect_to_sso: true,
+					default_sso_provider: "microsoft",
+				},
+			});
+		});
+	});
+});

--- a/client/src/pages/settings/OAuth.tsx
+++ b/client/src/pages/settings/OAuth.tsx
@@ -16,6 +16,14 @@ import {
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui/select";
 import {
 	Dialog,
 	DialogContent,
@@ -44,6 +52,7 @@ import {
 } from "lucide-react";
 import {
 	useOAuthConfigs,
+	useUpdateOAuthLoginPreference,
 	useUpdateMicrosoftConfig,
 	useUpdateGoogleConfig,
 	useUpdateOIDCConfig,
@@ -389,6 +398,10 @@ export function OAuth() {
 		client_secret: "",
 		display_name: "SSO",
 	});
+	const [loginPreferenceDraft, setLoginPreferenceDraft] = useState<{
+		auto_redirect_to_sso: boolean;
+		default_sso_provider: OAuthProvider | null;
+	} | null>(null);
 
 	// Load configurations
 	const { data: configData, isLoading, refetch } = useOAuthConfigs();
@@ -397,6 +410,7 @@ export function OAuth() {
 	const updateMicrosoft = useUpdateMicrosoftConfig();
 	const updateGoogle = useUpdateGoogleConfig();
 	const updateOIDC = useUpdateOIDCConfig();
+	const updateLoginPreference = useUpdateOAuthLoginPreference();
 	const deleteConfig = useDeleteOAuthConfig();
 	const testConfig = useTestOAuthConfig();
 
@@ -413,9 +427,128 @@ export function OAuth() {
 	const microsoftConfig = providers.find((p) => p.provider === "microsoft");
 	const googleConfig = providers.find((p) => p.provider === "google");
 	const oidcConfig = providers.find((p) => p.provider === "oidc");
+	const configuredProviders = providers.filter((provider) => provider.configured);
+	const autoRedirectToSso =
+		loginPreferenceDraft?.auto_redirect_to_sso ??
+		configData?.login_preference.auto_redirect_to_sso ??
+		false;
+	const defaultSsoProvider = loginPreferenceDraft
+		? loginPreferenceDraft.default_sso_provider
+		: (configData?.login_preference.default_sso_provider ?? null);
+
+	const saveLoginPreference = async () => {
+		try {
+			await updateLoginPreference.mutateAsync({
+				body: {
+					auto_redirect_to_sso: autoRedirectToSso,
+					default_sso_provider: defaultSsoProvider ?? null,
+				},
+			});
+			await refetch();
+			setLoginPreferenceDraft(null);
+			toast.success("Preferred sign-in updated");
+		} catch (error) {
+			toast.error("Failed to update preferred sign-in", {
+				description:
+					error instanceof Error ? error.message : "Unknown error",
+			});
+		}
+	};
 
 	return (
 		<div className="space-y-6">
+			<Card>
+				<CardHeader>
+					<CardTitle>Preferred sign-in</CardTitle>
+					<CardDescription>
+						Optionally send users to one configured provider before
+						showing the full sign-in screen. Going Back or cancelling
+						shows all available sign-in options.
+					</CardDescription>
+				</CardHeader>
+				<CardContent className="space-y-5">
+					<div className="flex items-center justify-between gap-6">
+						<div className="space-y-0.5">
+							<Label htmlFor="preferred-sso-redirect" className="text-base">
+								Prefer SSO on login
+							</Label>
+							<p className="text-sm text-muted-foreground">
+								Try the selected provider once before presenting the
+								standard login screen.
+							</p>
+						</div>
+						<Switch
+							id="preferred-sso-redirect"
+							checked={autoRedirectToSso}
+							disabled={configuredProviders.length === 0}
+							onCheckedChange={(checked) => {
+								setLoginPreferenceDraft({
+									auto_redirect_to_sso: checked,
+									default_sso_provider:
+										defaultSsoProvider ??
+										(checked
+											? configuredProviders[0]?.provider ?? null
+											: null),
+								});
+							}}
+						/>
+					</div>
+
+					<div className="space-y-2">
+						<Label htmlFor="preferred-sso-provider">
+							Preferred provider
+						</Label>
+						<Select
+							value={defaultSsoProvider ?? ""}
+							onValueChange={(value: OAuthProvider) =>
+								setLoginPreferenceDraft({
+									auto_redirect_to_sso: autoRedirectToSso,
+									default_sso_provider: value,
+								})
+							}
+							disabled={configuredProviders.length === 0}
+						>
+							<SelectTrigger id="preferred-sso-provider">
+								<SelectValue placeholder="Select a configured provider" />
+							</SelectTrigger>
+							<SelectContent>
+								{configuredProviders.map((provider) => (
+									<SelectItem
+										key={provider.provider}
+										value={provider.provider}
+									>
+										{provider.provider === "microsoft"
+											? "Microsoft Entra ID"
+											: provider.provider === "google"
+												? "Google"
+												: provider.display_name || "OIDC Provider"}
+									</SelectItem>
+								))}
+							</SelectContent>
+						</Select>
+						{configuredProviders.length === 0 && (
+							<p className="text-sm text-muted-foreground">
+								Configure a provider below before enabling preferred
+								sign-in.
+							</p>
+						)}
+					</div>
+
+					<Button
+						onClick={saveLoginPreference}
+						disabled={
+							updateLoginPreference.isPending ||
+							(autoRedirectToSso && !defaultSsoProvider)
+						}
+					>
+						{updateLoginPreference.isPending && (
+							<Loader2 className="h-4 w-4 mr-2 animate-spin" />
+						)}
+						Save preference
+					</Button>
+				</CardContent>
+			</Card>
+
 			{/* Microsoft */}
 			<ProviderCard
 				provider="microsoft"

--- a/client/src/services/auth.test.ts
+++ b/client/src/services/auth.test.ts
@@ -1,0 +1,41 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+	clearPreferredSsoRedirectAttempt,
+	getAuthStatus,
+	PREFERRED_SSO_REDIRECT_ATTEMPTED_KEY,
+} from "./auth";
+
+describe("auth service", () => {
+	beforeEach(() => {
+		sessionStorage.clear();
+		vi.restoreAllMocks();
+	});
+
+	it("loads the public login policy", async () => {
+		const status = {
+			needs_setup: false,
+			password_login_enabled: true,
+			mfa_required_for_password: false,
+			oauth_providers: [],
+			auto_redirect_to_sso: true,
+			default_sso_provider: "microsoft" as const,
+		};
+		vi.spyOn(globalThis, "fetch").mockResolvedValue(
+			new Response(JSON.stringify(status), { status: 200 }),
+		);
+
+		await expect(getAuthStatus()).resolves.toEqual(status);
+		expect(fetch).toHaveBeenCalledWith("/auth/status");
+	});
+
+	it("clears the one-attempt guard after authentication", () => {
+		sessionStorage.setItem(PREFERRED_SSO_REDIRECT_ATTEMPTED_KEY, "true");
+
+		clearPreferredSsoRedirectAttempt();
+
+		expect(
+			sessionStorage.getItem(PREFERRED_SSO_REDIRECT_ATTEMPTED_KEY),
+		).toBeNull();
+	});
+});

--- a/client/src/services/auth.ts
+++ b/client/src/services/auth.ts
@@ -20,6 +20,13 @@ export type TOTPVerifyResponse = components["schemas"]["MFAVerifyResponse"];
 export type RecoveryCodesCount =
 	components["schemas"]["RecoveryCodesCountResponse"];
 
+export const PREFERRED_SSO_REDIRECT_ATTEMPTED_KEY =
+	"preferred_sso_redirect_attempted";
+
+export function clearPreferredSsoRedirectAttempt(): void {
+	sessionStorage.removeItem(PREFERRED_SSO_REDIRECT_ATTEMPTED_KEY);
+}
+
 // =============================================================================
 // Auth Status
 // =============================================================================

--- a/client/src/services/oauth-config.test.ts
+++ b/client/src/services/oauth-config.test.ts
@@ -1,0 +1,52 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+	invalidateQueries: vi.fn(),
+	useMutation: vi.fn(
+		(_method: unknown, _path: unknown, _options: unknown) => ({
+			mutateAsync: vi.fn(),
+		}),
+	),
+}));
+
+vi.mock("@tanstack/react-query", () => ({
+	useQueryClient: () => ({ invalidateQueries: mocks.invalidateQueries }),
+}));
+
+vi.mock("@/lib/api-client", () => ({
+	$api: {
+		useMutation: mocks.useMutation,
+		useQuery: vi.fn(),
+	},
+}));
+
+import { useUpdateOAuthLoginPreference } from "./oauth-config";
+
+describe("OAuth config service", () => {
+	beforeEach(() => {
+		mocks.invalidateQueries.mockReset();
+		mocks.useMutation.mockClear();
+	});
+
+	it("updates the login preference and invalidates both consumers", () => {
+		useUpdateOAuthLoginPreference();
+
+		expect(mocks.useMutation).toHaveBeenCalledWith(
+			"put",
+			"/api/settings/oauth/login-preference",
+			expect.objectContaining({ onSuccess: expect.any(Function) }),
+		);
+
+		const options = mocks.useMutation.mock.calls[0]?.[2] as {
+			onSuccess: () => void;
+		};
+		options.onSuccess();
+
+		expect(mocks.invalidateQueries).toHaveBeenCalledWith({
+			queryKey: ["get", "/api/settings/oauth"],
+		});
+		expect(mocks.invalidateQueries).toHaveBeenCalledWith({
+			queryKey: ["get", "/auth/status"],
+		});
+	});
+});

--- a/client/src/services/oauth-config.ts
+++ b/client/src/services/oauth-config.ts
@@ -15,6 +15,8 @@ export type OAuthProviderConfig =
 export type OAuthConfigList = components["schemas"]["OAuthConfigListResponse"];
 export type OAuthConfigTestResponse =
 	components["schemas"]["OAuthConfigTestResponse"];
+export type OAuthLoginPreference =
+	components["schemas"]["OAuthLoginPreference"];
 export type MicrosoftOAuthConfig =
 	components["schemas"]["MicrosoftOAuthConfigRequest"];
 export type GoogleOAuthConfig =
@@ -28,6 +30,24 @@ export type OAuthProvider = "microsoft" | "google" | "oidc";
  */
 export function useOAuthConfigs() {
 	return $api.useQuery("get", "/api/settings/oauth");
+}
+
+/**
+ * Hook to update whether login should first redirect to a preferred provider.
+ */
+export function useUpdateOAuthLoginPreference() {
+	const queryClient = useQueryClient();
+
+	return $api.useMutation("put", "/api/settings/oauth/login-preference", {
+		onSuccess: () => {
+			queryClient.invalidateQueries({
+				queryKey: ["get", "/api/settings/oauth"],
+			});
+			queryClient.invalidateQueries({
+				queryKey: ["get", "/auth/status"],
+			});
+		},
+	});
 }
 
 /**

--- a/plugins/bifrost/skills/bifrost-build/generated/openapi-digest.md
+++ b/plugins/bifrost/skills/bifrost-build/generated/openapi-digest.md
@@ -421,6 +421,7 @@
 | PUT | `/api/settings/ai/pricing/{pricing_id}` |
 | GET | `/api/settings/oauth` |
 | PUT | `/api/settings/oauth/google` |
+| PUT | `/api/settings/oauth/login-preference` |
 | PUT | `/api/settings/oauth/microsoft` |
 | PUT | `/api/settings/oauth/oidc` |
 | DELETE | `/api/settings/oauth/{provider}` |


### PR DESCRIPTION
## Summary

- add a platform-admin preferred sign-in setting using the existing system configuration store
- redirect to one configured SSO provider once before showing the full login screen
- keep Back and provider cancellation on the full screen with every available sign-in method
- prevent deletion of an actively preferred provider and clear disabled stale preferences
- rename the settings tab from SSO to Authentication

## Scope

This is the first delivery for #567. It intentionally does not add email-first method discovery, per-user sign-in eligibility, or SSO enforcement.

## Testing

- `./test.sh quality api`
- `./test.sh tests/unit/services/test_oauth_config_service.py -v` — 5 passed
- `./test.sh tests/e2e/api/test_oauth_config.py -v` — 2 passed
- `./test.sh tests/unit/test_dto_flags.py tests/unit/test_contract_version.py -v` — 64 passed
- `./test.sh tests/unit/test_skill_appendix_fresh.py -v` — 1 passed
- `./test.sh client unit src/services/auth.test.ts src/services/oauth-config.test.ts src/pages/Login.test.tsx src/pages/Settings.test.tsx src/pages/settings/OAuth.test.tsx` — 7 passed
- post-fix focused Vitest run for login, OAuth settings, and OAuth service — 4 passed
- `./test.sh client e2e e2e/preferred-sso.admin.spec.ts` — setup plus preferred SSO happy path passed
- `npm run tsc`
- `npm run lint` — passes with one existing React Compiler warning in `FormRenderer.tsx`
- GitHub Actions — all required checks passed, including the 5,520-test backend unit suite and both E2E shards

The browser test uses the real Bifrost status/init boundary and stubs only the external Microsoft page. A real-provider smoke test remains pending a public HTTPS URL for the running dev stack.