### PR TITLE
fix(mcp): queue agent delegation by default

### DIFF
--- a/api/src/jobs/consumers/agent_run.py
+++ b/api/src/jobs/consumers/agent_run.py
@@ -244,8 +244,10 @@ class AgentRunConsumer(BaseConsumer):
                     await r.lpush(result_key, json.dumps({  # pyright: ignore[reportGeneralTypeIssues]
                         "output": run_result.get("output"),
                         "status": run_result.get("status", "completed"),
+                        "error": run_result.get("error"),
                         "iterations_used": run_result.get("iterations_used", 0),
                         "tokens_used": run_result.get("tokens_used", 0),
+                        "llm_model": run_result.get("llm_model"),
                     }))
                     await r.expire(result_key, 300)
 

--- a/api/src/models/contracts/mcp.py
+++ b/api/src/models/contracts/mcp.py
@@ -5,7 +5,7 @@ Pydantic models for MCP configuration API requests and responses.
 """
 
 from datetime import datetime
-from typing import Any
+from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
@@ -89,6 +89,8 @@ class MCPGatewayToolSummary(BaseModel):
     name: str
     description: str
     source: str
+    supports_async: bool
+    default_async: bool
     input_schema: dict[str, Any] | None = None
     schema_included: bool = False
 
@@ -147,7 +149,14 @@ class MCPGatewayExecuteRequest(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
 
     arguments: dict[str, Any] = Field(default_factory=dict)
-    async_: bool = Field(default=False, alias="async")
+    async_: bool | None = Field(
+        default=None,
+        alias="async",
+        description=(
+            "Override the capability's default execution mode. When omitted, "
+            "delegations run asynchronously and other tools run synchronously."
+        ),
+    )
 
 
 class MCPGatewayExecuteResponse(BaseModel):
@@ -167,6 +176,7 @@ class MCPGatewayExecuteResponse(BaseModel):
     duration_ms: int
     async_: bool = Field(default=False, alias="async")
     execution_id: str | None = None
+    execution_type: Literal["workflow", "agent_run"] | None = None
     status: str | None = None
     result: Any = None
 
@@ -175,8 +185,11 @@ class MCPGatewayExecutionResponse(BaseModel):
     """Compact, ownership-checked execution status and paged result."""
 
     execution_id: str
+    execution_type: Literal["workflow", "agent_run"]
     workflow_id: str | None = None
     workflow_name: str | None = None
+    agent_id: str | None = None
+    agent_name: str | None = None
     status: str
     created_at: datetime | None = None
     started_at: datetime | None = None

--- a/api/src/services/execution/agent_run_service.py
+++ b/api/src/services/execution/agent_run_service.py
@@ -70,6 +70,21 @@ async def enqueue_agent_run(
     return run_id
 
 
+async def get_pending_agent_run_context(run_id: str) -> dict | None:
+    """Return the short-lived enqueue context before its AgentRun row exists."""
+    redis_key = f"{REDIS_PREFIX}:{run_id}:context"
+    async with get_redis() as redis:
+        raw_context = await redis.get(redis_key)
+    if raw_context is None:
+        return None
+    try:
+        context = json.loads(raw_context)
+    except (TypeError, json.JSONDecodeError):
+        logger.warning("Invalid pending agent-run context for %s", run_id)
+        return None
+    return context if isinstance(context, dict) else None
+
+
 async def wait_for_agent_run_result(run_id: str, timeout: int = 1800) -> dict | None:
     """Block until agent run completes. Used for sync SDK calls.
 

--- a/api/src/services/execution/agent_run_service.py
+++ b/api/src/services/execution/agent_run_service.py
@@ -6,6 +6,7 @@ from uuid import uuid4
 import redis.asyncio as aioredis
 
 from src.core.cache.redis_client import get_redis
+from src.core.log_safety import log_safe
 from src.jobs.rabbitmq import publish_message
 
 logger = logging.getLogger(__name__)
@@ -80,7 +81,7 @@ async def get_pending_agent_run_context(run_id: str) -> dict | None:
     try:
         context = json.loads(raw_context)
     except (TypeError, json.JSONDecodeError):
-        logger.warning("Invalid pending agent-run context for %s", run_id)
+        logger.warning("Invalid pending agent-run context for %s", log_safe(run_id))
         return None
     return context if isinstance(context, dict) else None
 

--- a/api/src/services/mcp_server/gateway.py
+++ b/api/src/services/mcp_server/gateway.py
@@ -19,6 +19,7 @@ from sqlalchemy.orm import selectinload
 
 from src.core.org_filter import OrgFilterType
 from src.models.orm.agents import Agent
+from src.models.orm.agent_runs import AgentRun
 from src.models.orm.executions import Execution
 from src.models.orm.external_mcp import MCPConnection, MCPServer
 from src.repositories.agents import AgentRepository
@@ -98,6 +99,8 @@ class ResolvedGatewayTool:
             "name": self.definition.name,
             "description": self.definition.description,
             "source": self.source,
+            "supports_async": self.source in {"workflow", "delegation"},
+            "default_async": self.source == "delegation",
         }
 
 
