### PR TITLE
Fix CLI download for uv-backed pipx installs

### DIFF
--- a/.claude/skills/bifrost-build/generated/openapi-digest.md
+++ b/.claude/skills/bifrost-build/generated/openapi-digest.md
@@ -111,7 +111,9 @@
 | DELETE | `/api/claims/{name}` |
 | GET | `/api/claims/{name}` |
 | PATCH | `/api/claims/{name}` |
+| GET | `/api/cli/artifacts/{filename}` |
 | GET | `/api/cli/download` |
+| GET | `/api/cli/download/bifrost-cli.tar.gz` |
 | GET | `/api/config` |
 | POST | `/api/config` |
 | DELETE | `/api/config/{config_id}` |

--- a/.claude/skills/bifrost-setup/SKILL.md
+++ b/.claude/skills/bifrost-setup/SKILL.md
@@ -135,13 +135,13 @@ the authenticated current connection is the default link base.
 **Use the detected pip command** (from `$BIFROST_PIP_CMD`):
 
 ```bash
-$BIFROST_PIP_CMD {url}/api/cli/download
+$BIFROST_PIP_CMD {url}/api/cli/download/bifrost-cli.tar.gz
 ```
 
 On native Windows, prefer:
 
 ```powershell
-py -3.11 -m pipx install --force {url}/api/cli/download
+py -3.11 -m pipx install --force {url}/api/cli/download/bifrost-cli.tar.gz
 ```
 
 Verify with:
@@ -159,11 +159,11 @@ the others; update the CLI first because it supplies the SDK-update command.
 
 1. **CLI from the intended Bifrost instance:**
    ```bash
-   pipx install --force {url}/api/cli/download
+   pipx install --force {url}/api/cli/download/bifrost-cli.tar.gz
    bifrost --version
    ```
    On native Windows, use
-   `py -3.11 -m pipx install --force {url}/api/cli/download`.
+   `py -3.11 -m pipx install --force {url}/api/cli/download/bifrost-cli.tar.gz`.
 2. **Vendored web SDK in each Solution workspace:**
    ```bash
    cd /path/to/solution
@@ -250,7 +250,7 @@ If MCP was skipped (SDK-first only), tell the user:
 ## Troubleshooting
 
 ### pipx install fails with network error
-- Verify URL is accessible: `curl {url}/api/cli/download -o /dev/null -w "%{http_code}"`
+- Verify URL is accessible: `curl -L {url}/api/cli/download/bifrost-cli.tar.gz -o /dev/null -w "%{http_code}"`
 
 ### bifrost login hangs
 - Check if URL is accessible in browser

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,7 +63,7 @@ Use this whenever you need a running Bifrost instance to exercise — clicking a
    cd /tmp/bifrost-cli-<name>
    python3 -m venv .venv
    .venv/bin/pip install --quiet --upgrade pip
-   .venv/bin/pip install --quiet "<API_URL>/api/cli/download"
+   .venv/bin/pip install --quiet "<API_URL>/api/cli/download/bifrost-cli.tar.gz"
    ```
    The download endpoint serves the build matching the running API; installing this version avoids the version-mismatch warning that otherwise short-circuits subcommand output.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,7 +62,7 @@ Use this whenever you need a running Bifrost instance to exercise — clicking a
    cd /tmp/bifrost-cli-<name>
    python3 -m venv .venv
    .venv/bin/pip install --quiet --upgrade pip
