### PR TITLE
feat: consolidate MCP capability discovery

### DIFF
--- a/.claude/skills/bifrost-build/generated/openapi-digest.md
+++ b/.claude/skills/bifrost-build/generated/openapi-digest.md
@@ -288,10 +288,9 @@
 | DELETE | `/api/mcp/config` |
 | GET | `/api/mcp/config` |
 | PUT | `/api/mcp/config` |
-| GET | `/api/mcp/gateway/agents` |
-| GET | `/api/mcp/gateway/agents/{agent_id}` |
-| GET | `/api/mcp/gateway/agents/{agent_id}/tools/{tool_ref}` |
 | POST | `/api/mcp/gateway/agents/{agent_id}/tools/{tool_ref}/execute` |
+| POST | `/api/mcp/gateway/capabilities/search` |
+| GET | `/api/mcp/gateway/executions/{execution_id}` |
 | GET | `/api/mcp/run` |
 | GET | `/api/mcp/run/plugin` |
 | GET | `/api/mcp/status` |

--- a/api/src/models/contracts/mcp.py
+++ b/api/src/models/contracts/mcp.py
@@ -7,7 +7,7 @@ Pydantic models for MCP configuration API requests and responses.
 from datetime import datetime
 from typing import Any
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 
 class MCPConfigResponse(BaseModel):
@@ -82,70 +82,82 @@ class MCPRunInfoResponse(BaseModel):
     )
 
 
-class MCPGatewayAgentSummary(BaseModel):
-    """Compact agent metadata returned by gateway discovery."""
+class MCPGatewayToolSummary(BaseModel):
+    """A matching agent-bound tool, optionally hydrated with its schema."""
+
+    tool_ref: str
+    name: str
+    description: str
+    source: str
+    input_schema: dict[str, Any] | None = None
+    schema_included: bool = False
+
+
+class MCPGatewayCapabilityAgent(BaseModel):
+    """One agent and the bounded subset of tools relevant to the search."""
 
     id: str
     name: str
     description: str | None = None
+    instructions: str | None = None
+    instructions_included: bool = False
+    matching_tools: list[MCPGatewayToolSummary]
+    total_tools: int
+    returned_tools: int
+    complete: bool
+    total_matching_tools: int
+    has_more_matches: bool
+    search_again: str | None = None
 
 
-class MCPGatewayFindAgentsResponse(BaseModel):
-    """Search results for agents visible to the caller."""
+class MCPGatewayCapabilitySearchRequest(BaseModel):
+    """Progressively search or hydrate the live agent capability catalog."""
+
+    query: str | None = Field(default=None, max_length=500)
+    agent_id: str | None = None
+    tool_ref: str | None = None
+    limit: int = Field(default=10, ge=1, le=20)
+
+    @model_validator(mode="after")
+    def validate_scope(self) -> "MCPGatewayCapabilitySearchRequest":
+        if self.tool_ref and not self.agent_id:
+            raise ValueError("tool_ref requires agent_id")
+        if not self.agent_id and not (self.query and self.query.strip()):
+            raise ValueError("query is required unless agent_id is provided")
+        return self
+
+
+class MCPGatewayCapabilitySearchResponse(BaseModel):
+    """Bounded search results with explicit disclosure completeness."""
 
     query: str | None = None
-    agents: list[MCPGatewayAgentSummary]
-    count: int
+    agent_id: str | None = None
+    tool_ref: str | None = None
+    agents: list[MCPGatewayCapabilityAgent]
+    returned_matches: int
     total_matches: int
-    has_more: bool
-
-
-class MCPGatewayAgentDetail(MCPGatewayAgentSummary):
-    """Live task instructions for a selected agent."""
-
-    instructions: str | None = None
-
-
-class MCPGatewayToolSummary(BaseModel):
-    """Schema-free tool metadata returned with an agent."""
-
-    tool_ref: str
-    name: str
-    description: str
-    source: str
-
-
-class MCPGatewayAgentResponse(BaseModel):
-    """Selected agent instructions and compact tool catalog."""
-
-    agent: MCPGatewayAgentDetail
-    tools: list[MCPGatewayToolSummary]
-    tool_count: int
-
-
-class MCPGatewayToolSchemaResponse(BaseModel):
-    """Live schema for one agent-bound tool reference."""
-
-    agent_id: str
-    tool_ref: str
-    name: str
-    description: str
-    source: str
-    input_schema: dict[str, Any]
+    has_more_matches: bool
+    response_complete: bool
+    guidance: str
 
 
 class MCPGatewayExecuteRequest(BaseModel):
     """Arguments passed to an agent-bound tool."""
 
+    model_config = ConfigDict(populate_by_name=True)
+
     arguments: dict[str, Any] = Field(default_factory=dict)
+    async_: bool = Field(default=False, alias="async")
 
 
 class MCPGatewayExecuteResponse(BaseModel):
     """Internal REST envelope for an auditable gateway tool call.
 
-    The public MCP execute tool returns ``result`` directly; the remaining
-    fields support the REST bridge and server-side diagnostics.
+    Synchronous public MCP calls return ``result`` directly. Async calls return
+    this compact receipt so the caller can poll ``bifrost_get_execution``.
     """
+
+    model_config = ConfigDict(populate_by_name=True)
 
     agent_id: str
     agent_name: str
@@ -153,4 +165,24 @@ class MCPGatewayExecuteResponse(BaseModel):
     tool_name: str
     source: str
     duration_ms: int
-    result: Any
+    async_: bool = Field(default=False, alias="async")
+    execution_id: str | None = None
+    status: str | None = None
+    result: Any = None
+
+
+class MCPGatewayExecutionResponse(BaseModel):
+    """Compact, ownership-checked execution status and paged result."""
+
+    execution_id: str
+    workflow_id: str | None = None
+    workflow_name: str | None = None
+    status: str
+    created_at: datetime | None = None
+    started_at: datetime | None = None
+    completed_at: datetime | None = None
+    duration_ms: int | None = None
+    error: str | None = None
+    result_available: bool
+    result: Any = None
+    result_page: dict[str, Any] | None = None

