### PR TITLE
Flatten dynamic MCP tool results

### DIFF
--- a/api/src/models/contracts/mcp.py
+++ b/api/src/models/contracts/mcp.py
@@ -131,7 +131,11 @@ class MCPGatewayExecuteRequest(BaseModel):
 
 
 class MCPGatewayExecuteResponse(BaseModel):
-    """Auditable envelope returned after a gateway tool call."""
+    """Internal REST envelope for an auditable gateway tool call.
+
+    The public MCP execute tool returns ``result`` directly; the remaining
+    fields support the REST bridge and server-side diagnostics.
+    """
 
     agent_id: str
     agent_name: str

--- a/api/src/services/mcp_server/gateway.py
+++ b/api/src/services/mcp_server/gateway.py
@@ -549,13 +549,12 @@ class MCPAgentGatewayService:
                 retryable=True,
                 details={"underlying_result": structured},
             )
-        return {
-            "content": pydantic_core.to_jsonable_python(
-                getattr(result, "content", result),
-                fallback=str,
-            ),
-            "structured_content": structured,
-        }
+        if structured is not None:
+            return structured
+        return pydantic_core.to_jsonable_python(
+            getattr(result, "content", result),
+            fallback=str,
+        )
 
     async def _dispatch_workflow(
         self,
@@ -594,7 +593,7 @@ class MCPAgentGatewayService:
                 response.error or "Workflow execution failed.",
                 details={"underlying_result": data},
             )
-        return data
+        return response.result
 
     async def _dispatch_delegation(
         self,
@@ -684,13 +683,14 @@ class MCPAgentGatewayService:
                         "External MCP connection is no longer available.",
                         retryable=True,
                     )
-                return await mcp_dispatch.invoke(
+                result = await mcp_dispatch.invoke(
                     connection=connection,
                     tool_name=tool.remote_tool_name,
                     arguments=arguments,
                     caller_user_id=UUID(str(self.context.user_id)),
                     db=db,
                 )
+                return self.unwrap_external_result(result)
         except NeedsReauthError as exc:
             raise GatewayError(
                 "NEEDS_REAUTH",
@@ -715,3 +715,24 @@ class MCPAgentGatewayService:
                 retryable=True,
                 details={"connection_id": str(tool.source_id)},
             ) from exc
+
+    @staticmethod
+    def unwrap_external_result(result: dict[str, Any]) -> Any:
+        """Return an external MCP tool's payload without its transport envelope."""
+        if result.get("is_error"):
+            structured = result.get("structured_content")
+            message = (
+                structured.get("error")
+                if isinstance(structured, dict)
+                else None
+            )
+            raise GatewayError(
+                "TOOL_EXECUTION_FAILED",
+                str(message or "External MCP tool reported an error."),
+                retryable=True,
+                details={"underlying_result": result},
+            )
+        structured = result.get("structured_content")
+        if structured is not None:
+            return structured
+        return result.get("content")

--- a/api/src/services/mcp_server/tool_result.py
+++ b/api/src/services/mcp_server/tool_result.py
@@ -16,6 +16,17 @@ from typing import Any
 from fastmcp.tools import ToolResult
 
 
+def direct_result(data: Any) -> ToolResult:
+    """Return a tool payload without adding display or metadata envelopes.
+
+    MCP ``structuredContent`` only accepts JSON objects, so using it would
+    either duplicate object payloads or require wrapping arrays and scalars.
+    Direct execution results instead use the required content channel for
+    every JSON value, preserving the selected tool's exact return shape.
+    """
+    return ToolResult(content="null" if data is None else data)
+
+
 def success_result(display_text: str, data: dict[str, Any] | None = None) -> ToolResult:
     """
     Create a successful tool result with display text and structured data.

--- a/api/src/services/mcp_server/tools/gateway.py
+++ b/api/src/services/mcp_server/tools/gateway.py
@@ -7,7 +7,11 @@ from fastmcp.tools import ToolResult
 from src.services.mcp_server.generators.fastmcp_generator import (
     register_tool_with_context,
 )
-from src.services.mcp_server.tool_result import error_result, success_result
+from src.services.mcp_server.tool_result import (
+    direct_result,
+    error_result,
+    success_result,
+)
 from src.services.mcp_server.tools._http_bridge import call_rest
 
 GATEWAY_INSTRUCTIONS = """When the four bifrost_* gateway tools are available,
@@ -94,10 +98,7 @@ async def bifrost_execute_tool(
     )
     if status_code != 200 or not isinstance(data, dict):
         return _rest_error("Tool execution", status_code, data)
-    return success_result(
-        f"Executed '{data['tool_name']}' through '{data['agent_name']}'.",
-        data,
-    )
+    return direct_result(data["result"])
 
 
 TOOLS = [
@@ -124,7 +125,7 @@ TOOLS = [
         "Execute Bifrost Tool",
         "Execute a tool reference through its selected agent after inspecting its "
         "live schema. Arguments are strictly validated and authorization is "
-        "rechecked on every call.",
+        "rechecked on every call. Returns the selected tool's result directly.",
     ),
 ]
 

--- a/api/tests/e2e/api-integration/test_mcp_gateway.py
+++ b/api/tests/e2e/api-integration/test_mcp_gateway.py
@@ -1,12 +1,11 @@
 """Wire-level proof for progressive agent discovery on the default MCP URL."""
 
+import json
 import os
 import uuid
 
 import pytest
 import requests
-
-from tests.fixtures.auth import create_test_jwt
 
 TEST_API_URL = os.getenv("TEST_API_URL", "http://api:8000")
 MCP_ACCEPT = "application/json, text/event-stream"
@@ -63,24 +62,30 @@ def _call_gateway(token: str, name: str, arguments: dict) -> dict:
         "tools/call",
         {"name": name, "arguments": arguments},
     )