@@ -459,6 +462,8 @@ class MCPAgentGatewayService:
             "name": tool.definition.name,
             "description": _compact_description(tool.definition.description) or "",
             "source": tool.source,
+            "supports_async": tool.source in {"workflow", "delegation"},
+            "default_async": tool.source == "delegation",
             "input_schema": None,
             "schema_included": False,
         }
@@ -558,7 +563,7 @@ class MCPAgentGatewayService:
         tool_ref: str,
         arguments: dict[str, Any],
         *,
-        async_execution: bool = False,
+        async_execution: bool | None = None,
     ) -> dict[str, Any]:
         """Re-resolve, validate, and execute an agent-bound tool."""
         snapshot = await self.get_agent_snapshot(agent_id)
@@ -595,6 +600,12 @@ class MCPAgentGatewayService:
                 select(Execution).where(Execution.id == parsed_execution_id)
             )
             execution = result.scalar_one_or_none()
+            agent_run = None
+            if execution is None:
+                agent_result = await db.execute(
+                    select(AgentRun).where(AgentRun.id == parsed_execution_id)
+                )
+                agent_run = agent_result.scalar_one_or_none()
 
         if execution is not None:
             if (
@@ -617,10 +628,13 @@ class MCPAgentGatewayService:
                 )
             return {
                 "execution_id": str(execution.id),
+                "execution_type": "workflow",
                 "workflow_id": (
                     str(execution.workflow_id) if execution.workflow_id else None
                 ),
                 "workflow_name": execution.workflow_name,
+                "agent_id": None,
+                "agent_name": None,
                 "status": execution.status.value,
                 "created_at": execution.created_at,
                 "started_at": execution.started_at,
@@ -632,24 +646,97 @@ class MCPAgentGatewayService:
                 "result_page": result_page,
             }
 
+        if agent_run is not None:
+            if (
+                not self.context.is_platform_admin
+                and agent_run.caller_user_id != str(self.context.user_id)
+            ):
+                raise GatewayError(
+                    "EXECUTION_NOT_FOUND_OR_FORBIDDEN",
+                    "Execution not found or you do not have access.",
+                )
+            result_available = agent_run.output is not None
+            result_value = None
+            result_page = None
+            if result_available:
+                result_value, result_page = self._page_execution_result(
+                    agent_run.output,
+                    result_path=result_path,
+                    offset=offset,
+                    limit=limit,
+                )
+            return {
+                "execution_id": str(agent_run.id),
+                "execution_type": "agent_run",
+                "workflow_id": None,
+                "workflow_name": None,
+                "agent_id": str(agent_run.agent_id),
+                "agent_name": agent_run.agent.name if agent_run.agent else None,
+                "status": self._agent_run_gateway_status(agent_run.status),
+                "created_at": agent_run.created_at,
+                "started_at": agent_run.started_at,
+                "completed_at": agent_run.completed_at,
+                "duration_ms": agent_run.duration_ms,
+                "error": agent_run.error,
+                "result_available": result_available,
+                "result": result_value,
+                "result_page": result_page,
+            }
+
         pending = await get_redis_client().get_pending_execution(execution_id)
-        if pending is None or (
+        if pending is not None:
+            if (
+                not self.context.is_platform_admin
+                and pending.get("user_id") != str(self.context.user_id)
+            ):
+                raise GatewayError(
+                    "EXECUTION_NOT_FOUND_OR_FORBIDDEN",
+                    "Execution not found or you do not have access.",
+                )
+            created_at = pending.get("created_at")
+            return {
+                "execution_id": execution_id,
+                "execution_type": "workflow",
+                "workflow_id": pending.get("workflow_id"),
+                "workflow_name": pending.get("script_name"),
+                "agent_id": None,
+                "agent_name": None,
+                "status": "Pending",
+                "created_at": (
+                    datetime.fromisoformat(created_at) if created_at else None
+                ),
+                "started_at": None,
+                "completed_at": None,
+                "duration_ms": None,
+                "error": None,
+                "result_available": False,
+                "result": None,
+                "result_page": None,
+            }
+
+        from src.services.execution.agent_run_service import (
+            get_pending_agent_run_context,
+        )
+
+        pending_agent_run = await get_pending_agent_run_context(execution_id)
+        if pending_agent_run is None or (
             not self.context.is_platform_admin
-            and pending.get("user_id") != str(self.context.user_id)
+            and pending_agent_run.get("caller", {}).get("user_id")
+            != str(self.context.user_id)
         ):
             raise GatewayError(
                 "EXECUTION_NOT_FOUND_OR_FORBIDDEN",
                 "Execution not found or you do not have access.",
             )
-        created_at = pending.get("created_at")
         return {
             "execution_id": execution_id,
-            "workflow_id": pending.get("workflow_id"),
-            "workflow_name": pending.get("script_name"),
+            "execution_type": "agent_run",
+            "workflow_id": None,
+            "workflow_name": None,
+            "agent_id": pending_agent_run.get("agent_id"),
+            "agent_name": None,
             "status": "Pending",
-            "created_at": (
-                datetime.fromisoformat(created_at) if created_at else None
-            ),
+            "created_at": None,
             "started_at": None,
             "completed_at": None,
             "duration_ms": None,
@@ -658,6 +745,20 @@ class MCPAgentGatewayService:
             "result": None,
             "result_page": None,
         }
+
+    @staticmethod
+    def _agent_run_gateway_status(status: str) -> str:
+        """Normalize agent-run states to the gateway execution vocabulary."""
+        return {
+            "queued": "Pending",
+            "running": "Running",
+            "completed": "Success",
+            "failed": "Failed",
+            "timeout": "Timeout",
+            "cancelled": "Cancelled",
+            "budget_exceeded": "BudgetExceeded",
+            "paused": "Paused",
+        }.get(status, status)
 
     @classmethod
     def _page_execution_result(
@@ -955,23 +1056,28 @@ class MCPAgentGatewayService:
         tool: ResolvedGatewayTool,
         arguments: dict[str, Any],
         *,
-        async_execution: bool = False,
+        async_execution: bool | None = None,
     ) -> dict[str, Any]:
         started = time.monotonic()
+        resolved_async = (
+            tool.source == "delegation"
+            if async_execution is None
+            else async_execution
+        )
 
         try:
             self.validate_arguments(tool, arguments)
-            if async_execution and tool.source != "workflow":
+            if resolved_async and tool.source not in {"workflow", "delegation"}:
                 raise GatewayError(
                     "ASYNC_NOT_SUPPORTED",
-                    "Async execution is currently supported only for workflow tools.",
+                    "Async execution is supported only for workflow and delegation tools.",
                     retryable=True,
                 )
             result = await self._dispatch(
                 snapshot.agent,
                 tool,
                 arguments,
-                async_execution=async_execution,
+                async_execution=resolved_async,
             )
         except GatewayError as exc:
             duration_ms = int((time.monotonic() - started) * 1000)
@@ -1025,13 +1131,15 @@ class MCPAgentGatewayService:
             "tool_name": tool.definition.name,
             "source": tool.source,
             "duration_ms": duration_ms,
-            "async": async_execution,
+            "async": resolved_async,
             "execution_id": None,
+            "execution_type": None,
             "status": None,
             "result": result,
         }
