### PR TITLE
Improve deployment resilience for executions, subscriptions, and app assets

### DIFF
--- a/.claude/skills/bifrost-build/references/web-sdk-v2.md
+++ b/.claude/skills/bifrost-build/references/web-sdk-v2.md
@@ -2,6 +2,16 @@
 
 The instance-served `bifrost` package is the runtime SDK for `standalone_v2` Solution apps. Use `../generated/web-sdk-surface.md` for the exact export/type surface. Read `apps-v2.md` for project structure and `app-quality.md` for UI completion.
 
+## Keeping an existing app current
+
+The web SDK is vendored into each app. A platform deployment does not update an existing app's installed SDK automatically. When a reported behavior is fixed in the web SDK, or an app predates the SDK behavior it now relies on, refresh that app before rebuilding it:
+
+```bash
+bifrost solution sdk update [PATH] --app <app-slug>
+```
+
+Omit `--app` for a single-app Solution. This command downloads the SDK from the connected Bifrost instance and reinstalls the vendored package; do not hand-edit the generated SDK files. After updating, run the app's typecheck, tests, and production build, then redeploy it. API-only execution fixes and host-shell asset fixes do not require an app SDK update.
+
 ## Provider and context
 
 Keep the scaffolded `BifrostProvider` wiring in `src/main.tsx`. The host supplies the API URL, viewer token, org scope, app ID, theme, logout handler, and mount basename.

--- a/api/shared/pending_execution.py
+++ b/api/shared/pending_execution.py
@@ -1,0 +1,79 @@
+"""Read-through representation for executions awaiting worker persistence."""
+
+import logging
+from typing import TYPE_CHECKING
+from uuid import UUID
+
+from sqlalchemy import select
+
+from src.core.principal import UserPrincipal
+from src.core.redis_client import get_redis_client
+from src.models import WorkflowExecution
+from src.models.enums import ExecutionStatus
+from src.models.orm.workflows import Workflow
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+logger = logging.getLogger(__name__)
+
+
+async def get_pending_execution_fallback(
+    execution_id: UUID,
+    user: UserPrincipal,
+    db: "AsyncSession",
+) -> tuple[WorkflowExecution | None, str | None]:
+    """Return an owned Redis-pending execution after PostgreSQL misses."""
+    try:
+        pending = await get_redis_client().get_pending_execution(str(execution_id))
+    except Exception:
+        logger.warning(
+            "Could not check Redis for pending execution %s",
+            execution_id,
+            exc_info=True,
+        )
+        return None, "NotFound"
+
+    if pending is None:
+        return None, "NotFound"
+
+    pending_user_id = pending.get("user_id")
+    if not user.is_superuser and pending_user_id != str(user.user_id):
+        return None, "Forbidden"
+
+    workflow_id = pending.get("workflow_id")
+    workflow_name = pending.get("script_name")
+    if not workflow_name and workflow_id:
+        workflow_result = await db.execute(
+            select(Workflow.name).where(Workflow.id == UUID(workflow_id))
+        )
+        workflow_name = workflow_result.scalar_one_or_none()
+
+    org_id = pending.get("org_id")
+    if isinstance(org_id, str) and org_id.startswith("ORG:"):
+        org_id = org_id.removeprefix("ORG:")
+
+    return (
+        WorkflowExecution(
+            execution_id=str(execution_id),
+            workflow_name=workflow_name or "Pending execution",
+            workflow_id=workflow_id,
+            org_id=org_id,
+            org_name="Global" if org_id is None else None,
+            form_id=pending.get("form_id"),
+            executed_by=pending_user_id,
+            executed_by_name=pending.get("user_name") or pending_user_id,
+            executed_by_email=pending.get("user_email"),
+            status=(
+                ExecutionStatus.CANCELLED
+                if pending.get("cancelled")
+                else ExecutionStatus.PENDING
+            ),
+            input_data=pending.get("parameters") or {},
+            result=None,
+            logs=[],
+            started_at=None,
+            completed_at=None,
+        ),
+        None,
+    )

--- a/api/shared/pending_execution.py
+++ b/api/shared/pending_execution.py
@@ -6,6 +6,7 @@ from uuid import UUID
 
 from sqlalchemy import select
 
+from src.core.log_safety import log_safe
 from src.core.principal import UserPrincipal
 from src.core.redis_client import get_redis_client
 from src.models import WorkflowExecution