-   .venv/bin/pip install --quiet "<API_URL>/api/cli/download"
+   .venv/bin/pip install --quiet "<API_URL>/api/cli/download/bifrost-cli.tar.gz"
    ```
    The download endpoint serves the build matching the running API; installing this version avoids the version-mismatch warning that otherwise short-circuits subcommand output.
 

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -35,6 +35,7 @@ RUN pip install --no-cache-dir --require-hashes -r requirements.lock
 FROM python:3.14-slim@sha256:cea0e6040540fb2b965b6e7fb5ffa00871e632eef63719f0ea54bca189ce14a6
 
 WORKDIR /app
+ARG BIFROST_VERSION=unknown
 
 # Install runtime dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -69,6 +70,13 @@ COPY api/bifrost.py /app/
 COPY api/scripts/ /app/scripts/
 COPY assets/ /app/assets/
 RUN chmod -R a+rX /app/assets
+
+# Build the CLI once as an immutable image artifact. The API serves this file;
+# it never packages the live source tree in a request handler.
+RUN PYTHONPATH=/app python /app/scripts/build_cli_artifact.py \
+      --source /app/bifrost \
+      --output /app/artifacts \
+      --version "${BIFROST_VERSION}"
 
 # Install app compiler Node.js dependencies
 COPY api/src/services/app_compiler/package.json api/src/services/app_compiler/package-lock.json* /app/src/services/app_compiler/
@@ -125,7 +133,6 @@ ENTRYPOINT ["/entrypoint.sh"]
 ENV PYTHONPATH=/app
 ENV PYTHONUNBUFFERED=1
 
-ARG BIFROST_VERSION=unknown
 ENV BIFROST_VERSION=${BIFROST_VERSION}
 
 # No default CMD - let docker-compose specify the command per service

--- a/api/Dockerfile.dev
+++ b/api/Dockerfile.dev
@@ -36,6 +36,7 @@ RUN pip install --no-cache-dir --require-hashes -r requirements.lock \
 FROM python:3.14-slim@sha256:cea0e6040540fb2b965b6e7fb5ffa00871e632eef63719f0ea54bca189ce14a6
 
 WORKDIR /app
+ARG BIFROST_VERSION=unknown
 
 # Install runtime dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -104,6 +105,17 @@ COPY client/src/lib/app-sdk/index.v2.ts /app/src/services/sdk_package/sdk_src/in
 COPY client/src/lib/app-sdk/sdk-contract.json /app/src/services/sdk_package/sdk_src/sdk-contract.json
 RUN chmod -R a+rX /app/src/services/sdk_package
 
+# Source is bind-mounted at runtime in development, but the downloadable CLI
+# is deliberately frozen at image-build time just as it is in production.
+COPY api/bifrost/ /tmp/cli-build/bifrost/
+COPY api/shared/cli_artifact.py /tmp/cli-build/shared/cli_artifact.py
+COPY api/scripts/build_cli_artifact.py /tmp/cli-build/build_cli_artifact.py
+RUN PYTHONPATH=/tmp/cli-build python /tmp/cli-build/build_cli_artifact.py \
+      --source /tmp/cli-build/bifrost \
+      --output /app/artifacts \
+      --version "${BIFROST_VERSION}" \
+    && rm -rf /tmp/cli-build
+
 # Copy entrypoint script
 COPY api/entrypoint.sh /entrypoint.sh
 COPY assets/ /app/assets/
@@ -119,7 +131,6 @@ ENV PYTHONPATH=/app
 ENV PYTHONUNBUFFERED=1
 ENV PYTHONDONTWRITEBYTECODE=1
 
-ARG BIFROST_VERSION=unknown
 ENV BIFROST_VERSION=${BIFROST_VERSION}
 
 # No default CMD - let docker-compose specify the command per service

--- a/api/bifrost/cli.py
+++ b/api/bifrost/cli.py
@@ -272,7 +272,7 @@ def _check_cli_version() -> None:
                 f"Your CLI is incompatible with this server "
                 f"(CLI contract v{CONTRACT_VERSION}, server contract "
                 f"v{server_contract}). You must upgrade:\n"
-                f"  pipx install --force {api_url}/api/cli/download"
+                f"  pipx install --force {api_url}/api/cli/download/bifrost-cli.tar.gz"
             )
             sys.exit(1)
         # Gate 2 — build drift (SOFT, deduped). Contract is fine; just nudge.
@@ -284,7 +284,7 @@ def _check_cli_version() -> None:
                     f"A newer Bifrost CLI is available "
                     f"({installed} → {server_version}); your current CLI is still "
                     f"compatible. Update when convenient:\n"
-                    f"  pipx install --force {api_url}/api/cli/download"
+                    f"  pipx install --force {api_url}/api/cli/download/bifrost-cli.tar.gz"
                 )
                 _version_notice.mark_notified(api_url, server_version)
         return
@@ -897,7 +897,7 @@ Examples:
         return 1
 
     resolved_url = resolved_url.rstrip("/")
-    download_url = f"{resolved_url}/api/cli/download"
+    download_url = f"{resolved_url}/api/cli/download/bifrost-cli.tar.gz"
     try:
         command = _update_install_command(download_url)
     except RuntimeError as exc:

--- a/api/bifrost/contracts/__init__.py
+++ b/api/bifrost/contracts/__init__.py
@@ -4,7 +4,7 @@ The CLI's entity commands (``bifrost/commands/*.py``) build flags and
 request bodies from Pydantic ``XxxCreate`` / ``XxxUpdate`` DTOs via
 ``bifrost.dto_flags.build_cli_flags`` / ``assemble_body``. Those DTOs
 originally live in ``src.models.contracts.*`` on the server side, but the
-CLI tarball shipped by ``/api/cli/download`` does **not** include ``src/``
+CLI tarball shipped by ``/api/cli/download/bifrost-cli.tar.gz`` does **not** include ``src/``
 — so a fresh ``pip install`` of that tarball produced a CLI where every
 ``bifrost <entity> <verb>`` crashed with ``ModuleNotFoundError: No module
 named 'src'``.

--- a/api/scripts/build_cli_artifact.py
+++ b/api/scripts/build_cli_artifact.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+"""Build the CLI archive that the API image serves as a static artifact."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from shared.cli_artifact import build_cli_artifact
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--source", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--version", required=True)
+    args = parser.parse_args()
+
+    artifact = build_cli_artifact(args.source, args.output, args.version)
+    print(artifact)
+
+
+if __name__ == "__main__":
+    main()

--- a/api/shared/cli_artifact.py
+++ b/api/shared/cli_artifact.py
@@ -1,0 +1,145 @@
+"""Build the installable Bifrost CLI artifact bundled with the API image."""
+
+from __future__ import annotations
+
+import gzip
+import io
+import re
+import tarfile
+from pathlib import Path
+
+_EXCLUDED_FILES = {
+    "_internal.py",  # Platform-only permission checks
+    "_logging.py",  # Platform-only logging
+    "_sync.py",  # Platform-only sync utilities
+    "_write_buffer.py",  # Platform-only, requires Redis
+}
+_RUNTIME_DATA_FILES = {"lucide_icon_names.json"}
+
+
+def to_pep440(version: str) -> str:
+    """Coerce a Bifrost build version to a PEP 440 package version."""
+    if not version or version == "unknown":
+        return "0.0.0"
+
+    value = version[1:] if version.startswith("v") else version
+    dirty = value.endswith("-dirty")
+    if dirty:
+        value = value[: -len("-dirty")]
+
+    dev_release = re.fullmatch(r"(\d+(?:\.\d+)*)-dev\.(\d+)", value)
+    if dev_release:
+        base, number = dev_release.groups()
+        normalized = f"{base}.dev{number}"
+        return f"{normalized}+dirty" if dirty else normalized
+
+    described = re.fullmatch(r"(.+)-(\d+)-(g[0-9a-f]+)", value)
+    if described:
+        tag, count, sha = described.groups()
+        local = f"{sha}.dirty" if dirty else sha
+        return f"{tag}.post{count}+{local}"
+
+    if re.fullmatch(r"\d+(\.\d+)*", value):
+        return f"{value}+dirty" if dirty else value
+
+    # ``git describe --always`` normally yields a hexadecimal SHA here. Keep
+    # the fallback valid and filename-safe even when a development build
+    # supplies a label such as ``debug`` instead.
+    local = re.sub(r"[^a-zA-Z0-9]+", ".", value).strip(".").lower() or "unknown"
+    if dirty:
+        local = f"{local}.dirty"
+    return f"0.0.0+g{local}"
+
+
+def cli_artifact_filename(version: str) -> str:
+    """Return the immutable, installer-compatible artifact filename."""
+    return f"bifrost-cli-{to_pep440(version)}.tar.gz"
+
+
+def _tar_info(name: str, data: bytes, mode: int = 0o644) -> tarfile.TarInfo:
+    info = tarfile.TarInfo(name=name)
+    info.size = len(data)
+    info.mode = mode
+    info.mtime = 0
+    info.uid = 0
+    info.gid = 0
+    info.uname = "root"
+    info.gname = "root"
+    return info
+
+
+def build_cli_artifact(source_dir: Path, output_dir: Path, version: str) -> Path:
+    """Build a deterministic source archive from the standalone CLI package."""
+    source_dir = source_dir.resolve()
+    pyproject_path = source_dir / "pyproject.toml"
+    if not pyproject_path.is_file():
+        raise FileNotFoundError(f"CLI pyproject not found: {pyproject_path}")
+
+    pep440_version = to_pep440(version)
+    pyproject, replacements = re.subn(
+        r'^version\s*=\s*"[^"]*"',
+        f'version = "{pep440_version}"',
+        pyproject_path.read_text(),
+        count=1,
+        flags=re.MULTILINE,
+    )
+    if replacements != 1:
+        raise ValueError(f"CLI version field not found in {pyproject_path}")
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    artifact_path = output_dir / cli_artifact_filename(version)
+    temporary_path = artifact_path.with_suffix(f"{artifact_path.suffix}.tmp")
+
+    try:
+        with temporary_path.open("wb") as raw_file:
+            with gzip.GzipFile(fileobj=raw_file, mode="wb", mtime=0) as gzip_file:
+                with tarfile.open(fileobj=gzip_file, mode="w") as archive:
+                    pyproject_data = pyproject.encode()
+                    archive.addfile(
+                        _tar_info("pyproject.toml", pyproject_data),
+                        io.BytesIO(pyproject_data),
+                    )
+
+                    for file_path in sorted(source_dir.rglob("*")):
+                        if not file_path.is_file():
+                            continue
+                        if "__pycache__" in file_path.parts:
+                            continue
+                        if file_path.name in _EXCLUDED_FILES:
+                            continue
+                        if (
+                            file_path.suffix not in {".py", ".toml"}
+                            and file_path.name not in _RUNTIME_DATA_FILES
+                        ):
+                            continue
+                        if file_path == pyproject_path:
+                            continue
+
+                        data = file_path.read_bytes()
+                        if file_path == source_dir / "__init__.py":
+                            stamped = re.subn(
+                                rb"^__version__\s*=\s*_compute_version\(\)",
+                                f'__version__ = "{version}"'.encode(),
+                                data,
+                                count=1,
+                                flags=re.MULTILINE,
+                            )
+                            data, replacements = stamped
+                            if replacements != 1:
+                                raise ValueError(
+                                    f"CLI __version__ assignment not found in {file_path}"
+                                )
+
+                        archive_name = f"bifrost/{file_path.relative_to(source_dir)}"
+                        mode = file_path.stat().st_mode & 0o777
+                        archive.addfile(
+                            _tar_info(archive_name, data, mode),
+                            io.BytesIO(data),
+                        )
+
+        temporary_path.replace(artifact_path)
+    except Exception:
+        temporary_path.unlink(missing_ok=True)
+        raise
+
+    return artifact_path

--- a/api/src/repositories/README.md
+++ b/api/src/repositories/README.md
@@ -352,12 +352,12 @@ against the authenticated principal and pass the user's actual
 privileges (`is_superuser=user.is_superuser`) to the repository so
 role-based filters fire.
 
-**`/api/cli/download` is a deliberate exception.** It serves the
-`pip install` URL for the Bifrost CLI itself and stays at its current
-path because the URL IS the install command users type. Served by a
-separate `install_router` in `routers/cli.py` so its semantics are
-explicit, not a router-prefix carve-out. This is the only path under
-`/api/cli/*` that survives the 2026-05 rename.
+**`/api/cli/download/bifrost-cli.tar.gz` is a deliberate exception.** It is
+the installer-compatible URL for the Bifrost CLI itself; the suffix is required
+by uv-backed pipx before it makes an HTTP request. The historical extensionless
+`/api/cli/download` path redirects for compatibility with HTTP clients that do
+fetch it. Both are served by a separate `install_router` in `routers/cli.py` so
+their semantics are explicit, not a router-prefix carve-out.
 
 ---
 

--- a/api/src/routers/cli.py
+++ b/api/src/routers/cli.py
@@ -42,17 +42,16 @@ Note: File operations have been moved to /api/files router.
 """
 
 import asyncio
-import io
 import json
 import logging
-import tarfile
+import os
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 from uuid import UUID, uuid4
 
 from fastapi import APIRouter, Depends, HTTPException, status
-from fastapi.responses import Response, StreamingResponse
+from fastapi.responses import FileResponse, RedirectResponse, Response, StreamingResponse
 from pydantic import BaseModel, Field
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -109,13 +108,16 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/sdk", tags=["SDK"])
 
-# /api/cli/download is the permanent home for the CLI install
-# endpoint. It lives at /api/cli/ (not /api/sdk/) because users type
-# the URL — `pip install <SERVER_URL>/api/cli/download` — so the path
-# is intentionally "the CLI." Not a legacy shim; not a compat carve-out.
+# /api/cli/download/bifrost-cli.tar.gz is the permanent, installer-compatible
+# home for the CLI install endpoint. The extensionless /api/cli/download path
+# remains a compatibility redirect for clients that actually make the request.
+# These live at /api/cli/ (not /api/sdk/) because users type the URL.
 # The rest of /api/cli/* moved to /api/sdk/* in the 2026-05 overhaul
 # because those endpoints are the SDK execution surface, not the CLI.
 install_router = APIRouter(prefix="/api/cli", tags=["CLI Install"])
+
+CLI_DOWNLOAD_ALIAS = "bifrost-cli.tar.gz"
+CLI_ARTIFACT_DIR = Path(os.environ.get("BIFROST_CLI_ARTIFACT_DIR", "/app/artifacts"))
 
 
 # =============================================================================
@@ -2568,159 +2570,65 @@ async def cli_knowledge_get(
 # =============================================================================
 
 
-def _to_pep440(version: str) -> str:
-    """Coerce `git describe --tags --always --dirty` output to a PEP 440 version.
-
-    Examples:
-        "v0.6-219-g24b8acb9-dirty" -> "0.6.post219+g24b8acb9.dirty"
-        "v1.2.3"                   -> "1.2.3"
-        "v1.2.3-dirty"             -> "1.2.3+dirty"
-        "abc1234"                  -> "0.0.0+gabc1234"   (no-tag fallback)
-        "unknown"                  -> "0.0.0"
-    """
-    import re as _re
-
-    if not version or version == "unknown":
-        return "0.0.0"
-
-    # Strip leading 'v' from tag prefix
-    v = version[1:] if version.startswith("v") else version
-
-    dirty = v.endswith("-dirty")
-    if dirty:
-        v = v[: -len("-dirty")]
-
-    # Bifrost release tags use a semver-ish dev release shape
-    # (e.g. "1.0.8-dev.11"). Preserve the actual release instead of treating it
-    # as a no-tag git hash fallback, which makes package tools report
-    # "0.0.0+g1.0.8.dev.11".
-    m = _re.match(r"^(\d+(?:\.\d+)*)-dev\.(\d+)$", v)
-    if m:
-        base, n = m.group(1), m.group(2)
-        pep = f"{base}.dev{n}"
-        return f"{pep}+dirty" if dirty else pep
-
-    # Shape: <tag>-<N>-g<sha>
-    m = _re.match(r"^(.+)-(\d+)-(g[0-9a-f]+)$", v)
-    if m:
-        tag, n, sha = m.group(1), m.group(2), m.group(3)
-        local = f"{sha}.dirty" if dirty else sha
-        return f"{tag}.post{n}+{local}"
-
-    # Clean tag (e.g. "1.2.3")
-    if _re.match(r"^\d+(\.\d+)*$", v):
-        return f"{v}+dirty" if dirty else v
-
-    # No-tag fallback: bare sha from `git describe --always`
-    local = f"g{v}.dirty" if dirty else f"g{v}"
-    return f"0.0.0+{local}"
+@install_router.get(
+    "/download",
+    summary="Legacy CLI download URL",
+    description="Redirect to the installer-compatible CLI download URL",
+)
+async def download_cli() -> RedirectResponse:
+    """Preserve the historical URL for HTTP clients that follow redirects."""
+    return RedirectResponse(
+        url=f"/api/cli/download/{CLI_DOWNLOAD_ALIAS}",
+        status_code=status.HTTP_307_TEMPORARY_REDIRECT,
+    )
 
 
 @install_router.get(
-    "/download",
+    f"/download/{CLI_DOWNLOAD_ALIAS}",
     summary="Download CLI package",
-    description="Download the Bifrost CLI as a pip-installable tarball",
+    description="Redirect to the versioned, pip-installable CLI artifact",
 )
-async def download_cli() -> Response:
-    """
-    Serve CLI as installable package.
-
-    Returns a tarball that can be installed with:
-    pip install https://your-bifrost-instance.com/api/cli/download
-    """
+async def download_cli_alias() -> RedirectResponse:
+    """Give uv/pipx a suffix-bearing URL before any network request occurs."""
+    from shared.cli_artifact import cli_artifact_filename
     from shared.version import get_version
 
-    package_dir = Path(__file__).parent.parent.parent / "bifrost"
+    filename = cli_artifact_filename(get_version())
+    return RedirectResponse(
+        url=f"/api/cli/artifacts/{filename}",
+        status_code=status.HTTP_307_TEMPORARY_REDIRECT,
+    )
 
-    if not package_dir.exists():
+
+@install_router.get(
+    "/artifacts/{filename}",
+    summary="Serve a versioned CLI artifact",
+    description="Serve the immutable CLI artifact bundled into the API image",
+)
+async def download_cli_artifact(filename: str) -> FileResponse:
+    """Serve only the artifact matching this API build."""
+    from shared.cli_artifact import cli_artifact_filename
+    from shared.version import get_version
+
+    expected_filename = cli_artifact_filename(get_version())
+    if filename != expected_filename:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail="CLI package not found",
+            detail="CLI artifact not found",
         )
 
-    buffer = io.BytesIO()
+    artifact_path = CLI_ARTIFACT_DIR / expected_filename
+    if not artifact_path.is_file():
+        logger.error("Bundled CLI artifact is missing: %s", artifact_path)
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="CLI artifact unavailable",
+        )
 
-    # Files to exclude (platform-only internal files)
-    exclude_files = {
-        "_internal.py",     # Platform-only permission checks
-        "_write_buffer.py", # Platform-only, requires Redis
-        "_logging.py",      # Platform-only logging
-        "_sync.py",         # Platform-only sync utilities
-    }
-
-    def _generate_tarball():
-        """Generate tarball synchronously in thread."""
-        import re as _re
-        import io as _io
-        live_version = get_version()
-        pep440_version = _to_pep440(live_version)
-
-        with tarfile.open(fileobj=buffer, mode="w:gz") as tar:
-            # Add pyproject.toml at root level with PEP 440 version stamped
-            # (setuptools validates project.version against PEP 440; git describe
-            # output like "v0.6-219-gabc1234-dirty" must be coerced first)
-            pyproject_path = package_dir / "pyproject.toml"
-            if pyproject_path.exists():
-                content = pyproject_path.read_text()
-                content = _re.sub(
-                    r'^version\s*=\s*"[^"]*"',
-                    f'version = "{pep440_version}"',
-                    content,
-                    flags=_re.MULTILINE,
-                )
-                data = content.encode()
-                info = tarfile.TarInfo(name="pyproject.toml")
-                info.size = len(data)
-                tar.addfile(info, fileobj=_io.BytesIO(data))
-
-            # Add all Python files from bifrost/
-            for file_path in package_dir.rglob("*"):
-                if not file_path.is_file():
-                    continue
-                if "__pycache__" in str(file_path):
-                    continue
-                if file_path.name in exclude_files:
-                    continue
-                # Ship .py + .toml, PLUS the data files the CLI reads at runtime.
-                # lucide_icon_names.json is the snapshot `bifrost migrate-imports`
-                # uses to classify lucide icons; excluding it ships a CLI that
-                # silently leaves icon imports in "bifrost" and breaks a v1→v2
-                # app migration (battle-test 2026-06-13).
-                _data_files = {"lucide_icon_names.json"}
-                if file_path.suffix not in (".py", ".toml") and file_path.name not in _data_files:
-                    continue
-                if file_path.name == "pyproject.toml":
-                    continue  # Already added above
-
-                arcname = f"bifrost/{file_path.relative_to(package_dir)}"
-
-                # Stamp __version__ in __init__.py
-                if file_path.name == "__init__.py" and file_path.parent == package_dir:
-                    content = file_path.read_text()
-                    content = _re.sub(
-                        r"^__version__\s*=\s*_compute_version\(\)",
-                        f'__version__ = "{live_version}"',
-                        content,
-                        flags=_re.MULTILINE,
-                    )
-                    data = content.encode()
-                    info = tarfile.TarInfo(name=arcname)
-                    info.size = len(data)
-                    tar.addfile(info, fileobj=_io.BytesIO(data))
-                else:
-                    tar.add(file_path, arcname=arcname)
-
-    await asyncio.to_thread(_generate_tarball)
-
-    # Get the complete tarball content after it's fully finalized
-    tarball_content = buffer.getvalue()
-
-    return Response(
-        content=tarball_content,
+    return FileResponse(
+        path=artifact_path,
         media_type="application/gzip",
-        headers={
-            "Content-Disposition": f"attachment; filename=bifrost-cli-{get_version()}.tar.gz",
-        },
+        filename=expected_filename,
     )
 
 
@@ -2737,9 +2645,10 @@ async def download_cli() -> Response:
 async def download_sdk() -> Response:
     """Build + serve the installable ``bifrost`` SDK package (npm tarball).
 
-    Mirrors ``/api/cli/download`` (the Python CLI tarball): the package is built
-    on the fly from the SDK source shipped in the api image and version-stamped
-    to the running instance, so dev and deploy use one resolution mechanism.
+    Like ``/api/cli/download/bifrost-cli.tar.gz`` (the Python CLI tarball), this
+    package is tied to the API build. The web SDK remains bundled on demand from
+    source shipped in the image, while the Python CLI artifact is built into the
+    image ahead of time.
     """
     from shared.version import get_version
     from src.services.sdk_package import build_sdk_tarball

--- a/api/src/services/sdk_package/__init__.py
+++ b/api/src/services/sdk_package/__init__.py
@@ -5,7 +5,7 @@ resolves it from the instance (``npm install`` against /api/sdk/download), so th
 SAME mechanism works on a developer laptop (``npm run dev``) and in the platform's
 server-side build. This module produces the npm-installable tarball on the fly,
 version-stamped to the running instance — directly analogous to the CLI's
-``/api/cli/download`` (a Python tarball).
+``/api/cli/download/bifrost-cli.tar.gz`` (a Python tarball).
 
 The SDK source (provider, tables, hooks) lives in ``client/src/lib/app-sdk`` and
 is copied into the api image at ``sdk_src/`` (see Dockerfile). It is bundled with

--- a/api/tests/e2e/api/test_cli.py
+++ b/api/tests/e2e/api/test_cli.py
@@ -557,9 +557,25 @@ class TestCLIConfigOperations:
 # Download Tests
 # =============================================================================
 
+CLI_DOWNLOAD_URL = "/api/cli/download/bifrost-cli.tar.gz"
+
 
 class TestCLIDownload:
     """Test SDK download endpoint."""
+
+    def test_legacy_download_redirects_to_suffix_bearing_url(self, e2e_client):
+        response = e2e_client.get("/api/cli/download", follow_redirects=False)
+
+        assert response.status_code == 307
+        assert response.headers["location"] == CLI_DOWNLOAD_URL
+
+    def test_download_alias_redirects_to_versioned_artifact(self, e2e_client):
+        response = e2e_client.get(CLI_DOWNLOAD_URL, follow_redirects=False)
+
+        assert response.status_code == 307
+        location = response.headers["location"]
+        assert location.startswith("/api/cli/artifacts/bifrost-cli-")
+        assert location.endswith(".tar.gz")
 
     def test_download_sdk(
         self,
@@ -568,11 +584,15 @@ class TestCLIDownload:
     ):
         """Test downloading the SDK package."""
         response = e2e_client.get(
-            "/api/cli/download",
+            CLI_DOWNLOAD_URL,
             headers=platform_admin.headers,
+            follow_redirects=True,
         )
         assert response.status_code == 200
         assert response.headers.get("content-type") == "application/gzip"
+        assert response.url.path.startswith("/api/cli/artifacts/bifrost-cli-")
+        assert response.url.path.endswith(".tar.gz")
+        assert ".tar.gz" in response.headers["content-disposition"]
 
     def test_download_sdk_includes_new_files(
         self,
@@ -584,8 +604,9 @@ class TestCLIDownload:
         import io
 
         response = e2e_client.get(
-            "/api/cli/download",
+            CLI_DOWNLOAD_URL,
             headers=platform_admin.headers,
+            follow_redirects=True,
         )
         assert response.status_code == 200
 
@@ -617,8 +638,9 @@ class TestCLIDownload:
         import io
 
         response = e2e_client.get(
-            "/api/cli/download",
+            CLI_DOWNLOAD_URL,
             headers=platform_admin.headers,
+            follow_redirects=True,
         )
         assert response.status_code == 200
 
@@ -643,8 +665,9 @@ class TestCLIDownload:
         import io
 
         response = e2e_client.get(
-            "/api/cli/download",
+            CLI_DOWNLOAD_URL,
             headers=platform_admin.headers,
+            follow_redirects=True,
         )
         assert response.status_code == 200
 
@@ -666,8 +689,9 @@ class TestCLIDownload:
         import io
 
         response = e2e_client.get(
-            "/api/cli/download",
+            CLI_DOWNLOAD_URL,
             headers=platform_admin.headers,
+            follow_redirects=True,
         )
         assert response.status_code == 200
 
@@ -689,8 +713,9 @@ class TestCLIDownload:
         import io
 
         response = e2e_client.get(
-            "/api/cli/download",
+            CLI_DOWNLOAD_URL,
             headers=platform_admin.headers,
+            follow_redirects=True,
         )
         assert response.status_code == 200
 
@@ -718,8 +743,9 @@ class TestCLIDownload:
 
         # Download the SDK
         response = e2e_client.get(
-            "/api/cli/download",
+            CLI_DOWNLOAD_URL,
             headers=platform_admin.headers,
+            follow_redirects=True,
         )
         assert response.status_code == 200
 
@@ -785,8 +811,9 @@ print('SUCCESS')
 
         # Download the SDK
         response = e2e_client.get(
-            "/api/cli/download",
+            CLI_DOWNLOAD_URL,
             headers=platform_admin.headers,
+            follow_redirects=True,
         )
         assert response.status_code == 200
 

--- a/api/tests/unit/cli/test_cli_update.py
+++ b/api/tests/unit/cli/test_cli_update.py
@@ -48,7 +48,10 @@ def test_update_resolves_current_connection_and_normalizes_url(
     assert rc == 0
     resolve.assert_called_once_with(None, prompt_for_default=True)
     run.assert_called_once_with(
-        ["installer", "https://bifrost.example.com/api/cli/download"],
+        [
+            "installer",
+            "https://bifrost.example.com/api/cli/download/bifrost-cli.tar.gz",
+        ],
         check=False,
     )
 
@@ -90,11 +93,12 @@ def test_update_uses_pipx_for_pipx_managed_install(
     monkeypatch.setattr(cli.sys, "prefix", str(tmp_path))
     monkeypatch.setattr(cli.shutil, "which", lambda name: "/usr/bin/pipx")
 
-    assert cli._update_install_command("https://example.com/api/cli/download") == [
+    download_url = "https://example.com/api/cli/download/bifrost-cli.tar.gz"
+    assert cli._update_install_command(download_url) == [
         "/usr/bin/pipx",
         "install",
         "--force",
-        "https://example.com/api/cli/download",
+        download_url,
     ]
 
 
@@ -105,13 +109,14 @@ def test_update_uses_current_python_outside_pipx(
     monkeypatch.setattr(cli.sys, "prefix", str(tmp_path))
     monkeypatch.setattr(cli.sys, "executable", "/venv/bin/python")
 
-    assert cli._update_install_command("https://example.com/api/cli/download") == [
+    download_url = "https://example.com/api/cli/download/bifrost-cli.tar.gz"
+    assert cli._update_install_command(download_url) == [
         "/venv/bin/python",
         "-m",
         "pip",
         "install",
         "--upgrade",
-        "https://example.com/api/cli/download",
+        download_url,
     ]
 
 

--- a/api/tests/unit/routers/test_cli_download_version.py
+++ b/api/tests/unit/routers/test_cli_download_version.py
@@ -1,12 +1,43 @@
-"""CLI download package version normalization."""
+"""CLI build-time artifact generation."""
 
-from src.routers.cli import _to_pep440
+import tarfile
+from pathlib import Path
+
+from shared.cli_artifact import build_cli_artifact, cli_artifact_filename, to_pep440
 
 
 def test_to_pep440_preserves_dev_release_versions() -> None:
-    assert _to_pep440("1.0.8-dev.11") == "1.0.8.dev11"
-    assert _to_pep440("v1.0.8-dev.11") == "1.0.8.dev11"
+    assert to_pep440("1.0.8-dev.11") == "1.0.8.dev11"
+    assert to_pep440("v1.0.8-dev.11") == "1.0.8.dev11"
 
 
 def test_to_pep440_preserves_dirty_dev_release_versions() -> None:
-    assert _to_pep440("1.0.8-dev.11-dirty") == "1.0.8.dev11+dirty"
+    assert to_pep440("1.0.8-dev.11-dirty") == "1.0.8.dev11+dirty"
+
+
+def test_build_cli_artifact_stamps_and_filters_package(tmp_path: Path) -> None:
+    source_dir = Path(__file__).resolve().parents[3] / "bifrost"
+
+    artifact = build_cli_artifact(source_dir, tmp_path, "v1.2.3")
+
+    assert artifact.name == cli_artifact_filename("v1.2.3")
+    with tarfile.open(artifact, mode="r:gz") as archive:
+        names = archive.getnames()
+        pyproject = archive.extractfile("pyproject.toml")
+        init = archive.extractfile("bifrost/__init__.py")
+        assert pyproject is not None
+        assert init is not None
+        assert 'version = "1.2.3"' in pyproject.read().decode()
+        assert '__version__ = "v1.2.3"' in init.read().decode()
+
+    assert "bifrost/lucide_icon_names.json" in names
+    assert "bifrost/_write_buffer.py" not in names
+    assert "bifrost/_logging.py" not in names
+
+
+def test_build_cli_artifact_is_deterministic(tmp_path: Path) -> None:
+    source_dir = Path(__file__).resolve().parents[3] / "bifrost"
+    first = build_cli_artifact(source_dir, tmp_path / "first", "debug")
+    second = build_cli_artifact(source_dir, tmp_path / "second", "debug")
+
+    assert first.read_bytes() == second.read_bytes()

--- a/client/src/lib/v1.d.ts
+++ b/client/src/lib/v1.d.ts
@@ -4790,10 +4790,50 @@ export interface paths {
             cookie?: never;
         };
         /**
-         * Download CLI package
-         * @description Download the Bifrost CLI as a pip-installable tarball
+         * Legacy CLI download URL
+         * @description Redirect to the installer-compatible CLI download URL
          */
         get: operations["download_cli_api_cli_download_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/cli/download/bifrost-cli.tar.gz": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Download CLI package
+         * @description Redirect to the versioned, pip-installable CLI artifact
+         */
+        get: operations["download_cli_alias_api_cli_download_bifrost_cli_tar_gz_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/cli/artifacts/{filename}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Serve a versioned CLI artifact
+         * @description Serve the immutable CLI artifact bundled into the API image
+         */
+        get: operations["download_cli_artifact_api_cli_artifacts__filename__get"];
         put?: never;
         post?: never;
         delete?: never;
@@ -34026,6 +34066,57 @@ export interface operations {
                 };
                 content: {
                     "application/json": unknown;
+                };
+            };
+        };
+    };
+    download_cli_alias_api_cli_download_bifrost_cli_tar_gz_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+        };
+    };
+    download_cli_artifact_api_cli_artifacts__filename__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                filename: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
                 };
             };
         };