-    return payload["result"]["structuredContent"]
+    result = payload["result"]
+    structured = result.get("structuredContent")
+    if structured is not None:
+        return structured
+    assert len(result["content"]) == 1, result
+    return json.loads(result["content"][0]["text"])
 
 
 @pytest.mark.e2e
 class TestMCPAgentGateway:
     @pytest.fixture(autouse=True, scope="class")
-    def gateway_fixture(self, request):
+    def gateway_fixture(self, request, platform_admin):
         suffix = uuid.uuid4().hex[:8]
         function_name = f"gateway_echo_{suffix}"
         path = f"workflows/{function_name}.py"
-        token = create_test_jwt(is_superuser=True)
+        token = platform_admin.access_token
+        assert token is not None
         headers = _api_headers(token)
 
         content = (
             "from bifrost import tool\n\n"
             "@tool(description='Echo a message for the MCP gateway proof.')\n"
-            f"def {function_name}(message: str) -> dict:\n"
-            "    return {'echo': message}\n"
+            f"async def {function_name}(message: str) -> list[dict]:\n"
+            "    return [{'echo': message}]\n"
         )
         write_response = requests.put(
             f"{TEST_API_URL}/api/files/editor/content",
@@ -202,6 +207,23 @@ class TestMCPAgentGateway:
         )
         assert schema["input_schema"]["required"] == ["message"]
 
+        execution_payload = _mcp_request(
+            self.token,
+            "tools/call",
+            {
+                "name": "bifrost_execute_tool",
+                "arguments": {
+                    "agent_id": self.agent_id,
+                    "tool_ref": tool_ref,
+                    "arguments": {"message": "hello"},
+                },
+            },
+        )["result"]
+        assert "structuredContent" not in execution_payload
+        assert json.loads(execution_payload["content"][0]["text"]) == [
+            {"echo": "hello"}
+        ]
+
         invalid = _call_gateway(
             self.token,
             "bifrost_execute_tool",
@@ -225,10 +247,7 @@ class TestMCPAgentGateway:
                 "arguments": {},
             },
         )