@@ -29,7 +30,7 @@ async def get_pending_execution_fallback(
     except Exception:
         logger.warning(
             "Could not check Redis for pending execution %s",
-            execution_id,
+            log_safe(execution_id),
             exc_info=True,
         )
         return None, "NotFound"

--- a/api/src/routers/executions.py
+++ b/api/src/routers/executions.py
@@ -36,6 +36,7 @@ from src.models.contracts.executions import (
 from src.models.orm.ai_usage import AIUsage
 
 from bifrost._logging import read_logs_from_stream
+from shared.pending_execution import get_pending_execution_fallback
 from src.core.auth import Context, RequirePlatformAdmin
 from src.core.principal import UserPrincipal
 from src.core.log_safety import log_safe
@@ -815,11 +816,13 @@ async def get_execution(
     execution, error = await repo.get_execution(execution_id, ctx.user)
 
     if error == "NotFound":
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Execution {execution_id} not found",
+        execution, error = await get_pending_execution_fallback(
+            execution_id,
+            ctx.user,
+            ctx.db,
         )
-    elif error == "Forbidden":
+
+    if error == "Forbidden":
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="You do not have permission to view this execution",

--- a/api/tests/e2e/api/test_executions.py
+++ b/api/tests/e2e/api/test_executions.py
@@ -122,6 +122,43 @@ class TestSyncExecution:
 class TestAsyncExecution:
     """Test asynchronous workflow execution."""
 
+    @pytest.mark.asyncio
+    async def test_redis_only_execution_is_immediately_readable(
+        self,
+        e2e_client,
+        platform_admin,
+    ):
+        """A receipt is readable before the worker creates its database row."""
+        from src.core.redis_client import get_redis_client
+
+        execution_id = str(uuid.uuid4())
+        redis_client = get_redis_client()
+        await redis_client.set_pending_execution(
+            execution_id=execution_id,
+            workflow_id=None,
+            script_name="e2e_pending_receipt",
+            parameters={"domain": "example.com"},
+            org_id=None,
+            user_id=str(platform_admin.user_id),
+            user_name=platform_admin.name,
+            user_email=platform_admin.email,
+        )
+        try:
+            response = e2e_client.get(
+                f"/api/executions/{execution_id}",
+                headers=platform_admin.headers,
+            )
+        finally:
+            await redis_client.delete_pending_execution(execution_id)
+
+        assert response.status_code == 200, response.text
+        data = response.json()
+        assert data["execution_id"] == execution_id
+        assert data["workflow_name"] == "e2e_pending_receipt"
+        assert data["status"] == "Pending"
+        assert data["input_data"] == {"domain": "example.com"}
+        assert data["started_at"] is None
+
     def test_execute_async_workflow(self, e2e_client, platform_admin, async_workflow):
         """Platform admin executes async workflow."""
         response = e2e_client.post(

--- a/api/tests/unit/routers/test_executions_get_pending.py
+++ b/api/tests/unit/routers/test_executions_get_pending.py
@@ -1,0 +1,68 @@
+"""Regression tests for the PostgreSQL-first pending execution read path."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+from fastapi import HTTPException
+
+from src.routers.executions import get_execution
+
+
+@pytest.mark.asyncio
+async def test_get_execution_falls_back_to_redis_only_after_database_miss():
+    execution_id = uuid4()
+    ctx = MagicMock()
+    database_execution = MagicMock(name="database_execution")
+    pending_execution = MagicMock(name="pending_execution")
+
+    with (
+        patch(
+            "src.routers.executions.ExecutionRepository.get_execution",
+            new=AsyncMock(return_value=(None, "NotFound")),
+        ),
+        patch(
+            "src.routers.executions.get_pending_execution_fallback",
+            new=AsyncMock(return_value=(pending_execution, None)),
+        ) as fallback,
+    ):
+        result = await get_execution(execution_id, ctx)
+
+    assert result is pending_execution
+    fallback.assert_awaited_once_with(execution_id, ctx.user, ctx.db)
+
+    with (
+        patch(
+            "src.routers.executions.ExecutionRepository.get_execution",
+            new=AsyncMock(return_value=(database_execution, None)),
+        ),
+        patch(
+            "src.routers.executions.get_pending_execution_fallback",
+            new=AsyncMock(),
+        ) as fallback,
+    ):
+        result = await get_execution(execution_id, ctx)
+
+    assert result is database_execution
+    fallback.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_get_execution_remains_not_found_when_database_and_redis_miss():
+    execution_id = uuid4()
+    ctx = MagicMock()
+
+    with (
+        patch(
+            "src.routers.executions.ExecutionRepository.get_execution",
+            new=AsyncMock(return_value=(None, "NotFound")),
+        ),
+        patch(
+            "src.routers.executions.get_pending_execution_fallback",
+            new=AsyncMock(return_value=(None, "NotFound")),
+        ),
+        pytest.raises(HTTPException) as exc_info,
+    ):
+        await get_execution(execution_id, ctx)
+
+    assert exc_info.value.status_code == 404

--- a/api/tests/unit/shared/test_pending_execution.py
+++ b/api/tests/unit/shared/test_pending_execution.py
@@ -1,0 +1,166 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import UUID
+
+import pytest
+
+from shared.pending_execution import get_pending_execution_fallback
+from src.core.principal import UserPrincipal
+from src.models.enums import ExecutionStatus
+
+
+EXECUTION_ID = UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+USER_ID = UUID("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
+OTHER_USER_ID = UUID("cccccccc-cccc-cccc-cccc-cccccccccccc")
+
+
+def _principal(*, user_id: UUID = USER_ID, is_superuser: bool = False) -> UserPrincipal:
+    return UserPrincipal(
+        user_id=user_id,
+        email="user@example.com",
+        organization_id=None,
+        is_superuser=is_superuser,
+    )
+
+
+def _pending(**overrides):
+    value = {
+        "execution_id": str(EXECUTION_ID),
+        "workflow_id": "dddddddd-dddd-dddd-dddd-dddddddddddd",
+        "script_name": None,
+        "parameters": {"domain": "example.com"},
+        "org_id": None,
+        "user_id": str(USER_ID),
+        "user_name": "Example User",
+        "user_email": "user@example.com",
+        "form_id": None,
+        "api_key_id": None,
+        "startup": None,
+        "form_inputs": {},
+        "embed": {},
+        "sync": False,
+        "is_platform_admin": False,
+        "event": None,
+        "created_at": "2026-08-14T12:00:00+00:00",
+        "cancelled": False,
+    }
+    value.update(overrides)
+    return value
+
+
+@pytest.mark.asyncio
+async def test_pending_execution_is_returned_as_contract_valid_pending_state():
+    redis = AsyncMock()
+    redis.get_pending_execution.return_value = _pending()
+    db = AsyncMock()
+    result = MagicMock()
+    result.scalar_one_or_none.return_value = "DMARC report ingestion"
+    db.execute.return_value = result
+
+    with patch(
+        "shared.pending_execution.get_redis_client",
+        return_value=redis,
+    ):
+        execution, error = await get_pending_execution_fallback(
+            EXECUTION_ID,
+            _principal(),
+            db,
+        )
+
+    assert error is None
+    assert execution is not None
+    assert execution.execution_id == str(EXECUTION_ID)
+    assert execution.workflow_name == "DMARC report ingestion"
+    assert execution.status == ExecutionStatus.PENDING
+    assert execution.started_at is None
+    assert execution.input_data == {"domain": "example.com"}
+    assert execution.executed_by == str(USER_ID)
+
+
+@pytest.mark.asyncio
+async def test_pending_execution_preserves_owner_authorization():
+    redis = AsyncMock()
+    redis.get_pending_execution.return_value = _pending(user_id=str(OTHER_USER_ID))
+
+    with patch(
+        "shared.pending_execution.get_redis_client",
+        return_value=redis,
+    ):
+        execution, error = await get_pending_execution_fallback(
+            EXECUTION_ID,
+            _principal(),
+            AsyncMock(),
+        )
+
+    assert execution is None
+    assert error == "Forbidden"
+
+
+@pytest.mark.asyncio
+async def test_platform_admin_can_read_any_pending_execution():
+    redis = AsyncMock()
+    redis.get_pending_execution.return_value = _pending(
+        user_id=str(OTHER_USER_ID),
+        script_name="inline_script",
+        workflow_id=None,
+    )
+
+    with patch(
+        "shared.pending_execution.get_redis_client",
+        return_value=redis,
+    ):
+        execution, error = await get_pending_execution_fallback(
+            EXECUTION_ID,
+            _principal(is_superuser=True),
+            AsyncMock(),
+        )
+
+    assert error is None
+    assert execution is not None
+    assert execution.workflow_name == "inline_script"
+
+
+@pytest.mark.asyncio
+async def test_cancelled_pending_execution_is_not_reported_as_pending():
+    redis = AsyncMock()
+    redis.get_pending_execution.return_value = _pending(
+        cancelled=True,
+        script_name="pending script",
+        workflow_id=None,
+    )
+
+    with patch(
+        "shared.pending_execution.get_redis_client",
+        return_value=redis,
+    ):
+        execution, error = await get_pending_execution_fallback(
+            EXECUTION_ID,
+            _principal(),
+            AsyncMock(),
+        )
+
+    assert error is None
+    assert execution is not None
+    assert execution.status == ExecutionStatus.CANCELLED
+
+
+@pytest.mark.asyncio
+async def test_missing_or_unavailable_redis_preserves_not_found():
+    for redis_result in (None, RuntimeError("redis unavailable")):
+        redis = AsyncMock()
+        if isinstance(redis_result, Exception):
+            redis.get_pending_execution.side_effect = redis_result
+        else:
+            redis.get_pending_execution.return_value = redis_result
+
+        with patch(
+            "shared.pending_execution.get_redis_client",
+            return_value=redis,
+        ):
+            execution, error = await get_pending_execution_fallback(
+                EXECUTION_ID,
+                _principal(),
+                AsyncMock(),
+            )
+
+        assert execution is None
+        assert error == "NotFound"

--- a/client/e2e/fixtures/v2-lazy-app/src/main.tsx
+++ b/client/e2e/fixtures/v2-lazy-app/src/main.tsx
@@ -4,6 +4,7 @@ import { createRoot } from "react-dom/client";
 import "./style.css";
 
 export const sharedLabel = "Lazy chunk rendered";
+const buildLabel = import.meta.env.VITE_ASSET_FIXTURE ?? "default";
 
 interface Bootstrap {
 	basename: string;
@@ -42,6 +43,7 @@ const LazyPage = lazy(() => import("./LazyPage"));
 function FixtureApp({ bootstrap }: { bootstrap: Bootstrap }) {
 	return (
 		<main>
+			<p data-testid="fixture-build">{buildLabel}</p>
 			<p data-testid="fixture-basename">{bootstrap.basename}</p>
 			<Suspense fallback={<p>Loading lazy chunk…</p>}>
 				<LazyPage />

--- a/client/e2e/fixtures/v2-lazy-app/src/style.css
+++ b/client/e2e/fixtures/v2-lazy-app/src/style.css
@@ -1,3 +1,13 @@
 body {
 	font-family: sans-serif;
 }
+
+main {
+	max-width: 42rem;
+	margin: 3rem auto;
+	padding: 2rem;
+	border: 4px solid rgb(37 99 235);
+	border-radius: 1rem;
+	background: rgb(219 234 254);
+	color: rgb(30 64 175);
+}

--- a/client/e2e/solution-v2-code-splitting.admin.spec.ts
+++ b/client/e2e/solution-v2-code-splitting.admin.spec.ts
@@ -114,13 +114,16 @@ function workspaceZip(
 	]);
 }
 
-async function buildFixture(): Promise<BuiltFixture> {
+async function buildFixture(version = "default"): Promise<BuiltFixture> {
 	const root = resolve(import.meta.dirname, "fixtures/v2-lazy-app");
 	const outDir = mkdtempSync(join(tmpdir(), "bifrost-v2-lazy-"));
 	await build({
 		root,
 		base: "./",
 		plugins: [react()],
+		define: {
+			"import.meta.env.VITE_ASSET_FIXTURE": JSON.stringify(version),
+		},
 		build: { outDir, emptyOutDir: true },
 		logLevel: "silent",
 	});
@@ -262,6 +265,137 @@ test.describe("Apps v2 code splitting", () => {
 			});
 			expect(entryRequests).toHaveLength(1);
 			expect(errors, errors.join("\n")).toEqual([]);
+		} finally {
+			await api
+				.delete(`/api/solutions/${solutionId}`, {
+					params: { confirm: SOLUTION_SLUG },
+				})
+				.catch(() => {});
+		}
+	});
+
+	test("a stale deployed entry refreshes the manifest and mounts the new styled bundle", async ({
+		page,
+		api,
+	}, testInfo) => {
+		test.setTimeout(180_000);
+		const stale = await buildFixture("stale-build");
+		const fresh = await buildFixture("recovered-build");
+		expect(fresh.entry).not.toBe(stale.entry);
+
+		const appId = crypto.randomUUID();
+		const solution = await api.post("/api/solutions", {
+			data: {
+				slug: SOLUTION_SLUG,
+				name: SOLUTION_SLUG,
+				scope: "global",
+				global_repo_access: false,
+			},
+		});
+		expect(solution.ok(), await solution.text()).toBeTruthy();
+		const solutionId = (await solution.json()).id;
+
+		const deploy = async (distFiles: Record<string, string>) => {
+			const response = await page
+				.context()
+				.request.post(`/api/solutions/${solutionId}/deploy`, {
+					headers: await api.csrfHeader(),
+					multipart: {
+						file: {
+							name: "solution.zip",
+							mimeType: "application/zip",
+							buffer: workspaceZip(appId, distFiles),
+						},
+					},
+				});
+			expect(response.status(), await response.text()).toBe(202);
+			const jobId = (await response.json()).deploy_job_id;
+			await expect
+				.poll(
+					async () => {
+						const job = await api.get(
+							`/api/solutions/deploy-jobs/${jobId}`,
+						);
+						const body = await job.json();
+						if (body.status === "failed") throw new Error(body.error);
+						return body.status;
+					},
+					{ timeout: 60_000 },
+				)
+				.toBe("succeeded");
+		};
+
+		try {
+			await deploy(stale.distFiles);
+
+			let manifestRequests = 0;
+			let staleEntryFailures = 0;
+			let documentLoads = 0;
+			let resolveFirstManifest!: () => void;
+			let rejectFirstManifest!: (reason?: unknown) => void;
+			const firstManifestHandled = new Promise<void>((resolve, reject) => {
+				resolveFirstManifest = resolve;
+				rejectFirstManifest = reject;
+			});
+			page.on("load", () => {
+				documentLoads += 1;
+			});
+			await page.route(`**/${stale.entry}`, async (route) => {
+				staleEntryFailures += 1;
+				await route.fulfill({ status: 404, body: "stale deployment asset" });
+			});
+			await page.route(
+				/\/api\/applications\/[^/]+\/bundle-manifest\?mode=live$/,
+				async (route) => {
+					manifestRequests += 1;
+					if (manifestRequests !== 1) {
+						await route.continue();
+						return;
+					}
+
+					// Capture the old manifest, deploy the replacement, then release
+					// the old response. The browser now has the exact stale-tab race:
+					// old immutable URL + a server that only has the new bundle.
+					try {
+						const oldResponse = await route.fetch();
+						const oldBody = await oldResponse.body();
+						await deploy(fresh.distFiles);
+						await route.fulfill({
+							status: oldResponse.status(),
+							headers: oldResponse.headers(),
+							body: oldBody,
+						});
+						resolveFirstManifest();
+					} catch (error) {
+						rejectFirstManifest(error);
+						throw error;
+					}
+				},
+			);
+
+			await page.goto(`/apps/${APP_SLUG}`);
+			await firstManifestHandled;
+			await expect(page.getByTestId("fixture-build")).toHaveText(
+				"recovered-build",
+			);
+			await expect(page.getByTestId("lazy-page")).toHaveText(
+				"Lazy chunk rendered",
+			);
+			await expect
+				.poll(() =>
+					page.getByTestId("fixture-build").evaluate((element) =>
+						getComputedStyle(element.closest("main")!).backgroundColor,
+					),
+				)
+				.toBe("rgb(219, 234, 254)");
+
+			expect(staleEntryFailures).toBe(1);
+			expect(manifestRequests).toBe(2);
+			expect(documentLoads).toBe(1);
+			await page.screenshot({
+				path: testInfo.outputPath("stale-asset-recovered.png"),
+				fullPage: true,
+			});
 		} finally {
 			await api
 				.delete(`/api/solutions/${solutionId}`, {

--- a/client/e2e/solution-v2-code-splitting.admin.spec.ts
+++ b/client/e2e/solution-v2-code-splitting.admin.spec.ts
@@ -277,7 +277,7 @@ test.describe("Apps v2 code splitting", () => {
 	test("a stale deployed entry refreshes the manifest and mounts the new styled bundle", async ({
 		page,
 		api,
-	}, testInfo) => {
+	}) => {
 		test.setTimeout(180_000);
 		const stale = await buildFixture("stale-build");
 		const fresh = await buildFixture("recovered-build");
@@ -333,9 +333,13 @@ test.describe("Apps v2 code splitting", () => {
 			let documentLoads = 0;
 			let resolveFirstManifest!: () => void;
 			let rejectFirstManifest!: (reason?: unknown) => void;
+			let releaseRecoveryManifest!: () => void;
 			const firstManifestHandled = new Promise<void>((resolve, reject) => {
 				resolveFirstManifest = resolve;
 				rejectFirstManifest = reject;
+			});
+			const recoveryManifestCanContinue = new Promise<void>((resolve) => {
+				releaseRecoveryManifest = resolve;
 			});
 			page.on("load", () => {
 				documentLoads += 1;
@@ -349,6 +353,7 @@ test.describe("Apps v2 code splitting", () => {
 				async (route) => {
 					manifestRequests += 1;
 					if (manifestRequests !== 1) {
+						await recoveryManifestCanContinue;
 						await route.continue();
 						return;
 					}
@@ -375,6 +380,14 @@ test.describe("Apps v2 code splitting", () => {
 
 			await page.goto(`/apps/${APP_SLUG}`);
 			await firstManifestHandled;
+			await expect(
+				page.getByRole("heading", { name: "Application updated" }),
+			).toBeVisible();
+			await page.screenshot({
+				path: "playwright-results/application-update-transition.png",
+				fullPage: true,
+			});
+			releaseRecoveryManifest();
 			await expect(page.getByTestId("fixture-build")).toHaveText(
 				"recovered-build",
 			);
@@ -393,7 +406,7 @@ test.describe("Apps v2 code splitting", () => {
 			expect(manifestRequests).toBe(2);
 			expect(documentLoads).toBe(1);
 			await page.screenshot({
-				path: testInfo.outputPath("stale-asset-recovered.png"),
+				path: "playwright-results/stale-asset-recovered.png",
 				fullPage: true,
 			});
 		} finally {

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -15,6 +15,7 @@ import { EditorOverlay } from "@/components/editor/EditorOverlay";
 import { UnifiedDock } from "@/components/layout/UnifiedDock";
 import { QuickAccess } from "@/components/quick-access/QuickAccess";
 import { PageLoader } from "@/components/PageLoader";
+import { ApplicationUpdateGate } from "@/components/ApplicationUpdateScreen";
 import { RouteTransitionProgress } from "@/components/layout/RouteTransitionProgress";
 import { useEditorStore } from "@/stores/editorStore";
 import { useQuickAccessStore } from "@/stores/quickAccessStore";
@@ -792,18 +793,20 @@ function AppRoutes() {
 
 function App() {
 	return (
-		<ErrorBoundary>
-			<BrowserRouter>
-				<RouteTransitionProgress />
-				<AuthProvider>
-					<OrgScopeProvider>
-						<KeyboardProvider>
-							<AppRoutes />
-						</KeyboardProvider>
-					</OrgScopeProvider>
-				</AuthProvider>
-			</BrowserRouter>
-		</ErrorBoundary>
+		<ApplicationUpdateGate>
+			<ErrorBoundary>
+				<BrowserRouter>
+					<RouteTransitionProgress />
+					<AuthProvider>
+						<OrgScopeProvider>
+							<KeyboardProvider>
+								<AppRoutes />
+							</KeyboardProvider>
+						</OrgScopeProvider>
+					</AuthProvider>
+				</BrowserRouter>
+			</ErrorBoundary>
+		</ApplicationUpdateGate>
 	);
 }
 

--- a/client/src/components/ApplicationUpdateScreen.test.tsx
+++ b/client/src/components/ApplicationUpdateScreen.test.tsx
@@ -1,4 +1,4 @@
-import { act, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { requestApplicationReload } from "@/lib/application-update";
@@ -9,8 +9,10 @@ import {
 
 describe("ApplicationUpdateScreen", () => {
 	afterEach(() => {
+		vi.useRealTimers();
 		vi.restoreAllMocks();
 		sessionStorage.clear();
+		document.documentElement.style.removeProperty("--logo-square-url");
 	});
 
 	it("explains that fresh application assets are loading", () => {
@@ -21,10 +23,31 @@ describe("ApplicationUpdateScreen", () => {
 		).toBeInTheDocument();
 		expect(screen.getByText("Loading the latest version…")).toBeInTheDocument();
 		expect(screen.getByRole("status")).toHaveAttribute("aria-live", "polite");
+		expect(screen.getByRole("img", { name: "Application logo" })).toHaveAttribute(
+			"src",
+			"/logo.svg",
+		);
+	});
+
+	it("uses applied branding with the default logo as an error fallback", () => {
+		document.documentElement.style.setProperty(
+			"--logo-square-url",
+			'url("https://example.test/custom-logo.png")',
+		);
+		render(<ApplicationUpdateScreen />);
+
+		const logo = screen.getByRole("img", { name: "Application logo" });
+		expect(logo).toHaveAttribute(
+			"src",
+			"https://example.test/custom-logo.png",
+		);
+
+		fireEvent.error(logo);
+		expect(logo).toHaveAttribute("src", "/logo.svg");
 	});
 
 	it("replaces the main application before a deployment reload", () => {
-		vi.spyOn(window, "setTimeout").mockImplementation(() => 1);
+		vi.useFakeTimers();
 		render(
 			<ApplicationUpdateGate>
 				<div>Current application</div>

--- a/client/src/components/ApplicationUpdateScreen.test.tsx
+++ b/client/src/components/ApplicationUpdateScreen.test.tsx
@@ -1,0 +1,44 @@
+import { act, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { requestApplicationReload } from "@/lib/application-update";
+import {
+	ApplicationUpdateGate,
+	ApplicationUpdateScreen,
+} from "./ApplicationUpdateScreen";
+
+describe("ApplicationUpdateScreen", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+		sessionStorage.clear();
+	});
+
+	it("explains that fresh application assets are loading", () => {
+		render(<ApplicationUpdateScreen />);
+
+		expect(
+			screen.getByRole("heading", { name: "Application updated" }),
+		).toBeInTheDocument();
+		expect(screen.getByText("Loading the latest version…")).toBeInTheDocument();
+		expect(screen.getByRole("status")).toHaveAttribute("aria-live", "polite");
+	});
+
+	it("replaces the main application before a deployment reload", () => {
+		vi.spyOn(window, "setTimeout").mockImplementation(() => 1);
+		render(
+			<ApplicationUpdateGate>
+				<div>Current application</div>
+			</ApplicationUpdateGate>,
+		);
+
+		expect(screen.getByText("Current application")).toBeInTheDocument();
+		act(() => {
+			requestApplicationReload("component-update", 5_000);
+		});
+
+		expect(
+			screen.getByRole("heading", { name: "Application updated" }),
+		).toBeInTheDocument();
+		expect(screen.queryByText("Current application")).not.toBeInTheDocument();
+	});
+});

--- a/client/src/components/ApplicationUpdateScreen.tsx
+++ b/client/src/components/ApplicationUpdateScreen.tsx
@@ -1,5 +1,5 @@
-import { RefreshCw } from "lucide-react";
-import { type ReactNode, useSyncExternalStore } from "react";
+import { Loader2 } from "lucide-react";
+import { type ReactNode, useState, useSyncExternalStore } from "react";
 
 import {
 	getApplicationUpdateInProgress,
@@ -10,9 +10,21 @@ interface ApplicationUpdateScreenProps {
 	fullScreen?: boolean;
 }
 
+const DEFAULT_LOGO_URL = "/logo.svg";
+
+function getAppliedSquareLogoUrl(): string {
+	const cssUrl = document.documentElement.style
+		.getPropertyValue("--logo-square-url")
+		.trim();
+	const match = cssUrl.match(/^url\((['"]?)(.*)\1\)$/);
+	return match?.[2] || DEFAULT_LOGO_URL;
+}
+
 export function ApplicationUpdateScreen({
 	fullScreen = false,
 }: ApplicationUpdateScreenProps) {
+	const [logoUrl, setLogoUrl] = useState(getAppliedSquareLogoUrl);
+
 	return (
 		<div
 			className={
@@ -24,15 +36,19 @@ export function ApplicationUpdateScreen({
 			aria-live="polite"
 		>
 			<div className="flex max-w-sm flex-col items-center text-center">
-				<div className="mb-5 rounded-2xl bg-primary/10 p-4 text-primary ring-1 ring-primary/15">
-					<RefreshCw className="h-7 w-7 animate-spin" aria-hidden="true" />
-				</div>
+				<img
+					src={logoUrl}
+					alt="Application logo"
+					className="mb-5 h-16 w-16 object-contain"
+					onError={() => setLogoUrl(DEFAULT_LOGO_URL)}
+				/>
 				<h1 className="text-xl font-semibold tracking-tight">
 					Application updated
 				</h1>
-				<p className="mt-2 text-sm text-muted-foreground">
-					Loading the latest version…
-				</p>
+				<div className="mt-3 flex items-center gap-2 text-sm text-muted-foreground">
+					<Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+					<span>Loading the latest version…</span>
+				</div>
 			</div>
 		</div>
 	);

--- a/client/src/components/ApplicationUpdateScreen.tsx
+++ b/client/src/components/ApplicationUpdateScreen.tsx
@@ -1,0 +1,53 @@
+import { RefreshCw } from "lucide-react";
+import { type ReactNode, useSyncExternalStore } from "react";
+
+import {
+	getApplicationUpdateInProgress,
+	subscribeToApplicationUpdate,
+} from "@/lib/application-update";
+
+interface ApplicationUpdateScreenProps {
+	fullScreen?: boolean;
+}
+
+export function ApplicationUpdateScreen({
+	fullScreen = false,
+}: ApplicationUpdateScreenProps) {
+	return (
+		<div
+			className={
+				fullScreen
+					? "flex h-screen w-screen items-center justify-center bg-background p-6"
+					: "flex h-full min-h-[20rem] w-full items-center justify-center bg-background p-6"
+			}
+			role="status"
+			aria-live="polite"
+		>
+			<div className="flex max-w-sm flex-col items-center text-center">
+				<div className="mb-5 rounded-2xl bg-primary/10 p-4 text-primary ring-1 ring-primary/15">
+					<RefreshCw className="h-7 w-7 animate-spin" aria-hidden="true" />
+				</div>
+				<h1 className="text-xl font-semibold tracking-tight">
+					Application updated
+				</h1>
+				<p className="mt-2 text-sm text-muted-foreground">
+					Loading the latest version…
+				</p>
+			</div>
+		</div>
+	);
+}
+
+export function ApplicationUpdateGate({ children }: { children: ReactNode }) {
+	const updateInProgress = useSyncExternalStore(
+		subscribeToApplicationUpdate,
+		getApplicationUpdateInProgress,
+		() => false,
+	);
+
+	return updateInProgress ? (
+		<ApplicationUpdateScreen fullScreen />
+	) : (
+		children
+	);
+}

--- a/client/src/components/jsx-app/StandaloneV2App.test.tsx
+++ b/client/src/components/jsx-app/StandaloneV2App.test.tsx
@@ -221,7 +221,12 @@ describe("StandaloneV2App", () => {
 
 	it("recovers a stale JavaScript asset from a fresh manifest without reloading", async () => {
 		localStorage.setItem("bifrost_access_token", "tok-1");
-		mockAuthFetch.mockResolvedValueOnce(manifest("fresh"));
+		let resolveManifest!: (value: ReturnType<typeof manifest>) => void;
+		mockAuthFetch.mockReturnValueOnce(
+			new Promise((resolve) => {
+				resolveManifest = resolve;
+			}),
+		);
 		const mount = vi.fn<StandaloneV2Module["mount"]>(() => vi.fn());
 		render(<StandaloneV2App {...props("stale")} />);
 
@@ -230,7 +235,12 @@ describe("StandaloneV2App", () => {
 			stale = moduleScript("stale");
 		});
 		act(() => stale.dispatchEvent(new Event("error")));
+		expect(
+			await screen.findByRole("heading", { name: "Application updated" }),
+		).toBeInTheDocument();
+		expect(screen.getByText("Loading the latest version…")).toBeInTheDocument();
 
+		await act(async () => resolveManifest(manifest("fresh")));
 		await finishModuleLoad("fresh", mount);
 		await waitFor(() => expect(mount).toHaveBeenCalledTimes(1));
 		expect(mockAuthFetch).toHaveBeenCalledWith(

--- a/client/src/components/jsx-app/StandaloneV2App.test.tsx
+++ b/client/src/components/jsx-app/StandaloneV2App.test.tsx
@@ -12,6 +12,12 @@ const orgScopeState = vi.hoisted(() => ({
 	scope: { type: "global" as "global" | "organization", orgId: null as string | null },
 }));
 
+const { mockAuthFetch } = vi.hoisted(() => ({ mockAuthFetch: vi.fn() }));
+
+vi.mock("@/lib/api-client", () => ({
+	authFetch: (...args: unknown[]) => mockAuthFetch(...args),
+}));
+
 vi.mock("@/hooks/useOrgScope", () => ({
 	useOrgScope: () => ({ scope: orgScopeState.scope }),
 }));
@@ -30,6 +36,7 @@ function props(entry: string) {
 }
 
 let appendedScripts: HTMLScriptElement[] = [];
+let appendedStylesheets: HTMLLinkElement[] = [];
 
 function moduleScript(entry: string): HTMLScriptElement {
 	const script = appendedScripts.find(
@@ -37,6 +44,28 @@ function moduleScript(entry: string): HTMLScriptElement {
 	);
 	if (!script) throw new Error(`No module script found for ${entry}`);
 	return script;
+}
+
+function stylesheet(name: string): HTMLLinkElement {
+	const link = appendedStylesheets.find((candidate) =>
+		candidate.href.endsWith(`assets/${name}.css`),
+	);
+	if (!link) throw new Error(`No stylesheet found for ${name}`);
+	return link;
+}
+
+function manifest(entry: string, css: string | null = null) {
+	return {
+		ok: true,
+		status: 200,
+		json: async () => ({
+			entry: `assets/${entry}.js`,
+			css: css ? `assets/${css}.css` : null,
+			base_url: "/api/applications/app-1/dist",
+			app_model: "standalone_v2",
+			runtime_contract: "mount-v1",
+		}),
+	};
 }
 
 async function finishModuleLoad(
@@ -54,11 +83,13 @@ async function finishModuleLoad(
 
 beforeEach(() => {
 	appendedScripts = [];
+	appendedStylesheets = [];
 	localStorage.clear();
 	sessionStorage.clear();
 	orgScopeState.scope = { type: "global", orgId: null };
 	delete window.__BIFROST_APP__;
 	delete window.__BIFROST_APP_MODULES__;
+	mockAuthFetch.mockReset();
 	vi.spyOn(console, "error").mockImplementation(() => {});
 	const appendChild = document.head.appendChild.bind(document.head);
 	vi.spyOn(document.head, "appendChild").mockImplementation(
@@ -67,6 +98,10 @@ beforeEach(() => {
 			// error. Retain them in-memory so each test controls load completion.
 			if (node instanceof HTMLScriptElement) {
 				appendedScripts.push(node);
+				return node;
+			}
+			if (node instanceof HTMLLinkElement) {
+				appendedStylesheets.push(node);
 				return node;
 			}
 			return appendChild(node) as T;
@@ -95,13 +130,11 @@ describe("StandaloneV2App", () => {
 		);
 		expect(script.src).not.toMatch(/[?&](m|mode|import)=/);
 
-		const stylesheet = document.querySelector<HTMLLinkElement>(
-			'link[rel="stylesheet"]',
-		);
-		expect(stylesheet?.href).toBe(
+		const stylesheet = appendedStylesheets[0];
+		expect(stylesheet.href).toBe(
 			`${window.location.origin}/api/applications/app-1/dist/assets/main.css`,
 		);
-		expect(stylesheet?.href).not.toContain("?");
+		expect(stylesheet.href).not.toContain("?");
 	});
 
 	it("passes isolated bootstrap to mount and calls its teardown", async () => {
@@ -154,6 +187,88 @@ describe("StandaloneV2App", () => {
 			appId: "app-1",
 			basename: "/apps/dash",
 		});
+	});
+
+	it("remounts when the parent supplies a newer manifest", async () => {
+		localStorage.setItem("bifrost_access_token", "tok-1");
+		const firstTeardown = vi.fn();
+		const secondTeardown = vi.fn();
+		const firstMount = vi.fn<StandaloneV2Module["mount"]>(() => firstTeardown);
+		const secondMount = vi.fn<StandaloneV2Module["mount"]>(() => secondTeardown);
+		const { rerender } = render(<StandaloneV2App {...props("first")} />);
+
+		await finishModuleLoad("first", firstMount);
+		await waitFor(() => expect(firstMount).toHaveBeenCalledTimes(1));
+
+		rerender(<StandaloneV2App {...props("second")} />);
+		await finishModuleLoad("second", secondMount);
+
+		await waitFor(() => expect(secondMount).toHaveBeenCalledTimes(1));
+		expect(firstTeardown).toHaveBeenCalledTimes(1);
+	});
+
+	it("waits for both the module and stylesheet before mounting", async () => {
+		localStorage.setItem("bifrost_access_token", "tok-1");
+		const mount = vi.fn<StandaloneV2Module["mount"]>(() => vi.fn());
+		render(<StandaloneV2App {...props("styled")} css="assets/styled.css" />);
+
+		await finishModuleLoad("styled", mount);
+		expect(mount).not.toHaveBeenCalled();
+
+		act(() => stylesheet("styled").dispatchEvent(new Event("load")));
+		await waitFor(() => expect(mount).toHaveBeenCalledTimes(1));
+	});
+
+	it("recovers a stale JavaScript asset from a fresh manifest without reloading", async () => {
+		localStorage.setItem("bifrost_access_token", "tok-1");
+		mockAuthFetch.mockResolvedValueOnce(manifest("fresh"));
+		const mount = vi.fn<StandaloneV2Module["mount"]>(() => vi.fn());
+		render(<StandaloneV2App {...props("stale")} />);
+
+		let stale!: HTMLScriptElement;
+		await waitFor(() => {
+			stale = moduleScript("stale");
+		});
+		act(() => stale.dispatchEvent(new Event("error")));
+
+		await finishModuleLoad("fresh", mount);
+		await waitFor(() => expect(mount).toHaveBeenCalledTimes(1));
+		expect(mockAuthFetch).toHaveBeenCalledWith(
+			"/api/applications/app-1/bundle-manifest?mode=live",
+			expect.objectContaining({ cache: "no-store" }),
+		);
+	});
+
+	it("recovers a stale stylesheet and mounts only the refreshed bundle", async () => {
+		localStorage.setItem("bifrost_access_token", "tok-1");
+		mockAuthFetch.mockResolvedValueOnce(manifest("fresh-css", "fresh-css"));
+		const oldMount = vi.fn<StandaloneV2Module["mount"]>(() => vi.fn());
+		const freshMount = vi.fn<StandaloneV2Module["mount"]>(() => vi.fn());
+		render(<StandaloneV2App {...props("stale-css")} css="assets/stale-css.css" />);
+
+		await finishModuleLoad("stale-css", oldMount);
+		act(() => stylesheet("stale-css").dispatchEvent(new Event("error")));
+
+		await finishModuleLoad("fresh-css", freshMount);
+		act(() => stylesheet("fresh-css").dispatchEvent(new Event("load")));
+
+		await waitFor(() => expect(freshMount).toHaveBeenCalledTimes(1));
+		expect(oldMount).not.toHaveBeenCalled();
+	});
+
+	it("stops after one manifest refresh when the latest asset is still unavailable", async () => {
+		localStorage.setItem("bifrost_access_token", "tok-1");
+		mockAuthFetch.mockResolvedValueOnce(manifest("still-stale"));
+		render(<StandaloneV2App {...props("still-stale")} />);
+
+		let script!: HTMLScriptElement;
+		await waitFor(() => {
+			script = moduleScript("still-stale");
+		});
+		act(() => script.dispatchEvent(new Event("error")));
+
+		expect(await screen.findByText(/Failed to load the application entry/i)).toBeInTheDocument();
+		expect(mockAuthFetch).toHaveBeenCalledTimes(1);
 	});
 
 	it("uses the preview basename when requested", async () => {

--- a/client/src/components/jsx-app/StandaloneV2App.tsx
+++ b/client/src/components/jsx-app/StandaloneV2App.tsx
@@ -6,9 +6,10 @@
  * once per host mount. This preserves browser ES-module identity across lazy
  * chunks while still giving every mount its own React root and bootstrap.
  */
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 
 import { useOrgScope } from "@/hooks/useOrgScope";
+import { authFetch } from "@/lib/api-client";
 import { clearAuthTokens, getActiveToken } from "@/lib/auth-token";
 
 export interface BifrostAppBootstrap {
@@ -64,6 +65,8 @@ interface PendingLegacyLoad {
 
 const pendingLegacyLoads = new Map<string, PendingLegacyLoad>();
 
+class ApplicationAssetLoadError extends Error {}
+
 function registeredModule(entryUrl: string): StandaloneV2Module | undefined {
 	return window.__BIFROST_APP_MODULES__?.get(entryUrl);
 }
@@ -101,7 +104,11 @@ function loadMountModule(entryUrl: string): Promise<StandaloneV2Module> {
 		};
 		script.onerror = () => {
 			cleanup();
-			reject(new Error(`Failed to load the application entry: ${entryUrl}`));
+			reject(
+				new ApplicationAssetLoadError(
+					`Failed to load the application entry: ${entryUrl}`,
+				),
+			);
 		};
 		document.head.appendChild(script);
 	}).catch((error: unknown) => {
@@ -172,7 +179,11 @@ function loadLegacyOrUnmarkedModule(
 			};
 			script.onerror = () => {
 				cleanup();
-				reject(new Error(`Failed to load the legacy application entry: ${entryUrl}`));
+				reject(
+					new ApplicationAssetLoadError(
+						`Failed to load the legacy application entry: ${entryUrl}`,
+					),
+				);
 			};
 			document.head.appendChild(script);
 		});
@@ -210,6 +221,21 @@ interface StandaloneV2AppProps {
 	runtimeContract: StandaloneV2RuntimeContract;
 }
 
+interface StandaloneAssets {
+	entry: string;
+	css: string | null;
+	baseUrl: string;
+	runtimeContract: StandaloneV2RuntimeContract;
+}
+
+interface StandaloneBundleManifest {
+	entry: string | null;
+	css: string | null;
+	base_url: string;
+	app_model?: "inline_v1" | "standalone_v2";
+	runtime_contract?: StandaloneV2RuntimeContract;
+}
+
 export function StandaloneV2App({
 	appId,
 	appSlug,
@@ -222,6 +248,20 @@ export function StandaloneV2App({
 }: StandaloneV2AppProps) {
 	const containerRef = useRef<HTMLDivElement>(null);
 	const [loadError, setLoadError] = useState<string | null>(null);
+	const sourceAssets = useMemo<StandaloneAssets>(
+		() => ({ entry, css, baseUrl, runtimeContract }),
+		[entry, css, baseUrl, runtimeContract],
+	);
+	const sourceKey = useMemo(
+		() => JSON.stringify({ appId, isPreview, assets: sourceAssets }),
+		[appId, isPreview, sourceAssets],
+	);
+	const [recovery, setRecovery] = useState<{
+		sourceKey: string;
+		assets: StandaloneAssets;
+	} | null>(null);
+	const assets = recovery?.sourceKey === sourceKey ? recovery.assets : sourceAssets;
+	const recoveryAttempts = useRef(new Set<string>());
 	const { scope } = useOrgScope();
 
 	const token = getActiveToken();
@@ -237,14 +277,30 @@ export function StandaloneV2App({
 			: `/apps/${appSlug}`;
 		const orgScope =
 			appOrgId ?? (scope.type === "organization" ? scope.orgId : null);
-		const entryUrl = new URL(`${baseUrl}/${entry}`, window.location.origin).href;
+		const entryUrl = new URL(
+			`${assets.baseUrl}/${assets.entry}`,
+			window.location.origin,
+		).href;
 		mountEl.dataset.bifrostEntry = entryUrl;
 
 		let cssEl: HTMLLinkElement | null = null;
-		if (css) {
+		let stylesheetReady = Promise.resolve();
+		if (assets.css) {
 			cssEl = document.createElement("link");
 			cssEl.rel = "stylesheet";
-			cssEl.href = new URL(`${baseUrl}/${css}`, window.location.origin).href;
+			cssEl.href = new URL(
+				`${assets.baseUrl}/${assets.css}`,
+				window.location.origin,
+			).href;
+			stylesheetReady = new Promise<void>((resolve, reject) => {
+				cssEl!.onload = () => resolve();
+				cssEl!.onerror = () =>
+					reject(
+						new ApplicationAssetLoadError(
+							`Failed to load the application stylesheet: ${cssEl!.href}`,
+						),
+					);
+			});
 			document.head.appendChild(cssEl);
 		}
 
@@ -263,11 +319,60 @@ export function StandaloneV2App({
 			theme: document.documentElement.classList.contains("dark") ? "dark" : "light",
 		};
 
-		const reportError = (value: unknown) => {
-			if (!cancelled) {
+		const reportError = async (value: unknown) => {
+			if (cancelled) return;
+			if (!(value instanceof ApplicationAssetLoadError)) {
 				setLoadError(
 					value instanceof Error ? value.message : "Failed to load the application.",
 				);
+				return;
+			}
+			const failedAssetKey = JSON.stringify(assets);
+			const recoveryAttemptKey = JSON.stringify({ sourceKey, assets });
+			if (recoveryAttempts.current.has(recoveryAttemptKey)) {
+				setLoadError(
+					value instanceof Error ? value.message : "Failed to load the application.",
+				);
+				return;
+			}
+			recoveryAttempts.current.add(recoveryAttemptKey);
+
+			try {
+				const mode = isPreview ? "draft" : "live";
+				const response = await authFetch(
+					`/api/applications/${appId}/bundle-manifest?mode=${mode}`,
+					{
+						cache: "no-store",
+						headers: { "Cache-Control": "no-cache" },
+					},
+				);
+				if (!response.ok) {
+					throw new Error(`Bundle manifest refresh failed: ${response.status}`);
+				}
+				const manifest = (await response.json()) as StandaloneBundleManifest;
+				if (manifest.app_model !== "standalone_v2" || !manifest.entry) {
+					throw new Error("The refreshed manifest is not a built standalone app.");
+				}
+				const refreshed: StandaloneAssets = {
+					entry: manifest.entry,
+					css: manifest.css,
+					baseUrl: manifest.base_url,
+					runtimeContract: manifest.runtime_contract ?? null,
+				};
+				if (JSON.stringify(refreshed) === failedAssetKey) {
+					throw value instanceof Error
+						? value
+						: new Error("The latest application assets are unavailable.");
+				}
+				if (!cancelled) setRecovery({ sourceKey, assets: refreshed });
+			} catch (recoveryError) {
+				if (!cancelled) {
+					setLoadError(
+						recoveryError instanceof Error
+							? recoveryError.message
+							: "Failed to recover the application after deployment.",
+					);
+				}
 			}
 		};
 		const mountModule = (appModule: StandaloneV2Module) => {
@@ -280,8 +385,10 @@ export function StandaloneV2App({
 		};
 
 		let legacyBootstrap: LegacyBifrostAppBootstrap | null = null;
-		if (runtimeContract === "mount-v1") {
-			loadMountModule(entryUrl).then(mountModule).catch(reportError);
+		if (assets.runtimeContract === "mount-v1") {
+			Promise.all([loadMountModule(entryUrl), stylesheetReady])
+				.then(([appModule]) => mountModule(appModule))
+				.catch((error: unknown) => void reportError(error));
 		} else {
 			legacyBootstrap = {
 				...bootstrap,
@@ -290,7 +397,9 @@ export function StandaloneV2App({
 					appTeardown = teardown;
 				},
 			};
-			loadLegacyOrUnmarkedModule(entryUrl, legacyBootstrap)
+			const bootstrapForLoad = legacyBootstrap;
+			stylesheetReady
+				.then(() => loadLegacyOrUnmarkedModule(entryUrl, bootstrapForLoad))
 				.then((result) => {
 					if (cancelled) return;
 					if (result.kind === "module") {
@@ -305,7 +414,7 @@ export function StandaloneV2App({
 						);
 					}
 				})
-				.catch(reportError);
+				.catch((error: unknown) => void reportError(error));
 		}
 
 		return () => {
@@ -334,11 +443,9 @@ export function StandaloneV2App({
 		appId,
 		appSlug,
 		isPreview,
-		entry,
-		css,
-		baseUrl,
+		assets,
+		sourceKey,
 		appOrgId,
-		runtimeContract,
 		scope,
 		token,
 	]);

--- a/client/src/components/jsx-app/StandaloneV2App.tsx
+++ b/client/src/components/jsx-app/StandaloneV2App.tsx
@@ -8,6 +8,7 @@
  */
 import { useEffect, useMemo, useRef, useState } from "react";
 
+import { ApplicationUpdateScreen } from "@/components/ApplicationUpdateScreen";
 import { useOrgScope } from "@/hooks/useOrgScope";
 import { authFetch } from "@/lib/api-client";
 import { clearAuthTokens, getActiveToken } from "@/lib/auth-token";
@@ -248,6 +249,7 @@ export function StandaloneV2App({
 }: StandaloneV2AppProps) {
 	const containerRef = useRef<HTMLDivElement>(null);
 	const [loadError, setLoadError] = useState<string | null>(null);
+	const [isRecovering, setIsRecovering] = useState(false);
 	const sourceAssets = useMemo<StandaloneAssets>(
 		() => ({ entry, css, baseUrl, runtimeContract }),
 		[entry, css, baseUrl, runtimeContract],
@@ -336,6 +338,7 @@ export function StandaloneV2App({
 				return;
 			}
 			recoveryAttempts.current.add(recoveryAttemptKey);
+			setIsRecovering(true);
 
 			try {
 				const mode = isPreview ? "draft" : "live";
@@ -364,9 +367,13 @@ export function StandaloneV2App({
 						? value
 						: new Error("The latest application assets are unavailable.");
 				}
-				if (!cancelled) setRecovery({ sourceKey, assets: refreshed });
+				if (!cancelled) {
+					setRecovery({ sourceKey, assets: refreshed });
+					setIsRecovering(false);
+				}
 			} catch (recoveryError) {
 				if (!cancelled) {
+					setIsRecovering(false);
 					setLoadError(
 						recoveryError instanceof Error
 							? recoveryError.message
@@ -459,6 +466,8 @@ export function StandaloneV2App({
 			</div>
 		);
 	}
+
+	if (isRecovering) return <ApplicationUpdateScreen />;
 
 	return (
 		<div

--- a/client/src/lib/app-sdk/execution-stream.test.ts
+++ b/client/src/lib/app-sdk/execution-stream.test.ts
@@ -31,7 +31,11 @@ beforeEach(() => {
   MockWebSocket.instances = [];
   vi.stubGlobal("WebSocket", MockWebSocket);
 });
-afterEach(() => vi.unstubAllGlobals());
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
 
 describe("subscribeToExecution", () => {
   it("subscribes to the execution channel on open", () => {
@@ -138,11 +142,58 @@ describe("subscribeToExecution", () => {
 
   it("dedupes onSocketDown when error is followed by close", () => {
     const down = vi.fn();
-    subscribeToExecution("abc-123", () => {}, down);
+    const unsubscribe = subscribeToExecution("abc-123", () => {}, down);
     const ws = MockWebSocket.instances[0];
     ws.emit("error", {});
     ws.emit("close", { code: 1000 });
     expect(down).toHaveBeenCalledTimes(1);
+    unsubscribe();
+  });
+
+  it("reconnects after a deployment close and re-emits ready after acknowledgement", () => {
+    vi.useFakeTimers();
+    vi.spyOn(Math, "random").mockReturnValue(0.5);
+    const events: ExecutionStreamEvent[] = [];
+    const down = vi.fn();
+    const unsubscribe = subscribeToExecution(
+      "abc-123",
+      (event) => events.push(event),
+      down,
+    );
+
+    const first = MockWebSocket.instances[0];
+    first.emit("open", {});
+    first.emit("message", {
+      data: JSON.stringify({ type: "subscribed", channel: "execution:abc-123" }),
+    });
+    first.emit("close", { code: 1012 });
+
+    expect(down).toHaveBeenCalledTimes(1);
+    expect(MockWebSocket.instances).toHaveLength(1);
+    vi.advanceTimersByTime(500);
+
+    const second = MockWebSocket.instances[1];
+    second.emit("open", {});
+    second.emit("message", {
+      data: JSON.stringify({ type: "subscribed", channel: "execution:abc-123" }),
+    });
+
+    expect(JSON.parse(second.sent[0])).toEqual({
+      type: "subscribe",
+      channels: [{ name: "execution:abc-123" }],
+    });
+    expect(events).toEqual([{ type: "ready" }, { type: "ready" }]);
+    unsubscribe();
+  });
+
+  it("does not retry authentication and policy close codes", () => {
+    vi.useFakeTimers();
+    const unsubscribe = subscribeToExecution("abc-123", () => {});
+    MockWebSocket.instances[0].emit("close", { code: 4001 });
+
+    vi.advanceTimersByTime(60_000);
+    expect(MockWebSocket.instances).toHaveLength(1);
+    unsubscribe();
   });
 
   it("ignores unparseable frames", () => {

--- a/client/src/lib/app-sdk/execution-stream.ts
+++ b/client/src/lib/app-sdk/execution-stream.ts
@@ -8,7 +8,7 @@
  * result (large results are not rebroadcast; see #483) — the caller fetches
  * `/api/executions/{id}` when isTerminal fires.
  */
-import { buildWsUrl } from "./ws-client";
+import { createReconnectingSubscription } from "./ws-client";
 
 const TERMINAL_STATUSES = new Set([
   "Success",
@@ -30,78 +30,55 @@ export function subscribeToExecution(
   onEvent: (evt: ExecutionStreamEvent) => void,
   onSocketDown?: () => void,
 ): () => void {
-  const ws = new WebSocket(buildWsUrl());
   const channel = `execution:${executionId}`;
-  let closedByClient = false;
-  let downFired = false;
-
-  const fireSocketDown = () => {
-    if (!closedByClient && !downFired) {
-      downFired = true;
-      onSocketDown?.();
-    }
-  };
-
-  ws.addEventListener("open", () => {
-    ws.send(
-      JSON.stringify({
-        type: "subscribe",
-        channels: [{ name: channel }],
-      }),
-    );
-  });
-
-  ws.addEventListener("message", (e) => {
-    try {
-      const msg = JSON.parse(e.data);
+  return createReconnectingSubscription({
+    channel,
+    subscribeFrame: {
+      type: "subscribe",
+      channels: [{ name: channel }],
+    },
+    label: "execution stream",
+    onSocketDown,
+    onMessage: (msg) => {
       if (msg.type === "subscribed" && msg.channel === channel) {
         // The server adds the socket to the channel before acknowledging it.
-        // A result check at this point closes the gap between the initial GET
-        // and the live subscription becoming authoritative.
+        // This fires after every successful reconnect as well as the initial
+        // connection, closing any gap with an authoritative REST read.
         onEvent({ type: "ready" });
       } else if (
-        (msg.type === "error" && (msg.channel === undefined || msg.channel === channel)) ||
+        (msg.type === "error" &&
+          (msg.channel === undefined || msg.channel === channel)) ||
         (msg.type === "subscription_revoked" && msg.channel === channel)
       ) {
         console.warn("[bifrost-sdk] execution stream subscription unavailable");
-        fireSocketDown();
-        ws.close();
-      } else if (msg.type === "execution_update" && msg.executionId === executionId) {
+        onSocketDown?.();
+        return false;
+      } else if (
+        msg.type === "execution_update" &&
+        msg.executionId === executionId
+      ) {
+        const status = typeof msg.status === "string" ? msg.status : undefined;
         onEvent({
           type: "status",
-          status: msg.status,
-          isTerminal: TERMINAL_STATUSES.has(msg.status),
+          status,
+          isTerminal: status ? TERMINAL_STATUSES.has(status) : false,
         });
-      } else if (msg.type === "execution_log" && msg.executionId === executionId) {
+      } else if (
+        msg.type === "execution_log" &&
+        msg.executionId === executionId
+      ) {
         onEvent({
           type: "log",
           log: {
-            level: msg.level,
-            message: msg.message,
-            timestamp: msg.timestamp,
-            sequence: msg.sequence,
+            level: String(msg.level ?? "info"),
+            message: String(msg.message ?? ""),
+            timestamp: String(msg.timestamp ?? ""),
+            sequence:
+              typeof msg.sequence === "number" ? msg.sequence : undefined,
           },
         });
       }
-    } catch {
-      // ignore unparseable frames — same policy as subscribeToTable
-    }
+      return true;
+    },
   });
-
-  ws.addEventListener("error", () => {
-    console.warn("[bifrost-sdk] execution stream socket error");
-    fireSocketDown();
-  });
-
-  ws.addEventListener("close", (e) => {
-    if (!closedByClient && !downFired) {
-      console.warn("[bifrost-sdk] execution stream closed", e.code);
-      fireSocketDown();
-    }
-  });
-
-  return () => {
-    closedByClient = true;
-    ws.close();
-  };
 }

--- a/client/src/lib/app-sdk/tables.ts
+++ b/client/src/lib/app-sdk/tables.ts
@@ -314,9 +314,10 @@ export const tables = {
     tableId: string,
     filter: Expr | null,
     onEvent: (evt: TableChangeEvent) => void,
+    onReconnect?: () => void,
   ): () => void {
     return subscribeToTable(tableId, filter, (msg) => {
       onEvent(msg as TableChangeEvent);
-    });
+    }, onReconnect);
   },
 };

--- a/client/src/lib/app-sdk/use-files.test.tsx
+++ b/client/src/lib/app-sdk/use-files.test.tsx
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 const subscribeMock = vi.fn();
 let lastOnEvent: ((evt: Record<string, unknown>) => void) | null = null;
 let lastUnsubscribe: ReturnType<typeof vi.fn> | null = null;
+let lastOnReconnect: (() => void) | null = null;
 
 vi.mock("./ws-client", () => ({
 	subscribeToFiles: (
@@ -11,10 +12,13 @@ vi.mock("./ws-client", () => ({
 		prefix: string,
 		scope: string | null | undefined,
 		cb: (evt: Record<string, unknown>) => void,
+		onReconnect?: () => void,
 	) => {
 		lastOnEvent = cb;
+		lastOnReconnect = onReconnect ?? null;
 		lastUnsubscribe = vi.fn(() => {
 			lastOnEvent = null;
+			lastOnReconnect = null;
 		});
 		subscribeMock(location, prefix, scope, cb);
 		return lastUnsubscribe;
@@ -37,6 +41,7 @@ describe("useFiles", () => {
 		subscribeMock.mockClear();
 		lastOnEvent = null;
 		lastUnsubscribe = null;
+		lastOnReconnect = null;
 	});
 
 	// Unstub the global `fetch` after the last test too, so the stub does not
@@ -142,6 +147,26 @@ describe("useFiles", () => {
 
 		await waitFor(() =>
 			expect(result.current.files).toEqual(["a.txt", "b.txt"]),
+		);
+		expect(fetchMock).toHaveBeenCalledTimes(2);
+	});
+
+	it("refetches the list after a subscription reconnect", async () => {
+		const fetchMock = vi
+			.fn()
+			.mockResolvedValueOnce(okJson({ files: ["a.txt"], files_metadata: [] }))
+			.mockResolvedValueOnce(
+				okJson({ files: ["a.txt", "missed.txt"], files_metadata: [] }),
+			);
+		vi.stubGlobal("fetch", fetchMock);
+
+		const { result } = renderHook(() => useFiles(""));
+		await waitFor(() => expect(result.current.files).toEqual(["a.txt"]));
+
+		act(() => lastOnReconnect?.());
+
+		await waitFor(() =>
+			expect(result.current.files).toEqual(["a.txt", "missed.txt"]),
 		);
 		expect(fetchMock).toHaveBeenCalledTimes(2);
 	});

--- a/client/src/lib/app-sdk/use-files.ts
+++ b/client/src/lib/app-sdk/use-files.ts
@@ -99,6 +99,11 @@ export function useFiles(
 					void loadIfCurrent();
 				}
 			},
+			() => {
+				// Re-list after the replacement subscription is acknowledged so
+				// changes made during the disconnected window cannot stay hidden.
+				void loadIfCurrent();
+			},
 		);
 
 		return () => {

--- a/client/src/lib/app-sdk/use-infinite-table.test.tsx
+++ b/client/src/lib/app-sdk/use-infinite-table.test.tsx
@@ -5,17 +5,21 @@ const subscribeMock = vi.fn();
 let lastOnEvent:
   | ((evt: Record<string, unknown>) => void)
   | null = null;
+let lastOnReconnect: (() => void) | null = null;
 
 vi.mock("./ws-client", () => ({
   subscribeToTable: (
     _tableId: string,
     _filter: unknown,
     cb: (evt: Record<string, unknown>) => void,
+    onReconnect?: () => void,
   ) => {
     lastOnEvent = cb;
+    lastOnReconnect = onReconnect ?? null;
     subscribeMock(_tableId, _filter, cb);
     return () => {
       lastOnEvent = null;
+      lastOnReconnect = null;
     };
   },
 }));
@@ -41,6 +45,7 @@ describe("useInfiniteTable", () => {
     vi.restoreAllMocks();
     subscribeMock.mockClear();
     lastOnEvent = null;
+    lastOnReconnect = null;
   });
 
   it("loads the first page with skip_count omitted (server returns count)", async () => {
@@ -80,6 +85,33 @@ describe("useInfiniteTable", () => {
     expect(secondBody.skip_count).toBe(true);
     expect(secondBody.offset).toBe(2);
     expect(result.current.rows.map((r) => r.id)).toEqual(["a", "b", "c", "d"]);
+  });
+
+  it("refreshes all loaded rows after a subscription reconnect", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(makePage(["a", "b"], 4))
+      .mockResolvedValueOnce(makePage(["c", "d"], 4))
+      .mockResolvedValueOnce(makePage(["a", "b", "c", "changed"], 4));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { result } = renderHook(() =>
+      useInfiniteTable("t1", { pageSize: 2 }),
+    );
+    await waitFor(() => expect(result.current.rows).toHaveLength(2));
+    await act(async () => result.current.loadMore());
+    expect(result.current.rows.map((row) => row.id)).toEqual(["a", "b", "c", "d"]);
+
+    act(() => lastOnReconnect?.());
+
+    await waitFor(() =>
+      expect(result.current.rows.map((row) => row.id)).toEqual([
+        "a",
+        "b",
+        "c",
+        "changed",
+      ]),
+    );
   });
 
   it("hasMore flips false when a partial page comes back", async () => {

--- a/client/src/lib/app-sdk/use-infinite-table.ts
+++ b/client/src/lib/app-sdk/use-infinite-table.ts
@@ -102,6 +102,41 @@ export function useInfiniteTable(
 
     let unsubscribe: (() => void) | null = null;
 
+    async function refreshLoadedSnapshot() {
+      const targetCount = Math.max(offsetRef.current, pageSize);
+      const refreshedRows: TableRow[] = [];
+      let refreshOffset = 0;
+      let total = 0;
+
+      while (refreshOffset < targetCount) {
+        const limit = Math.min(1000, targetCount - refreshOffset);
+        const snap = await tables.query(
+          name,
+          {
+            where,
+            limit,
+            offset: refreshOffset,
+            order_by,
+            order_dir,
+            skip_count: refreshOffset > 0 ? true : undefined,
+          },
+          scope,
+        );
+        if (cancelledRef.current) return;
+        if (refreshOffset === 0) total = snap.total;
+        const pageRows = snap.documents.map(flattenDocument);
+        refreshedRows.push(...pageRows);
+        refreshOffset += pageRows.length;
+        if (pageRows.length < limit) break;
+      }
+
+      if (cancelledRef.current) return;
+      setRows(refreshedRows);
+      offsetRef.current = refreshedRows.length;
+      setHasMore(refreshedRows.length < total);
+      setError(null);
+    }
+
     async function init() {
       try {
         // Pre-compile the filter so we surface unsupported-operator errors
@@ -131,6 +166,13 @@ export function useInfiniteTable(
                 return;
               }
               applyEvent(evt, setRows);
+            },
+            () => {
+              void refreshLoadedSnapshot().catch((e) => {
+                if (!cancelledRef.current) {
+                  setError(e instanceof Error ? e : new Error(String(e)));
+                }
+              });
             },
           );
         }

--- a/client/src/lib/app-sdk/use-table.test.tsx
+++ b/client/src/lib/app-sdk/use-table.test.tsx
@@ -6,17 +6,21 @@ const subscribeMock = vi.fn();
 let lastOnEvent:
   | ((evt: Record<string, unknown>) => void)
   | null = null;
+let lastOnReconnect: (() => void) | null = null;
 
 vi.mock("./ws-client", () => ({
   subscribeToTable: (
     _tableId: string,
     _filter: unknown,
     cb: (evt: Record<string, unknown>) => void,
+    onReconnect?: () => void,
   ) => {
     lastOnEvent = cb;
+    lastOnReconnect = onReconnect ?? null;
     subscribeMock(_tableId, _filter, cb);
     return () => {
       lastOnEvent = null;
+      lastOnReconnect = null;
     };
   },
 }));
@@ -28,6 +32,7 @@ describe("useTable", () => {
     vi.restoreAllMocks();
     subscribeMock.mockClear();
     lastOnEvent = null;
+    lastOnReconnect = null;
   });
 
   it("returns initial snapshot flattened to match the ws event shape", async () => {
@@ -92,6 +97,31 @@ describe("useTable", () => {
     expect(result.current.rows).toHaveLength(1);
     expect(result.current.rows[0]?.id).toBe("r1");
     expect((result.current.rows[0] as { x?: unknown }).x).toBe(1);
+  });
+
+  it("refreshes the authoritative page snapshot after a reconnect", async () => {
+    const response = (id: string, value: number) =>
+      new Response(
+        JSON.stringify({
+          documents: [{ id, data: { value } }],
+          table_id: "tbl-uuid",
+          total: 1,
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(response("before", 1))
+      .mockResolvedValueOnce(response("after", 2));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { result } = renderHook(() => useTable("t1"));
+    await waitFor(() => expect(result.current.rows[0]?.id).toBe("before"));
+
+    act(() => lastOnReconnect?.());
+
+    await waitFor(() => expect(result.current.rows[0]?.id).toBe("after"));
+    expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
   it("applies updates by replacing the row with matching id", async () => {

--- a/client/src/lib/app-sdk/use-table.ts
+++ b/client/src/lib/app-sdk/use-table.ts
@@ -285,6 +285,20 @@ export function useTable(
     const offset = Math.max(0, (page - 1) * pageSize);
     const limit = pageSize;
 
+    async function loadSnapshot() {
+      const snap = await tables.query(
+        name,
+        { where, limit, offset, order_by, order_dir },
+        scope,
+      );
+      if (cancelled) return null;
+      setRows(snap.documents.map(flattenDocument));
+      setTotal(snap.total);
+      setError(null);
+      setLoading(false);
+      return snap;
+    }
+
     async function init() {
       try {
         // Compile the filter once, before issuing the snapshot — if the
@@ -295,15 +309,8 @@ export function useTable(
           ? compileFilterToExpr(where)
           : null;
 
-        const snap = await tables.query(
-          name,
-          { where, limit, offset, order_by, order_dir },
-          scope,
-        );
-        if (cancelled) return;
-        setRows(snap.documents.map(flattenDocument));
-        setTotal(snap.total);
-        setLoading(false);
+        const snap = await loadSnapshot();
+        if (!snap) return;
 
         // Subscribe by the canonical table UUID resolved server-side in the
         // requested scope. This sidesteps the cross-org name ambiguity that
@@ -325,6 +332,16 @@ export function useTable(
               return;
             }
             applyPagedEvent(evt, pageSize, setRows, setTotal);
+          },
+          () => {
+            // Events can be missed while the transport is down. Once the
+            // server acknowledges the replacement subscription, replace the
+            // visible window with a fresh authoritative snapshot.
+            void loadSnapshot().catch((e) => {
+              if (!cancelled) {
+                setError(e instanceof Error ? e : new Error(String(e)));
+              }
+            });
           },
         );
       } catch (e) {

--- a/client/src/lib/app-sdk/ws-client.test.ts
+++ b/client/src/lib/app-sdk/ws-client.test.ts
@@ -1,10 +1,128 @@
-import { afterEach, describe, expect, it } from "vitest";
-
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { setBifrostTransport } from "./tables";
-import { buildWsUrl } from "./ws-client";
+import { buildWsUrl, subscribeToTable } from "./ws-client";
+
+type MockEvent = { data?: string; code?: number };
+
+class MockWebSocket {
+  static instances: MockWebSocket[] = [];
+  sent: string[] = [];
+  listeners: Record<string, ((event: MockEvent) => void)[]> = {};
+
+  constructor(public url: string) {
+    MockWebSocket.instances.push(this);
+  }
+
+  addEventListener(type: string, callback: (event: MockEvent) => void) {
+    (this.listeners[type] ??= []).push(callback);
+  }
+
+  send(data: string) {
+    this.sent.push(data);
+  }
+
+  close() {
+    this.emit("close", { code: 1000 });
+  }
+
+  emit(type: string, event: MockEvent) {
+    for (const callback of this.listeners[type] ?? []) callback(event);
+  }
+}
+
+beforeEach(() => {
+  MockWebSocket.instances = [];
+  vi.useFakeTimers();
+  vi.spyOn(Math, "random").mockReturnValue(0.5);
+  vi.stubGlobal("WebSocket", MockWebSocket);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe("subscribeToTable", () => {
+  it("reconnects, resubscribes, and signals snapshot recovery after acknowledgement", () => {
+    const events: Record<string, unknown>[] = [];
+    const recovered = vi.fn();
+    const unsubscribe = subscribeToTable(
+      "table-1",
+      { eq: [{ row: "status" }, "active"] },
+      (event) => events.push(event),
+      recovered,
+    );
+
+    const first = MockWebSocket.instances[0];
+    first.emit("open", {});
+    first.emit("message", {
+      data: JSON.stringify({ type: "subscribed", channel: "table:table-1" }),
+    });
+    expect(recovered).not.toHaveBeenCalled();
+
+    first.emit("close", { code: 1012 });
+    vi.advanceTimersByTime(500);
+
+    const second = MockWebSocket.instances[1];
+    second.emit("open", {});
+    expect(JSON.parse(second.sent[0])).toEqual({
+      type: "subscribe",
+      channels: [
+        {
+          name: "table:table-1",
+          filter: { eq: [{ row: "status" }, "active"] },
+        },
+      ],
+    });
+    expect(recovered).not.toHaveBeenCalled();
+
+    second.emit("message", {
+      data: JSON.stringify({ type: "subscribed", channel: "table:table-1" }),
+    });
+    expect(recovered).toHaveBeenCalledTimes(1);
+    expect(events).toHaveLength(2);
+    unsubscribe();
+  });
+
+  it("cancels a scheduled reconnect when the caller unsubscribes", () => {
+    const unsubscribe = subscribeToTable("table-1", null, () => {});
+    MockWebSocket.instances[0].emit("close", { code: 1006 });
+
+    unsubscribe();
+    vi.advanceTimersByTime(60_000);
+
+    expect(MockWebSocket.instances).toHaveLength(1);
+  });
+
+  it("requests a snapshot refresh when the initial handshake only succeeds after retry", () => {
+    const recovered = vi.fn();
+    const unsubscribe = subscribeToTable("table-1", null, () => {}, recovered);
+    MockWebSocket.instances[0].emit("close", { code: 1006 });
+
+    vi.advanceTimersByTime(500);
+    MockWebSocket.instances[1].emit("message", {
+      data: JSON.stringify({ type: "subscribed", channel: "table:table-1" }),
+    });
+
+    expect(recovered).toHaveBeenCalledTimes(1);
+    unsubscribe();
+  });
+
+  it("treats an authorization close as terminal", () => {
+    const unsubscribe = subscribeToTable("table-1", null, () => {});
+    MockWebSocket.instances[0].emit("close", { code: 4003 });
+
+    vi.advanceTimersByTime(60_000);
+
+    expect(MockWebSocket.instances).toHaveLength(1);
+    unsubscribe();
+  });
+});
 
 describe("buildWsUrl", () => {
   let restore: (() => void) | null = null;
+
   afterEach(() => {
     restore?.();
     restore = null;

--- a/client/src/lib/app-sdk/ws-client.ts
+++ b/client/src/lib/app-sdk/ws-client.ts
@@ -43,42 +43,144 @@ export function buildWsUrl(): string {
   return url.toString();
 }
 
+const NON_RETRYABLE_CLOSE_CODES = new Set([4001, 4003]);
+const RECONNECT_BASE_DELAY_MS = 500;
+const RECONNECT_MAX_DELAY_MS = 30_000;
+
+type SubscriptionMessage = Record<string, unknown>;
+
+interface ReconnectingSubscriptionOptions {
+  channel: string;
+  subscribeFrame: Record<string, unknown>;
+  label: string;
+  onMessage: (message: SubscriptionMessage) => boolean | void;
+  onReconnect?: () => void;
+  onSocketDown?: () => void;
+}
+
+/**
+ * Keep one logical subscription alive across transient WebSocket closures.
+ * A connection only counts as restored after the server acknowledges the
+ * channel, so callers can safely refresh snapshots without racing the
+ * subscribe handshake. Authentication/policy close codes are terminal.
+ */
+export function createReconnectingSubscription({
+  channel,
+  subscribeFrame,
+  label,
+  onMessage,
+  onReconnect,
+  onSocketDown,
+}: ReconnectingSubscriptionOptions): () => void {
+  let socket: WebSocket | null = null;
+  let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  let stopped = false;
+  let reconnectAttempt = 0;
+  let hasSubscribed = false;
+  let socketDownFired = false;
+
+  const notifySocketDown = () => {
+    if (!stopped && !socketDownFired) {
+      socketDownFired = true;
+      onSocketDown?.();
+    }
+  };
+
+  const stop = () => {
+    if (stopped) return;
+    stopped = true;
+    if (reconnectTimer) clearTimeout(reconnectTimer);
+    reconnectTimer = null;
+    socket?.close();
+    socket = null;
+  };
+
+  const connect = () => {
+    if (stopped) return;
+
+    const current = new WebSocket(buildWsUrl());
+    socket = current;
+
+    current.addEventListener("open", () => {
+      current.send(JSON.stringify(subscribeFrame));
+    });
+
+    current.addEventListener("message", (event) => {
+      let message: SubscriptionMessage;
+      try {
+        message = JSON.parse(event.data) as SubscriptionMessage;
+      } catch {
+        return;
+      }
+
+      if (message.type === "subscribed" && message.channel === channel) {
+        const reconnected = hasSubscribed || reconnectAttempt > 0;
+        hasSubscribed = true;
+        reconnectAttempt = 0;
+        socketDownFired = false;
+        if (reconnected) onReconnect?.();
+      }
+
+      if (onMessage(message) === false) stop();
+    });
+
+    current.addEventListener("error", () => {
+      if (stopped) return;
+      notifySocketDown();
+    });
+
+    current.addEventListener("close", (event) => {
+      if (stopped || current !== socket) return;
+      socket = null;
+      notifySocketDown();
+
+      if (NON_RETRYABLE_CLOSE_CODES.has(event.code)) {
+        console.warn(`[bifrost-sdk] ${label} closed`, event.code);
+        return;
+      }
+
+      const baseDelay = Math.min(
+        RECONNECT_BASE_DELAY_MS * 2 ** reconnectAttempt,
+        RECONNECT_MAX_DELAY_MS,
+      );
+      reconnectAttempt += 1;
+      const delay = Math.min(
+        Math.round(baseDelay * (0.75 + Math.random() * 0.5)),
+        RECONNECT_MAX_DELAY_MS,
+      );
+      reconnectTimer = setTimeout(() => {
+        reconnectTimer = null;
+        connect();
+      }, delay);
+    });
+  };
+
+  connect();
+  return stop;
+}
+
 export function subscribeToTable(
   tableId: string,
   filter: Expr | null,
   onEvent: (evt: TableChangeMessage) => void,
+  onReconnect?: () => void,
 ): () => void {
-  const ws = new WebSocket(buildWsUrl());
-  let closedByClient = false;
-  ws.addEventListener("open", () => {
-    const channel: { name: string; filter?: Expr } = {
-      name: `table:${tableId}`,
-    };
-    if (filter !== null) channel.filter = filter;
-    ws.send(JSON.stringify({ type: "subscribe", channels: [channel] }));
+  const channelName = `table:${tableId}`;
+  const channel: { name: string; filter?: Expr } = { name: channelName };
+  if (filter !== null) channel.filter = filter;
+
+  return createReconnectingSubscription({
+    channel: channelName,
+    subscribeFrame: { type: "subscribe", channels: [channel] },
+    label: "table subscription",
+    onReconnect,
+    onMessage: (message) => {
+      onEvent(message as TableChangeMessage);
+      return !(
+        message.type === "error" || message.type === "subscription_revoked"
+      );
+    },
   });
-  ws.addEventListener("message", (e) => {
-    try {
-      const msg = JSON.parse(e.data);
-      onEvent(msg);
-    } catch {
-      // ignore unparseable messages
-    }
-  });
-  // Without these, a wrong-origin or unauthenticated (4001) socket dies
-  // silently: the snapshot loads but live updates just never arrive.
-  ws.addEventListener("error", () => {
-    console.warn("[bifrost-sdk] table subscription socket error");
-  });
-  ws.addEventListener("close", (e) => {
-    if (!closedByClient) {
-      console.warn("[bifrost-sdk] table subscription closed", e.code);
-    }
-  });
-  return () => {
-    closedByClient = true;
-    ws.close();
-  };
 }
 
 export function subscribeToFiles(
@@ -86,36 +188,22 @@ export function subscribeToFiles(
   prefix: string,
   scope: string | null | undefined,
   onEvent: (evt: FileChangeMessage) => void,
+  onReconnect?: () => void,
 ): () => void {
-  const ws = new WebSocket(buildWsUrl());
-  let closedByClient = false;
   const channel = `files:${location}:${prefix}`;
-  ws.addEventListener("open", () => {
-    ws.send(
-      JSON.stringify({
-        type: "subscribe",
-        channels: [{ name: channel, scope: scope ?? undefined }],
-      }),
-    );
+  return createReconnectingSubscription({
+    channel,
+    subscribeFrame: {
+      type: "subscribe",
+      channels: [{ name: channel, scope: scope ?? undefined }],
+    },
+    label: "file subscription",
+    onReconnect,
+    onMessage: (message) => {
+      onEvent(message as FileChangeMessage);
+      return !(
+        message.type === "error" || message.type === "subscription_revoked"
+      );
+    },
   });
-  ws.addEventListener("message", (e) => {
-    try {
-      const msg = JSON.parse(e.data);
-      onEvent(msg);
-    } catch {
-      // ignore unparseable messages
-    }
-  });
-  ws.addEventListener("error", () => {
-    console.warn("[bifrost-sdk] file subscription socket error");
-  });
-  ws.addEventListener("close", (e) => {
-    if (!closedByClient) {
-      console.warn("[bifrost-sdk] file subscription closed", e.code);
-    }
-  });
-  return () => {
-    closedByClient = true;
-    ws.close();
-  };
 }

--- a/client/src/lib/application-update.test.ts
+++ b/client/src/lib/application-update.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+	getApplicationUpdateInProgress,
+	requestApplicationReload,
+	subscribeToApplicationUpdate,
+} from "./application-update";
+
+describe("requestApplicationReload", () => {
+	afterEach(() => {
+		vi.useRealTimers();
+		sessionStorage.clear();
+	});
+
+	it("publishes the update state before reloading and honors the loop guard", () => {
+		vi.useFakeTimers();
+		const reload = vi.fn();
+		const originalLocation = window.location;
+		Object.defineProperty(window, "location", {
+			configurable: true,
+			value: { ...originalLocation, reload },
+		});
+		const listener = vi.fn();
+		const unsubscribe = subscribeToApplicationUpdate(listener);
+
+		expect(requestApplicationReload("test-update", 5_000)).toBe(true);
+		expect(getApplicationUpdateInProgress()).toBe(true);
+		expect(listener).toHaveBeenCalledTimes(1);
+		expect(reload).not.toHaveBeenCalled();
+
+		vi.runAllTimers();
+		expect(reload).toHaveBeenCalledTimes(1);
+		expect(requestApplicationReload("test-update", 5_000)).toBe(false);
+
+		unsubscribe();
+		Object.defineProperty(window, "location", {
+			configurable: true,
+			value: originalLocation,
+		});
+	});
+});

--- a/client/src/lib/application-update.ts
+++ b/client/src/lib/application-update.ts
@@ -1,0 +1,29 @@
+const listeners = new Set<() => void>();
+
+let applicationUpdateInProgress = false;
+
+export function getApplicationUpdateInProgress(): boolean {
+	return applicationUpdateInProgress;
+}
+
+export function subscribeToApplicationUpdate(listener: () => void): () => void {
+	listeners.add(listener);
+	return () => listeners.delete(listener);
+}
+
+export function requestApplicationReload(
+	storageKey: string,
+	loopGuardMs: number,
+): boolean {
+	const lastReload = sessionStorage.getItem(storageKey);
+	const now = Date.now();
+	if (lastReload && now - Number(lastReload) < loopGuardMs) return false;
+
+	sessionStorage.setItem(storageKey, String(now));
+	applicationUpdateInProgress = true;
+	listeners.forEach((listener) => listener());
+
+	// Give React one task to replace the current UI before navigation begins.
+	window.setTimeout(() => window.location.reload(), 0);
+	return true;
+}

--- a/client/src/lib/lazy-with-reload.test.tsx
+++ b/client/src/lib/lazy-with-reload.test.tsx
@@ -1,0 +1,77 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { Component, type ErrorInfo, type ReactNode, Suspense } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { lazyWithReload } from "./lazy-with-reload";
+
+const { mockRequestApplicationReload } = vi.hoisted(() => ({
+	mockRequestApplicationReload: vi.fn(),
+}));
+
+vi.mock("./application-update", () => ({
+	requestApplicationReload: (...args: unknown[]) =>
+		mockRequestApplicationReload(...args),
+}));
+
+class TestErrorBoundary extends Component<
+	{ children: ReactNode },
+	{ error: Error | null }
+> {
+	state = { error: null };
+
+	static getDerivedStateFromError(error: Error) {
+		return { error };
+	}
+
+	componentDidCatch(_error: Error, _info: ErrorInfo) {}
+
+	render() {
+		return this.state.error ? <div>route failed</div> : this.props.children;
+	}
+}
+
+describe("lazyWithReload", () => {
+	beforeEach(() => {
+		mockRequestApplicationReload.mockReset();
+		vi.spyOn(console, "error").mockImplementation(() => {});
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("keeps the failed route pending while the first stale chunk reloads", async () => {
+		mockRequestApplicationReload.mockReturnValue(true);
+		const Page = lazyWithReload(() => Promise.reject(new Error("missing chunk")));
+
+		render(
+			<TestErrorBoundary>
+				<Suspense fallback={<div>loading route</div>}>
+					<Page />
+				</Suspense>
+			</TestErrorBoundary>,
+		);
+
+		await waitFor(() =>
+			expect(mockRequestApplicationReload).toHaveBeenCalledTimes(1),
+		);
+		expect(screen.getByText("loading route")).toBeInTheDocument();
+		expect(screen.queryByText("route failed")).not.toBeInTheDocument();
+	});
+
+	it("surfaces a second failure instead of entering a reload loop", async () => {
+		mockRequestApplicationReload.mockReturnValue(false);
+		const Page = lazyWithReload(() => Promise.reject(new Error("broken chunk")));
+
+		render(
+			<TestErrorBoundary>
+				<Suspense fallback={<div>loading route</div>}>
+					<Page />
+				</Suspense>
+			</TestErrorBoundary>,
+		);
+
+		expect(await screen.findByText("route failed")).toBeInTheDocument();
+		expect(mockRequestApplicationReload).toHaveBeenCalledTimes(1);
+	});
+});

--- a/client/src/lib/lazy-with-reload.ts
+++ b/client/src/lib/lazy-with-reload.ts
@@ -1,4 +1,9 @@
-import { lazy, ComponentType } from "react";
+import { lazy, type ComponentType } from "react";
+
+import { requestApplicationReload } from "./application-update";
+
+const RELOAD_KEY = "chunk-reload-ts";
+const LOOP_GUARD_MS = 10_000;
 
 /**
  * Wrapper around React.lazy that auto-reloads the page once on chunk load failure.
@@ -11,19 +16,13 @@ export function lazyWithReload<T extends ComponentType<any>>(
 ) {
 	return lazy(() =>
 		importFn().catch((error) => {
-			// Only reload once per session to avoid infinite reload loops
-			const key = "chunk-reload-ts";
-			const lastReload = sessionStorage.getItem(key);
-			const now = Date.now();
-
-			// If we haven't reloaded in the last 10 seconds, reload
-			if (!lastReload || now - Number(lastReload) > 10_000) {
-				sessionStorage.setItem(key, String(now));
-				window.location.reload();
+			if (requestApplicationReload(RELOAD_KEY, LOOP_GUARD_MS)) {
+				// Navigation owns recovery now. Keeping the lazy import pending prevents
+				// React from painting its error boundary before the refreshed document.
+				return new Promise<never>(() => {});
 			}
 
-			// If we already reloaded recently, let the error propagate
-			// to the error boundary
+			// A second failure is a real broken-deploy condition, not a stale tab.
 			throw error;
 		}),
 	);

--- a/client/src/lib/preload-error-handler.test.ts
+++ b/client/src/lib/preload-error-handler.test.ts
@@ -28,6 +28,10 @@ describe("handleVitePreloadError", () => {
 			configurable: true,
 			value: { ...originalLocation, reload },
 		});
+		vi.spyOn(window, "setTimeout").mockImplementation((handler) => {
+			if (typeof handler === "function") handler();
+			return 1;
+		});
 
 		consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 	});
@@ -38,15 +42,18 @@ describe("handleVitePreloadError", () => {
 			value: originalLocation,
 		});
 		consoleErrorSpy.mockRestore();
+		vi.restoreAllMocks();
 		sessionStorage.clear();
 	});
 
 	it("first preload error reloads and stores timestamp", () => {
 		const before = Date.now();
-		handleVitePreloadError();
+		const event = new Event("vite:preloadError", { cancelable: true });
+		handleVitePreloadError(event);
 		const after = Date.now();
 
 		expect(reload).toHaveBeenCalledTimes(1);
+		expect(event.defaultPrevented).toBe(true);
 
 		const stored = sessionStorage.getItem(RELOAD_KEY);
 		expect(stored).not.toBeNull();

--- a/client/src/lib/preload-error-handler.test.ts
+++ b/client/src/lib/preload-error-handler.test.ts
@@ -17,6 +17,7 @@ describe("handleVitePreloadError", () => {
 	let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
 
 	beforeEach(() => {
+		vi.useFakeTimers();
 		sessionStorage.clear();
 
 		// Mirror the VersionUpdateBanner test pattern: replace window.location
@@ -28,15 +29,11 @@ describe("handleVitePreloadError", () => {
 			configurable: true,
 			value: { ...originalLocation, reload },
 		});
-		vi.spyOn(window, "setTimeout").mockImplementation((handler) => {
-			if (typeof handler === "function") handler();
-			return 1;
-		});
-
 		consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 	});
 
 	afterEach(() => {
+		vi.useRealTimers();
 		Object.defineProperty(window, "location", {
 			configurable: true,
 			value: originalLocation,
@@ -50,6 +47,7 @@ describe("handleVitePreloadError", () => {
 		const before = Date.now();
 		const event = new Event("vite:preloadError", { cancelable: true });
 		handleVitePreloadError(event);
+		vi.runOnlyPendingTimers();
 		const after = Date.now();
 
 		expect(reload).toHaveBeenCalledTimes(1);
@@ -79,6 +77,7 @@ describe("handleVitePreloadError", () => {
 		sessionStorage.setItem(RELOAD_KEY, String(Date.now() - 6000));
 
 		handleVitePreloadError();
+		vi.runOnlyPendingTimers();
 
 		expect(reload).toHaveBeenCalledTimes(1);
 	});

--- a/client/src/lib/preload-error-handler.ts
+++ b/client/src/lib/preload-error-handler.ts
@@ -1,3 +1,5 @@
+import { requestApplicationReload } from "./application-update";
+
 const RELOAD_KEY = "bifrost:last-preload-reload";
 const LOOP_GUARD_MS = 5_000;
 
@@ -8,15 +10,15 @@ const LOOP_GUARD_MS = 5_000;
  * Exported as a named function (not bound directly to addEventListener)
  * so tests can call it with mocked sessionStorage / location.
  */
-export function handleVitePreloadError(): void {
-	const lastReload = sessionStorage.getItem(RELOAD_KEY);
-	const now = Date.now();
-	if (lastReload && now - Number(lastReload) < LOOP_GUARD_MS) {
+export function handleVitePreloadError(event?: Event): void {
+	if (!requestApplicationReload(RELOAD_KEY, LOOP_GUARD_MS)) {
 		// Already reloaded within the last 5s — don't loop. The version banner
 		// will surface the version mismatch on the next poll cycle.
 		console.error("[bifrost] preload error after recent reload, suppressing");
 		return;
 	}
-	sessionStorage.setItem(RELOAD_KEY, String(now));
-	window.location.reload();
+
+	// Vite recommends cancelling the event when the application handles the
+	// stale import itself. This keeps the error boundary from flashing first.
+	event?.preventDefault();
 }

--- a/plugins/bifrost/skills/bifrost-build/references/web-sdk-v2.md
+++ b/plugins/bifrost/skills/bifrost-build/references/web-sdk-v2.md
@@ -2,6 +2,16 @@
 
 The instance-served `bifrost` package is the runtime SDK for `standalone_v2` Solution apps. Use `../generated/web-sdk-surface.md` for the exact export/type surface. Read `apps-v2.md` for project structure and `app-quality.md` for UI completion.
 
+## Keeping an existing app current
+
+The web SDK is vendored into each app. A platform deployment does not update an existing app's installed SDK automatically. When a reported behavior is fixed in the web SDK, or an app predates the SDK behavior it now relies on, refresh that app before rebuilding it:
+
+```bash
+bifrost solution sdk update [PATH] --app <app-slug>
+```
+
+Omit `--app` for a single-app Solution. This command downloads the SDK from the connected Bifrost instance and reinstalls the vendored package; do not hand-edit the generated SDK files. After updating, run the app's typecheck, tests, and production build, then redeploy it. API-only execution fixes and host-shell asset fixes do not require an app SDK update.
+
 ## Provider and context
 
 Keep the scaffolded `BifrostProvider` wiring in `src/main.tsx`. The host supplies the API URL, viewer token, org scope, app ID, theme, logout handler, and mount basename.


### PR DESCRIPTION
## Summary

This PR addresses three deployment-adjacent reliability failures:

- Return a contract-valid Pending execution from Redis when PostgreSQL has not yet been populated by the worker.
- Reconnect Web SDK execution, table, and file subscriptions after transient WebSocket closures, then refresh authoritative snapshots to heal events missed while disconnected.
- Recover standalone apps when an old immutable JavaScript or CSS hash disappears after deployment by refreshing the live/draft bundle manifest and mounting the replacement without a document reload.
- Show one shared “Application updated / Loading the latest version…” transition during standalone recovery and Bifrost shell stale-chunk reloads, instead of briefly painting an error boundary.
- Teach the Bifrost Build skill how to update an existing app's vendored SDK with `bifrost solution sdk update [PATH] --app <app-slug>`.

## Root causes and safety boundaries

The execution race was introduced intentionally when execution creation became Redis-first to preserve the sub-100 ms enqueue response and avoid two PostgreSQL writes. This PR does not change that write, queue, worker, cancellation, or persistence lifecycle. The GET path remains PostgreSQL-first and consults Redis only on a database miss, preserving PostgreSQL as authoritative once a row exists. Redis fallback also preserves owner/platform-admin authorization, and a Redis outage retains the existing 404 behavior.

WebSocket subscriptions previously treated every server restart or service-restart close as terminal. Transient closes now retry with capped exponential backoff and jitter. Authentication/policy close codes remain terminal. A subscription is considered restored only after the server acknowledges the replacement subscription; table/file hooks then re-read their authoritative snapshots, while execution hooks perform their existing REST reconciliation.

Standalone apps previously surfaced a hard error when an entry or stylesheet hash disappeared between the manifest read and asset load. The host now performs one no-cache manifest refresh for an actual asset-load failure. It remounts only when the manifest identifies a different standalone bundle and stops after one attempt when the server still reports the same unavailable assets. Ordinary parent-supplied manifest changes continue to tear down and remount immediately.

Bifrost's shell already reloaded once after stale Vite chunks, but the rejected lazy import could still reach the error boundary before navigation completed. Both lazy-import and `vite:preloadError` paths now publish the shared update state first; the handled import stays pending and the Vite event is cancelled while the reload begins. Existing 5/10-second loop guards remain intact, and a second failure still surfaces as a real error rather than looping.

## Validation

- `./test.sh tests/unit/shared/test_pending_execution.py tests/unit/routers/test_executions_get_pending.py -v` — 7 passed
- `./test.sh tests/e2e/api/test_executions.py::TestAsyncExecution::test_redis_only_execution_is_immediately_readable -v` — 1 passed
- `./test.sh quality api` — Pyright and Ruff passed
- Original focused SDK/host Vitest selection — 6 files, 67 tests passed
- Shared update-state Vitest selection on rebased main — 5 files, 23 tests passed
- Focused Playwright stale-asset scenario on rebased main — setup plus scenario passed; visibly asserted the update transition, then verified fresh JS/CSS and lazy-chunk rendering with exactly one document load
- `npm run tsc` — passed
- `npm run lint` — passed
- SDK package/skill freshness selection — 3 passed, 3 environment-specific skips
- `git diff --check` — passed

The full backend, full Vitest, and full Playwright suites were not run; validation was scoped to the changed behavior and contract boundaries.

Fixes #589
Fixes #590
Fixes #591