--- a/api/src/routers/mcp.py
+++ b/api/src/routers/mcp.py
@@ -41,11 +41,11 @@ from src.core.db_deps import DbSession
 from src.models.contracts.mcp import (
     MCPConfigRequest,
     MCPConfigResponse,
-    MCPGatewayAgentResponse,
+    MCPGatewayCapabilitySearchRequest,
+    MCPGatewayCapabilitySearchResponse,
     MCPGatewayExecuteRequest,
     MCPGatewayExecuteResponse,
-    MCPGatewayFindAgentsResponse,
-    MCPGatewayToolSchemaResponse,
+    MCPGatewayExecutionResponse,
     MCPRunInfoResponse,
     MCPToolInfo,
     MCPToolsResponse,
@@ -97,8 +97,12 @@ def _raise_gateway_http_error(exc: Exception) -> NoReturn:
         raise exc
     status_code = {
         "INVALID_ARGUMENTS": status.HTTP_422_UNPROCESSABLE_ENTITY,
+        "INVALID_CAPABILITY_SEARCH": status.HTTP_422_UNPROCESSABLE_ENTITY,
+        "INVALID_RESULT_PATH": status.HTTP_422_UNPROCESSABLE_ENTITY,
         "AGENT_NOT_FOUND_OR_FORBIDDEN": status.HTTP_404_NOT_FOUND,
         "TOOL_NOT_FOUND_OR_FORBIDDEN": status.HTTP_404_NOT_FOUND,
+        "EXECUTION_NOT_FOUND_OR_FORBIDDEN": status.HTTP_404_NOT_FOUND,
+        "ASYNC_NOT_SUPPORTED": status.HTTP_422_UNPROCESSABLE_ENTITY,
         "NEEDS_REAUTH": status.HTTP_409_CONFLICT,
         "TOOL_SCHEMA_INVALID": status.HTTP_500_INTERNAL_SERVER_ERROR,
         "TOOL_EXECUTION_FAILED": status.HTTP_502_BAD_GATEWAY,
@@ -106,57 +110,48 @@ def _raise_gateway_http_error(exc: Exception) -> NoReturn:
     raise HTTPException(status_code=status_code, detail=exc.as_dict()) from exc
 
 
-@router.get(
-    "/gateway/agents",
-    response_model=MCPGatewayFindAgentsResponse,
+@router.post(
+    "/gateway/capabilities/search",
+    response_model=MCPGatewayCapabilitySearchResponse,
 )
-async def find_gateway_agents(
-    current_user: CurrentActiveUser,
-    db: DbSession,
-    query: str | None = None,
-    limit: int = Query(default=10, ge=1, le=20),
-) -> dict:
-    """Find accessible agents for progressive MCP discovery."""
-    await _require_mcp_enabled(db)
-    return await _gateway_service(current_user).find_agents(
-        query=query,
-        limit=limit,
-    )
-
-
-@router.get(
-    "/gateway/agents/{agent_id}",
-    response_model=MCPGatewayAgentResponse,
-)
-async def get_gateway_agent(
-    agent_id: str,
+async def search_gateway_capabilities(
+    request: MCPGatewayCapabilitySearchRequest,
     current_user: CurrentActiveUser,
     db: DbSession,
 ) -> dict:
-    """Load one accessible agent's live capability package."""
+    """Search agents and tools or hydrate one exact capability."""
     await _require_mcp_enabled(db)
     try:
-        return await _gateway_service(current_user).get_agent(agent_id)
+        return await _gateway_service(current_user).search_capabilities(
+            query=request.query,
+            agent_id=request.agent_id,
+            tool_ref=request.tool_ref,
+            limit=request.limit,
+        )
     except Exception as exc:
         _raise_gateway_http_error(exc)
 
 
 @router.get(
-    "/gateway/agents/{agent_id}/tools/{tool_ref}",
-    response_model=MCPGatewayToolSchemaResponse,
+    "/gateway/executions/{execution_id}",
+    response_model=MCPGatewayExecutionResponse,
 )
-async def get_gateway_tool_schema(
-    agent_id: str,
-    tool_ref: str,
+async def get_gateway_execution(
+    execution_id: str,
     current_user: CurrentActiveUser,
     db: DbSession,
+    result_path: str = "",
+    offset: int = Query(default=0, ge=0),
+    limit: int = Query(default=20, ge=1, le=100),
 ) -> dict:
-    """Load the current schema for an agent-bound tool."""
+    """Read compact status and a bounded result page for an owned execution."""
     await _require_mcp_enabled(db)
     try:
-        return await _gateway_service(current_user).get_tool_schema(
-            agent_id,
-            tool_ref,
+        return await _gateway_service(current_user).get_execution(
+            execution_id,
+            result_path=result_path,
+            offset=offset,
+            limit=limit,
         )
     except Exception as exc:
         _raise_gateway_http_error(exc)
@@ -180,6 +175,7 @@ async def execute_gateway_tool(
             agent_id,
             tool_ref,
             request.arguments,
+            async_execution=request.async_,
         )
     except Exception as exc:
         _raise_gateway_http_error(exc)
@@ -261,7 +257,7 @@ async def mcp_status(
         )
 
     gateway = _gateway_service(current_user)
-    agent_result = await gateway.find_agents(limit=1)
+    accessible_agents_count = await gateway.accessible_agent_count()
     gateway_tools = sorted(GATEWAY_TOOL_NAMES)
 
     return {
@@ -270,7 +266,7 @@ async def mcp_status(
         "is_platform_admin": current_user.is_superuser,
         "tools_count": len(gateway_tools),
         "tools": gateway_tools,
-        "accessible_agents_count": agent_result["total_matches"],
+        "accessible_agents_count": accessible_agents_count,
         "mcp_endpoint": "/mcp",
         "transport": "streamable-http",
         "auth": "oauth2.1",

--- a/api/src/services/execution/service.py
+++ b/api/src/services/execution/service.py
@@ -540,11 +540,13 @@ async def execute_tool(
     is_platform_admin: bool = False,
     is_agent: bool = False,
     execution_id: str | None = None,
+    sync: bool = True,
 ) -> WorkflowExecutionResponse:
     """
     Execute a workflow as a tool (for AI agent tool calls).
 
-    Uses sync execution via RabbitMQ with Redis BLPOP for result.
+    Uses the existing execution queue. Sync calls wait for the worker result;
+    async calls return the generated execution ID immediately.
 
     Args:
         workflow_id: Workflow UUID
@@ -557,6 +559,7 @@ async def execute_tool(
         org_name: Organization name (optional)
         is_platform_admin: Whether user is platform admin
         execution_id: Optional pre-generated execution ID (for streaming)
+        sync: Whether to wait for the result instead of returning Pending
 
     Returns:
         WorkflowExecutionResponse with execution results
@@ -598,11 +601,10 @@ async def execute_tool(
         public_url=get_settings().public_url,
     )
 
-    # Execute synchronously via queue
     return await _enqueue_workflow_async(
         context=context,
         workflow_id=workflow_id,
         workflow_name=workflow_name,
         parameters=parameters,
-        sync=True,  # Wait for result
+        sync=sync,
     )

--- a/api/src/services/mcp_server/gateway.py
+++ b/api/src/services/mcp_server/gateway.py
@@ -6,6 +6,7 @@ import logging
 import re
 import time
 from dataclasses import dataclass
+from datetime import datetime
 from typing import TYPE_CHECKING, Any, Literal
 from uuid import UUID, uuid5
 
@@ -18,6 +19,7 @@ from sqlalchemy.orm import selectinload
 
 from src.core.org_filter import OrgFilterType
 from src.models.orm.agents import Agent
+from src.models.orm.executions import Execution
 from src.models.orm.external_mcp import MCPConnection, MCPServer
 from src.repositories.agents import AgentRepository
 from src.services.execution.agent_helpers import (
@@ -40,7 +42,9 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 GATEWAY_TOOL_NAMESPACE = UUID("bcf3f4d7-b95e-53cc-9b7f-35e7081d0d84")
-MAX_AGENT_RESULTS = 20
+MAX_CAPABILITY_RESULTS = 20
+MAX_CAPABILITY_RESPONSE_BYTES = 24_000
+MAX_EXECUTION_RESULT_BYTES = 24_000
 
 GatewayToolSource = Literal[
     "system",
@@ -149,6 +153,79 @@ def _agent_search_score(agent: Agent, query: str) -> int:
     return score
 
 
+def _tool_search_score(tool: ResolvedGatewayTool, query: str) -> int:
+    normalized_query = " ".join(_search_tokens(query))
+    if not normalized_query:
+        return 1
+
+    name = " ".join(_search_tokens(tool.definition.name))
+    description = " ".join(_search_tokens(tool.definition.description or ""))
+    schema = " ".join(
+        _search_tokens(
+            str(
+                pydantic_core.to_jsonable_python(
+                    tool.definition.parameters,
+                    fallback=str,
+                )
+            )
+        )
+    )
+    score = 0
+    if normalized_query == name:
+        score += 240
+    elif normalized_query in name:
+        score += 120
+    if normalized_query in description:
+        score += 50
+    if normalized_query in schema:
+        score += 15
+    for token in set(normalized_query.split()):
+        if token in name.split():
+            score += 25
+        elif token in name:
+            score += 15
+        if token in description:
+            score += 6
+        if token in schema:
+            score += 2
+    return score
+
+
+def _compact_description(value: str | None, limit: int = 800) -> str | None:
+    if value is None or len(value) <= limit:
+        return value
+    return f"{value[: limit - 20]}… [description cut]"
+
+
+def _serialized_size(value: Any) -> int:
+    return len(pydantic_core.to_json(value, fallback=str))
+
+
+def _search_again_guidance(
+    agent_id: str,
+    *,
+    complete: bool,
+    query: str | None,
+) -> str | None:
+    if complete:
+        return None
+    qualifier = (
+        "a different or narrower query"
+        if query and query.strip()
+        else "a query describing the missing capability"
+    )
+    return (
+        "This is not the agent's full tool catalog. Call "
+        "bifrost_search_capabilities again with "
+        f"agent_id='{agent_id}' and {qualifier}."
+    )
+
+
+def _append_json_pointer(path: str, part: str | int) -> str:
+    encoded = str(part).replace("~", "~0").replace("/", "~1")
+    return f"{path}/{encoded}" if path else f"/{encoded}"
+
+
 class MCPAgentGatewayService:
     """Resolve and execute agent capabilities for one authenticated MCP caller."""
 
@@ -164,48 +241,286 @@ class MCPAgentGatewayService:
             is_external=self.context.is_external,
         )
 
-    async def find_agents(
-        self,
-        *,
-        query: str | None = None,
-        limit: int = 10,
-    ) -> dict[str, Any]:
+    async def _list_accessible_agents(self) -> list[Agent]:
         from src.core.database import get_db_context
 
-        bounded_limit = min(max(limit, 1), MAX_AGENT_RESULTS)
         async with get_db_context() as db:
             repo = self._agent_repo(db)
             if self.context.is_platform_admin:
-                agents = await repo.list_all_in_scope(
+                return await repo.list_all_in_scope(
                     OrgFilterType.ALL,
                     active_only=True,
                 )
-            else:
-                agents = await repo.list_agents(active_only=True)
+            return await repo.list_agents(active_only=True)
 
-        scored = [
-            (_agent_search_score(agent, query or ""), agent)
-            for agent in agents
-        ]
-        if query and query.strip():
-            scored = [item for item in scored if item[0] > 0]
-        scored.sort(key=lambda item: (-item[0], item[1].name.lower(), str(item[1].id)))
+    async def accessible_agent_count(self) -> int:
+        """Return the caller's live accessible-agent count."""
+        return len(await self._list_accessible_agents())
 
-        matches = scored[:bounded_limit]
+    async def search_capabilities(
+        self,
+        *,
+        query: str | None = None,
+        agent_id: str | None = None,
+        tool_ref: str | None = None,
+        limit: int = 10,
+    ) -> dict[str, Any]:
+        """Search agents and tools, then progressively hydrate one selection."""
+        bounded_limit = min(max(limit, 1), MAX_CAPABILITY_RESULTS)
+        if agent_id is not None:
+            snapshot = await self.get_agent_snapshot(agent_id)
+            return self._search_agent_snapshot(
+                snapshot,
+                query=query,
+                tool_ref=tool_ref,
+                limit=bounded_limit,
+            )
+
+        normalized_query = (query or "").strip()
+        if not normalized_query:
+            raise GatewayError(
+                "INVALID_CAPABILITY_SEARCH",
+                "query is required unless agent_id is provided.",
+                retryable=True,
+            )
+
+        snapshots: list[AgentToolSnapshot] = []
+        for agent in await self._list_accessible_agents():
+            snapshots.append(await self.get_agent_snapshot(str(agent.id)))
+
+        candidates: list[tuple[int, str, AgentToolSnapshot, ResolvedGatewayTool | None]] = []
+        matching_tool_counts: dict[str, int] = {}
+        for snapshot in snapshots:
+            snapshot_id = str(snapshot.agent.id)
+            agent_score = _agent_search_score(snapshot.agent, normalized_query)
+            if agent_score > 0:
+                candidates.append((agent_score, "agent", snapshot, None))
+
+            matching_tools = 0
+            for tool in snapshot.tools:
+                score = _tool_search_score(tool, normalized_query)
+                if score > 0:
+                    matching_tools += 1
+                    candidates.append((score, "tool", snapshot, tool))
+            matching_tool_counts[snapshot_id] = matching_tools
+
+        candidates.sort(
+            key=lambda item: (
+                -item[0],
+                item[1],
+                item[2].agent.name.lower(),
+                item[3].definition.name.lower() if item[3] else "",
+            )
+        )
+        selected = candidates[:bounded_limit]
+        grouped: dict[str, dict[str, Any]] = {}
+        order: list[str] = []
+        for _score, kind, snapshot, tool in selected:
+            snapshot_id = str(snapshot.agent.id)
+            if snapshot_id not in grouped:
+                order.append(snapshot_id)
+                grouped[snapshot_id] = {
+                    "snapshot": snapshot,
+                    "tools": [],
+                    "selected_matches": 0,
+                }
+            grouped[snapshot_id]["selected_matches"] += 1
+            if kind == "tool" and tool is not None:
+                grouped[snapshot_id]["tools"].append(tool)
+
+        agents: list[dict[str, Any]] = []
+        returned_matches = 0
+        response_budget_exhausted = False
+        for snapshot_id in order:
+            group = grouped[snapshot_id]
+            snapshot = group["snapshot"]
+            tools = group["tools"]
+            agent_result = self._capability_agent_result(
+                snapshot,
+                tools=tools,
+                query=normalized_query,
+                include_instructions=False,
+                total_matching_tools=matching_tool_counts[snapshot_id],
+            )
+            proposed = [*agents, agent_result]
+            proposed_returned = returned_matches + group["selected_matches"]
+            proposed_has_more = len(candidates) > proposed_returned
+            budget_probe = {
+                "query": query,
+                "agent_id": None,
+                "tool_ref": None,
+                "agents": proposed,
+                "returned_matches": proposed_returned,
+                "total_matches": len(candidates),
+                "has_more_matches": proposed_has_more,
+                "response_complete": not proposed_has_more,
+                "guidance": self._capability_guidance(),
+            }
+            if _serialized_size(budget_probe) > MAX_CAPABILITY_RESPONSE_BYTES:
+                response_budget_exhausted = True
+                break
+            agents.append(agent_result)
+            returned_matches = proposed_returned
+
+        has_more = len(candidates) > returned_matches or response_budget_exhausted
         return {
             "query": query,
-            "agents": [
-                {
-                    "id": str(agent.id),
-                    "name": agent.name,
-                    "description": agent.description,
-                }
-                for _, agent in matches
-            ],
-            "count": len(matches),
-            "total_matches": len(scored),
-            "has_more": len(scored) > len(matches),
+            "agent_id": None,
+            "tool_ref": None,
+            "agents": agents,
+            "returned_matches": returned_matches,
+            "total_matches": len(candidates),
+            "has_more_matches": has_more,
+            "response_complete": not has_more,
+            "guidance": self._capability_guidance(),
         }
+
+    def _search_agent_snapshot(
+        self,
+        snapshot: AgentToolSnapshot,
+        *,
+        query: str | None,
+        tool_ref: str | None,
+        limit: int,
+    ) -> dict[str, Any]:
+        if tool_ref is not None:
+            tool = self.find_tool(snapshot, tool_ref)
+            tool_result = tool.compact()
+            tool_result.update(
+                {
+                    "input_schema": tool.definition.parameters,
+                    "schema_included": True,
+                }
+            )
+            tools = [tool_result]
+            total_matches = 1
+            returned_matches = 1
+            total_matching_tools = 1
+        elif query and query.strip():
+            scored = [
+                (_tool_search_score(tool, query), tool)
+                for tool in snapshot.tools
+            ]
+            scored = [item for item in scored if item[0] > 0]
+            scored.sort(
+                key=lambda item: (
+                    -item[0],
+                    item[1].definition.name.lower(),
+                    item[1].tool_ref,
+                )
+            )
+            total_matches = len(scored)
+            selected = [tool for _, tool in scored[:limit]]
+            tools = [self._compact_tool(tool) for tool in selected]
+            returned_matches = len(tools)
+            total_matching_tools = len(scored)
+        else:
+            tools = []
+            total_matches = 0
+            returned_matches = 0
+            total_matching_tools = 0
+
+        if tool_ref is not None:
+            agent_result = self._capability_agent_result_from_dicts(
+                snapshot,
+                tools=tools,
+                query=query,
+                include_instructions=True,
+                total_matching_tools=total_matching_tools,
+            )
+        else:
+            agent_result = self._capability_agent_result(
+                snapshot,
+                tools=[
+                    self.find_tool(snapshot, tool["tool_ref"])
+                    for tool in tools
+                ],
+                query=query,
+                include_instructions=True,
+                total_matching_tools=total_matching_tools,
+            )
+        has_more = total_matches > returned_matches
+        return {
+            "query": query,
+            "agent_id": str(snapshot.agent.id),
+            "tool_ref": tool_ref,
+            "agents": [agent_result],
+            "returned_matches": returned_matches,
+            "total_matches": total_matches,
+            "has_more_matches": has_more,
+            "response_complete": not has_more,
+            "guidance": self._capability_guidance(),
+        }
+
+    @staticmethod
+    def _compact_tool(tool: ResolvedGatewayTool) -> dict[str, Any]:
+        return {
+            "tool_ref": tool.tool_ref,
+            "name": tool.definition.name,
+            "description": _compact_description(tool.definition.description) or "",
+            "source": tool.source,
+            "input_schema": None,
+            "schema_included": False,
+        }
+
+    def _capability_agent_result(
+        self,
+        snapshot: AgentToolSnapshot,
+        *,
+        tools: list[ResolvedGatewayTool],
+        query: str | None,
+        include_instructions: bool,
+        total_matching_tools: int,
+    ) -> dict[str, Any]:
+        return self._capability_agent_result_from_dicts(
+            snapshot,
+            tools=[self._compact_tool(tool) for tool in tools],
+            query=query,
+            include_instructions=include_instructions,
+            total_matching_tools=total_matching_tools,
+        )
+
+    @staticmethod
+    def _capability_agent_result_from_dicts(
+        snapshot: AgentToolSnapshot,
+        *,
+        tools: list[dict[str, Any]],
+        query: str | None,
+        include_instructions: bool,
+        total_matching_tools: int,
+    ) -> dict[str, Any]:
+        returned_tools = len(tools)
+        total_tools = len(snapshot.tools)
+        complete = returned_tools == total_tools
+        agent_id = str(snapshot.agent.id)
+        return {
+            "id": agent_id,
+            "name": snapshot.agent.name,
+            "description": _compact_description(snapshot.agent.description),
+            "instructions": snapshot.agent.system_prompt if include_instructions else None,
+            "instructions_included": include_instructions,
+            "matching_tools": tools,
+            "total_tools": total_tools,
+            "returned_tools": returned_tools,
+            "complete": complete,
+            "total_matching_tools": total_matching_tools,
+            "has_more_matches": total_matching_tools > returned_tools,
+            "search_again": _search_again_guidance(
+                agent_id,
+                complete=complete,
+                query=query,
+            ),
+        }
+
+    @staticmethod
+    def _capability_guidance() -> str:
+        return (
+            "matching_tools is always a bounded, query-specific subset, not an "
+            "implicit full catalog. Select an agent by calling this tool again "
+            "with agent_id to load its instructions. Search again with that "
+            "agent_id and a different or narrower query whenever complete is "
+            "false. Add tool_ref to load one exact live input schema."
+        )
 
     async def get_agent_snapshot(self, agent_id: str) -> AgentToolSnapshot:
         from src.core.database import get_db_context
@@ -237,47 +552,254 @@ class MCPAgentGatewayService:
 
         return AgentToolSnapshot(agent=agent, tools=tools)
 
-    async def get_agent(self, agent_id: str) -> dict[str, Any]:
-        """Return one live agent capability package."""
-        snapshot = await self.get_agent_snapshot(agent_id)
-        return {
-            "agent": {
-                "id": str(snapshot.agent.id),
-                "name": snapshot.agent.name,
-                "description": snapshot.agent.description,
-                "instructions": snapshot.agent.system_prompt,
-            },
-            "tools": [tool.compact() for tool in snapshot.tools],
-            "tool_count": len(snapshot.tools),
-        }
-
-    async def get_tool_schema(
-        self,
-        agent_id: str,
-        tool_ref: str,
-    ) -> dict[str, Any]:
-        """Return the exact current schema for an agent-bound tool."""
-        snapshot = await self.get_agent_snapshot(agent_id)
-        tool = self.find_tool(snapshot, tool_ref)
-        return {
-            "agent_id": str(snapshot.agent.id),
-            "tool_ref": tool.tool_ref,
-            "name": tool.definition.name,
-            "description": tool.definition.description,
-            "source": tool.source,
-            "input_schema": tool.definition.parameters,
-        }
-
     async def execute_agent_tool(
         self,
         agent_id: str,
         tool_ref: str,
         arguments: dict[str, Any],
+        *,
+        async_execution: bool = False,
     ) -> dict[str, Any]:
         """Re-resolve, validate, and execute an agent-bound tool."""
         snapshot = await self.get_agent_snapshot(agent_id)
         tool = self.find_tool(snapshot, tool_ref)
-        return await self.execute_tool(snapshot, tool, arguments)
+        return await self.execute_tool(
+            snapshot,
+            tool,
+            arguments,
+            async_execution=async_execution,
+        )
+
+    async def get_execution(
+        self,
+        execution_id: str,
+        *,
+        result_path: str = "",
+        offset: int = 0,
+        limit: int = 20,
+    ) -> dict[str, Any]:
+        """Return compact status for an execution owned by the caller."""
+        from src.core.database import get_db_context
+        from src.core.redis_client import get_redis_client
+
+        try:
+            parsed_execution_id = UUID(execution_id)
+        except (TypeError, ValueError) as exc:
+            raise GatewayError(
+                "EXECUTION_NOT_FOUND_OR_FORBIDDEN",
+                "Execution not found or you do not have access.",
+            ) from exc
+
+        async with get_db_context() as db:
+            result = await db.execute(
+                select(Execution).where(Execution.id == parsed_execution_id)
+            )
+            execution = result.scalar_one_or_none()
+
+        if execution is not None:
+            if (
+                not self.context.is_platform_admin
+                and execution.executed_by != UUID(str(self.context.user_id))
+            ):
+                raise GatewayError(
+                    "EXECUTION_NOT_FOUND_OR_FORBIDDEN",
+                    "Execution not found or you do not have access.",
+                )
+            result_available = execution.result is not None
+            result_value = None
+            result_page = None
+            if result_available:
+                result_value, result_page = self._page_execution_result(
+                    execution.result,
+                    result_path=result_path,
+                    offset=offset,
+                    limit=limit,
+                )
+            return {
+                "execution_id": str(execution.id),
+                "workflow_id": (
+                    str(execution.workflow_id) if execution.workflow_id else None
+                ),
+                "workflow_name": execution.workflow_name,
+                "status": execution.status.value,
+                "created_at": execution.created_at,
+                "started_at": execution.started_at,
+                "completed_at": execution.completed_at,
+                "duration_ms": execution.duration_ms,
+                "error": execution.error_message,
+                "result_available": result_available,
+                "result": result_value,
+                "result_page": result_page,
+            }
+
+        pending = await get_redis_client().get_pending_execution(execution_id)
+        if pending is None or (
+            not self.context.is_platform_admin
+            and pending.get("user_id") != str(self.context.user_id)
+        ):
+            raise GatewayError(
+                "EXECUTION_NOT_FOUND_OR_FORBIDDEN",
+                "Execution not found or you do not have access.",
+            )
+        created_at = pending.get("created_at")
+        return {
+            "execution_id": execution_id,
+            "workflow_id": pending.get("workflow_id"),
+            "workflow_name": pending.get("script_name"),
+            "status": "Pending",
+            "created_at": (
+                datetime.fromisoformat(created_at) if created_at else None
+            ),
+            "started_at": None,
+            "completed_at": None,
+            "duration_ms": None,
+            "error": None,
+            "result_available": False,
+            "result": None,
+            "result_page": None,
+        }
+
+    @classmethod
+    def _page_execution_result(
+        cls,
+        value: Any,
+        *,
+        result_path: str,
+        offset: int,
+        limit: int,
+    ) -> tuple[Any, dict[str, Any]]:
+        selected = cls._resolve_result_path(value, result_path)
+        bounded_offset = max(offset, 0)
+        bounded_limit = min(max(limit, 1), 100)
+
+        if isinstance(selected, dict):
+            items = list(selected.items())
+            page: dict[str, Any] = {}
+            consumed = 0
+            for key, item_value in items[
+                bounded_offset : bounded_offset + bounded_limit
+            ]:
+                child_path = _append_json_pointer(result_path, key)
+                candidate_value = cls._bounded_result_value(item_value, child_path)
+                candidate = {**page, key: candidate_value}
+                if _serialized_size(candidate) > MAX_EXECUTION_RESULT_BYTES:
+                    break
+                page[key] = candidate_value
+                consumed += 1
+            next_offset = bounded_offset + consumed
+            has_more = next_offset < len(items)
+            return page, {
+                "path": result_path,
+                "kind": "object",
+                "offset": bounded_offset,
+                "returned": consumed,
+                "total": len(items),
+                "has_more": has_more,
+                "next_offset": next_offset if has_more else None,
+            }
+
+        if isinstance(selected, list):
+            page_list: list[Any] = []
+            consumed = 0
+            for index, item_value in enumerate(
+                selected[bounded_offset : bounded_offset + bounded_limit],
+                start=bounded_offset,
+            ):
+                child_path = _append_json_pointer(result_path, index)
+                candidate_value = cls._bounded_result_value(item_value, child_path)
+                candidate = [*page_list, candidate_value]
+                if _serialized_size(candidate) > MAX_EXECUTION_RESULT_BYTES:
+                    break
+                page_list.append(candidate_value)
+                consumed += 1
+            next_offset = bounded_offset + consumed
+            has_more = next_offset < len(selected)
+            return page_list, {
+                "path": result_path,
+                "kind": "array",
+                "offset": bounded_offset,
+                "returned": consumed,
+                "total": len(selected),
+                "has_more": has_more,
+                "next_offset": next_offset if has_more else None,
+            }
+
+        if isinstance(selected, str):
+            char_limit = min(bounded_limit * 200, MAX_EXECUTION_RESULT_BYTES - 500)
+            page_text = selected[bounded_offset : bounded_offset + char_limit]
+            next_offset = bounded_offset + len(page_text)
+            has_more = next_offset < len(selected)
+            return page_text, {
+                "path": result_path,
+                "kind": "string",
+                "offset": bounded_offset,
+                "returned": len(page_text),
+                "total": len(selected),
+                "has_more": has_more,
+                "next_offset": next_offset if has_more else None,
+                "unit": "characters",
+            }
+
+        return selected, {
+            "path": result_path,
+            "kind": "scalar",
+            "offset": 0,
+            "returned": 1,
+            "total": 1,
+            "has_more": False,
+            "next_offset": None,
+        }
+
+    @staticmethod
+    def _bounded_result_value(value: Any, path: str) -> Any:
+        if _serialized_size(value) <= MAX_EXECUTION_RESULT_BYTES // 2:
+            return value
+        return {
+            "$omitted": True,
+            "path": path,
+            "kind": (
+                "object"
+                if isinstance(value, dict)
+                else "array"
+                if isinstance(value, list)
+                else "string"
+                if isinstance(value, str)
+                else "scalar"
+            ),
+            "message": (
+                "Value omitted to keep this response bounded. Call "
+                "bifrost_get_execution again with this result_path."
+            ),
+        }
+
+    @staticmethod
+    def _resolve_result_path(value: Any, result_path: str) -> Any:
+        if not result_path:
+            return value
+        if not result_path.startswith("/"):
+            raise GatewayError(
+                "INVALID_RESULT_PATH",
+                "result_path must be an RFC 6901 JSON Pointer.",
+                retryable=True,
+            )
+        current = value
+        for raw_part in result_path[1:].split("/"):
+            part = raw_part.replace("~1", "/").replace("~0", "~")
+            try:
+                if isinstance(current, dict):
+                    current = current[part]
+                elif isinstance(current, list):
+                    current = current[int(part)]
+                else:
+                    raise KeyError(part)
+            except (KeyError, IndexError, TypeError, ValueError) as exc:
+                raise GatewayError(
+                    "INVALID_RESULT_PATH",
+                    "result_path does not exist in this execution result.",
+                    retryable=True,
+                    details={"result_path": result_path},
+                ) from exc
+        return current
 
     def _resolve_gateway_tools(
         self,
@@ -432,12 +954,25 @@ class MCPAgentGatewayService:
         snapshot: AgentToolSnapshot,
         tool: ResolvedGatewayTool,
         arguments: dict[str, Any],
+        *,
+        async_execution: bool = False,
     ) -> dict[str, Any]:
         started = time.monotonic()
 
         try:
             self.validate_arguments(tool, arguments)
-            result = await self._dispatch(snapshot.agent, tool, arguments)
+            if async_execution and tool.source != "workflow":
+                raise GatewayError(
+                    "ASYNC_NOT_SUPPORTED",
+                    "Async execution is currently supported only for workflow tools.",
+                    retryable=True,
+                )
+            result = await self._dispatch(
+                snapshot.agent,
+                tool,
+                arguments,
+                async_execution=async_execution,
+            )
         except GatewayError as exc:
             duration_ms = int((time.monotonic() - started) * 1000)
             exc.details.setdefault("agent_id", str(snapshot.agent.id))
@@ -483,26 +1018,40 @@ class MCPAgentGatewayService:
             tool.source,
             duration_ms,
         )
-        return {
+        response = {
             "agent_id": str(snapshot.agent.id),
             "agent_name": snapshot.agent.name,
             "tool_ref": tool.tool_ref,
             "tool_name": tool.definition.name,
             "source": tool.source,
             "duration_ms": duration_ms,
+            "async": async_execution,
+            "execution_id": None,
+            "status": None,
             "result": result,
         }
+        if async_execution:
+            response["execution_id"] = result["execution_id"]
+            response["status"] = result["status"]
+            response["result"] = None
+        return response
 
     async def _dispatch(
         self,
         agent: Agent,
         tool: ResolvedGatewayTool,
         arguments: dict[str, Any],
+        *,
+        async_execution: bool = False,
     ) -> Any:
         if tool.source in {"system", "knowledge"}:
             return await self._dispatch_system_tool(agent, tool, arguments)
         if tool.source == "workflow":
-            return await self._dispatch_workflow(tool, arguments)
+            return await self._dispatch_workflow(
+                tool,
+                arguments,
+                async_execution=async_execution,
+            )
         if tool.source == "delegation":
             return await self._dispatch_delegation(agent, tool, arguments)
         if tool.source == "external_mcp":
@@ -560,6 +1109,8 @@ class MCPAgentGatewayService:
         self,
         tool: ResolvedGatewayTool,
         arguments: dict[str, Any],
+        *,
+        async_execution: bool = False,
     ) -> Any:
         from src.services.execution.service import execute_tool
 
@@ -578,6 +1129,7 @@ class MCPAgentGatewayService:
             org_id=str(self.context.org_id) if self.context.org_id else None,
             is_platform_admin=self.context.is_platform_admin,
             is_agent=True,
+            sync=not async_execution,
         )
         data = {
             "execution_id": response.execution_id,
@@ -587,6 +1139,11 @@ class MCPAgentGatewayService:
             "error": response.error,
             "error_type": response.error_type,
         }
+        if async_execution:
+            return {
+                "execution_id": response.execution_id,
+                "status": response.status.value,
+            }
         if response.status.value != "Success":
             raise GatewayError(
                 "TOOL_EXECUTION_FAILED",

--- a/api/src/services/mcp_server/tools/gateway.py
+++ b/api/src/services/mcp_server/tools/gateway.py
@@ -1,8 +1,9 @@
 """Stable progressive-discovery tools exposed by the unscoped MCP endpoint."""
 
-from typing import Any
+from typing import Annotated, Any
 
 from fastmcp.tools import ToolResult
+from pydantic import Field
 
 from src.services.mcp_server.generators.fastmcp_generator import (
     register_tool_with_context,
@@ -19,17 +20,24 @@ At the beginning of every task, call bifrost_get_required_instructions exactly
 once before calling any other Bifrost tool. Follow any returned instructions;
 if none are returned, continue normally.
 
-Use bifrost_find_agents with the user's task to locate relevant agents.
-Discovery and inspection do not need confirmation. Call bifrost_get_agent before
-using an agent, and follow its live instructions as task-specific guidance
-subject to the user's request, your higher-level safety instructions, and all
-applicable policies. Reuse the selected agent while it remains relevant.
+Use bifrost_search_capabilities with the user's task to search accessible agents
+and their tools. Results are bounded: matching_tools is never an implicit full
+catalog. Read total_tools, returned_tools, complete, and has_more_matches. When
+complete is false—or when no matching tool is returned—assume more tools may
+exist and search again with the same agent_id plus a different or narrower
+query. Do not conclude that a capability is absent from a partial result.
 
-Before executing a tool, call bifrost_get_tool_schema for the selected tool
-reference. Do not guess tool references or arguments. If the user's request
-authorizes the action, call bifrost_execute_tool with the agent id, tool
-reference, and validated arguments. If the request does not authorize execution,
-offer the action instead of executing it.
+After selecting an agent, call bifrost_search_capabilities again with agent_id
+to load its live instructions. Follow those instructions as task-specific
+guidance subject to the user's request, your higher-level safety instructions,
+and all applicable policies. Add tool_ref to the same call to load the exact
+live input schema before execution. Do not guess tool references or arguments.
+
+If the user's request authorizes the action, call bifrost_execute_tool. Calls
+are synchronous by default. Set async=true only for workflow tools when an
+immediate execution ID is preferable, then use bifrost_get_execution until it
+reaches a terminal state. If the request does not authorize execution, offer
+the action instead of executing it.
 
 If validation fails, correct the arguments using the returned live schema and
 repair guidance. Do not call a tool that was not returned for the selected
@@ -44,22 +52,29 @@ def _rest_error(action: str, status_code: int, body: Any) -> ToolResult:
     return error_result(message, payload)
 
 
-async def bifrost_find_agents(
+async def bifrost_search_capabilities(
     context: Any,
     query: str | None = None,
+    agent_id: str | None = None,
+    tool_ref: str | None = None,
     limit: int = 10,
 ) -> ToolResult:
-    """Find live Bifrost agents relevant to a task."""
+    """Search live agents and tools, or hydrate one selected capability."""
     status_code, data = await call_rest(
         context,
-        "GET",
-        "/api/mcp/gateway/agents",
-        params={"query": query, "limit": limit},
+        "POST",
+        "/api/mcp/gateway/capabilities/search",
+        json_body={
+            "query": query,
+            "agent_id": agent_id,
+            "tool_ref": tool_ref,
+            "limit": limit,
+        },
     )
     if status_code != 200 or not isinstance(data, dict):
-        return _rest_error("Agent search", status_code, data)
+        return _rest_error("Capability search", status_code, data)
     return success_result(
-        f"Found {data['count']} accessible agent(s).",
+        f"Returned {data['returned_matches']} capability match(es).",
         data,
     )
 
@@ -128,50 +143,54 @@ async def bifrost_remove_memory(context: Any, memory_id: str) -> ToolResult:
     return success_result("Removed private memory. Tell the user it was forgotten.", data)
 
 
-async def bifrost_get_agent(context: Any, agent_id: str) -> ToolResult:
-    """Get one accessible agent's live instructions and compact tool catalog."""
-    status_code, data = await call_rest(
-        context,
-        "GET",
-        f"/api/mcp/gateway/agents/{agent_id}",
-    )
-    if status_code != 200 or not isinstance(data, dict):
-        return _rest_error("Agent lookup", status_code, data)
-    return success_result(f"Loaded agent '{data['agent']['name']}'.", data)
-
-
-async def bifrost_get_tool_schema(
-    context: Any,
-    agent_id: str,
-    tool_ref: str,
-) -> ToolResult:
-    """Get the exact live input schema for one tool returned by get-agent."""
-    status_code, data = await call_rest(
-        context,
-        "GET",
-        f"/api/mcp/gateway/agents/{agent_id}/tools/{tool_ref}",
-    )
-    if status_code != 200 or not isinstance(data, dict):
-        return _rest_error("Tool schema lookup", status_code, data)
-    return success_result(f"Loaded schema for '{data['name']}'.", data)
-
-
 async def bifrost_execute_tool(
     context: Any,
     agent_id: str,
     tool_ref: str,
     arguments: dict[str, Any],
+    async_: Annotated[bool, Field(alias="async")] = False,
 ) -> ToolResult:
     """Validate and execute one live tool through its selected agent."""
     status_code, data = await call_rest(
         context,
         "POST",
         f"/api/mcp/gateway/agents/{agent_id}/tools/{tool_ref}/execute",
-        json_body={"arguments": arguments},
+        json_body={"arguments": arguments, "async": async_},
     )
     if status_code != 200 or not isinstance(data, dict):
         return _rest_error("Tool execution", status_code, data)
+    if data.get("async") is True:
+        return success_result(
+            f"Queued execution {data['execution_id']}.",
+            data,
+        )
     return direct_result(data["result"])
+
+
+async def bifrost_get_execution(
+    context: Any,
+    execution_id: str,
+    result_path: str = "",
+    offset: int = 0,
+    limit: int = 20,
+) -> ToolResult:
+    """Get compact status and a bounded result page for an owned execution."""
+    status_code, data = await call_rest(
+        context,
+        "GET",
+        f"/api/mcp/gateway/executions/{execution_id}",
+        params={
+            "result_path": result_path,
+            "offset": offset,
+            "limit": limit,
+        },
+    )
+    if status_code != 200 or not isinstance(data, dict):
+        return _rest_error("Execution lookup", status_code, data)
+    return success_result(
+        f"Execution {execution_id} is {data['status']}.",
+        data,
+    )
 
 
 TOOLS = [
@@ -183,29 +202,25 @@ TOOLS = [
         "guidance when applicable; continue normally when none is returned.",
     ),
     (
-        "bifrost_find_agents",
-        "Find Bifrost Agents",
-        "Search accessible live Bifrost agents for capabilities relevant to a task. "
-        "Call this first instead of guessing an agent.",
-    ),
-    (
-        "bifrost_get_agent",
-        "Get Bifrost Agent",
-        "Load one accessible agent's current instructions and compact tool catalog. "
-        "Tool schemas are intentionally omitted; inspect the selected tool next.",
-    ),
-    (
-        "bifrost_get_tool_schema",
-        "Get Bifrost Tool Schema",
-        "Load the exact live input schema for one tool reference returned by "
-        "bifrost_get_agent.",
+        "bifrost_search_capabilities",
+        "Search Bifrost Capabilities",
+        "Search accessible agents and tools through one bounded, progressive "
+        "surface. Results explicitly disclose omitted tools. Reuse this tool with "
+        "agent_id to load instructions and tool_ref to load one exact schema.",
     ),
     (
         "bifrost_execute_tool",
         "Execute Bifrost Tool",
         "Execute a tool reference through its selected agent after inspecting its "
         "live schema. Arguments are strictly validated and authorization is "
-        "rechecked on every call. Returns the selected tool's result directly.",
+        "rechecked on every call. Sync is the default; async=true immediately "
+        "returns an execution ID for workflow-backed tools.",
+    ),
+    (
+        "bifrost_get_execution",
+        "Get Bifrost Execution",
+        "Get ownership-checked status and a bounded result page for an execution "
+        "ID returned by async tool execution.",
     ),
     (
         "bifrost_search_memory",
@@ -235,10 +250,9 @@ def register_tools(mcp: Any, get_context_fn: Any) -> None:
     """Register the stable gateway tools with FastMCP."""
     functions = {
         "bifrost_get_required_instructions": bifrost_get_required_instructions,
-        "bifrost_find_agents": bifrost_find_agents,
-        "bifrost_get_agent": bifrost_get_agent,
-        "bifrost_get_tool_schema": bifrost_get_tool_schema,
+        "bifrost_search_capabilities": bifrost_search_capabilities,
         "bifrost_execute_tool": bifrost_execute_tool,
+        "bifrost_get_execution": bifrost_get_execution,
         "bifrost_search_memory": bifrost_search_memory,
         "bifrost_save_memory": bifrost_save_memory,
         "bifrost_remove_memory": bifrost_remove_memory,

--- a/api/tests/e2e/api-integration/test_mcp_endpoints.py
+++ b/api/tests/e2e/api-integration/test_mcp_endpoints.py
@@ -376,15 +376,14 @@ class TestMCPStatusEndpoint:
         assert "tools" in data
         assert set(data["tools"]) == {
             "bifrost_get_required_instructions",
-            "bifrost_find_agents",
-            "bifrost_get_agent",
-            "bifrost_get_tool_schema",
+            "bifrost_search_capabilities",
             "bifrost_execute_tool",
+            "bifrost_get_execution",
             "bifrost_search_memory",
             "bifrost_save_memory",
             "bifrost_remove_memory",
         }
-        assert data["tools_count"] == 8
+        assert data["tools_count"] == 7
 
 
 # ==================== Bifrost Agent Plugin Endpoint Tests ====================
@@ -441,7 +440,7 @@ class TestMCPRunEndpoint:
         assert data["setup_prompt"].startswith(
             "Help me create a reusable skill or agent with this exact prompt:"
         )
-        assert "bifrost_find_agents" in data["setup_prompt"]
+        assert "bifrost_search_capabilities" in data["setup_prompt"]
         assert "bifrost_get_required_instructions" in data["setup_prompt"]
 
     @pytest.mark.e2e
@@ -661,9 +660,10 @@ class TestMCPConfigToolFiltering:
         )
         assert configured.status_code == 200
 
-        response = requests.get(
-            f"{TEST_API_URL}/api/mcp/gateway/agents",
+        response = requests.post(
+            f"{TEST_API_URL}/api/mcp/gateway/capabilities/search",
             headers=headers,
+            json={"query": "anything"},
         )
         assert response.status_code == 403
         assert response.json()["detail"] == "External MCP access is disabled"

--- a/api/tests/e2e/api-integration/test_mcp_gateway.py
+++ b/api/tests/e2e/api-integration/test_mcp_gateway.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+import time
 import uuid
 
 import pytest
@@ -11,10 +12,9 @@ TEST_API_URL = os.getenv("TEST_API_URL", "http://api:8000")
 MCP_ACCEPT = "application/json, text/event-stream"
 GATEWAY_TOOLS = {
     "bifrost_get_required_instructions",
-    "bifrost_find_agents",
-    "bifrost_get_agent",
-    "bifrost_get_tool_schema",
+    "bifrost_search_capabilities",
     "bifrost_execute_tool",
+    "bifrost_get_execution",
     "bifrost_search_memory",
     "bifrost_save_memory",
     "bifrost_remove_memory",
@@ -156,7 +156,7 @@ class TestMCPAgentGateway:
                 "clientInfo": {"name": "gateway-e2e", "version": "1.0"},
             },
         )
-        assert "bifrost_find_agents" in initialize["result"]["instructions"]
+        assert "bifrost_search_capabilities" in initialize["result"]["instructions"]
         assert "bifrost_get_required_instructions" in initialize["result"]["instructions"]
 
         default_tools = _mcp_request(
@@ -165,6 +165,13 @@ class TestMCPAgentGateway:
             {},
         )["result"]["tools"]
         assert {tool["name"] for tool in default_tools} == GATEWAY_TOOLS
+        execute_schema = next(
+            tool["inputSchema"]
+            for tool in default_tools
+            if tool["name"] == "bifrost_execute_tool"
+        )
+        assert "async" in execute_schema["properties"]
+        assert "async_" not in execute_schema["properties"]
 
         scoped_tools = _mcp_request(
             self.token,
@@ -281,35 +288,59 @@ class TestMCPAgentGateway:
     def test_live_discovery_schema_execution_and_revocation(self):
         found = _call_gateway(
             self.token,
-            "bifrost_find_agents",
+            "bifrost_search_capabilities",
             {"query": self.agent_name},
         )
-        assert any(
-            agent["id"] == self.agent_id for agent in found["agents"]
+        found_agent = next(
+            agent for agent in found["agents"] if agent["id"] == self.agent_id
         )
+        assert found_agent["instructions_included"] is False
+        assert found_agent["complete"] is False
+        assert "not the agent's full tool catalog" in found_agent["search_again"]
 
         loaded = _call_gateway(
             self.token,
-            "bifrost_get_agent",
+            "bifrost_search_capabilities",
             {"agent_id": self.agent_id},
         )
-        assert loaded["agent"]["instructions"] == self.prompt
+        selected_agent = loaded["agents"][0]
+        assert selected_agent["instructions"] == self.prompt
+        assert selected_agent["matching_tools"] == []
+        assert selected_agent["total_tools"] == 2
+        assert selected_agent["returned_tools"] == 0
+        assert selected_agent["complete"] is False
+
+        matched = _call_gateway(
+            self.token,
+            "bifrost_search_capabilities",
+            {"agent_id": self.agent_id, "query": "echo message"},
+        )
         workflow_tool = next(
-            tool for tool in loaded["tools"] if tool["source"] == "workflow"
+            tool
+            for tool in matched["agents"][0]["matching_tools"]
+            if tool["source"] == "workflow"
         )
         tool_ref = workflow_tool["tool_ref"]
+
+        system_search = _call_gateway(
+            self.token,
+            "bifrost_search_capabilities",
+            {"agent_id": self.agent_id, "query": "platform documentation"},
+        )
         system_tool = next(
             tool
-            for tool in loaded["tools"]
+            for tool in system_search["agents"][0]["matching_tools"]
             if tool["source"] == "system" and tool["name"] == "get_docs"
         )
 
         schema = _call_gateway(
             self.token,
-            "bifrost_get_tool_schema",
+            "bifrost_search_capabilities",
             {"agent_id": self.agent_id, "tool_ref": tool_ref},
         )
-        assert schema["input_schema"]["required"] == ["message"]
+        hydrated_tool = schema["agents"][0]["matching_tools"][0]
+        assert hydrated_tool["schema_included"] is True
+        assert hydrated_tool["input_schema"]["required"] == ["message"]
 
         execution_payload = _mcp_request(
             self.token,
@@ -327,6 +358,48 @@ class TestMCPAgentGateway:
         assert json.loads(execution_payload["content"][0]["text"]) == [
             {"echo": "hello"}
         ]
+
+        async_receipt = _call_gateway(
+            self.token,
+            "bifrost_execute_tool",
+            {
+                "agent_id": self.agent_id,
+                "tool_ref": tool_ref,
+                "arguments": {"message": "later"},
+                "async": True,
+            },
+        )
+        assert async_receipt["async"] is True
+        assert async_receipt["status"] == "Pending"
+        assert async_receipt["execution_id"]
+
+        deadline = time.monotonic() + 15
+        while True:
+            async_result = _call_gateway(
+                self.token,
+                "bifrost_get_execution",
+                {"execution_id": async_receipt["execution_id"]},
+            )
+            if async_result["status"] not in {"Pending", "Running"}:
+                break
+            assert time.monotonic() < deadline, async_result
+            time.sleep(0.1)
+        assert async_result["status"] == "Success"
+        assert async_result["result"] == [{"echo": "later"}]
+        assert async_result["result_page"]["has_more"] is False
+
+        unsupported_async = _call_gateway(
+            self.token,
+            "bifrost_execute_tool",
+            {
+                "agent_id": self.agent_id,
+                "tool_ref": system_tool["tool_ref"],
+                "arguments": {},
+                "async": True,
+            },
+        )
+        assert unsupported_async["code"] == "ASYNC_NOT_SUPPORTED"
+        assert unsupported_async["retryable"] is True
 
         invalid = _call_gateway(
             self.token,
@@ -362,10 +435,10 @@ class TestMCPAgentGateway:
         assert update_response.status_code == 200, update_response.text
         refreshed = _call_gateway(
             self.token,
-            "bifrost_get_agent",
+            "bifrost_search_capabilities",
             {"agent_id": self.agent_id},
         )
-        assert refreshed["agent"]["instructions"] == updated_prompt
+        assert refreshed["agents"][0]["instructions"] == updated_prompt
 
         revoke_response = requests.put(
             f"{TEST_API_URL}/api/agents/{self.agent_id}",

--- a/api/tests/e2e/api-integration/test_mcp_protocol.py
+++ b/api/tests/e2e/api-integration/test_mcp_protocol.py
@@ -117,7 +117,7 @@ class TestMCPProtocol:
         result = data["result"]
         assert "serverInfo" in result
         assert "protocolVersion" in result
-        assert "bifrost_find_agents" in result["instructions"]
+        assert "bifrost_search_capabilities" in result["instructions"]
 
     def test_mcp_list_tools(self):
         """Should be able to list available tools.
@@ -168,10 +168,9 @@ class TestMCPProtocol:
         tool_names = {t["name"] for t in tools}
         assert tool_names == {
             "bifrost_get_required_instructions",
-            "bifrost_find_agents",
-            "bifrost_get_agent",
-            "bifrost_get_tool_schema",
+            "bifrost_search_capabilities",
             "bifrost_execute_tool",
+            "bifrost_get_execution",
             "bifrost_search_memory",
             "bifrost_save_memory",
             "bifrost_remove_memory",

--- a/api/tests/e2e/api/test_mcp_knowledge_scoping.py
+++ b/api/tests/e2e/api/test_mcp_knowledge_scoping.py
@@ -250,10 +250,9 @@ class TestMCPKnowledgeScoping:
 
         assert {tool["name"] for tool in tools} == {
             "bifrost_get_required_instructions",
-            "bifrost_find_agents",
-            "bifrost_get_agent",
-            "bifrost_get_tool_schema",
+            "bifrost_search_capabilities",
             "bifrost_execute_tool",
+            "bifrost_get_execution",
             "bifrost_search_memory",
             "bifrost_save_memory",
             "bifrost_remove_memory",
@@ -261,10 +260,16 @@ class TestMCPKnowledgeScoping:
         loaded = _gateway_call(
             e2e_client,
             platform_admin.headers,
-            "bifrost_get_agent",
-            {"agent_id": _knowledge_scoping_setup["agent_alpha_id"]},
+            "bifrost_search_capabilities",
+            {
+                "agent_id": _knowledge_scoping_setup["agent_alpha_id"],
+                "query": "search knowledge",
+            },
         )
-        assert any(tool["name"] == "search_knowledge" for tool in loaded["tools"])
+        assert any(
+            tool["name"] == "search_knowledge"
+            for tool in loaded["agents"][0]["matching_tools"]
+        )
 
     def test_agent_scoped_lists_search_knowledge(
         self, e2e_client, platform_admin, _knowledge_scoping_setup
@@ -289,12 +294,15 @@ class TestMCPKnowledgeScoping:
         loaded_alpha = _gateway_call(
             e2e_client,
             platform_admin.headers,
-            "bifrost_get_agent",
-            {"agent_id": _knowledge_scoping_setup["agent_alpha_id"]},
+            "bifrost_search_capabilities",
+            {
+                "agent_id": _knowledge_scoping_setup["agent_alpha_id"],
+                "query": "search knowledge",
+            },
         )
         alpha_ref = next(
             tool["tool_ref"]
-            for tool in loaded_alpha["tools"]
+            for tool in loaded_alpha["agents"][0]["matching_tools"]
             if tool["name"] == "search_knowledge"
         )
         result = _gateway_call(
@@ -389,12 +397,15 @@ class TestMCPKnowledgeScoping:
         loaded = _gateway_call(
             e2e_client,
             platform_admin.headers,
-            "bifrost_get_agent",
-            {"agent_id": _knowledge_scoping_setup["agent_alpha_id"]},
+            "bifrost_search_capabilities",
+            {
+                "agent_id": _knowledge_scoping_setup["agent_alpha_id"],
+                "query": "search knowledge",
+            },
         )
         search_ref = next(
             tool["tool_ref"]
-            for tool in loaded["tools"]
+            for tool in loaded["agents"][0]["matching_tools"]
             if tool["name"] == "search_knowledge"
         )
         result = _gateway_call(

--- a/api/tests/unit/services/mcp_server/test_gateway.py
+++ b/api/tests/unit/services/mcp_server/test_gateway.py
@@ -1,5 +1,6 @@
 """Unit tests for the unscoped MCP agent gateway."""
 
+from dataclasses import replace
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
@@ -42,13 +43,14 @@ def _agent() -> MagicMock:
 def _resolved_tool(
     *,
     name: str = "lookup_ticket",
+    description: str = "Look up a ticket",
     parameters: dict | None = None,
 ) -> ResolvedGatewayTool:
     return ResolvedGatewayTool(
         tool_ref=str(uuid4()),
         definition=ToolDefinition(
             name=name,
-            description="Look up a ticket",
+            description=description,
             parameters=parameters
             or {
                 "type": "object",
@@ -154,6 +156,224 @@ def test_unknown_reference_does_not_fall_back_to_tool_name():
     assert exc_info.value.retryable is True
 
 
+def test_agent_hydration_never_implies_zero_matches_is_a_full_catalog():
+    service = MCPAgentGatewayService(_context())
+    agent = _agent()
+    snapshot = AgentToolSnapshot(
+        agent=agent,
+        tools=[_resolved_tool(name="lookup_ticket"), _resolved_tool(name="close_ticket")],
+    )
+
+    result = service._search_agent_snapshot(
+        snapshot,
+        query=None,
+        tool_ref=None,
+        limit=10,
+    )
+
+    found = result["agents"][0]
+    assert found["instructions"] == agent.system_prompt
+    assert found["instructions_included"] is True
+    assert found["matching_tools"] == []
+    assert found["total_tools"] == 2
+    assert found["returned_tools"] == 0
+    assert found["complete"] is False
+    assert "not the agent's full tool catalog" in found["search_again"]
+
+
+def test_scoped_search_returns_only_matching_tools_with_disclosure_counts():
+    service = MCPAgentGatewayService(_context())
+    snapshot = AgentToolSnapshot(
+        agent=_agent(),
+        tools=[
+            _resolved_tool(name="lookup_ticket"),
+            _resolved_tool(
+                name="send_invoice",
+                description="Send an invoice",
+                parameters={
+                    "type": "object",
+                    "properties": {"invoice_id": {"type": "integer"}},
+                },
+            ),
+        ],
+    )
+
+    result = service._search_agent_snapshot(
+        snapshot,
+        query="ticket",
+        tool_ref=None,
+        limit=10,
+    )
+
+    found = result["agents"][0]
+    assert [tool["name"] for tool in found["matching_tools"]] == ["lookup_ticket"]
+    assert found["total_tools"] == 2
+    assert found["returned_tools"] == 1
+    assert found["complete"] is False
+    assert found["total_matching_tools"] == 1
+    assert found["has_more_matches"] is False
+    assert result["response_complete"] is True
+
+
+def test_exact_tool_hydration_includes_only_the_selected_live_schema():
+    service = MCPAgentGatewayService(_context())
+    tool = _resolved_tool()
+    snapshot = AgentToolSnapshot(agent=_agent(), tools=[tool])
+
+    result = service._search_agent_snapshot(
+        snapshot,
+        query=None,
+        tool_ref=tool.tool_ref,
+        limit=10,
+    )
+
+    found_tool = result["agents"][0]["matching_tools"][0]
+    assert found_tool["tool_ref"] == tool.tool_ref
+    assert found_tool["schema_included"] is True
+    assert found_tool["input_schema"] == tool.definition.parameters
+
+
+def test_execution_result_pages_large_values_without_invalid_json_truncation():
+    result, page = MCPAgentGatewayService._page_execution_result(
+        {
+            "small": 42,
+            "huge": {"rows": ["x" * 30_000]},
+            "after": True,
+        },
+        result_path="",
+        offset=0,
+        limit=20,
+    )
+
+    assert result["small"] == 42
+    assert result["huge"]["$omitted"] is True
+    assert result["huge"]["path"] == "/huge"
+    assert result["after"] is True
+    assert page["has_more"] is False
+
+
+def test_execution_result_path_can_hydrate_an_omitted_value():
+    result, page = MCPAgentGatewayService._page_execution_result(
+        {"huge": {"rows": list(range(50))}},
+        result_path="/huge/rows",
+        offset=10,
+        limit=5,
+    )
+
+    assert result == [10, 11, 12, 13, 14]
+    assert page["next_offset"] == 15
+    assert page["has_more"] is True
+
+
+@pytest.mark.asyncio
+async def test_get_execution_authorizes_redis_only_pending_receipt():
+    context = _context()
+    service = MCPAgentGatewayService(context)
+    execution_id = str(uuid4())
+    db = AsyncMock()
+    db_result = MagicMock()
+    db_result.scalar_one_or_none.return_value = None
+    db.execute.return_value = db_result
+    db_context = MagicMock()
+    db_context.__aenter__ = AsyncMock(return_value=db)
+    db_context.__aexit__ = AsyncMock(return_value=None)
+    redis = MagicMock()
+    redis.get_pending_execution = AsyncMock(
+        return_value={
+            "execution_id": execution_id,
+            "workflow_id": str(uuid4()),
+            "script_name": None,
+            "user_id": str(context.user_id),
+            "created_at": "2026-08-13T12:00:00+00:00",
+        }
+    )
+
+    with (
+        patch("src.core.database.get_db_context", return_value=db_context),
+        patch("src.core.redis_client.get_redis_client", return_value=redis),
+    ):
+        result = await service.get_execution(execution_id)
+
+    assert result["execution_id"] == execution_id
+    assert result["status"] == "Pending"
+    assert result["result_available"] is False
+
+
+@pytest.mark.asyncio
+async def test_get_execution_hides_another_users_redis_only_receipt():
+    service = MCPAgentGatewayService(_context())
+    execution_id = str(uuid4())
+    db = AsyncMock()
+    db_result = MagicMock()
+    db_result.scalar_one_or_none.return_value = None
+    db.execute.return_value = db_result
+    db_context = MagicMock()
+    db_context.__aenter__ = AsyncMock(return_value=db)
+    db_context.__aexit__ = AsyncMock(return_value=None)
+    redis = MagicMock()
+    redis.get_pending_execution = AsyncMock(
+        return_value={"user_id": str(uuid4())}
+    )
+
+    with (
+        patch("src.core.database.get_db_context", return_value=db_context),
+        patch("src.core.redis_client.get_redis_client", return_value=redis),
+    ):
+        with pytest.raises(GatewayError) as exc_info:
+            await service.get_execution(execution_id)
+
+    assert exc_info.value.code == "EXECUTION_NOT_FOUND_OR_FORBIDDEN"
+
+
+@pytest.mark.asyncio
+async def test_capability_search_stops_before_the_serialized_response_budget(
+    monkeypatch,
+):
+    service = MCPAgentGatewayService(_context())
+    agents = []
+    snapshots = {}
+    for index in range(8):
+        agent = _agent()
+        agent.id = uuid4()
+        agent.name = f"Ticket Agent {index}"
+        agent.description = "ticket operations " * 100
+        agents.append(agent)
+        snapshots[str(agent.id)] = AgentToolSnapshot(
+            agent=agent,
+            tools=[
+                _resolved_tool(
+                    name=f"lookup_ticket_{index}",
+                    description="ticket lookup " * 100,
+                )
+            ],
+        )
+
+    monkeypatch.setattr(
+        "src.services.mcp_server.gateway.MAX_CAPABILITY_RESPONSE_BYTES",
+        4_000,
+    )
+    with (
+        patch.object(
+            service,
+            "_list_accessible_agents",
+            new=AsyncMock(return_value=agents),
+        ),
+        patch.object(
+            service,
+            "get_agent_snapshot",
+            new=AsyncMock(side_effect=lambda agent_id: snapshots[agent_id]),
+        ),
+    ):
+        result = await service.search_capabilities(query="ticket", limit=20)
+
+    from src.services.mcp_server.gateway import _serialized_size
+
+    assert _serialized_size(result) <= 4_000
+    assert result["has_more_matches"] is True
+    assert result["response_complete"] is False
+    assert result["returned_matches"] < result["total_matches"]
+
+
 @pytest.mark.asyncio
 async def test_execute_validates_before_dispatch():
     service = MCPAgentGatewayService(_context())
@@ -196,6 +416,7 @@ async def test_execute_returns_auditable_envelope():
     assert result["tool_ref"] == tool.tool_ref
     assert result["tool_name"] == "lookup_ticket"
     assert result["source"] == "workflow"
+    assert result["async"] is False
     assert result["result"] == {"ticket": 42}
     assert isinstance(result["duration_ms"], int)
 
@@ -219,6 +440,53 @@ async def test_workflow_dispatch_returns_only_the_workflow_result():
         result = await service._dispatch_workflow(tool, {"ticket_id": 42})
 
     assert result == [{"ticket": 42}]
+
+
+@pytest.mark.asyncio
+async def test_async_workflow_dispatch_returns_immediate_execution_receipt():
+    service = MCPAgentGatewayService(_context())
+    tool = _resolved_tool()
+    execution_id = str(uuid4())
+    response = MagicMock()
+    response.execution_id = execution_id
+    response.status.value = "Pending"
+    response.duration_ms = None
+    response.result = None
+    response.error = None
+    response.error_type = None
+
+    with patch(
+        "src.services.execution.service.execute_tool",
+        new=AsyncMock(return_value=response),
+    ) as execute:
+        result = await service._dispatch_workflow(
+            tool,
+            {"ticket_id": 42},
+            async_execution=True,
+        )
+
+    assert result == {"execution_id": execution_id, "status": "Pending"}
+    assert execute.await_args.kwargs["sync"] is False
+
+
+@pytest.mark.asyncio
+async def test_async_rejects_non_workflow_sources_without_dispatching():
+    service = MCPAgentGatewayService(_context())
+    agent = _agent()
+    tool = replace(_resolved_tool(), source="system")
+    snapshot = AgentToolSnapshot(agent=agent, tools=[tool])
+
+    with patch.object(service, "_dispatch", new_callable=AsyncMock) as dispatch:
+        with pytest.raises(GatewayError) as exc_info:
+            await service.execute_tool(
+                snapshot,
+                tool,
+                {"ticket_id": 42},
+                async_execution=True,
+            )
+
+    assert exc_info.value.code == "ASYNC_NOT_SUPPORTED"
+    dispatch.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/api/tests/unit/services/mcp_server/test_middleware.py
+++ b/api/tests/unit/services/mcp_server/test_middleware.py
@@ -127,7 +127,7 @@ class TestOnListTools:
         from src.services.mcp_server.middleware import ToolFilterMiddleware
 
         middleware = ToolFilterMiddleware()
-        all_tools = [mock_tool("bifrost_find_agents")]
+        all_tools = [mock_tool("bifrost_search_capabilities")]
         call_next = AsyncMock(return_value=all_tools)
         context = MagicMock()
         token = mock_access_token()
@@ -145,7 +145,7 @@ class TestOnListTools:
         ):
             result = await middleware.on_list_tools(context, call_next)
 
-        assert [tool.name for tool in result] == ["bifrost_find_agents"]
+        assert [tool.name for tool in result] == ["bifrost_search_capabilities"]
         mock_db_context.assert_not_called()
 
 

--- a/api/tests/unit/test_mcp_thin_wrapper.py
+++ b/api/tests/unit/test_mcp_thin_wrapper.py
@@ -100,10 +100,9 @@ PARITY_HANDLERS: dict[str, set[str]] = {
     },
     "gateway": {
         "bifrost_get_required_instructions",
-        "bifrost_find_agents",
-        "bifrost_get_agent",
-        "bifrost_get_tool_schema",
+        "bifrost_search_capabilities",
         "bifrost_execute_tool",
+        "bifrost_get_execution",
         "bifrost_search_memory",
         "bifrost_save_memory",
         "bifrost_remove_memory",

--- a/client/src/lib/v1.d.ts
+++ b/client/src/lib/v1.d.ts
@@ -6959,27 +6959,27 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/mcp/gateway/agents": {
+    "/api/mcp/gateway/capabilities/search": {
         parameters: {
             query?: never;
             header?: never;
             path?: never;
             cookie?: never;
         };
-        /**
-         * Find Gateway Agents
-         * @description Find accessible agents for progressive MCP discovery.
-         */
-        get: operations["find_gateway_agents_api_mcp_gateway_agents_get"];
+        get?: never;
         put?: never;
-        post?: never;
+        /**
+         * Search Gateway Capabilities
+         * @description Search agents and tools or hydrate one exact capability.
+         */
+        post: operations["search_gateway_capabilities_api_mcp_gateway_capabilities_search_post"];
         delete?: never;
         options?: never;
         head?: never;
         patch?: never;
         trace?: never;
     };
-    "/api/mcp/gateway/agents/{agent_id}": {
+    "/api/mcp/gateway/executions/{execution_id}": {
         parameters: {
             query?: never;
             header?: never;
@@ -6987,30 +6987,10 @@ export interface paths {
             cookie?: never;
         };
         /**
-         * Get Gateway Agent
-         * @description Load one accessible agent's live capability package.
+         * Get Gateway Execution
+         * @description Read compact status and a bounded result page for an owned execution.
          */
-        get: operations["get_gateway_agent_api_mcp_gateway_agents__agent_id__get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/mcp/gateway/agents/{agent_id}/tools/{tool_ref}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Gateway Tool Schema
-         * @description Load the current schema for an agent-bound tool.
-         */
-        get: operations["get_gateway_tool_schema_api_mcp_gateway_agents__agent_id__tools__tool_ref__get"];
+        get: operations["get_gateway_execution_api_mcp_gateway_executions__execution_id__get"];
         put?: never;
         post?: never;
         delete?: never;
@@ -7068,7 +7048,7 @@ export interface paths {
         };
         /**
          * Download Mcp Run Plugin
-         * @description Download the Bifrost Agent Plugins 1.0 package.
+         * @description Download the instance-matched Bifrost Agent package.
          */
         get: operations["download_mcp_run_plugin_api_mcp_run_plugin_get"];
         put?: never;
@@ -18397,10 +18377,10 @@ export interface components {
             service_oauth_token_id?: string | null;
         };
         /**
-         * MCPGatewayAgentDetail
-         * @description Live task instructions for a selected agent.
+         * MCPGatewayCapabilityAgent
+         * @description One agent and the bounded subset of tools relevant to the search.
          */
-        MCPGatewayAgentDetail: {
+        MCPGatewayCapabilityAgent: {
             /** Id */
             id: string;
             /** Name */
@@ -18409,29 +18389,66 @@ export interface components {
             description?: string | null;
             /** Instructions */
             instructions?: string | null;
+            /**
+             * Instructions Included
+             * @default false
+             */
+            instructions_included: boolean;
+            /** Matching Tools */
+            matching_tools: components["schemas"]["MCPGatewayToolSummary"][];
+            /** Total Tools */
+            total_tools: number;
+            /** Returned Tools */
+            returned_tools: number;
+            /** Complete */
+            complete: boolean;
+            /** Total Matching Tools */
+            total_matching_tools: number;
+            /** Has More Matches */
+            has_more_matches: boolean;
+            /** Search Again */
+            search_again?: string | null;
         };
         /**
-         * MCPGatewayAgentResponse
-         * @description Selected agent instructions and compact tool catalog.
+         * MCPGatewayCapabilitySearchRequest
+         * @description Progressively search or hydrate the live agent capability catalog.
          */
-        MCPGatewayAgentResponse: {
-            agent: components["schemas"]["MCPGatewayAgentDetail"];
-            /** Tools */
-            tools: components["schemas"]["MCPGatewayToolSummary"][];
-            /** Tool Count */
-            tool_count: number;
+        MCPGatewayCapabilitySearchRequest: {
+            /** Query */
+            query?: string | null;
+            /** Agent Id */
+            agent_id?: string | null;
+            /** Tool Ref */
+            tool_ref?: string | null;
+            /**
+             * Limit
+             * @default 10
+             */
+            limit: number;
         };
         /**
-         * MCPGatewayAgentSummary
-         * @description Compact agent metadata returned by gateway discovery.
+         * MCPGatewayCapabilitySearchResponse
+         * @description Bounded search results with explicit disclosure completeness.
          */
-        MCPGatewayAgentSummary: {
-            /** Id */
-            id: string;
-            /** Name */
-            name: string;
-            /** Description */
-            description?: string | null;
+        MCPGatewayCapabilitySearchResponse: {
+            /** Query */
+            query?: string | null;
+            /** Agent Id */
+            agent_id?: string | null;
+            /** Tool Ref */
+            tool_ref?: string | null;
+            /** Agents */
+            agents: components["schemas"]["MCPGatewayCapabilityAgent"][];
+            /** Returned Matches */
+            returned_matches: number;
+            /** Total Matches */
+            total_matches: number;
+            /** Has More Matches */
+            has_more_matches: boolean;
+            /** Response Complete */
+            response_complete: boolean;
+            /** Guidance */
+            guidance: string;
         };
         /**
          * MCPGatewayExecuteRequest
@@ -18442,13 +18459,18 @@ export interface components {
             arguments?: {
                 [key: string]: unknown;
             };
+            /**
+             * Async
+             * @default false
+             */
+            async: boolean;
         };
         /**
          * MCPGatewayExecuteResponse
          * @description Internal REST envelope for an auditable gateway tool call.
          *
-         *     The public MCP execute tool returns ``result`` directly; the remaining
-         *     fields support the REST bridge and server-side diagnostics.
+         *     Synchronous public MCP calls return ``result`` directly. Async calls return
+         *     this compact receipt so the caller can poll ``bifrost_get_execution``.
          */
         MCPGatewayExecuteResponse: {
             /** Agent Id */
@@ -18463,48 +18485,53 @@ export interface components {
             source: string;
             /** Duration Ms */
             duration_ms: number;
+            /**
+             * Async
+             * @default false
+             */
+            async: boolean;
+            /** Execution Id */
+            execution_id?: string | null;
+            /** Status */
+            status?: string | null;
             /** Result */
-            result: unknown;
+            result?: unknown;
         };
         /**
-         * MCPGatewayFindAgentsResponse
-         * @description Search results for agents visible to the caller.
+         * MCPGatewayExecutionResponse
+         * @description Compact, ownership-checked execution status and paged result.
          */
-        MCPGatewayFindAgentsResponse: {
-            /** Query */
-            query?: string | null;
-            /** Agents */
-            agents: components["schemas"]["MCPGatewayAgentSummary"][];
-            /** Count */
-            count: number;
-            /** Total Matches */
-            total_matches: number;
-            /** Has More */
-            has_more: boolean;
-        };
-        /**
-         * MCPGatewayToolSchemaResponse
-         * @description Live schema for one agent-bound tool reference.
-         */
-        MCPGatewayToolSchemaResponse: {
-            /** Agent Id */
-            agent_id: string;
-            /** Tool Ref */
-            tool_ref: string;
-            /** Name */
-            name: string;
-            /** Description */
-            description: string;
-            /** Source */
-            source: string;
-            /** Input Schema */
-            input_schema: {
+        MCPGatewayExecutionResponse: {
+            /** Execution Id */
+            execution_id: string;
+            /** Workflow Id */
+            workflow_id?: string | null;
+            /** Workflow Name */
+            workflow_name?: string | null;
+            /** Status */
+            status: string;
+            /** Created At */
+            created_at?: string | null;
+            /** Started At */
+            started_at?: string | null;
+            /** Completed At */
+            completed_at?: string | null;
+            /** Duration Ms */
+            duration_ms?: number | null;
+            /** Error */
+            error?: string | null;
+            /** Result Available */
+            result_available: boolean;
+            /** Result */
+            result?: unknown;
+            /** Result Page */
+            result_page?: {
                 [key: string]: unknown;
-            };
+            } | null;
         };
         /**
          * MCPGatewayToolSummary
-         * @description Schema-free tool metadata returned with an agent.
+         * @description A matching agent-bound tool, optionally hydrated with its schema.
          */
         MCPGatewayToolSummary: {
             /** Tool Ref */
@@ -18515,6 +18542,15 @@ export interface components {
             description: string;
             /** Source */
             source: string;
+            /** Input Schema */
+            input_schema?: {
+                [key: string]: unknown;
+            } | null;
+            /**
+             * Schema Included
+             * @default false
+             */
+            schema_included: boolean;
         };
         /**
          * MCPRunInfoResponse
@@ -37904,17 +37940,18 @@ export interface operations {
             };
         };
     };
-    find_gateway_agents_api_mcp_gateway_agents_get: {
+    search_gateway_capabilities_api_mcp_gateway_capabilities_search_post: {
         parameters: {
-            query?: {
-                query?: string | null;
-                limit?: number;
-            };
+            query?: never;
             header?: never;
             path?: never;
             cookie?: never;
         };
-        requestBody?: never;
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["MCPGatewayCapabilitySearchRequest"];
+            };
+        };
         responses: {
             /** @description Successful Response */
             200: {
@@ -37922,7 +37959,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["MCPGatewayFindAgentsResponse"];
+                    "application/json": components["schemas"]["MCPGatewayCapabilitySearchResponse"];
                 };
             };
             /** @description Validation Error */
@@ -37936,12 +37973,16 @@ export interface operations {
             };
         };
     };
-    get_gateway_agent_api_mcp_gateway_agents__agent_id__get: {
+    get_gateway_execution_api_mcp_gateway_executions__execution_id__get: {
         parameters: {
-            query?: never;
+            query?: {
+                result_path?: string;
+                offset?: number;
+                limit?: number;
+            };
             header?: never;
             path: {
-                agent_id: string;
+                execution_id: string;
             };
             cookie?: never;
         };
@@ -37953,39 +37994,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["MCPGatewayAgentResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_gateway_tool_schema_api_mcp_gateway_agents__agent_id__tools__tool_ref__get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                agent_id: string;
-                tool_ref: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["MCPGatewayToolSchemaResponse"];
+                    "application/json": components["schemas"]["MCPGatewayExecutionResponse"];
                 };
             };
             /** @description Validation Error */

--- a/plugins/bifrost/skills/bifrost-build/generated/openapi-digest.md
+++ b/plugins/bifrost/skills/bifrost-build/generated/openapi-digest.md
@@ -288,10 +288,9 @@
 | DELETE | `/api/mcp/config` |
 | GET | `/api/mcp/config` |
 | PUT | `/api/mcp/config` |
-| GET | `/api/mcp/gateway/agents` |
-| GET | `/api/mcp/gateway/agents/{agent_id}` |
-| GET | `/api/mcp/gateway/agents/{agent_id}/tools/{tool_ref}` |
 | POST | `/api/mcp/gateway/agents/{agent_id}/tools/{tool_ref}/execute` |
+| POST | `/api/mcp/gateway/capabilities/search` |
+| GET | `/api/mcp/gateway/executions/{execution_id}` |
 | GET | `/api/mcp/run` |
 | GET | `/api/mcp/run/plugin` |
 | GET | `/api/mcp/status` |


### PR DESCRIPTION
## Summary

- consolidate agent and tool discovery into `bifrost_search_capabilities` with explicit bounded-result guidance
- add optional async workflow execution with immediate execution IDs and ownership-checked result polling
- preserve required instructions, private memory tools, synchronous execution behavior, and agent-scoped MCP surfaces
- refresh generated OpenAPI and Bifrost Agent package instructions

## Verification

- `./test.sh ...` targeted MCP unit/E2E selection: 125 passed
- `./test.sh quality api`
- client `npm run tsc` and `npm run lint` in Docker
- skill-truth generator `--check`

Closes #584