-        assert executed["agent_id"] == self.agent_id
-        assert executed["tool_ref"] == system_tool["tool_ref"]
-        assert executed["source"] == "system"
-        assert "schema" in executed["result"]["structured_content"]
+        assert "schema" in executed
 
         updated_prompt = f"{self.prompt} updated"
         update_response = requests.put(

--- a/api/tests/unit/services/mcp_server/test_gateway.py
+++ b/api/tests/unit/services/mcp_server/test_gateway.py
@@ -198,3 +198,101 @@ async def test_execute_returns_auditable_envelope():
     assert result["source"] == "workflow"
     assert result["result"] == {"ticket": 42}
     assert isinstance(result["duration_ms"], int)
+
+
+@pytest.mark.asyncio
+async def test_workflow_dispatch_returns_only_the_workflow_result():
+    service = MCPAgentGatewayService(_context())
+    tool = _resolved_tool()
+    response = MagicMock()
+    response.execution_id = str(uuid4())
+    response.status.value = "Success"
+    response.duration_ms = 125
+    response.result = [{"ticket": 42}]
+    response.error = None
+    response.error_type = None
+
+    with patch(
+        "src.services.execution.service.execute_tool",
+        new=AsyncMock(return_value=response),
+    ):
+        result = await service._dispatch_workflow(tool, {"ticket_id": 42})
+
+    assert result == [{"ticket": 42}]
+
+
+@pytest.mark.asyncio
+async def test_workflow_dispatch_keeps_execution_details_on_failure():
+    service = MCPAgentGatewayService(_context())
+    tool = _resolved_tool()
+    execution_id = str(uuid4())
+    response = MagicMock()
+    response.execution_id = execution_id
+    response.status.value = "Failed"
+    response.duration_ms = 125
+    response.result = None
+    response.error = "HaloPSA rejected the query"
+    response.error_type = "UserError"
+
+    with patch(
+        "src.services.execution.service.execute_tool",
+        new=AsyncMock(return_value=response),
+    ):
+        with pytest.raises(GatewayError) as exc_info:
+            await service._dispatch_workflow(tool, {"ticket_id": 42})
+
+    error = exc_info.value
+    assert error.message == "HaloPSA rejected the query"
+    assert error.details["underlying_result"] == {
+        "execution_id": execution_id,
+        "status": "Failed",
+        "duration_ms": 125,
+        "result": None,
+        "error": "HaloPSA rejected the query",
+        "error_type": "UserError",
+    }
+
+
+def test_external_dispatch_prefers_the_structured_tool_payload():
+    result = MCPAgentGatewayService.unwrap_external_result(
+        {
+            "content": [{"type": "text", "text": "fallback"}],
+            "structured_content": {"tickets": [42]},
+            "is_error": False,
+            "_resolution_path": "user_token",
+        }
+    )
+
+    assert result == {"tickets": [42]}
+
+
+def test_external_dispatch_uses_content_without_structured_payload():
+    content = [{"type": "text", "text": "plain result"}]
+
+    result = MCPAgentGatewayService.unwrap_external_result(
+        {
+            "content": content,
+            "structured_content": None,
+            "is_error": False,
+            "_resolution_path": "service_token",
+        }
+    )
+
+    assert result == content
+
+
+def test_external_dispatch_preserves_structured_error_details():
+    underlying = {
+        "content": [{"type": "text", "text": "vendor rejected request"}],
+        "structured_content": {"error": "Invalid project"},
+        "is_error": True,
+        "_resolution_path": "user_token",
+    }
+
+    with pytest.raises(GatewayError) as exc_info:
+        MCPAgentGatewayService.unwrap_external_result(underlying)
+
+    error = exc_info.value
+    assert error.message == "Invalid project"
+    assert error.retryable is True
+    assert error.details["underlying_result"] == underlying

--- a/api/tests/unit/services/mcp_server/test_tool_result.py
+++ b/api/tests/unit/services/mcp_server/test_tool_result.py
@@ -4,6 +4,7 @@
 from fastmcp.tools import ToolResult
 
 from src.services.mcp_server.tool_result import (
+    direct_result,
     error_result,
     format_diff,
     format_file_content,
@@ -22,6 +23,28 @@ class TestSuccessResult:
         result = success_result("Found items", {"count": 5, "items": ["a", "b"]})
         assert isinstance(result, ToolResult)
         assert result.structured_content == {"count": 5, "items": ["a", "b"]}
+
+
+class TestDirectResult:
+    def test_returns_array_as_the_only_content(self):
+        result = direct_result([{"echo": "hello"}])
+
+        assert result.structured_content is None
+        assert len(result.content) == 1
+        assert result.content[0].text == '[{"echo":"hello"}]'
+
+    def test_returns_object_without_a_gateway_envelope(self):
+        result = direct_result({"echo": "hello"})
+
+        assert result.structured_content is None
+        assert len(result.content) == 1
+        assert result.content[0].text == '{"echo":"hello"}'
+
+    def test_serializes_null_result(self):
+        result = direct_result(None)
+
+        assert result.structured_content is None
+        assert result.content[0].text == "null"
 
 
 class TestErrorResult:

--- a/docs/superpowers/specs/2026-07-27-mcp-agent-gateway.md
+++ b/docs/superpowers/specs/2026-07-27-mcp-agent-gateway.md
@@ -120,7 +120,9 @@ default gateway obtains live agent instructions through `bifrost_get_agent`.
   - external MCP tools: `mcp_client.dispatch.invoke`.
 - Uses the authenticated MCP caller identity for downstream execution and
   OAuth resolution.
-- Returns resolved agent/tool provenance, result, and duration.
+- Returns the selected tool's result directly to the MCP caller. Agent/tool
+  provenance, execution identifiers, status, and duration remain in server
+  logs and source-specific execution records rather than the model payload.
 
 The gateway logs the authenticated caller, resolved agent, resolved tool name,
 source, success/failure, and duration. Existing workflow, agent-run, and


### PR DESCRIPTION
## Summary
- return successful `bifrost_execute_tool` payloads directly
- keep audit/provenance metadata in server-side execution records
- normalize workflow, system/knowledge, and external MCP result handling
- preserve structured execution details on failures
- add wire-level regression coverage for array payloads

## Root cause
The gateway wrapped source-specific execution envelopes inside a second agent/tool provenance envelope, then duplicated that object into MCP text and structured content. Dynamic callers had to read nested `result` properties and carry metadata irrelevant to the model.

## Result
Successful dynamic calls now expose the selected tool's own JSON value as the MCP result. For the reporting workflow in the motivating example, callers receive the rows array directly.

## Documentation
- Updated the gateway architecture spec in this PR.
- Screenshot/docs catch-up opened separately: https://github.com/gobifrost/website/pull/7

## Validation
- `./test.sh tests/unit/` — 5,472 passed, 3 skipped
- `./test.sh tests/e2e/api-integration/test_mcp_gateway.py -v` — 2 passed
- `./test.sh tests/unit/test_mcp_thin_wrapper.py -v` — 41 passed
- `./test.sh tests/unit/services/mcp_server/test_tool_result.py tests/unit/services/mcp_server/test_gateway.py -v` — 22 passed
- `./test.sh quality api` — pyright and ruff passed