-        if async_execution:
+        if resolved_async:
             response["execution_id"] = result["execution_id"]
+            response["execution_type"] = result["execution_type"]
             response["status"] = result["status"]
             response["result"] = None
         return response
@@ -1053,7 +1161,12 @@ class MCPAgentGatewayService:
                 async_execution=async_execution,
             )
         if tool.source == "delegation":
-            return await self._dispatch_delegation(agent, tool, arguments)
+            return await self._dispatch_delegation(
+                agent,
+                tool,
+                arguments,
+                async_execution=async_execution,
+            )
         if tool.source == "external_mcp":
             return await self._dispatch_external_mcp(tool, arguments)
         raise GatewayError(
@@ -1142,6 +1255,7 @@ class MCPAgentGatewayService:
         if async_execution:
             return {
                 "execution_id": response.execution_id,
+                "execution_type": "workflow",
                 "status": response.status.value,
             }
         if response.status.value != "Success":
@@ -1157,11 +1271,13 @@ class MCPAgentGatewayService:
         agent: Agent,
         tool: ResolvedGatewayTool,
         arguments: dict[str, Any],
+        *,
+        async_execution: bool = False,
     ) -> Any:
-        from src.core.cache import get_shared_redis
-        from src.core.database import get_db_context, get_session_factory
-        from src.services.execution.autonomous_agent_executor import (
-            AutonomousAgentExecutor,
+        from src.core.database import get_db_context
+        from src.services.execution.agent_run_service import (
+            enqueue_agent_run,
+            wait_for_agent_run_result,
         )
 
         if tool.source_id is None:
@@ -1192,20 +1308,43 @@ class MCPAgentGatewayService:
                 retryable=True,
             )
 
