### PR TITLE
Fix agent lifecycle actions

### DIFF
--- a/.claude/skills/bifrost-build/generated/cli-reference.md
+++ b/.claude/skills/bifrost-build/generated/cli-reference.md
@@ -15,9 +15,9 @@ Options:
 
 Commands:
   create  Create a new agent.
-  delete  Soft-delete an agent.
+  delete  Permanently delete an agent.
   get     Get a single agent by UUID or name.
-  list    List all agents.
+  list    List active agents by default.
   update  Update an agent.
 ```
 
@@ -73,7 +73,7 @@ Options:
 ```
 Usage: agents delete [OPTIONS] REF
 
-  Soft-delete an agent.
+  Permanently delete an agent.
 
   ``REF`` is a UUID or agent name. The server returns ``204 No Content`` on
   success; the CLI reports the resolved UUID.
@@ -100,11 +100,12 @@ Options:
 ```
 Usage: agents list [OPTIONS]
 
-  List all agents.
+  List active agents by default.
 
 Options:
-  --json  Emit JSON instead of human-readable output.
-  --help  Show this message and exit.
+  --include-inactive  Include inactive agents.
+  --json              Emit JSON instead of human-readable output.
+  --help              Show this message and exit.
 ```
 
 ### `agents update`

--- a/api/bifrost/commands/agents.py
+++ b/api/bifrost/commands/agents.py
@@ -133,17 +133,25 @@ _UPDATE_FLAGS = build_cli_flags(
 
 
 @agents_group.command("list")
+@click.option(
+    "--include-inactive",
+    is_flag=True,
+    default=False,
+    help="Include inactive agents.",
+)
 @click.pass_context
 @pass_resolver
 @run_async
 async def list_agents(
     ctx: click.Context,
+    include_inactive: bool,
     *,
     client: BifrostClient,
     resolver: RefResolver,  # noqa: ARG001 - kept for signature parity
 ) -> None:
-    """List all agents."""
-    response = await client.get("/api/agents")
+    """List active agents by default."""
+    params = {"active_only": False} if include_inactive else None
+    response = await client.get("/api/agents", params=params)
     response.raise_for_status()
     output_result(response.json(), ctx=ctx)
 
@@ -287,7 +295,7 @@ async def delete_agent(
     client: BifrostClient,
     resolver: RefResolver,
 ) -> None:
-    """Soft-delete an agent.
+    """Permanently delete an agent.
 
     ``REF`` is a UUID or agent name. The server returns ``204 No Content``
     on success; the CLI reports the resolved UUID.

--- a/api/src/routers/agents.py
+++ b/api/src/routers/agents.py
@@ -846,7 +846,7 @@ async def delete_agent(
     db: DbSession,
     user: CurrentActiveUser,
 ) -> None:
-    """Soft delete an agent. Admins can delete any agent. Users can delete their own private agents.
+    """Permanently delete an agent. Admins can delete any agent. Users can delete their own private agents.
 
     System agents can be deleted - they will be recreated on next startup
     if they are still defined in the system agent definitions.
@@ -871,9 +871,9 @@ async def delete_agent(
         if agent.owner_user_id != user.user_id:
             raise HTTPException(403, "You can only delete your own private agents")
 
-    # Soft delete
-    agent.is_active = False
-    agent.updated_at = datetime.now(timezone.utc)
+    # Use a SQL DELETE so database-level cascades remove run history and agent
+    # memberships while SET NULL references (such as conversations) are preserved.
+    await db.execute(delete(Agent).where(Agent.id == agent_id))
     await db.flush()
 
 

--- a/api/src/services/mcp_server/tools/agents.py
+++ b/api/src/services/mcp_server/tools/agents.py
@@ -13,6 +13,7 @@ from uuid import uuid4
 from fastmcp.tools import ToolResult
 
 from src.services.mcp_server.tool_result import error_result, success_result
+from src.services.mcp_server.tools._http_bridge import call_rest
 from src.services.mcp_server.tools.db import get_tool_db
 
 # MCPContext is imported where needed to avoid circular imports
@@ -59,7 +60,7 @@ async def get_agent_schema(context: Any) -> ToolResult:  # noqa: ARG001
 - `get_agent` - Get agent details by ID or name
 - `create_agent` - Create a new agent
 - `update_agent` - Update agent properties
-- `delete_agent` - Soft-delete an agent (deactivate)
+- `delete_agent` - Permanently delete an agent
 """
 
     schema_doc = model_docs + channels_doc
@@ -627,7 +628,7 @@ async def delete_agent(
     context: Any,
     agent_id: str,
 ) -> ToolResult:
-    """Delete an agent (soft delete).
+    """Permanently delete an agent through the canonical REST endpoint.
 
     Args:
         context: MCP context with user permissions
@@ -636,69 +637,31 @@ async def delete_agent(
     Returns:
         ToolResult with deletion confirmation
     """
-    from sqlalchemy import select
-
-    from src.models.orm import Agent
-
     logger.info(f"MCP delete_agent called: agent_id={agent_id}")
 
     if not agent_id:
         return error_result("agent_id is required")
 
-    # Validate agent_id is a valid UUID
     try:
         uuid_id = UUID(agent_id)
     except ValueError:
         return error_result(f"'{agent_id}' is not a valid UUID")
 
-    try:
-        async with get_tool_db(context) as db:
-            result = await db.execute(
-                select(Agent).where(Agent.id == uuid_id)
-            )
-            agent = result.scalar_one_or_none()
+    status_code, body = await call_rest(
+        context,
+        "DELETE",
+        f"/api/agents/{uuid_id}",
+    )
+    if status_code != 204:
+        return error_result(
+            f"delete_agent failed: HTTP {status_code}",
+            {"body": body},
+        )
 
-            if not agent:
-                return error_result(f"Agent '{agent_id}' not found. Use list_agents to see available agents.")
-
-            # Solution-managed agents are read-only (criterion 6). Refuse BEFORE
-            # mutating so the caller gets the clean locked message instead of the
-            # before_flush backstop raising a 500 (audit M-MCP).
-            from src.services.solutions.guard import (
-                SOLUTION_MANAGED_MESSAGE,
-                is_solution_managed,
-            )
-
-            if is_solution_managed(agent):
-                return error_result(SOLUTION_MANAGED_MESSAGE)
-
-            # Check access for non-admins
-            if not context.is_platform_admin:
-                if agent.organization_id:
-                    if context.org_id and str(agent.organization_id) != str(context.org_id):
-                        return error_result("You don't have permission to delete this agent.")
-                # Global agents can only be deleted by admins
-                if agent.organization_id is None:
-                    return error_result("Only platform admins can delete global agents.")
-
-            # Soft delete
-            agent.is_active = False
-            agent.updated_at = datetime.now(timezone.utc)
-            await db.flush()
-
-            logger.info(f"Deleted (soft) agent {agent.id}: {agent.name}")
-
-            display_text = f"Deleted agent: {agent.name}"
-            return success_result(display_text, {
-                "success": True,
-                "id": str(agent.id),
-                "name": agent.name,
-                "message": f"Agent '{agent.name}' has been deactivated.",
-            })
-
-    except Exception as e:
-        logger.exception(f"Error deleting agent via MCP: {e}")
-        return error_result(f"Error deleting agent: {str(e)}")
+    return success_result(
+        f"Deleted agent {uuid_id}",
+        {"deleted": str(uuid_id)},
+    )
 
 
 # Tool metadata for registration
@@ -707,7 +670,7 @@ TOOLS = [
     ("get_agent", "Get Agent", "Get detailed information about a specific agent including assigned tools and delegation targets."),
     ("create_agent", "Create Agent", "Create a new AI agent with system prompt and configuration."),
     ("update_agent", "Update Agent", "Update an existing agent's properties."),
-    ("delete_agent", "Delete Agent", "Delete an agent (soft delete - sets is_active to false)."),
+    ("delete_agent", "Delete Agent", "Permanently delete an agent."),
 ]
 
 

--- a/api/tests/e2e/api/test_agents.py
+++ b/api/tests/e2e/api/test_agents.py
@@ -5,8 +5,13 @@ Tests agent CRUD operations and role assignment.
 """
 
 import logging
+from uuid import UUID, uuid4
 
 import pytest
+from sqlalchemy import func, select
+
+from src.models.orm.agents import Agent
+from src.models.orm.agent_runs import AgentRun
 
 logger = logging.getLogger(__name__)
 
@@ -99,20 +104,73 @@ class TestAgentsCRUD:
         platform_admin,
         test_agent,
     ):
-        """Test soft deleting an agent."""
+        """Test permanently deleting an agent."""
         response = e2e_client.delete(
             f"/api/agents/{test_agent['id']}",
             headers=platform_admin.headers,
         )
         assert response.status_code == 204
 
-        # Verify it's inactive
+        # Verify the row no longer exists.
         response = e2e_client.get(
             f"/api/agents/{test_agent['id']}",
             headers=platform_admin.headers,
         )
-        assert response.status_code == 200
-        assert response.json()["is_active"] is False
+        assert response.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_delete_agent_removes_run_history(
+        self,
+        e2e_client,
+        platform_admin,
+        db_session,
+    ):
+        """Permanent deletion cascades through the agent's run history."""
+        create_response = e2e_client.post(
+            "/api/agents",
+            json={
+                "name": f"Delete Cascade {uuid4().hex[:8]}",
+                "system_prompt": "You are a deletion cascade test agent.",
+                "access_level": "authenticated",
+            },
+            headers=platform_admin.headers,
+        )
+        assert create_response.status_code == 201, create_response.text
+        agent_id = UUID(create_response.json()["id"])
+
+        db_session.add(
+            AgentRun(
+                agent_id=agent_id,
+                trigger_type="test",
+                status="completed",
+                iterations_used=1,
+                tokens_used=10,
+            )
+        )
+        await db_session.commit()
+
+        try:
+            delete_response = e2e_client.delete(
+                f"/api/agents/{agent_id}",
+                headers=platform_admin.headers,
+            )
+            assert delete_response.status_code == 204, delete_response.text
+
+            agent_count = await db_session.scalar(
+                select(func.count()).select_from(Agent).where(Agent.id == agent_id)
+            )
+            run_count = await db_session.scalar(
+                select(func.count())
+                .select_from(AgentRun)
+                .where(AgentRun.agent_id == agent_id)
+            )
+            assert agent_count == 0
+            assert run_count == 0
+        finally:
+            e2e_client.delete(
+                f"/api/agents/{agent_id}",
+                headers=platform_admin.headers,
+            )
 
     def test_list_agents_excludes_inactive_by_default(
         self,
@@ -121,9 +179,10 @@ class TestAgentsCRUD:
         test_agent,
     ):
         """Test that inactive agents are excluded from list by default."""
-        # First delete the agent
-        e2e_client.delete(
+        # First deactivate the agent without deleting it.
+        e2e_client.put(
             f"/api/agents/{test_agent['id']}",
+            json={"is_active": False},
             headers=platform_admin.headers,
         )
 

--- a/api/tests/e2e/platform/test_cli_agents.py
+++ b/api/tests/e2e/platform/test_cli_agents.py
@@ -6,8 +6,8 @@ Covers the CRUD surface from Task 5e of the CLI mutation surface plan:
   new agent with the prompt loaded from disk.
 * ``bifrost agents update <ref> --llm-model ...`` — PUTs (the audit
   correction — **not** PATCH) by UUID or name ref.
-* ``bifrost agents delete <ref>`` — soft-deletes the agent; subsequent
-  fetches via the admin API return 404 / mark the record inactive.
+* ``bifrost agents update <ref> --no-is-active`` — deactivates the agent.
+* ``bifrost agents delete <ref>`` — permanently deletes the agent.
 
 The commands are invoked via :class:`click.testing.CliRunner` against the
 real API stack. ``BifrostClient.get_instance`` is patched via the thread-
@@ -136,21 +136,40 @@ class TestCliAgents:
         # The unrelated prompt should be left untouched (default-omit for unset flags).
         assert updated["system_prompt"] == prompt_text
 
+        # --- deactivate and reactivate (existing DTO-generated CLI flags) ---
+        deactivate_result = _invoke(
+            ["--json", "update", created_id, "--no-is-active"]
+        )
+        assert deactivate_result.exit_code == 0, deactivate_result.output
+        assert json.loads(deactivate_result.output)["is_active"] is False
+
+        default_list_result = _invoke(["--json", "list"])
+        assert default_list_result.exit_code == 0, default_list_result.output
+        default_ids = {str(a["id"]) for a in json.loads(default_list_result.output)}
+        assert created_id not in default_ids
+
+        all_list_result = _invoke(["--json", "list", "--include-inactive"])
+        assert all_list_result.exit_code == 0, all_list_result.output
+        all_ids = {str(a["id"]) for a in json.loads(all_list_result.output)}
+        assert created_id in all_ids
+
+        reactivate_result = _invoke(
+            ["--json", "update", created_id, "--is-active"]
+        )
+        assert reactivate_result.exit_code == 0, reactivate_result.output
+        assert json.loads(reactivate_result.output)["is_active"] is True
+
         # --- delete (by UUID — exercise the pass-through path) ---
         delete_result = _invoke(["--json", "delete", created_id])
         assert delete_result.exit_code == 0, delete_result.output
         deleted_payload = json.loads(delete_result.output)
         assert deleted_payload["deleted"] == created_id
 
-        # Confirm the soft-delete: admin list filters inactive agents by default.
-        list_resp = e2e_client.get(
-            "/api/agents", headers=platform_admin.headers
+        # Confirm permanent deletion rather than another deactivation.
+        get_deleted_resp = e2e_client.get(
+            f"/api/agents/{created_id}", headers=platform_admin.headers
         )
-        assert list_resp.status_code == 200
-        active_ids = {str(a["id"]) for a in list_resp.json()}
-        assert created_id not in active_ids, (
-            f"Agent {created_id} should be absent from active list after delete"
-        )
+        assert get_deleted_resp.status_code == 404
 
     def test_update_tool_ids_persists_exact_set(
         self,

--- a/api/tests/unit/test_cli_agents.py
+++ b/api/tests/unit/test_cli_agents.py
@@ -16,7 +16,7 @@ from bifrost.commands.agents import agents_group
 class _FakeClient:
     """Minimal async client for agents CLI unit tests."""
 
-    def __init__(self, *, put_body: dict[str, Any]) -> None:
+    def __init__(self, *, put_body: Any) -> None:
         self.api_url = "http://test.local"
         self._access_token = "test-token"
         self.calls: list[tuple[str, str, dict[str, Any] | None]] = []
@@ -30,8 +30,13 @@ class _FakeClient:
         self.calls.append(("PUT", path, json))
         return self._response("PUT", path, self._put_body)
 
-    async def get(self, path: str) -> httpx.Response:
-        self.calls.append(("GET", path, None))
+    async def get(
+        self,
+        path: str,
+        *,
+        params: dict[str, Any] | None = None,
+    ) -> httpx.Response:
+        self.calls.append(("GET", path, params))
         return self._response("GET", path, self._put_body)
 
 
@@ -70,3 +75,15 @@ def test_update_tool_ids_fails_when_persisted_ids_differ(_patch_client) -> None:
     assert "tool_ids" in result.output
     assert "did not persist" in result.output
     assert fake.calls[0] == ("PUT", f"/api/agents/{agent_id}", {"tool_ids": [tool_id]})
+
+
+def test_list_include_inactive_requests_all_agents(_patch_client) -> None:
+    fake = _patch_client(_FakeClient(put_body=[]))
+
+    result = CliRunner().invoke(
+        agents_group,
+        ["--json", "list", "--include-inactive"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert fake.calls == [("GET", "/api/agents", {"active_only": False})]

--- a/api/tests/unit/test_mcp_solution_managed.py
+++ b/api/tests/unit/test_mcp_solution_managed.py
@@ -578,8 +578,6 @@ async def test_mcp_update_form_refuses_managed_without_deleting_fields(db_sessio
 
 
 async def test_mcp_delete_agent_refuses_managed(db_session, monkeypatch):
-    from contextlib import asynccontextmanager
-
     from sqlalchemy import select
 
     from src.models.orm.agents import Agent
@@ -587,18 +585,19 @@ async def test_mcp_delete_agent_refuses_managed(db_session, monkeypatch):
 
     aid, _wf = await _managed_agent_with_tool(db_session)
 
-    @asynccontextmanager
-    async def _fake_tool_db(_context):
-        yield db_session
+    async def _fake_call_rest(_context, method, path):
+        assert method == "DELETE"
+        assert path == f"/api/agents/{aid}"
+        return 409, {"detail": SOLUTION_MANAGED_MESSAGE}
 
-    monkeypatch.setattr(mcp_agents, "get_tool_db", _fake_tool_db)
+    monkeypatch.setattr(mcp_agents, "call_rest", _fake_call_rest)
 
     context = SimpleNamespace(is_platform_admin=True, org_id=None, user_id=uuid.uuid4())
     result = await mcp_agents.delete_agent(context, agent_id=str(aid))
 
     text = str(result.model_dump() if hasattr(result, "model_dump") else result)
     assert SOLUTION_MANAGED_MESSAGE in text, text
-    # The agent is still active — the soft-delete never ran.
+    # The canonical REST endpoint refused the delete, so the agent is unchanged.
     is_active = (await db_session.execute(
         select(Agent.is_active).where(Agent.id == aid)
     )).scalar_one()

--- a/client/e2e/agents-fleet.admin.spec.ts
+++ b/client/e2e/agents-fleet.admin.spec.ts
@@ -9,7 +9,7 @@
 import { test, expect } from "./fixtures/api-fixture";
 
 test.describe("Agents Fleet Page (admin)", () => {
-	test("hides inactive agents until Show inactive is enabled", async ({
+	test("hides inactive agents until Show Inactive is enabled", async ({
 		page,
 		api,
 	}) => {
@@ -43,7 +43,7 @@ test.describe("Agents Fleet Page (admin)", () => {
 			).toBeVisible({ timeout: 10000 });
 			await expect(page.getByText(name)).toHaveCount(0);
 
-			await page.getByRole("switch", { name: /show inactive/i }).click();
+			await page.getByRole("switch", { name: "Show Inactive" }).click();
 			await expect(page.getByText(name)).toBeVisible();
 		} finally {
 			await api.delete(`/api/agents/${agent.id}`);

--- a/client/e2e/agents-fleet.admin.spec.ts
+++ b/client/e2e/agents-fleet.admin.spec.ts
@@ -6,9 +6,50 @@
  * Phase 5 visual review pass.
  */
 
-import { test, expect } from "@playwright/test";
+import { test, expect } from "./fixtures/api-fixture";
 
 test.describe("Agents Fleet Page (admin)", () => {
+	test("hides inactive agents until Show inactive is enabled", async ({
+		page,
+		api,
+	}) => {
+		const name = `Inactive Fleet Agent ${Date.now()}`;
+		const createResponse = await api.post("/api/agents", {
+			data: {
+				name,
+				system_prompt:
+					"You are an inactive fleet visibility test agent.",
+				access_level: "authenticated",
+			},
+		});
+		expect(createResponse.ok(), await createResponse.text()).toBe(true);
+		const agent = await createResponse.json();
+
+		try {
+			const deactivateResponse = await api.put(
+				`/api/agents/${agent.id}`,
+				{
+					data: { is_active: false },
+				},
+			);
+			expect(
+				deactivateResponse.ok(),
+				await deactivateResponse.text(),
+			).toBe(true);
+
+			await page.goto("/agents");
+			await expect(
+				page.getByRole("heading", { name: /agents/i }).first(),
+			).toBeVisible({ timeout: 10000 });
+			await expect(page.getByText(name)).toHaveCount(0);
+
+			await page.getByRole("switch", { name: /show inactive/i }).click();
+			await expect(page.getByText(name)).toBeVisible();
+		} finally {
+			await api.delete(`/api/agents/${agent.id}`);
+		}
+	});
+
 	test("displays fleet stats and agent cards", async ({ page }) => {
 		await page.goto("/agents");
 
@@ -54,9 +95,7 @@ test.describe("Agents Fleet Page (admin)", () => {
 			// match your search" when there were agents, or "No agents yet"
 			// when the fleet was empty to begin with).
 			await expect(
-				page
-					.getByRole("heading", { name: /no agents/i })
-					.first(),
+				page.getByRole("heading", { name: /no agents/i }).first(),
 			).toBeVisible({ timeout: 5000 });
 		}
 	});

--- a/client/e2e/solution-lifecycle.admin.spec.ts
+++ b/client/e2e/solution-lifecycle.admin.spec.ts
@@ -22,9 +22,9 @@ test.describe("Solution lifecycle UI (admin)", () => {
 			page.getByRole("heading", { name: "Solutions", exact: true }),
 		).toBeVisible({ timeout: 10000 });
 
-		// Show-inactive toggle must be present on the list page.
+		// Show Inactive uses the standard list-filter switch.
 		await expect(
-			page.locator('[data-testid="show-inactive-toggle"]'),
+			page.getByRole("switch", { name: "Show Inactive" }),
 		).toBeVisible();
 	});
 

--- a/client/e2e/users.admin.spec.ts
+++ b/client/e2e/users.admin.spec.ts
@@ -18,7 +18,7 @@ test.describe("User Listing", () => {
 			page.getByRole("heading", { name: /users/i }).first(),
 		).toBeVisible({ timeout: 10000 });
 		await expect(
-			page.getByRole("switch", { name: "Show Disabled" }),
+			page.getByRole("switch", { name: "Show Inactive" }),
 		).toBeVisible();
 	});
 

--- a/client/e2e/users.admin.spec.ts
+++ b/client/e2e/users.admin.spec.ts
@@ -17,6 +17,9 @@ test.describe("User Listing", () => {
 		await expect(
 			page.getByRole("heading", { name: /users/i }).first(),
 		).toBeVisible({ timeout: 10000 });
+		await expect(
+			page.getByRole("switch", { name: "Show Disabled" }),
+		).toBeVisible();
 	});
 
 	test("should list existing users", async ({ page }) => {

--- a/client/src/pages/Solutions.test.tsx
+++ b/client/src/pages/Solutions.test.tsx
@@ -242,8 +242,8 @@ describe("Solutions — list", () => {
 		const { user } = await renderPage();
 		await screen.findByText("Active One");
 
-		const toggle = screen.getByTestId("show-inactive-toggle");
-		await user.click(toggle.querySelector("input")!);
+		const toggle = screen.getByRole("switch", { name: "Show Inactive" });
+		await user.click(toggle);
 
 		await waitFor(() =>
 			expect(screen.getByText("Inactive One")).toBeInTheDocument(),

--- a/client/src/pages/Solutions.tsx
+++ b/client/src/pages/Solutions.tsx
@@ -37,6 +37,8 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
+import { Switch } from "@/components/ui/switch";
+import { Label } from "@/components/ui/label";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 import {
 	DataTable,
@@ -406,19 +408,19 @@ export function Solutions() {
 						placeholder="All organizations"
 					/>
 				</div>
-				<label
-					className="flex cursor-pointer items-center gap-2 whitespace-nowrap text-sm text-muted-foreground"
-					data-testid="show-inactive-toggle"
-				>
-					<input
-						type="checkbox"
+				<div className="flex items-center gap-2 sm:ml-auto">
+					<Switch
+						id="show-inactive-solutions"
 						checked={showInactive}
-						onChange={(e) => setShowInactive(e.target.checked)}
-						className="accent-primary"
-						aria-label="Show inactive"
+						onCheckedChange={setShowInactive}
 					/>
-					Show inactive
-				</label>
+					<Label
+						htmlFor="show-inactive-solutions"
+						className="cursor-pointer whitespace-nowrap text-sm text-muted-foreground"
+					>
+						Show Inactive
+					</Label>
+				</div>
 			</div>
 
 			<div className="flex-1 min-h-0 overflow-auto">

--- a/client/src/pages/Users.test.tsx
+++ b/client/src/pages/Users.test.tsx
@@ -295,13 +295,13 @@ describe("Users", () => {
 		expect(row).not.toHaveTextContent("—");
 	});
 
-	it("includes disabled users when Show Disabled is enabled", async () => {
+	it("includes inactive users when Show Inactive is enabled", async () => {
 		const { user } = renderWithProviders(<Users />);
 
 		expect(mockUseUsersFiltered).toHaveBeenLastCalledWith(undefined, false);
 
 		await user.click(
-			screen.getByRole("switch", { name: "Show Disabled" }),
+			screen.getByRole("switch", { name: "Show Inactive" }),
 		);
 
 		expect(mockUseUsersFiltered).toHaveBeenLastCalledWith(undefined, true);

--- a/client/src/pages/Users.test.tsx
+++ b/client/src/pages/Users.test.tsx
@@ -294,4 +294,16 @@ describe("Users", () => {
 		expect(within(row!).getByText("Provider")).toBeInTheDocument();
 		expect(row).not.toHaveTextContent("—");
 	});
+
+	it("includes disabled users when Show Disabled is enabled", async () => {
+		const { user } = renderWithProviders(<Users />);
+
+		expect(mockUseUsersFiltered).toHaveBeenLastCalledWith(undefined, false);
+
+		await user.click(
+			screen.getByRole("switch", { name: "Show Disabled" }),
+		);
+
+		expect(mockUseUsersFiltered).toHaveBeenLastCalledWith(undefined, true);
+	});
 });

--- a/client/src/pages/Users.tsx
+++ b/client/src/pages/Users.tsx
@@ -434,7 +434,7 @@ export function Users() {
 						htmlFor="show-disabled"
 						className="text-sm text-muted-foreground cursor-pointer"
 					>
-						Show disabled
+						Show Disabled
 					</Label>
 				</div>
 			</div>

--- a/client/src/pages/Users.tsx
+++ b/client/src/pages/Users.tsx
@@ -434,7 +434,7 @@ export function Users() {
 						htmlFor="show-disabled"
 						className="text-sm text-muted-foreground cursor-pointer"
 					>
-						Show Disabled
+						Show Inactive
 					</Label>
 				</div>
 			</div>

--- a/client/src/pages/agents/FleetPage.test.tsx
+++ b/client/src/pages/agents/FleetPage.test.tsx
@@ -15,7 +15,10 @@ import { fireEvent, renderWithProviders, screen, within } from "@/test-utils";
 
 const mockUseAgents = vi.fn();
 vi.mock("@/hooks/useAgents", () => ({
-	useAgents: () => mockUseAgents(),
+	useAgents: (
+		filterScope?: string | null,
+		options?: { includeInactive?: boolean },
+	) => mockUseAgents(filterScope, options),
 }));
 
 const mockUseAgentStats = vi.fn();
@@ -124,7 +127,9 @@ describe("FleetPage — header + fleet stats", () => {
 			isLoading: false,
 		});
 		await renderPage();
-		expect(screen.getByTestId("mobile-fleet-metrics")).toHaveClass("md:hidden");
+		expect(screen.getByTestId("mobile-fleet-metrics")).toHaveClass(
+			"md:hidden",
+		);
 		expect(screen.getByTestId("desktop-fleet-stats")).toHaveClass(
 			"hidden",
 			"md:grid",
@@ -169,6 +174,21 @@ describe("FleetPage — header + fleet stats", () => {
 });
 
 describe("FleetPage — agent cards (grid)", () => {
+	it("hides inactive agents by default and includes them when requested", async () => {
+		const { user } = await renderPage();
+
+		expect(mockUseAgents).toHaveBeenLastCalledWith(undefined, {
+			includeInactive: false,
+		});
+
+		const toggle = screen.getByRole("switch", { name: /show inactive/i });
+		await user.click(toggle);
+
+		expect(mockUseAgents).toHaveBeenLastCalledWith(undefined, {
+			includeInactive: true,
+		});
+	});
+
 	it("renders one card per agent in grid view by default", async () => {
 		mockUseAgents.mockReturnValue({
 			data: [
@@ -295,7 +315,10 @@ describe("FleetPage — agent MCP URL copy badge", () => {
 		});
 		await renderPage();
 		const badge = screen.getByTestId("agent-mcp-copy");
-		const event = new MouseEvent("click", { bubbles: true, cancelable: true });
+		const event = new MouseEvent("click", {
+			bubbles: true,
+			cancelable: true,
+		});
 		badge.dispatchEvent(event);
 		expect(writeText).toHaveBeenCalledTimes(1);
 		expect(event.defaultPrevented).toBe(true);

--- a/client/src/pages/agents/FleetPage.test.tsx
+++ b/client/src/pages/agents/FleetPage.test.tsx
@@ -181,7 +181,7 @@ describe("FleetPage — agent cards (grid)", () => {
 			includeInactive: false,
 		});
 
-		const toggle = screen.getByRole("switch", { name: /show inactive/i });
+		const toggle = screen.getByRole("switch", { name: "Show Inactive" });
 		await user.click(toggle);
 
 		expect(mockUseAgents).toHaveBeenLastCalledWith(undefined, {

--- a/client/src/pages/agents/FleetPage.tsx
+++ b/client/src/pages/agents/FleetPage.tsx
@@ -41,7 +41,9 @@ import {
 	DataTableRow,
 } from "@/components/ui/data-table";
 import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
 import { Skeleton } from "@/components/ui/skeleton";
+import { Switch } from "@/components/ui/switch";
 
 import { QueueBanner } from "@/components/agents/QueueBanner";
 import { Sparkline } from "@/components/agents/Sparkline";
@@ -84,16 +86,16 @@ type Organization = components["schemas"]["OrganizationPublic"];
 export function FleetPage() {
 	const [view, setView] = useState<ViewMode>("grid");
 	const [query, setQuery] = useState("");
+	const [showInactive, setShowInactive] = useState(false);
 	const [filterOrgId, setFilterOrgId] = useState<string | null | undefined>(
 		undefined,
 	);
 	const { isPlatformAdmin } = useAuth();
 	const terminology = useTerminology();
 
-	// Fleet view shows paused agents too (they need to be visible to un-pause).
 	const { data: agents, isLoading: agentsLoading } = useAgents(
 		isPlatformAdmin ? filterOrgId : undefined,
-		{ includeInactive: true },
+		{ includeInactive: showInactive },
 	);
 	const { data: fleetStats, isLoading: fleetLoading } = useFleetStats();
 
@@ -240,7 +242,8 @@ export function FleetPage() {
 							delta={
 								fleetStats.total_runs > 0
 									? `${formatCost(
-											Number(fleetStats.total_cost_7d) / 7,
+											Number(fleetStats.total_cost_7d) /
+												7,
 										)}/day avg`
 									: "—"
 							}
@@ -264,7 +267,9 @@ export function FleetPage() {
 									? "runs marked — click to open"
 									: "All runs reviewed"
 							}
-							deltaTone={fleetStats.needs_review > 0 ? "down" : "up"}
+							deltaTone={
+								fleetStats.needs_review > 0 ? "down" : "up"
+							}
 						/>
 					</div>
 				</>
@@ -294,6 +299,19 @@ export function FleetPage() {
 							/>
 						</div>
 					)}
+					<div className="flex items-center gap-2 sm:ml-auto">
+						<Switch
+							id="show-inactive"
+							checked={showInactive}
+							onCheckedChange={setShowInactive}
+						/>
+						<Label
+							htmlFor="show-inactive"
+							className="cursor-pointer whitespace-nowrap text-sm text-muted-foreground"
+						>
+							Show inactive
+						</Label>
+					</div>
 				</div>
 				<div className="inline-flex items-center rounded-2xl bg-muted p-[3px]">
 					<button
@@ -331,7 +349,12 @@ export function FleetPage() {
 			<div className="flex-1 min-h-0 overflow-auto">
 				{agentsLoading ? (
 					view === "grid" ? (
-						<div className={cn("grid md:grid-cols-2 xl:grid-cols-3", GAP_CARD)}>
+						<div
+							className={cn(
+								"grid md:grid-cols-2 xl:grid-cols-3",
+								GAP_CARD,
+							)}
+						>
 							{[...Array(6)].map((_, i) => (
 								<Skeleton key={i} className="h-52 w-full" />
 							))}
@@ -346,7 +369,12 @@ export function FleetPage() {
 				) : filtered.length === 0 ? (
 					<EmptyState hasQuery={query.trim().length > 0} />
 				) : view === "grid" ? (
-					<div className={cn("grid md:grid-cols-2 xl:grid-cols-3", GAP_CARD)}>
+					<div
+						className={cn(
+							"grid md:grid-cols-2 xl:grid-cols-3",
+							GAP_CARD,
+						)}
+					>
 						{filtered.map((agent) => (
 							<AgentGridCard
 								key={agent.id}
@@ -468,7 +496,9 @@ function AgentGridCard({
 							entityType="agent"
 							entityId={agent.id}
 							logo={agent.logo ?? null}
-							fallback={<Bot className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />}
+							fallback={
+								<Bot className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+							}
 							size={20}
 							className="h-5 w-5 rounded shrink-0 object-cover"
 						/>
@@ -481,7 +511,9 @@ function AgentGridCard({
 							</Badge>
 						) : null}
 						{agent.is_solution_managed ? (
-							<SolutionManagedBadge solutionId={agent.solution_id} />
+							<SolutionManagedBadge
+								solutionId={agent.solution_id}
+							/>
 						) : null}
 					</div>
 					<div className="flex shrink-0 flex-wrap gap-1">
@@ -536,7 +568,9 @@ function AgentGridCard({
 									? `Last run ${formatRelativeTime(stats!.last_run_at)}`
 									: "—"}
 							</span>
-							<span>avg {formatDuration(stats!.avg_duration_ms)}</span>
+							<span>
+								avg {formatDuration(stats!.avg_duration_ms)}
+							</span>
 						</div>
 					</>
 				) : (
@@ -618,9 +652,7 @@ function MiniStat({
 			<div className="mb-0.5 text-[11px] text-muted-foreground">
 				{label}
 			</div>
-			<div className={cn(TYPE_MINI_STAT_VALUE, valueClass)}>
-				{value}
-			</div>
+			<div className={cn(TYPE_MINI_STAT_VALUE, valueClass)}>{value}</div>
 		</div>
 	);
 }

--- a/client/src/pages/agents/FleetPage.tsx
+++ b/client/src/pages/agents/FleetPage.tsx
@@ -309,7 +309,7 @@ export function FleetPage() {
 							htmlFor="show-inactive"
 							className="cursor-pointer whitespace-nowrap text-sm text-muted-foreground"
 						>
-							Show inactive
+							Show Inactive
 						</Label>
 					</div>
 				</div>

--- a/plugins/bifrost/skills/bifrost-build/generated/cli-reference.md
+++ b/plugins/bifrost/skills/bifrost-build/generated/cli-reference.md
@@ -15,9 +15,9 @@ Options:
 
 Commands:
   create  Create a new agent.
-  delete  Soft-delete an agent.
+  delete  Permanently delete an agent.
   get     Get a single agent by UUID or name.
-  list    List all agents.
+  list    List active agents by default.
   update  Update an agent.
 ```
 
@@ -73,7 +73,7 @@ Options:
 ```
 Usage: agents delete [OPTIONS] REF
 
-  Soft-delete an agent.
+  Permanently delete an agent.
 
   ``REF`` is a UUID or agent name. The server returns ``204 No Content`` on
   success; the CLI reports the resolved UUID.
@@ -100,11 +100,12 @@ Options:
 ```
 Usage: agents list [OPTIONS]
 
-  List all agents.
+  List active agents by default.
 
 Options:
-  --json  Emit JSON instead of human-readable output.
-  --help  Show this message and exit.
+  --include-inactive  Include inactive agents.
+  --json              Emit JSON instead of human-readable output.
+  --help              Show this message and exit.
 ```
 
 ### `agents update`


### PR DESCRIPTION
## Summary

- hide inactive agents by default in the fleet and add a Show inactive toggle
- make confirmed REST and MCP agent deletion permanent, including run-history cascades
- keep CLI deactivation via update --no-is-active, add list --include-inactive, and make delete permanent
- refresh generated CLI references and add component, Playwright, API, CLI, and MCP regression coverage

## Verification

- ./test.sh client unit src/pages/agents/FleetPage.test.tsx
- ./test.sh client e2e e2e/agents-fleet.admin.spec.ts
- ./test.sh tests/unit/test_cli_agents.py tests/unit/test_mcp_solution_managed.py::test_mcp_delete_agent_refuses_managed -v
- ./test.sh tests/e2e/api/test_agents.py::TestAgentsCRUD::test_delete_agent tests/e2e/api/test_agents.py::TestAgentsCRUD::test_delete_agent_removes_run_history tests/e2e/api/test_agents.py::TestAgentsCRUD::test_list_agents_excludes_inactive_by_default tests/e2e/platform/test_cli_agents.py::TestCliAgents::test_create_update_delete_roundtrip -v
- ./test.sh tests/unit/test_cli_surface_smoke.py tests/unit/test_skill_appendix_fresh.py tests/unit/test_codex_mirror_sync.py tests/unit/test_mcp_thin_wrapper.py -v
- ./test.sh quality api
- npm run tsc
- npm run lint (passes with one pre-existing FormRenderer warning)
- targeted Prettier and ESLint checks for touched frontend files

Fixes #579