--- a/client/src/pages/user-settings/Developer.test.tsx
+++ b/client/src/pages/user-settings/Developer.test.tsx
@@ -1,0 +1,20 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { DeveloperSettings } from "./Developer";
+
+describe("DeveloperSettings", () => {
+	it("advertises the uv-compatible CLI install and download URLs", () => {
+		render(<DeveloperSettings />);
+
+		expect(
+			screen.getByText(
+				/\/api\/cli\/download\/bifrost-cli\.tar\.gz$/,
+			),
+		).toBeInTheDocument();
+		expect(screen.getByRole("link", { name: "Download SDK" })).toHaveAttribute(
+			"href",
+			"/api/cli/download/bifrost-cli.tar.gz",
+		);
+	});
+});

--- a/client/src/pages/user-settings/Developer.tsx
+++ b/client/src/pages/user-settings/Developer.tsx
@@ -48,6 +48,8 @@ function CopyButton({ text }: { text: string }) {
 }
 
 export function DeveloperSettings() {
+	const cliDownloadUrl = `${window.location.origin}${sdkService.getSdkDownloadUrl()}`;
+
 	return (
 		<div className="space-y-6">
 			{/* SDK Setup Instructions */}
@@ -75,8 +77,8 @@ export function DeveloperSettings() {
 								<div className="flex-1">
 									<p>Install the SDK:</p>
 									<code className="flex items-center mt-1 p-2 bg-muted rounded-md text-xs">
-										<span>pipx install --force {window.location.origin}/api/cli/download</span>
-										<CopyButton text={`pipx install --force ${window.location.origin}/api/cli/download`} />
+										<span>pipx install --force {cliDownloadUrl}</span>
+										<CopyButton text={`pipx install --force ${cliDownloadUrl}`} />
 									</code>
 								</div>
 							</div>

--- a/client/src/services/sdk.test.ts
+++ b/client/src/services/sdk.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from "vitest";
+
+import { getSdkDownloadUrl } from "./sdk";
+
+describe("getSdkDownloadUrl", () => {
+	it("returns a Python artifact URL that uv can classify before downloading", () => {
+		expect(getSdkDownloadUrl()).toBe(
+			"/api/cli/download/bifrost-cli.tar.gz",
+		);
+	});
+});

--- a/client/src/services/sdk.ts
+++ b/client/src/services/sdk.ts
@@ -12,7 +12,7 @@
 // =============================================================================
 
 export function getSdkDownloadUrl(): string {
-	return "/api/cli/download";
+	return "/api/cli/download/bifrost-cli.tar.gz";
 }
 
 // =============================================================================

--- a/docs/runbooks/web-sdk.md
+++ b/docs/runbooks/web-sdk.md
@@ -27,8 +27,8 @@ dependencies. The `/api/sdk/download` endpoint returns a gzip npm tarball with:
 - package entry: `dist/index.mjs`
 - peer dependencies: React, React DOM, and lucide-react
 
-This mirrors `/api/cli/download`: the SDK is tied to the instance that served
-it.
+This mirrors `/api/cli/download/bifrost-cli.tar.gz`: the SDK is tied to the
+instance that served it.
 
 ## Local Apps
 

--- a/plugins/bifrost/skills/bifrost-build/generated/openapi-digest.md
+++ b/plugins/bifrost/skills/bifrost-build/generated/openapi-digest.md
@@ -111,7 +111,9 @@
 | DELETE | `/api/claims/{name}` |
 | GET | `/api/claims/{name}` |
 | PATCH | `/api/claims/{name}` |
+| GET | `/api/cli/artifacts/{filename}` |
 | GET | `/api/cli/download` |
+| GET | `/api/cli/download/bifrost-cli.tar.gz` |
 | GET | `/api/config` |
 | POST | `/api/config` |
 | DELETE | `/api/config/{config_id}` |

--- a/plugins/bifrost/skills/bifrost-setup/SKILL.md
+++ b/plugins/bifrost/skills/bifrost-setup/SKILL.md
@@ -135,13 +135,13 @@ the authenticated current connection is the default link base.
 **Use the detected pip command** (from `$BIFROST_PIP_CMD`):
 
 ```bash
-$BIFROST_PIP_CMD {url}/api/cli/download
+$BIFROST_PIP_CMD {url}/api/cli/download/bifrost-cli.tar.gz
 ```
 
 On native Windows, prefer:
 
 ```powershell
-py -3.11 -m pipx install --force {url}/api/cli/download
+py -3.11 -m pipx install --force {url}/api/cli/download/bifrost-cli.tar.gz
 ```
 
 Verify with:
@@ -159,11 +159,11 @@ the others; update the CLI first because it supplies the SDK-update command.
 
 1. **CLI from the intended Bifrost instance:**
    ```bash
-   pipx install --force {url}/api/cli/download
+   pipx install --force {url}/api/cli/download/bifrost-cli.tar.gz
    bifrost --version
    ```
    On native Windows, use
-   `py -3.11 -m pipx install --force {url}/api/cli/download`.
+   `py -3.11 -m pipx install --force {url}/api/cli/download/bifrost-cli.tar.gz`.
 2. **Vendored web SDK in each Solution workspace:**
    ```bash
    cd /path/to/solution
@@ -250,7 +250,7 @@ If MCP was skipped (SDK-first only), tell the user:
 ## Troubleshooting
 
 ### pipx install fails with network error
-- Verify URL is accessible: `curl {url}/api/cli/download -o /dev/null -w "%{http_code}"`
+- Verify URL is accessible: `curl -L {url}/api/cli/download/bifrost-cli.tar.gz -o /dev/null -w "%{http_code}"`
 
 ### bifrost login hangs
 - Check if URL is accessible in browser


### PR DESCRIPTION
## Summary

- build the Bifrost CLI source distribution during API image builds
- preserve `/api/cli/download` as a compatibility redirect
- advertise `/api/cli/download/bifrost-cli.tar.gz`, which redirects to the versioned artifact URL
- serve the final artifact from static bundled storage rather than packaging it per request
- update CLI self-update, UI guidance, setup documentation, and generated API references

## Root cause

uv-backed pipx validates direct URL filenames before downloading. The extensionless `/api/cli/download` URL therefore failed before the server could return the dynamically generated archive.

## Verification

- full backend unit suite: 5,506 passed, 3 skipped; one generated-appendix freshness failure was fixed and its focused rerun passed
- focused CLI download/update/packaging tests: 18 passed
- CLI download E2E tests: 10 passed
- focused client tests: 2 passed
- API pyright and ruff passed
- client TypeScript and lint passed (one pre-existing React Hook Form warning)
- API Docker build check and development image build passed
- isolated `uv tool install` against the filename-bearing route succeeded