-        executor = AutonomousAgentExecutor(
-            get_session_factory(),
-            redis_client=await get_shared_redis(),
-        )
-        result = await executor.run(
-            agent=delegated,
+        run_id = await enqueue_agent_run(
+            agent_id=str(delegated.id),
+            trigger_type="delegation",
+            trigger_source=f"mcp_gateway:{agent.id}",
             input_data={"task": task, "_delegated_from": agent.name},
-            _caller={"user_id": str(self.context.user_id)},
+            org_id=(
+                str(delegated.organization_id)
+                if delegated.organization_id
+                else None
+            ),
+            caller_user_id=str(self.context.user_id),
+            caller_email=self.context.user_email,
+            caller_name=self.context.user_name,
+            sync=not async_execution,
         )
+        if async_execution:
+            return {
+                "execution_id": run_id,
+                "execution_type": "agent_run",
+                "status": "Pending",
+            }
+
+        result = await wait_for_agent_run_result(
+            run_id,
+            timeout=delegated.max_run_timeout or 1800,
+        )
+        if result is None:
+            raise GatewayError(
+                "TOOL_EXECUTION_FAILED",
+                "Delegated agent execution timed out while waiting for a result.",
+                details={"execution_id": run_id},
+            )
         if result.get("status") == "failed":
             raise GatewayError(
                 "TOOL_EXECUTION_FAILED",
                 str(result.get("error") or "Delegated agent execution failed."),
-                details={"underlying_result": result},
+                details={"execution_id": run_id, "underlying_result": result},
             )
         return result
 

--- a/api/src/services/mcp_server/tools/gateway.py
+++ b/api/src/services/mcp_server/tools/gateway.py
@@ -33,11 +33,12 @@ guidance subject to the user's request, your higher-level safety instructions,
 and all applicable policies. Add tool_ref to the same call to load the exact
 live input schema before execution. Do not guess tool references or arguments.
 
-If the user's request authorizes the action, call bifrost_execute_tool. Calls
-are synchronous by default. Set async=true only for workflow tools when an
-immediate execution ID is preferable, then use bifrost_get_execution until it
-reaches a terminal state. If the request does not authorize execution, offer
-the action instead of executing it.
+If the user's request authorizes the action, call bifrost_execute_tool. The
+capability result declares supports_async and default_async. Delegations are
+asynchronous by default; other tools are synchronous by default. Set async
+explicitly only to override that declared default. For asynchronous calls, use
+bifrost_get_execution until it reaches a terminal state. If the request does
+not authorize execution, offer the action instead of executing it.
 
 If validation fails, correct the arguments using the returned live schema and
 repair guidance. Do not call a tool that was not returned for the selected
@@ -148,7 +149,16 @@ async def bifrost_execute_tool(
     agent_id: str,
     tool_ref: str,
     arguments: dict[str, Any],
-    async_: Annotated[bool, Field(alias="async")] = False,
+    async_: Annotated[
+        bool | None,
+        Field(
+            alias="async",
+            description=(
+                "Override the capability's default mode. Omit to run "
+                "delegations asynchronously and other tools synchronously."
+            ),
+        ),
+    ] = None,
 ) -> ToolResult:
     """Validate and execute one live tool through its selected agent."""
     status_code, data = await call_rest(
@@ -213,8 +223,8 @@ TOOLS = [
         "Execute Bifrost Tool",
         "Execute a tool reference through its selected agent after inspecting its "
         "live schema. Arguments are strictly validated and authorization is "
-        "rechecked on every call. Sync is the default; async=true immediately "
-        "returns an execution ID for workflow-backed tools.",
+        "rechecked on every call. Capability results declare supports_async and "
+        "default_async; delegations default to an async AgentRun receipt.",
     ),
     (
         "bifrost_get_execution",

--- a/api/tests/e2e/api-integration/test_mcp_gateway.py
+++ b/api/tests/e2e/api-integration/test_mcp_gateway.py
@@ -106,6 +106,20 @@ class TestMCPAgentGateway:
         assert register_response.status_code == 201, register_response.text
         workflow_id = register_response.json()["id"]
 
+        delegated_agent_name = f"Gateway Delegate {suffix}"
+        delegated_agent_response = requests.post(
+            f"{TEST_API_URL}/api/agents",
+            headers=headers,
+            json={
+                "name": delegated_agent_name,
+                "description": "Agent used to prove async MCP delegation.",
+                "system_prompt": "Return a concise result without using tools.",
+                "channels": ["chat"],
+            },
+        )
+        assert delegated_agent_response.status_code == 201, delegated_agent_response.text
+        delegated_agent_id = delegated_agent_response.json()["id"]
+
         agent_name = f"Gateway Proof {suffix}"
         prompt = f"Live gateway instructions {suffix}"
         agent_response = requests.post(
@@ -118,6 +132,7 @@ class TestMCPAgentGateway:
                 "channels": ["chat"],
                 "tool_ids": [workflow_id],
                 "system_tools": ["get_docs"],
+                "delegated_agent_ids": [delegated_agent_id],
             },
         )
         assert agent_response.status_code == 201, agent_response.text
@@ -129,11 +144,17 @@ class TestMCPAgentGateway:
         request.cls.agent_name = agent_name
         request.cls.prompt = prompt
         request.cls.function_name = function_name
+        request.cls.delegated_agent_id = delegated_agent_id
+        request.cls.delegated_agent_name = delegated_agent_name
 
         yield
 
         requests.delete(
             f"{TEST_API_URL}/api/agents/{agent_id}",
+            headers=headers,
+        )
+        requests.delete(
+            f"{TEST_API_URL}/api/agents/{delegated_agent_id}",
             headers=headers,
         )
         requests.delete(
@@ -172,6 +193,7 @@ class TestMCPAgentGateway:
         )
         assert "async" in execute_schema["properties"]
         assert "async_" not in execute_schema["properties"]
+        assert "async" not in execute_schema.get("required", [])
 
         scoped_tools = _mcp_request(
             self.token,
@@ -306,7 +328,7 @@ class TestMCPAgentGateway:
         selected_agent = loaded["agents"][0]
         assert selected_agent["instructions"] == self.prompt
         assert selected_agent["matching_tools"] == []
-        assert selected_agent["total_tools"] == 2
+        assert selected_agent["total_tools"] == 3
         assert selected_agent["returned_tools"] == 0
         assert selected_agent["complete"] is False
 
@@ -321,6 +343,21 @@ class TestMCPAgentGateway:
             if tool["source"] == "workflow"
         )
         tool_ref = workflow_tool["tool_ref"]
+        assert workflow_tool["supports_async"] is True
+        assert workflow_tool["default_async"] is False
+
+        delegation_search = _call_gateway(
+            self.token,
+            "bifrost_search_capabilities",
+            {"agent_id": self.agent_id, "query": self.delegated_agent_name},
+        )
+        delegation_tool = next(
+            tool
+            for tool in delegation_search["agents"][0]["matching_tools"]
+            if tool["source"] == "delegation"
+        )
+        assert delegation_tool["supports_async"] is True
+        assert delegation_tool["default_async"] is True
 
         system_search = _call_gateway(
             self.token,
@@ -370,6 +407,7 @@ class TestMCPAgentGateway:
             },
         )
         assert async_receipt["async"] is True
+        assert async_receipt["execution_type"] == "workflow"
         assert async_receipt["status"] == "Pending"
         assert async_receipt["execution_id"]
 
@@ -385,8 +423,39 @@ class TestMCPAgentGateway:
             assert time.monotonic() < deadline, async_result
             time.sleep(0.1)
         assert async_result["status"] == "Success"
+        assert async_result["execution_type"] == "workflow"
         assert async_result["result"] == [{"echo": "later"}]
         assert async_result["result_page"]["has_more"] is False
+
+        delegation_receipt = _call_gateway(
+            self.token,
+            "bifrost_execute_tool",
+            {
+                "agent_id": self.agent_id,
+                "tool_ref": delegation_tool["tool_ref"],
+                "arguments": {"task": "Return a concise gateway proof."},
+            },
+        )
+        assert delegation_receipt["async"] is True
+        assert delegation_receipt["execution_type"] == "agent_run"
+        assert delegation_receipt["status"] == "Pending"
+        assert delegation_receipt["execution_id"]
+
+        deadline = time.monotonic() + 15
+        while True:
+            delegation_result = _call_gateway(
+                self.token,
+                "bifrost_get_execution",
+                {"execution_id": delegation_receipt["execution_id"]},
+            )
+            if delegation_result["status"] not in {"Pending", "Running"}:
+                break
+            assert time.monotonic() < deadline, delegation_result
+            time.sleep(0.1)
+        assert delegation_result["execution_type"] == "agent_run"
+        assert delegation_result["agent_id"] == self.delegated_agent_id
+        assert delegation_result["status"] == "Failed"
+        assert delegation_result["error"]
 
         unsupported_async = _call_gateway(
             self.token,

--- a/api/tests/unit/services/mcp_server/test_gateway.py
+++ b/api/tests/unit/services/mcp_server/test_gateway.py
@@ -231,6 +231,18 @@ def test_exact_tool_hydration_includes_only_the_selected_live_schema():
     assert found_tool["tool_ref"] == tool.tool_ref
     assert found_tool["schema_included"] is True
     assert found_tool["input_schema"] == tool.definition.parameters
+    assert found_tool["supports_async"] is True
+    assert found_tool["default_async"] is False
+
+
+def test_delegation_capability_declares_async_default():
+    tool = replace(_resolved_tool(), source="delegation")
+
+    compact = tool.compact()
+
+    assert compact["source"] == "delegation"
+    assert compact["supports_async"] is True
+    assert compact["default_async"] is True
 
 
 def test_execution_result_pages_large_values_without_invalid_json_truncation():
@@ -263,6 +275,28 @@ def test_execution_result_path_can_hydrate_an_omitted_value():
     assert result == [10, 11, 12, 13, 14]
     assert page["next_offset"] == 15
     assert page["has_more"] is True
+
+
+@pytest.mark.parametrize(
+    ("agent_status", "gateway_status"),
+    [
+        ("queued", "Pending"),
+        ("running", "Running"),
+        ("completed", "Success"),
+        ("failed", "Failed"),
+        ("timeout", "Timeout"),
+        ("cancelled", "Cancelled"),
+        ("budget_exceeded", "BudgetExceeded"),
+    ],
+)
+def test_agent_run_status_uses_gateway_execution_vocabulary(
+    agent_status,
+    gateway_status,
+):
+    assert (
+        MCPAgentGatewayService._agent_run_gateway_status(agent_status)
+        == gateway_status
+    )
 
 
 @pytest.mark.asyncio
@@ -321,6 +355,101 @@ async def test_get_execution_hides_another_users_redis_only_receipt():
     ):
         with pytest.raises(GatewayError) as exc_info:
             await service.get_execution(execution_id)
+
+    assert exc_info.value.code == "EXECUTION_NOT_FOUND_OR_FORBIDDEN"
+
+
+@pytest.mark.asyncio
+async def test_get_execution_returns_owned_pending_agent_run_receipt():
+    context = _context()
+    service = MCPAgentGatewayService(context)
+    execution_id = str(uuid4())
+    db = AsyncMock()
+    missing = MagicMock()
+    missing.scalar_one_or_none.return_value = None
+    db.execute.return_value = missing
+    db_context = MagicMock()
+    db_context.__aenter__ = AsyncMock(return_value=db)
+    db_context.__aexit__ = AsyncMock(return_value=None)
+    redis = MagicMock()
+    redis.get_pending_execution = AsyncMock(return_value=None)
+
+    with (
+        patch("src.core.database.get_db_context", return_value=db_context),
+        patch("src.core.redis_client.get_redis_client", return_value=redis),
+        patch(
+            "src.services.execution.agent_run_service.get_pending_agent_run_context",
+            new=AsyncMock(
+                return_value={
+                    "agent_id": str(uuid4()),
+                    "caller": {"user_id": str(context.user_id)},
+                }
+            ),
+        ),
+    ):
+        result = await service.get_execution(execution_id)
+
+    assert result["execution_id"] == execution_id
+    assert result["execution_type"] == "agent_run"
+    assert result["status"] == "Pending"
+    assert result["result_available"] is False
+
+
+@pytest.mark.asyncio
+async def test_get_execution_returns_completed_owned_agent_run():
+    context = _context()
+    service = MCPAgentGatewayService(context)
+    execution_id = uuid4()
+    workflow_result = MagicMock()
+    workflow_result.scalar_one_or_none.return_value = None
+    agent_run_result = MagicMock()
+    agent_run = MagicMock()
+    agent_run.id = execution_id
+    agent_run.agent_id = uuid4()
+    agent_run.agent.name = "Process Agent"
+    agent_run.caller_user_id = str(context.user_id)
+    agent_run.status = "completed"
+    agent_run.output = {"text": "Done"}
+    agent_run.created_at = None
+    agent_run.started_at = None
+    agent_run.completed_at = None
+    agent_run.duration_ms = 125
+    agent_run.error = None
+    agent_run_result.scalar_one_or_none.return_value = agent_run
+    db = AsyncMock()
+    db.execute.side_effect = [workflow_result, agent_run_result]
+    db_context = MagicMock()
+    db_context.__aenter__ = AsyncMock(return_value=db)
+    db_context.__aexit__ = AsyncMock(return_value=None)
+
+    with patch("src.core.database.get_db_context", return_value=db_context):
+        result = await service.get_execution(str(execution_id))
+
+    assert result["execution_type"] == "agent_run"
+    assert result["agent_id"] == str(agent_run.agent_id)
+    assert result["agent_name"] == "Process Agent"
+    assert result["status"] == "Success"
+    assert result["result"] == {"text": "Done"}
+
+
+@pytest.mark.asyncio
+async def test_get_execution_hides_another_users_agent_run():
+    service = MCPAgentGatewayService(_context())
+    workflow_result = MagicMock()
+    workflow_result.scalar_one_or_none.return_value = None
+    agent_run_result = MagicMock()
+    agent_run = MagicMock()
+    agent_run.caller_user_id = str(uuid4())
+    agent_run_result.scalar_one_or_none.return_value = agent_run
+    db = AsyncMock()
+    db.execute.side_effect = [workflow_result, agent_run_result]
+    db_context = MagicMock()
+    db_context.__aenter__ = AsyncMock(return_value=db)
+    db_context.__aexit__ = AsyncMock(return_value=None)
+
+    with patch("src.core.database.get_db_context", return_value=db_context):
+        with pytest.raises(GatewayError) as exc_info:
+            await service.get_execution(str(uuid4()))
 
     assert exc_info.value.code == "EXECUTION_NOT_FOUND_OR_FORBIDDEN"
 
@@ -422,6 +551,62 @@ async def test_execute_returns_auditable_envelope():
 
 
 @pytest.mark.asyncio
+async def test_delegation_defaults_to_async_execution():
+    service = MCPAgentGatewayService(_context())
+    agent = _agent()
+    tool = replace(_resolved_tool(), source="delegation")
+    snapshot = AgentToolSnapshot(agent=agent, tools=[tool])
+    execution_id = str(uuid4())
+
+    with patch.object(
+        service,
+        "_dispatch",
+        new=AsyncMock(
+            return_value={
+                "execution_id": execution_id,
+                "execution_type": "agent_run",
+                "status": "Pending",
+            }
+        ),
+    ) as dispatch:
+        result = await service.execute_tool(
+            snapshot,
+            tool,
+            {"ticket_id": 42},
+        )
+
+    assert dispatch.await_args.kwargs["async_execution"] is True
+    assert result["async"] is True
+    assert result["execution_id"] == execution_id
+    assert result["execution_type"] == "agent_run"
+    assert result["result"] is None
+
+
+@pytest.mark.asyncio
+async def test_delegation_allows_explicit_synchronous_execution():
+    service = MCPAgentGatewayService(_context())
+    agent = _agent()
+    tool = replace(_resolved_tool(), source="delegation")
+    snapshot = AgentToolSnapshot(agent=agent, tools=[tool])
+
+    with patch.object(
+        service,
+        "_dispatch",
+        new=AsyncMock(return_value={"text": "Done"}),
+    ) as dispatch:
+        result = await service.execute_tool(
+            snapshot,
+            tool,
+            {"ticket_id": 42},
+            async_execution=False,
+        )
+
+    assert dispatch.await_args.kwargs["async_execution"] is False
+    assert result["async"] is False
+    assert result["result"] == {"text": "Done"}
+
+
+@pytest.mark.asyncio
 async def test_workflow_dispatch_returns_only_the_workflow_result():
     service = MCPAgentGatewayService(_context())
     tool = _resolved_tool()
@@ -465,12 +650,16 @@ async def test_async_workflow_dispatch_returns_immediate_execution_receipt():
             async_execution=True,
         )
 
