### PR TITLE
Improve organization management

### DIFF
--- a/api/src/routers/organizations.py
+++ b/api/src/routers/organizations.py
@@ -6,9 +6,10 @@ CRUD operations for client organizations.
 
 import logging
 from datetime import datetime, timezone
+from typing import Annotated
 from uuid import UUID
 
-from fastapi import APIRouter, HTTPException, status
+from fastapi import APIRouter, HTTPException, Query, status
 from sqlalchemy import select
 
 from src.core.auth import CurrentSuperuser
@@ -35,24 +36,29 @@ router = APIRouter(prefix="/api/organizations", tags=["Organizations"])
 @router.get(
     "",
     response_model=list[OrganizationPublic],
-    summary="List all organizations",
-    description="Get all organizations (Platform admin only)",
+    summary="List organizations",
+    description="Get active organizations, optionally including inactive ones (Platform admin only)",
 )
 async def list_organizations(
     user: CurrentSuperuser,
     db: DbSession,
+    include_inactive: Annotated[
+        bool,
+        Query(description="Include inactive (disabled) organizations"),
+    ] = False,
 ) -> list[OrganizationPublic]:
-    """List all organizations.
+    """List organizations.
 
-    Provider organization is always listed first, followed by other orgs alphabetically.
+    Provider organization is always listed first, followed by active and inactive
+    organizations alphabetically.
     """
-    query = (
-        select(OrganizationORM)
-        .where(OrganizationORM.is_active)
-        .order_by(
-            OrganizationORM.is_provider.desc(),  # Provider org first
-            OrganizationORM.name,
-        )
+    query = select(OrganizationORM)
+    if not include_inactive:
+        query = query.where(OrganizationORM.is_active)
+    query = query.order_by(
+        OrganizationORM.is_provider.desc(),  # Provider org first
+        OrganizationORM.is_active.desc(),
+        OrganizationORM.name,
     )
     result = await db.execute(query)
     orgs = result.scalars().all()
@@ -157,6 +163,12 @@ async def update_organization(
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Organization not found",
+        )
+
+    if org.is_provider and request.is_active is False:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Provider organization cannot be disabled",
         )
 
     if request.name is not None:

--- a/api/tests/e2e/api/test_organizations.py
+++ b/api/tests/e2e/api/test_organizations.py
@@ -36,6 +36,45 @@ class TestOrganizationCRUD:
         assert "Bifrost Dev Org" in org_names
         assert "Second Test Org" in org_names
 
+    def test_list_organizations_can_include_inactive(
+        self,
+        e2e_client,
+        platform_admin,
+        org2,
+    ):
+        """Inactive organizations are hidden by default and available on request."""
+        update_response = e2e_client.patch(
+            f"/api/organizations/{org2['id']}",
+            headers=platform_admin.headers,
+            json={"is_active": False},
+        )
+        assert update_response.status_code == 200
+
+        active_response = e2e_client.get(
+            "/api/organizations",
+            headers=platform_admin.headers,
+        )
+        assert active_response.status_code == 200
+        assert org2["id"] not in {org["id"] for org in active_response.json()}
+
+        all_response = e2e_client.get(
+            "/api/organizations",
+            params={"include_inactive": True},
+            headers=platform_admin.headers,
+        )
+        assert all_response.status_code == 200
+        inactive_org = next(
+            org for org in all_response.json() if org["id"] == org2["id"]
+        )
+        assert inactive_org["is_active"] is False
+
+        restore_response = e2e_client.patch(
+            f"/api/organizations/{org2['id']}",
+            headers=platform_admin.headers,
+            json={"is_active": True},
+        )
+        assert restore_response.status_code == 200
+
     def test_get_organization_by_id(self, e2e_client, platform_admin, org1):
         """Platform admin can get specific organization."""
         response = e2e_client.get(
@@ -46,6 +85,28 @@ class TestOrganizationCRUD:
         org = response.json()
         assert org["id"] == org1["id"]
         assert org["name"] == "Bifrost Dev Org"
+
+    def test_provider_organization_cannot_be_disabled(
+        self,
+        e2e_client,
+        platform_admin,
+    ):
+        """The provider organization remains active when updated directly."""
+        list_response = e2e_client.get(
+            "/api/organizations",
+            headers=platform_admin.headers,
+        )
+        assert list_response.status_code == 200
+        provider = next(org for org in list_response.json() if org["is_provider"])
+
+        response = e2e_client.patch(
+            f"/api/organizations/{provider['id']}",
+            headers=platform_admin.headers,
+            json={"is_active": False},
+        )
+
+        assert response.status_code == 403
+        assert response.json()["detail"] == "Provider organization cannot be disabled"
 
 
 @pytest.mark.e2e

--- a/client/e2e/memory.admin.spec.ts
+++ b/client/e2e/memory.admin.spec.ts
@@ -129,8 +129,8 @@ test.describe("Private memory", () => {
 		await page
 			.getByRole("row")
 			.filter({ hasText: organizationId })
-			.getByRole("button", { name: "Edit required instructions" })
 			.click();
+		await page.getByRole("tab", { name: "Instructions" }).click();
 		const organizationEditor = page.locator(
 			'[aria-label="Organization Instructions editor"]',
 		);

--- a/client/e2e/organizations.admin.spec.ts
+++ b/client/e2e/organizations.admin.spec.ts
@@ -7,10 +7,12 @@
  * Mirrors: api/tests/e2e/api/test_organizations.py
  */
 
-import { test, expect } from "@playwright/test";
+import { test, expect } from "./fixtures/api-fixture";
 
 test.describe("Organization Management", () => {
-	test("should display organizations list", async ({ page }) => {
+	test("displays the organization list with standard row actions", async ({
+		page,
+	}) => {
 		await page.goto("/organizations");
 
 		// Should see organizations page
@@ -18,41 +20,64 @@ test.describe("Organization Management", () => {
 			page.getByRole("heading", { name: /organizations/i }).first(),
 		).toBeVisible({ timeout: 10000 });
 
-		// Should see some organization content or empty state
-		const hasOrgs = (await page.locator("table tbody tr").count()) > 0;
-		const hasCards =
-			(await page.locator("[data-testid='org-card']").count()) > 0;
-		const hasContent = await page
-			.getByText(/bifrost|gobifrost|organization/i)
-			.first()
-			.isVisible()
-			.catch(() => false);
+		const organizationRow = page.locator("table tbody tr").first();
+		await expect(organizationRow).toBeVisible();
 
-		expect(hasOrgs || hasCards || hasContent).toBe(true);
+		await organizationRow.getByRole("button", { name: /actions$/ }).click();
+		await expect(
+			page.getByRole("menuitem", { name: /^Edit / }),
+		).toBeVisible();
+		await expect(
+			page.getByRole("menuitem", { name: /^Disable / }),
+		).toBeVisible();
 	});
 
-	test("should show organization details", async ({ page }) => {
-		await page.goto("/organizations");
+	test("edits status and instructions from the organization row", async ({
+		page,
+		api,
+	}) => {
+		const organizationName = `Organization UX ${Date.now()}`;
+		const createResponse = await api.post("/api/organizations", {
+			data: { name: organizationName, domain: "organization-ux.example" },
+		});
+		expect(createResponse.ok(), await createResponse.text()).toBeTruthy();
+		const organization = (await createResponse.json()) as { id: string };
 
-		// Wait for list to load
-		await expect(
-			page.getByRole("heading", { name: /organizations/i }).first(),
-		).toBeVisible({ timeout: 10000 });
+		try {
+			await page.goto("/organizations");
+			const organizationRow = page.getByRole("row", {
+				name: new RegExp(organizationName),
+			});
+			await expect(organizationRow).toBeVisible({ timeout: 10000 });
 
-		// Click on first organization
-		const orgRow = page
-			.locator(
-				"table tbody tr, [data-testid='org-row'], [data-testid='org-card']",
-			)
-			.first();
-
-		if (await orgRow.isVisible().catch(() => false)) {
-			await orgRow.click();
-
-			// Should show organization details
+			await organizationRow.click();
 			await expect(
-				page.getByText(/details|settings|members/i),
-			).toBeVisible({ timeout: 5000 });
+				page.getByRole("heading", { name: "Edit Organization" }),
+			).toBeVisible();
+			await page
+				.getByRole("switch", { name: "Organization Status" })
+				.click();
+			await page.getByRole("button", { name: "Save Changes" }).click();
+			await expect(
+				page.getByRole("heading", { name: "Edit Organization" }),
+			).toBeHidden();
+			await expect(organizationRow).toBeHidden();
+
+			await page.getByRole("switch", { name: "Show Inactive" }).click();
+			await expect(organizationRow).toBeVisible();
+			await organizationRow.click();
+			await expect(
+				page.getByRole("switch", { name: "Organization Status" }),
+			).not.toBeChecked();
+
+			await page.getByRole("tab", { name: "Instructions" }).click();
+			await expect(
+				page.getByRole("heading", {
+					name: "Organization Instructions",
+				}),
+			).toBeVisible();
+		} finally {
+			await api.delete(`/api/organizations/${organization.id}`);
 		}
 	});
 

--- a/client/src/hooks/useOrganizations.test.ts
+++ b/client/src/hooks/useOrganizations.test.ts
@@ -1,0 +1,45 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockUseQuery } = vi.hoisted(() => ({
+	mockUseQuery: vi.fn(),
+}));
+
+vi.mock("@/lib/api-client", () => ({
+	$api: {
+		useQuery: (...args: unknown[]) => mockUseQuery(...args),
+	},
+}));
+
+import { useOrganizations } from "./useOrganizations";
+
+beforeEach(() => {
+	mockUseQuery.mockReset();
+});
+
+describe("useOrganizations", () => {
+	it("requests active organizations by default", () => {
+		useOrganizations();
+
+		expect(mockUseQuery).toHaveBeenCalledWith(
+			"get",
+			"/api/organizations",
+			{
+				params: { query: { include_inactive: false } },
+			},
+			{ enabled: true },
+		);
+	});
+
+	it("can request inactive organizations and preserve the enabled option", () => {
+		useOrganizations({ includeInactive: true, enabled: false });
+
+		expect(mockUseQuery).toHaveBeenCalledWith(
+			"get",
+			"/api/organizations",
+			{
+				params: { query: { include_inactive: true } },
+			},
+			{ enabled: false },
+		);
+	});
+});

--- a/client/src/hooks/useOrganizations.ts
+++ b/client/src/hooks/useOrganizations.ts
@@ -9,13 +9,22 @@ import { getErrorMessage } from "@/lib/api-error";
 import { toast } from "sonner";
 
 /**
- * Fetch all organizations visible to the current user
+ * Fetch active organizations visible to the current user, optionally including inactive ones
  */
-export function useOrganizations(options?: { enabled?: boolean }) {
+export function useOrganizations(options?: {
+	enabled?: boolean;
+	includeInactive?: boolean;
+}) {
 	return $api.useQuery(
 		"get",
 		"/api/organizations",
-		{},
+		{
+			params: {
+				query: {
+					include_inactive: options?.includeInactive ?? false,
+				},
+			},
+		},
 		{ enabled: options?.enabled ?? true },
 	);
 }
@@ -86,29 +95,6 @@ export function useUpdateOrganization() {
 		},
 		onError: (error) => {
 			toast.error("Failed to update organization", {
-				description: getErrorMessage(error, "Unknown error occurred"),
-			});
-		},
-	});
-}
-
-/**
- * Delete an organization
- */
-export function useDeleteOrganization() {
-	const queryClient = useQueryClient();
-
-	return $api.useMutation("delete", "/api/organizations/{org_id}", {
-		onSuccess: () => {
-			queryClient.invalidateQueries({
-				queryKey: ["get", "/api/organizations"],
-			});
-			toast.success("Organization deleted", {
-				description: "The organization has been successfully deleted",
-			});
-		},
-		onError: (error) => {
-			toast.error("Failed to delete organization", {
 				description: getErrorMessage(error, "Unknown error occurred"),
 			});
 		},

--- a/client/src/lib/v1.d.ts
+++ b/client/src/lib/v1.d.ts
@@ -1273,8 +1273,8 @@ export interface paths {
             cookie?: never;
         };
         /**
-         * List all organizations
-         * @description Get all organizations (Platform admin only)
+         * List organizations
+         * @description Get active organizations, optionally including inactive ones (Platform admin only)
          */
         get: operations["list_organizations_api_organizations_get"];
         put?: never;
@@ -27267,7 +27267,10 @@ export interface operations {
     };
     list_organizations_api_organizations_get: {
         parameters: {
-            query?: never;
+            query?: {
+                /** @description Include inactive (disabled) organizations */
+                include_inactive?: boolean;
+            };
             header?: never;
             path?: never;
             cookie?: never;
@@ -27281,6 +27284,15 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["OrganizationPublic"][];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
                 };
             };
         };

--- a/client/src/pages/Organizations.test.tsx
+++ b/client/src/pages/Organizations.test.tsx
@@ -1,32 +1,59 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockUseOrganizations, mockUpdate } = vi.hoisted(() => ({
+	mockUseOrganizations: vi.fn(),
+	mockUpdate: vi.fn(),
+}));
+
+const organizations = [
+	{
+		id: "org-1",
+		name: "Acme",
+		domain: "acme.example",
+		is_active: true,
+		is_provider: false,
+		settings: {},
+		created_at: "2026-08-13T00:00:00Z",
+		updated_at: "2026-08-13T00:00:00Z",
+		created_by: "admin@example.com",
+	},
+	{
+		id: "org-2",
+		name: "Dormant Co",
+		domain: "dormant.example",
+		is_active: false,
+		is_provider: false,
+		settings: {},
+		created_at: "2026-08-12T00:00:00Z",
+		updated_at: "2026-08-12T00:00:00Z",
+		created_by: "admin@example.com",
+	},
+];
 
 vi.mock("@/hooks/useOrganizations", () => ({
-	useOrganizations: () => ({
-		data: [
-			{
-				id: "org-1",
-				name: "Acme",
-				domain: "acme.example",
-				is_active: true,
-				is_provider: false,
-				settings: {},
-				created_at: "2026-08-13T00:00:00Z",
-				updated_at: "2026-08-13T00:00:00Z",
-				created_by: "admin@example.com",
-			},
-		],
-		isLoading: false,
-		refetch: vi.fn(),
-	}),
+	useOrganizations: (options?: { includeInactive?: boolean }) => {
+		mockUseOrganizations(options);
+		return {
+			data: options?.includeInactive
+				? organizations
+				: organizations.filter((org) => org.is_active),
+			isLoading: false,
+			refetch: vi.fn(),
+		};
+	},
 	useCreateOrganization: () => ({ isPending: false, mutateAsync: vi.fn() }),
-	useUpdateOrganization: () => ({ isPending: false, mutateAsync: vi.fn() }),
-	useDeleteOrganization: () => ({ isPending: false, mutateAsync: vi.fn() }),
+	useUpdateOrganization: () => ({
+		isPending: false,
+		mutateAsync: mockUpdate,
+	}),
 }));
+
 vi.mock("@/hooks/useSearch", () => ({
 	useSearch: (items: unknown[]) => items,
 }));
+
 vi.mock("@/pages/settings/RequiredInstructionsSettings", () => ({
 	RequiredInstructionsSettings: ({ organizationId }: { organizationId: string }) => (
 		<div>Instructions for {organizationId}</div>
@@ -35,18 +62,85 @@ vi.mock("@/pages/settings/RequiredInstructionsSettings", () => ({
 
 import { Organizations } from "./Organizations";
 
+beforeEach(() => {
+	mockUseOrganizations.mockClear();
+	mockUpdate.mockReset();
+	mockUpdate.mockResolvedValue({});
+});
+
 describe("Organizations", () => {
-	it("opens the required-instructions editor for a selected organization", async () => {
+	it("hides inactive organizations until requested", async () => {
 		const user = userEvent.setup();
 		render(<Organizations />);
 
-		await user.click(
-			screen.getByRole("button", { name: "Edit required instructions" }),
-		);
+		expect(screen.getByText("Acme")).toBeVisible();
+		expect(screen.queryByText("Dormant Co")).not.toBeInTheDocument();
+
+		await user.click(screen.getByRole("switch", { name: "Show Inactive" }));
+
+		expect(screen.getByText("Dormant Co")).toBeVisible();
+		expect(mockUseOrganizations).toHaveBeenLastCalledWith({
+			includeInactive: true,
+		});
+	});
+
+	it("opens a tabbed editor from the organization row", async () => {
+		const user = userEvent.setup();
+		render(<Organizations />);
+
+		await user.click(screen.getByRole("row", { name: /Acme/ }));
 
 		expect(
-			screen.getByRole("heading", { name: "Acme" }),
+			screen.getByRole("heading", { name: "Edit Organization" }),
 		).toBeVisible();
+		expect(screen.getByRole("tab", { name: "General" })).toBeVisible();
+
+		await user.click(screen.getByRole("tab", { name: "Instructions" }));
+
 		expect(screen.getByText("Instructions for org-1")).toBeVisible();
+	});
+
+	it("saves organization status from the General tab", async () => {
+		const user = userEvent.setup();
+		render(<Organizations />);
+
+		await user.click(screen.getByRole("row", { name: /Acme/ }));
+		await user.click(
+			screen.getByRole("switch", { name: "Organization Status" }),
+		);
+		await user.click(screen.getByRole("button", { name: "Save Changes" }));
+
+		await waitFor(() =>
+			expect(mockUpdate).toHaveBeenCalledWith({
+				params: { path: { org_id: "org-1" } },
+				body: {
+					name: "Acme",
+					domain: "acme.example",
+					is_active: false,
+				},
+			}),
+		);
+	});
+
+	it("offers a reversible disable action from the row menu", async () => {
+		const user = userEvent.setup();
+		render(<Organizations />);
+
+		await user.click(screen.getByRole("button", { name: "Acme actions" }));
+		await user.click(
+			screen.getByRole("menuitem", { name: "Disable Acme" }),
+		);
+		expect(
+			screen.getByRole("heading", { name: "Disable Acme?" }),
+		).toBeVisible();
+
+		await user.click(screen.getByRole("button", { name: "Disable" }));
+
+		await waitFor(() =>
+			expect(mockUpdate).toHaveBeenCalledWith({
+				params: { path: { org_id: "org-1" } },
+				body: { is_active: false },
+			}),
+		);
 	});
 });

--- a/client/src/pages/Organizations.tsx
+++ b/client/src/pages/Organizations.tsx
@@ -1,6 +1,19 @@
 import { useState } from "react";
-import { Building2, FileText, Plus, Pencil, Trash2, RefreshCw, Star } from "lucide-react";
+import {
+	Building2,
+	FileText,
+	MoreVertical,
+	Pencil,
+	Plus,
+	Power,
+	RefreshCw,
+	Settings,
+	Star,
+} from "lucide-react";
+
+import { SearchBox } from "@/components/search/SearchBox";
 import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
 import {
 	DataTable,
 	DataTableBody,
@@ -27,130 +40,161 @@ import {
 	AlertDialogHeader,
 	AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuSeparator,
+	DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
-import { SearchBox } from "@/components/search/SearchBox";
-import { useSearch } from "@/hooks/useSearch";
+import { Switch } from "@/components/ui/switch";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import {
-	useOrganizations,
 	useCreateOrganization,
+	useOrganizations,
 	useUpdateOrganization,
-	useDeleteOrganization,
 } from "@/hooks/useOrganizations";
+import { useSearch } from "@/hooks/useSearch";
 import type { components } from "@/lib/v1";
 import { RequiredInstructionsSettings } from "@/pages/settings/RequiredInstructionsSettings";
+
 type Organization = components["schemas"]["OrganizationPublic"];
+type EditTab = "general" | "instructions";
 
 interface OrganizationFormData {
 	name: string;
 	domain: string;
+	isActive: boolean;
 }
+
+const EMPTY_FORM: OrganizationFormData = {
+	name: "",
+	domain: "",
+	isActive: true,
+};
 
 export function Organizations() {
 	const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false);
 	const [isEditDialogOpen, setIsEditDialogOpen] = useState(false);
-	const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
-	const [isInstructionsDialogOpen, setIsInstructionsDialogOpen] = useState(false);
-	const [selectedOrg, setSelectedOrg] = useState<Organization | undefined>();
-	const [formData, setFormData] = useState<OrganizationFormData>({
-		name: "",
-		domain: "",
-	});
+	const [isDisableDialogOpen, setIsDisableDialogOpen] = useState(false);
+	const [selectedOrg, setSelectedOrg] = useState<Organization>();
+	const [activeEditTab, setActiveEditTab] = useState<EditTab>("general");
+	const [formData, setFormData] =
+		useState<OrganizationFormData>(EMPTY_FORM);
 	const [searchTerm, setSearchTerm] = useState("");
+	const [showInactive, setShowInactive] = useState(false);
 
-	const { data, isLoading, refetch } = useOrganizations();
+	const { data, isLoading, refetch } = useOrganizations({
+		includeInactive: showInactive,
+	});
 	const organizations: Organization[] = Array.isArray(data) ? data : [];
+	const visibleOrganizations = showInactive
+		? organizations
+		: organizations.filter((org) => org.is_active);
+	const filteredOrgs = useSearch(visibleOrganizations, searchTerm, [
+		"name",
+		"domain",
+		"id",
+	]);
 
 	const createMutation = useCreateOrganization();
 	const updateMutation = useUpdateOrganization();
-	const deleteMutation = useDeleteOrganization();
 
-	// Apply search filter
-	const filteredOrgs = useSearch(organizations, searchTerm, [
-		"name",
-		"domain",
-	]);
+	const resetSelection = () => {
+		setSelectedOrg(undefined);
+		setFormData(EMPTY_FORM);
+		setActiveEditTab("general");
+	};
 
 	const handleCreate = () => {
-		setFormData({ name: "", domain: "" });
+		setFormData(EMPTY_FORM);
 		setIsCreateDialogOpen(true);
 	};
 
-	const handleEdit = (org: Organization) => {
+	const handleEdit = (org: Organization, tab: EditTab = "general") => {
 		setSelectedOrg(org);
 		setFormData({
 			name: org.name,
 			domain: org.domain || "",
+			isActive: org.is_active,
 		});
+		setActiveEditTab(tab);
 		setIsEditDialogOpen(true);
 	};
 
-	const handleDelete = (org: Organization) => {
-		setSelectedOrg(org);
-		setIsDeleteDialogOpen(true);
-	};
-
-	const handleInstructions = (org: Organization) => {
-		setSelectedOrg(org);
-		setIsInstructionsDialogOpen(true);
-	};
-
-	const handleSubmitCreate = async (e: React.FormEvent) => {
-		e.preventDefault();
+	const handleSubmitCreate = async (event: React.FormEvent) => {
+		event.preventDefault();
 		await createMutation.mutateAsync({
 			body: {
-				name: formData.name,
-				domain: formData.domain || null,
+				name: formData.name.trim(),
+				domain: formData.domain.trim() || null,
 				is_active: true,
 				is_provider: false,
 			},
 		});
 		setIsCreateDialogOpen(false);
-		setFormData({ name: "", domain: "" });
+		setFormData(EMPTY_FORM);
 	};
 
-	const handleSubmitEdit = async (e: React.FormEvent) => {
-		e.preventDefault();
+	const handleSubmitEdit = async (event: React.FormEvent) => {
+		event.preventDefault();
 		if (!selectedOrg) return;
 
 		await updateMutation.mutateAsync({
 			params: { path: { org_id: selectedOrg.id } },
 			body: {
-				name: formData.name || null,
-				domain: formData.domain || null,
-				is_active: null,
+				name: formData.name.trim(),
+				domain: formData.domain.trim(),
+				is_active: formData.isActive,
 			},
 		});
 		setIsEditDialogOpen(false);
-		setSelectedOrg(undefined);
-		setFormData({ name: "", domain: "" });
+		resetSelection();
 	};
 
-	const handleConfirmDelete = async () => {
-		if (!selectedOrg) return;
-
-		await deleteMutation.mutateAsync({
-			params: { path: { org_id: selectedOrg.id } },
+	const setOrganizationActive = async (
+		org: Organization,
+		isActive: boolean,
+	) => {
+		await updateMutation.mutateAsync({
+			params: { path: { org_id: org.id } },
+			body: { is_active: isActive },
 		});
-		setIsDeleteDialogOpen(false);
-		setSelectedOrg(undefined);
 	};
 
-	const handleDialogClose = (open: boolean) => {
-		if (!open) {
-			setIsCreateDialogOpen(false);
-			setIsEditDialogOpen(false);
-			setFormData({ name: "", domain: "" });
-			setSelectedOrg(undefined);
+	const handleToggleActive = async (org: Organization) => {
+		if (org.is_provider) return;
+		if (org.is_active) {
+			setSelectedOrg(org);
+			setIsDisableDialogOpen(true);
+			return;
 		}
+		await setOrganizationActive(org, true);
+	};
+
+	const handleConfirmDisable = async () => {
+		if (!selectedOrg) return;
+		await setOrganizationActive(selectedOrg, false);
+		setIsDisableDialogOpen(false);
+		resetSelection();
+	};
+
+	const handleCreateDialogChange = (open: boolean) => {
+		setIsCreateDialogOpen(open);
+		if (!open) setFormData(EMPTY_FORM);
+	};
+
+	const handleEditDialogChange = (open: boolean) => {
+		setIsEditDialogOpen(open);
+		if (!open) resetSelection();
 	};
 
 	return (
-		<div className="h-full flex flex-col space-y-6 max-w-7xl mx-auto">
-			{/* Header: title left, actions right */}
-			<div className="flex items-center justify-between">
+		<div className="mx-auto flex h-full max-w-7xl flex-col space-y-6">
+			<div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
 				<div>
 					<h1 className="text-4xl font-extrabold tracking-tight">
 						Organizations
@@ -159,217 +203,215 @@ export function Organizations() {
 						Manage customer organizations and their configurations
 					</p>
 				</div>
-				<div className="flex items-center gap-2">
+				<div className="flex items-center gap-2 sm:shrink-0">
 					<Button
 						variant="outline"
 						size="icon"
 						onClick={() => refetch()}
-						title="Refresh"
+						aria-label="Refresh organizations"
+						title="Refresh organizations"
 					>
 						<RefreshCw className="h-4 w-4" />
 					</Button>
-					<Button
-						variant="outline"
-						size="icon"
-						onClick={handleCreate}
-						title="Create Organization"
-					>
+					<Button onClick={handleCreate} className="flex-1 sm:flex-none">
 						<Plus className="h-4 w-4" />
+						New Organization
 					</Button>
 				</div>
 			</div>
 
-			{/* Search and Filters */}
-			<div className="flex items-center gap-4">
+			<div className="flex flex-col gap-3 sm:flex-row sm:items-center">
 				<SearchBox
 					value={searchTerm}
 					onChange={setSearchTerm}
-					placeholder="Search organizations by name or domain..."
+					placeholder="Search by name, domain, or ID..."
 					className="flex-1"
 				/>
+				<div className="flex items-center gap-2 sm:ml-auto">
+					<Switch
+						id="show-inactive-organizations"
+						checked={showInactive}
+						onCheckedChange={setShowInactive}
+					/>
+					<Label
+						htmlFor="show-inactive-organizations"
+						className="cursor-pointer text-sm text-muted-foreground"
+					>
+						Show Inactive
+					</Label>
+				</div>
 			</div>
 
-			{/* Content directly - DataTable, no Card wrapper */}
-			{isLoading ? (
-				<div className="space-y-2">
-					{[...Array(5)].map((_, i) => (
-						<Skeleton key={i} className="h-12 w-full" />
-					))}
-				</div>
-			) : filteredOrgs && filteredOrgs.length > 0 ? (
-				<div className="flex-1 min-h-0">
-					<DataTable className="max-h-full">
+			<div className="min-h-0 flex-1">
+				{isLoading ? (
+					<div className="space-y-2">
+						{[...Array(5)].map((_, index) => (
+							<Skeleton key={index} className="h-12 w-full" />
+						))}
+					</div>
+				) : filteredOrgs.length > 0 ? (
+					<DataTable>
 						<DataTableHeader>
 							<DataTableRow>
 								<DataTableHead>Name</DataTableHead>
-								<DataTableHead className="w-0 whitespace-nowrap">Domain</DataTableHead>
-								<DataTableHead className="w-0 whitespace-nowrap">Organization ID</DataTableHead>
-								<DataTableHead className="w-0 whitespace-nowrap">Status</DataTableHead>
-								<DataTableHead className="w-0 whitespace-nowrap">Created</DataTableHead>
-								<DataTableHead className="w-0 whitespace-nowrap text-right"></DataTableHead>
+								<DataTableHead>Domain</DataTableHead>
+								<DataTableHead className="w-0 whitespace-nowrap">
+									Status
+								</DataTableHead>
+								<DataTableHead className="hidden w-0 whitespace-nowrap md:table-cell">
+									Created
+								</DataTableHead>
+								<DataTableHead className="w-0 whitespace-nowrap text-right" />
 							</DataTableRow>
 						</DataTableHeader>
 						<DataTableBody>
 							{filteredOrgs.map((org) => (
 								<DataTableRow
 									key={org.id}
-									className={
+									clickable
+									onClick={() => handleEdit(org)}
+									className={`group/row${
 										org.is_provider
-											? "bg-amber-50/50 dark:bg-amber-950/20"
+											? " bg-amber-50/50 dark:bg-amber-950/20"
 											: ""
-									}
+									}${!org.is_active ? " opacity-60" : ""}`}
 								>
-									<DataTableCell className="font-medium">
-										<div className="flex items-center gap-2">
+									<DataTableCell>
+										<div className="flex items-start gap-2">
 											{org.is_provider && (
-												<Star className="h-4 w-4 text-amber-500 fill-amber-500" />
+												<Star className="mt-0.5 h-4 w-4 shrink-0 fill-amber-500 text-amber-500" />
 											)}
-											{org.name}
-											{org.is_provider && (
-												<Badge
-													variant="outline"
-													className="text-amber-600 border-amber-300 bg-amber-50 dark:bg-amber-950/50"
-												>
-													Provider
-												</Badge>
-											)}
+											<div className="min-w-0">
+												<div className="flex flex-wrap items-center gap-2">
+													<span className="font-medium">{org.name}</span>
+													{org.is_provider && (
+														<Badge
+															variant="outline"
+															className="border-amber-300 bg-amber-50 text-amber-700 dark:bg-amber-950/50 dark:text-amber-300"
+														>
+															Provider
+														</Badge>
+													)}
+												</div>
+												<div className="mt-1 truncate font-mono text-xs text-muted-foreground">
+													{org.id}
+												</div>
+											</div>
 										</div>
 									</DataTableCell>
-									<DataTableCell className="w-0 whitespace-nowrap text-sm text-muted-foreground">
-										{org.domain || "-"}
-									</DataTableCell>
-									<DataTableCell className="w-0 whitespace-nowrap font-mono text-xs text-muted-foreground">
-										{org.id}
+									<DataTableCell className="text-sm text-muted-foreground">
+										{org.domain || "—"}
 									</DataTableCell>
 									<DataTableCell className="w-0 whitespace-nowrap">
-										<Badge
-											variant={
-												org.is_active
-													? "default"
-													: "secondary"
-											}
-										>
-											{org.is_active
-												? "Active"
-												: "Inactive"}
+										<Badge variant={org.is_active ? "default" : "secondary"}>
+											{org.is_active ? "Active" : "Inactive"}
 										</Badge>
 									</DataTableCell>
-									<DataTableCell className="w-0 whitespace-nowrap text-sm">
+									<DataTableCell className="hidden w-0 whitespace-nowrap text-sm text-muted-foreground md:table-cell">
 										{org.created_at
-											? new Date(
-													org.created_at,
-												).toLocaleDateString()
+											? new Date(org.created_at).toLocaleDateString()
 											: "N/A"}
 									</DataTableCell>
-									<DataTableCell className="w-0 whitespace-nowrap text-right">
-										<div className="flex items-center justify-end gap-2">
-											<Button
-												variant="ghost"
-												size="icon"
-												onClick={() => handleInstructions(org)}
-												title="Edit required instructions"
-											>
-												<FileText className="h-4 w-4" />
-											</Button>
-											<Button
-												variant="ghost"
-												size="icon"
-												onClick={() => handleEdit(org)}
-												title="Edit organization"
-											>
-												<Pencil className="h-4 w-4" />
-											</Button>
-											<Button
-												variant="ghost"
-												size="icon"
-												onClick={() =>
-													handleDelete(org)
-												}
-												disabled={org.is_provider}
-												title={
-													org.is_provider
-														? "Provider organization cannot be deleted"
-														: "Delete organization"
-												}
-											>
-												<Trash2 className="h-4 w-4" />
-											</Button>
-										</div>
+									<DataTableCell
+										className="w-0 whitespace-nowrap text-right"
+										onClick={(event) => event.stopPropagation()}
+									>
+										<DropdownMenu>
+											<DropdownMenuTrigger asChild>
+												<Button
+													variant="ghost"
+													size="icon"
+													aria-label={`${org.name} actions`}
+												>
+													<MoreVertical className="h-4 w-4" />
+												</Button>
+											</DropdownMenuTrigger>
+											<DropdownMenuContent align="end" className="w-48">
+												<DropdownMenuItem
+													className="min-h-9 whitespace-nowrap px-3"
+													onClick={() => handleEdit(org)}
+													aria-label={`Edit ${org.name}`}
+												>
+													<Pencil />
+													Edit
+												</DropdownMenuItem>
+												<DropdownMenuSeparator />
+												<DropdownMenuItem
+													className="min-h-9 whitespace-nowrap px-3"
+													onClick={() => handleToggleActive(org)}
+													disabled={org.is_provider}
+													aria-label={`${org.is_active ? "Disable" : "Enable"} ${org.name}`}
+												>
+													<Power />
+													{org.is_active ? "Disable" : "Enable"}
+												</DropdownMenuItem>
+											</DropdownMenuContent>
+										</DropdownMenu>
 									</DataTableCell>
 								</DataTableRow>
 							))}
 						</DataTableBody>
 					</DataTable>
-				</div>
-			) : (
-				<div className="flex flex-col items-center justify-center py-12 text-center">
-					<Building2 className="h-12 w-12 text-muted-foreground" />
-					<h3 className="mt-4 text-lg font-semibold">
-						{searchTerm
-							? "No organizations match your search"
-							: "No organizations found"}
-					</h3>
-					<p className="mt-2 text-sm text-muted-foreground">
-						{searchTerm
-							? "Try adjusting your search term or clear the filter"
-							: "Create your first organization to get started"}
-					</p>
-					<Button
-						variant="outline"
-						size="icon"
-						onClick={handleCreate}
-						title="Create Organization"
-						className="mt-4"
-					>
-						<Plus className="h-4 w-4" />
-					</Button>
-				</div>
-			)}
+				) : (
+					<div className="flex flex-col items-center justify-center py-12 text-center">
+						<Building2 className="h-12 w-12 text-muted-foreground" />
+						<h3 className="mt-4 text-lg font-semibold">
+							{searchTerm
+								? "No organizations match your search"
+								: showInactive
+									? "No organizations found"
+									: "No active organizations found"}
+						</h3>
+						<p className="mt-2 text-sm text-muted-foreground">
+							{searchTerm
+								? "Try adjusting your search or clearing the filter."
+								: showInactive
+									? "Create your first organization to get started."
+									: "Show inactive organizations or create a new one."}
+						</p>
+						<Button onClick={handleCreate} className="mt-4">
+							<Plus className="h-4 w-4" />
+							New Organization
+						</Button>
+					</div>
+				)}
+			</div>
 
-			{/* Create Dialog */}
-			<Dialog open={isCreateDialogOpen} onOpenChange={handleDialogClose}>
+			<Dialog open={isCreateDialogOpen} onOpenChange={handleCreateDialogChange}>
 				<DialogContent>
 					<form onSubmit={handleSubmitCreate}>
 						<DialogHeader>
 							<DialogTitle>Create Organization</DialogTitle>
 							<DialogDescription>
-								Add a new customer organization to the platform
+								Add a customer organization to the platform.
 							</DialogDescription>
 						</DialogHeader>
 						<div className="space-y-4 py-4">
 							<div className="space-y-2">
-								<Label htmlFor="name">
-									Organization Name *
-								</Label>
+								<Label htmlFor="organization-name">Organization Name</Label>
 								<Input
-									id="name"
+									id="organization-name"
 									value={formData.name}
-									onChange={(e) =>
-										setFormData({
-											...formData,
-											name: e.target.value,
-										})
+									onChange={(event) =>
+										setFormData({ ...formData, name: event.target.value })
 									}
 									placeholder="Acme Corporation"
 									required
 								/>
 							</div>
 							<div className="space-y-2">
-								<Label htmlFor="domain">Email Domain</Label>
+								<Label htmlFor="organization-domain">Email Domain</Label>
 								<Input
-									id="domain"
+									id="organization-domain"
 									value={formData.domain}
-									onChange={(e) =>
-										setFormData({
-											...formData,
-											domain: e.target.value,
-										})
+									onChange={(event) =>
+										setFormData({ ...formData, domain: event.target.value })
 									}
 									placeholder="acme.com"
 								/>
 								<p className="text-xs text-muted-foreground">
-									Users with this email domain will be
-									auto-provisioned to this organization
+									Users with this email domain are automatically provisioned to
+									this organization.
 								</p>
 							</div>
 						</div>
@@ -377,140 +419,161 @@ export function Organizations() {
 							<Button
 								type="button"
 								variant="outline"
-								onClick={() => handleDialogClose(false)}
+								onClick={() => handleCreateDialogChange(false)}
 							>
 								Cancel
 							</Button>
-							<Button
-								type="submit"
-								disabled={createMutation.isPending}
-							>
-								{createMutation.isPending
-									? "Creating..."
-									: "Create"}
+							<Button type="submit" disabled={createMutation.isPending}>
+								{createMutation.isPending ? "Creating..." : "Create Organization"}
 							</Button>
 						</DialogFooter>
 					</form>
 				</DialogContent>
 			</Dialog>
 
-			{/* Edit Dialog */}
-			<Dialog open={isEditDialogOpen} onOpenChange={handleDialogClose}>
-				<DialogContent>
-					<form onSubmit={handleSubmitEdit}>
-						<DialogHeader>
-							<DialogTitle>Edit Organization</DialogTitle>
-							<DialogDescription>
-								Update organization details
-							</DialogDescription>
-						</DialogHeader>
-						<div className="space-y-4 py-4">
-							<div className="space-y-2">
-								<Label htmlFor="edit-name">
-									Organization Name *
-								</Label>
-								<Input
-									id="edit-name"
-									value={formData.name}
-									onChange={(e) =>
-										setFormData({
-											...formData,
-											name: e.target.value,
-										})
-									}
-									placeholder="Acme Corporation"
-									required
-								/>
-							</div>
-							<div className="space-y-2">
-								<Label htmlFor="edit-domain">
-									Email Domain
-								</Label>
-								<Input
-									id="edit-domain"
-									value={formData.domain}
-									onChange={(e) =>
-										setFormData({
-											...formData,
-											domain: e.target.value,
-										})
-									}
-									placeholder="acme.com"
-								/>
-								<p className="text-xs text-muted-foreground">
-									Users with this email domain will be
-									auto-provisioned to this organization
-								</p>
-							</div>
-						</div>
-						<DialogFooter>
-							<Button
-								type="button"
-								variant="outline"
-								onClick={() => handleDialogClose(false)}
-							>
-								Cancel
-							</Button>
-							<Button
-								type="submit"
-								disabled={updateMutation.isPending}
-							>
-								{updateMutation.isPending
-									? "Updating..."
-									: "Update"}
-							</Button>
-						</DialogFooter>
-					</form>
-				</DialogContent>
-			</Dialog>
-
-			{/* Organization Instructions Dialog */}
-			<Dialog
-				open={isInstructionsDialogOpen}
-				onOpenChange={(open) => {
-					setIsInstructionsDialogOpen(open);
-					if (!open) setSelectedOrg(undefined);
-				}}
-			>
-				<DialogContent className="max-w-3xl">
+			<Dialog open={isEditDialogOpen} onOpenChange={handleEditDialogChange}>
+				<DialogContent className="flex max-h-[85vh] flex-col overflow-hidden sm:max-w-3xl">
 					<DialogHeader>
-						<DialogTitle>{selectedOrg?.name}</DialogTitle>
+						<DialogTitle>Edit Organization</DialogTitle>
 						<DialogDescription>
-							Configure instructions that apply only to this organization.
+							Manage details, status, and instructions for {selectedOrg?.name}.
 						</DialogDescription>
 					</DialogHeader>
-					{selectedOrg && (
-						<RequiredInstructionsSettings
-							key={selectedOrg.id}
-							organizationId={selectedOrg.id}
-							embedded
-						/>
+
+					<Tabs
+						value={activeEditTab}
+						onValueChange={(value) => setActiveEditTab(value as EditTab)}
+						className="min-h-0 flex-1 overflow-hidden"
+					>
+						<TabsList className="w-full shrink-0">
+							<TabsTrigger value="general">
+								<Settings className="h-4 w-4" />
+								General
+							</TabsTrigger>
+							<TabsTrigger value="instructions">
+								<FileText className="h-4 w-4" />
+								Instructions
+							</TabsTrigger>
+						</TabsList>
+
+						<div className="min-h-0 flex-1 overflow-y-auto py-4">
+							<TabsContent value="general" className="mt-0">
+								<form
+									id="edit-organization-form"
+									onSubmit={handleSubmitEdit}
+									className="space-y-5"
+								>
+									<div className="space-y-2">
+										<Label htmlFor="edit-organization-name">
+											Organization Name
+										</Label>
+										<Input
+											id="edit-organization-name"
+											value={formData.name}
+											onChange={(event) =>
+												setFormData({ ...formData, name: event.target.value })
+											}
+											required
+										/>
+									</div>
+									<div className="space-y-2">
+										<Label htmlFor="edit-organization-domain">
+											Email Domain
+										</Label>
+										<Input
+											id="edit-organization-domain"
+											value={formData.domain}
+											onChange={(event) =>
+												setFormData({ ...formData, domain: event.target.value })
+											}
+											placeholder="acme.com"
+										/>
+										<p className="text-xs text-muted-foreground">
+											Users with this email domain are automatically provisioned to
+											this organization.
+										</p>
+									</div>
+
+									<div className="flex items-center justify-between gap-4 rounded-xl bg-muted/50 p-4 ring-1 ring-foreground/5">
+										<div className="space-y-1">
+											<Label htmlFor="edit-organization-status">
+												Organization Status
+											</Label>
+											<p className="text-xs text-muted-foreground">
+												{selectedOrg?.is_provider
+													? "The provider organization must remain active."
+													: "Inactive organizations are hidden from active organization lists."}
+											</p>
+										</div>
+										<Switch
+											id="edit-organization-status"
+											checked={formData.isActive}
+											onCheckedChange={(isActive) =>
+												setFormData({ ...formData, isActive })
+											}
+											disabled={selectedOrg?.is_provider}
+										/>
+									</div>
+								</form>
+							</TabsContent>
+
+							<TabsContent value="instructions" className="mt-0">
+								{selectedOrg && (
+									<RequiredInstructionsSettings
+										key={selectedOrg.id}
+										organizationId={selectedOrg.id}
+										embedded
+									/>
+								)}
+							</TabsContent>
+						</div>
+					</Tabs>
+
+					{activeEditTab === "general" && (
+						<DialogFooter>
+							<Button
+								type="button"
+								variant="outline"
+								onClick={() => handleEditDialogChange(false)}
+							>
+								Cancel
+							</Button>
+							<Button
+								type="submit"
+								form="edit-organization-form"
+								disabled={updateMutation.isPending}
+							>
+								{updateMutation.isPending ? "Saving..." : "Save Changes"}
+							</Button>
+						</DialogFooter>
 					)}
 				</DialogContent>
 			</Dialog>
 
-			{/* Delete Confirmation Dialog */}
 			<AlertDialog
-				open={isDeleteDialogOpen}
-				onOpenChange={setIsDeleteDialogOpen}
+				open={isDisableDialogOpen}
+				onOpenChange={(open) => {
+					setIsDisableDialogOpen(open);
+					if (!open) resetSelection();
+				}}
 			>
 				<AlertDialogContent>
 					<AlertDialogHeader>
-						<AlertDialogTitle>Are you sure?</AlertDialogTitle>
+						<AlertDialogTitle>Disable {selectedOrg?.name}?</AlertDialogTitle>
 						<AlertDialogDescription>
-							This will permanently delete the organization "
-							{selectedOrg?.name}". This action cannot be undone.
+							{selectedOrg?.name} will be removed from active organization lists.
+							You can re-enable it later by showing inactive organizations.
 						</AlertDialogDescription>
 					</AlertDialogHeader>
 					<AlertDialogFooter>
 						<AlertDialogCancel>Cancel</AlertDialogCancel>
 						<AlertDialogAction
-							onClick={handleConfirmDelete}
+							onClick={handleConfirmDisable}
 							className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
 						>
-							{deleteMutation.isPending
-								? "Deleting..."
-								: "Delete"}
+							{updateMutation.isPending
+								? "Disabling..."
+								: "Disable"}
 						</AlertDialogAction>
 					</AlertDialogFooter>
 				</AlertDialogContent>


### PR DESCRIPTION
## Summary
- redesign the Organizations list around the current admin-page patterns
- add optional inactive-organization visibility and reversible enable/disable controls
- move organization instructions into the tabbed edit dialog
- keep provider organizations active and improve row/action-menu behavior

## Verification
- ./test.sh tests/e2e/api/test_organizations.py -v
- ./test.sh client unit src/pages/Organizations.test.tsx src/hooks/useOrganizations.test.ts
- ./test.sh client e2e --screenshots e2e/organizations.admin.spec.ts
- ./test.sh client e2e e2e/memory.admin.spec.ts
- ./test.sh quality api
- cd client && npm run tsc
- cd client && npm run lint
- Impeccable layout detector
- git diff --check

## Notes
- No matching GitHub issue was found for this design pass.
- Full backend, Vitest, and Playwright suites were not run locally; targeted coverage for the changed surfaces is green.