-    assert result == {"execution_id": execution_id, "status": "Pending"}
+    assert result == {
+        "execution_id": execution_id,
+        "execution_type": "workflow",
+        "status": "Pending",
+    }
     assert execute.await_args.kwargs["sync"] is False
 
 
 @pytest.mark.asyncio
-async def test_async_rejects_non_workflow_sources_without_dispatching():
+async def test_async_rejects_unsupported_sources_without_dispatching():
     service = MCPAgentGatewayService(_context())
     agent = _agent()
     tool = replace(_resolved_tool(), source="system")
@@ -487,6 +676,125 @@ async def test_async_rejects_non_workflow_sources_without_dispatching():
 
     assert exc_info.value.code == "ASYNC_NOT_SUPPORTED"
     dispatch.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_async_delegation_enqueues_agent_run():
+    context = _context()
+    service = MCPAgentGatewayService(context)
+    parent = _agent()
+    delegated = _agent()
+    delegated.name = "Process Agent"
+    delegated.is_active = True
+    tool = replace(
+        _resolved_tool(
+            name="delegate_to_process_agent",
+            parameters={
+                "type": "object",
+                "properties": {"task": {"type": "string"}},
+                "required": ["task"],
+            },
+        ),
+        source="delegation",
+        source_id=delegated.id,
+    )
+    db_context = MagicMock()
+    db_context.__aenter__ = AsyncMock(return_value=AsyncMock())
+    db_context.__aexit__ = AsyncMock(return_value=None)
+    repository = MagicMock()
+    repository.get_agent = AsyncMock(return_value=delegated)
+    execution_id = str(uuid4())
+
+    with (
+        patch("src.core.database.get_db_context", return_value=db_context),
+        patch(
+            "src.services.mcp_server.gateway.AgentRepository",
+            return_value=repository,
+        ),
+        patch(
+            "src.services.execution.agent_run_service.enqueue_agent_run",
+            new=AsyncMock(return_value=execution_id),
+        ) as enqueue,
+    ):
+        result = await service._dispatch_delegation(
+            parent,
+            tool,
+            {"task": "Assemble the customer report"},
+            async_execution=True,
+        )
+
+    assert result == {
+        "execution_id": execution_id,
+        "execution_type": "agent_run",
+        "status": "Pending",
+    }
+    assert enqueue.await_args.kwargs["sync"] is False
+    assert enqueue.await_args.kwargs["trigger_type"] == "delegation"
+    assert enqueue.await_args.kwargs["caller_user_id"] == str(context.user_id)
+
+
+@pytest.mark.asyncio
+async def test_sync_delegation_waits_for_queued_agent_run_result():
+    service = MCPAgentGatewayService(_context())
+    parent = _agent()
+    delegated = _agent()
+    delegated.name = "Process Agent"
+    delegated.is_active = True
+    delegated.max_run_timeout = 240
+    tool = replace(
+        _resolved_tool(
+            name="delegate_to_process_agent",
+            parameters={
+                "type": "object",
+                "properties": {"task": {"type": "string"}},
+                "required": ["task"],
+            },
+        ),
+        source="delegation",
+        source_id=delegated.id,
+    )
+    db_context = MagicMock()
+    db_context.__aenter__ = AsyncMock(return_value=AsyncMock())
+    db_context.__aexit__ = AsyncMock(return_value=None)
+    repository = MagicMock()
+    repository.get_agent = AsyncMock(return_value=delegated)
+    execution_id = str(uuid4())
+
+    with (
+        patch("src.core.database.get_db_context", return_value=db_context),
+        patch(
+            "src.services.mcp_server.gateway.AgentRepository",
+            return_value=repository,
+        ),
+        patch(
+            "src.services.execution.agent_run_service.enqueue_agent_run",
+            new=AsyncMock(return_value=execution_id),
+        ) as enqueue,
+        patch(
+            "src.services.execution.agent_run_service.wait_for_agent_run_result",
+            new=AsyncMock(
+                return_value={
+                    "status": "completed",
+                    "output": {"text": "Done"},
+                    "iterations_used": 1,
+                }
+            ),
+        ) as wait_for_result,
+    ):
+        result = await service._dispatch_delegation(
+            parent,
+            tool,
+            {"task": "Assemble the customer report"},
+            async_execution=False,
+        )
+
+    assert result == {
+        "status": "completed",
+        "output": {"text": "Done"},
+        "iterations_used": 1,
+    }
+    assert enqueue.await_args.kwargs["sync"] is True
+    wait_for_result.assert_awaited_once_with(execution_id, timeout=240)
 
 
 @pytest.mark.asyncio

--- a/api/tests/unit/services/test_agent_run_service.py
+++ b/api/tests/unit/services/test_agent_run_service.py
@@ -1,4 +1,5 @@
 import json
+import logging
 from unittest.mock import AsyncMock, patch
 from uuid import uuid4
 
@@ -127,3 +128,19 @@ class TestGetPendingAgentRunContext:
         result = await get_pending_agent_run_context(str(uuid4()))
 
         assert result is None
+
+    @pytest.mark.asyncio
+    @patch("src.services.execution.agent_run_service.get_redis")
+    async def test_invalid_context_sanitizes_run_id_in_warning(self, mock_get_redis, caplog):
+        mock_redis = AsyncMock()
+        mock_redis.get.return_value = "not-json"
+        mock_ctx = AsyncMock()
+        mock_ctx.__aenter__ = AsyncMock(return_value=mock_redis)
+        mock_ctx.__aexit__ = AsyncMock(return_value=False)
+        mock_get_redis.return_value = mock_ctx
+
+        with caplog.at_level(logging.WARNING):
+            result = await get_pending_agent_run_context("bad\nforged")
+
+        assert result is None
+        assert caplog.messages == ["Invalid pending agent-run context for bad\\nforged"]

--- a/api/tests/unit/services/test_agent_run_service.py
+++ b/api/tests/unit/services/test_agent_run_service.py
@@ -4,7 +4,10 @@ from uuid import uuid4
 
 import pytest
 
-from src.services.execution.agent_run_service import enqueue_agent_run
+from src.services.execution.agent_run_service import (
+    enqueue_agent_run,
+    get_pending_agent_run_context,
+)
 
 
 class TestEnqueueAgentRun:
@@ -93,3 +96,34 @@ class TestEnqueueAgentRun:
         call_args = mock_publish.call_args
         message = call_args[0][1]
         assert message["sync"] is True
+
+
+class TestGetPendingAgentRunContext:
+    @pytest.mark.asyncio
+    @patch("src.services.execution.agent_run_service.get_redis")
+    async def test_returns_pending_context(self, mock_get_redis):
+        expected = {"agent_id": str(uuid4()), "caller": {"user_id": str(uuid4())}}
+        mock_redis = AsyncMock()
+        mock_redis.get.return_value = json.dumps(expected)
+        mock_ctx = AsyncMock()
+        mock_ctx.__aenter__ = AsyncMock(return_value=mock_redis)
+        mock_ctx.__aexit__ = AsyncMock(return_value=False)
+        mock_get_redis.return_value = mock_ctx
+
+        result = await get_pending_agent_run_context(str(uuid4()))
+
+        assert result == expected
+
+    @pytest.mark.asyncio
+    @patch("src.services.execution.agent_run_service.get_redis")
+    async def test_returns_none_for_invalid_context(self, mock_get_redis):
+        mock_redis = AsyncMock()
+        mock_redis.get.return_value = "not-json"
+        mock_ctx = AsyncMock()
+        mock_ctx.__aenter__ = AsyncMock(return_value=mock_redis)
+        mock_ctx.__aexit__ = AsyncMock(return_value=False)
+        mock_get_redis.return_value = mock_ctx
+
+        result = await get_pending_agent_run_context(str(uuid4()))
+
+        assert result is None

--- a/client/src/lib/v1.d.ts
+++ b/client/src/lib/v1.d.ts
@@ -18501,9 +18501,9 @@ export interface components {
             };
             /**
              * Async
-             * @default false
+             * @description Override the capability's default execution mode. When omitted, delegations run asynchronously and other tools run synchronously.
              */
-            async: boolean;
+            async?: boolean | null;
         };
         /**
          * MCPGatewayExecuteResponse
@@ -18532,6 +18532,8 @@ export interface components {
             async: boolean;
             /** Execution Id */
             execution_id?: string | null;
+            /** Execution Type */
+            execution_type?: ("workflow" | "agent_run") | null;
             /** Status */
             status?: string | null;
             /** Result */
@@ -18544,10 +18546,19 @@ export interface components {
         MCPGatewayExecutionResponse: {
             /** Execution Id */
             execution_id: string;
+            /**
+             * Execution Type
+             * @enum {string}
+             */
+            execution_type: "workflow" | "agent_run";
             /** Workflow Id */
             workflow_id?: string | null;
             /** Workflow Name */
             workflow_name?: string | null;
+            /** Agent Id */
+            agent_id?: string | null;
+            /** Agent Name */
+            agent_name?: string | null;
             /** Status */
             status: string;
             /** Created At */
@@ -18582,6 +18593,10 @@ export interface components {
             description: string;
             /** Source */
             source: string;
+            /** Supports Async */
+            supports_async: boolean;
+            /** Default Async */
+            default_async: boolean;
             /** Input Schema */
             input_schema?: {
                 [key: string]: unknown;


### PR DESCRIPTION
## Summary

- advertise async support and default semantics on MCP gateway capabilities
- queue delegated agent runs by default and return the normal execution receipt immediately
- poll workflow executions and agent runs through the same bifrost_get_execution tool, distinguished by execution_type
- preserve explicit synchronous delegation for callers that opt into it

## Verification

- 150 targeted unit, DTO parity, contract-version, and MCP thin-wrapper tests passed
- 4 live MCP gateway E2E tests passed
- API pyright and Ruff checks passed with zero findings
- client TypeScript check passed
- client ESLint passed with zero errors and one pre-existing FormRenderer warning
- generated skill appendices freshness check passed

Fixes #588