### PR TITLE
Build Chat V3 governed models and attachments

### DIFF
--- a/.claude/skills/bifrost-build/generated/openapi-digest.md
+++ b/.claude/skills/bifrost-build/generated/openapi-digest.md
@@ -104,8 +104,12 @@
 | POST | `/api/chat/conversations` |
 | DELETE | `/api/chat/conversations/{conversation_id}` |
 | GET | `/api/chat/conversations/{conversation_id}` |
+| POST | `/api/chat/conversations/{conversation_id}/attachments` |
+| DELETE | `/api/chat/conversations/{conversation_id}/attachments/{attachment_id}` |
+| GET | `/api/chat/conversations/{conversation_id}/attachments/{attachment_id}/content` |
 | GET | `/api/chat/conversations/{conversation_id}/messages` |
 | POST | `/api/chat/conversations/{conversation_id}/messages` |
+| GET | `/api/chat/model-tiers` |
 | GET | `/api/claims` |
 | POST | `/api/claims` |
 | DELETE | `/api/claims/{name}` |

--- a/api/alembic/versions/20260815_chat_attachments.py
+++ b/api/alembic/versions/20260815_chat_attachments.py
@@ -1,0 +1,62 @@
+"""add chat message attachments
+
+Revision ID: 20260815_chat_attachments
+Revises: 20260815_optional_agent_limits
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "20260815_chat_attachments"
+down_revision = "20260815_optional_agent_limits"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "message_attachments",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column(
+            "message_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("messages.id", ondelete="CASCADE"),
+            nullable=True,
+        ),
+        sa.Column(
+            "conversation_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("conversations.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("s3_key", sa.String(length=1024), nullable=False),
+        sa.Column("filename", sa.String(length=500), nullable=False),
+        sa.Column("content_type", sa.String(length=255), nullable=False),
+        sa.Column("size_bytes", sa.Integer(), nullable=False),
+        sa.Column("extracted_text", sa.Text(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("NOW()"),
+        ),
+    )
+    op.create_index(
+        "ix_message_attachments_message_id", "message_attachments", ["message_id"]
+    )
+    op.create_index(
+        "ix_message_attachments_conversation_id",
+        "message_attachments",
+        ["conversation_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_message_attachments_conversation_id", table_name="message_attachments"
+    )
+    op.drop_index(
+        "ix_message_attachments_message_id", table_name="message_attachments"
+    )
+    op.drop_table("message_attachments")

--- a/api/src/models/contracts/agents.py
+++ b/api/src/models/contracts/agents.py
@@ -321,6 +321,44 @@ class ConversationSummary(BaseModel):
 # ==================== MESSAGE MODELS ====================
 
 
+class AttachmentPublic(BaseModel):
+    """Metadata for a file attached to a chat message."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID
+    filename: str
+    content_type: str
+    size_bytes: int
+
+    @field_serializer("id")
+    def serialize_id(self, value: UUID) -> str:
+        return str(value)
+
+
+class AttachmentUploadResponse(BaseModel):
+    """Files accepted for the next message in a conversation."""
+
+    attachments: list[AttachmentPublic]
+
+
+ChatModelTierId = Literal["fast", "balanced", "pro"]
+
+
+class ChatModelTierPublic(BaseModel):
+    """One administrator-governed model choice exposed in Chat."""
+
+    id: ChatModelTierId
+    label: str
+
+
+class ChatModelTiersResponse(BaseModel):
+    """Enabled Chat model tiers and the default selection."""
+
+    tiers: list[ChatModelTierPublic]
+    default_tier: ChatModelTierId
+
+
 class MessagePublic(BaseModel):
     """Message output for API responses."""
     model_config = ConfigDict(from_attributes=True)
@@ -329,6 +367,7 @@ class MessagePublic(BaseModel):
     conversation_id: UUID
     role: MessageRole
     content: str | None = None
+    attachments: list[AttachmentPublic] = Field(default_factory=list)
     tool_calls: list[ToolCall] | None = None
     tool_call_id: str | None = None
     tool_name: str | None = None
@@ -358,8 +397,16 @@ class MessagePublic(BaseModel):
 
 class ChatRequest(BaseModel):
     """Request for sending a chat message."""
-    message: str = Field(..., min_length=1, max_length=100000)
+    message: str = Field(default="", max_length=100000)
     stream: bool = Field(default=True, description="Whether to stream the response")
+    attachment_ids: list[UUID] = Field(default_factory=list, max_length=5)
+    model_tier: ChatModelTierId = "balanced"
+
+    @model_validator(mode="after")
+    def require_content(self):
+        if not self.message.strip() and not self.attachment_ids:
+            raise ValueError("A message or attachment is required")
+        return self
 
 
 class ChatResponse(BaseModel):

--- a/api/src/models/contracts/llm.py
+++ b/api/src/models/contracts/llm.py
@@ -19,6 +19,12 @@ class LLMConfigResponse(BaseModel):
     default_system_prompt: str | None = None
     summarization_model: str | None = None
     tuning_model: str | None = None
+    chat_fast_label: str = "Fast"
+    chat_fast_model: str | None = None
+    chat_balanced_label: str = "Balanced"
+    chat_balanced_model: str | None = None
+    chat_pro_label: str = "Pro"
+    chat_pro_model: str | None = None
     is_configured: bool = True
     api_key_set: bool = False
 
@@ -60,6 +66,21 @@ class LLMConfigRequest(BaseModel):
     tuning_model: str | None = Field(
         default=None,
         description="Model override for tuning chat + dry-run. Falls back to primary model if unset.",
+    )
+    chat_fast_label: str = Field(default="Fast", min_length=1, max_length=30)
+    chat_fast_model: str | None = Field(
+        default=None,
+        description="Optional model exposed as the Fast Chat tier.",
+    )
+    chat_balanced_label: str = Field(default="Balanced", min_length=1, max_length=30)
+    chat_balanced_model: str | None = Field(
+        default=None,
+        description="Optional Balanced model; the primary model is used when unset.",
+    )
+    chat_pro_label: str = Field(default="Pro", min_length=1, max_length=30)
+    chat_pro_model: str | None = Field(
+        default=None,
+        description="Optional model exposed as the Pro Chat tier.",
     )
 
 

--- a/api/src/models/orm/__init__.py
+++ b/api/src/models/orm/__init__.py
@@ -12,7 +12,7 @@ from src.models.orm.agent_run_flag_conversations import AgentRunFlagConversation
 from src.models.orm.agent_run_verdict_history import AgentRunVerdictHistory
 from src.models.orm.agent_runs import AgentRun, AgentRunStep
 from src.models.orm.summary_backfill_job import SummaryBackfillJob
-from src.models.orm.agents import Agent, AgentDelegation, AgentRole, AgentTool, Conversation, Message
+from src.models.orm.agents import Agent, AgentDelegation, AgentRole, AgentTool, Conversation, Message, MessageAttachment
 from src.models.orm.ai_usage import AIModelPricing, AIUsage
 from src.models.orm.app_embed_secrets import AppEmbedSecret
 from src.models.orm.platform_jobs import PlatformJob
@@ -110,6 +110,7 @@ __all__ = [
     "AgentRole",
     "Conversation",
     "Message",
+    "MessageAttachment",
     # AI Usage
     "AIModelPricing",
     "AIUsage",

--- a/api/src/models/orm/agents.py
+++ b/api/src/models/orm/agents.py
@@ -226,6 +226,10 @@ class Conversation(Base):
         cascade="all, delete-orphan",
         order_by="Message.sequence",
     )
+    attachments: Mapped[list["MessageAttachment"]] = relationship(
+        back_populates="conversation",
+        cascade="all, delete-orphan",
+    )
     ai_usages: Mapped[list["AIUsage"]] = relationship(back_populates="conversation")
 
     __table_args__ = (
@@ -280,7 +284,44 @@ class Message(Base):
 
     # Relationships
     conversation: Mapped["Conversation"] = relationship(back_populates="messages")
+    attachments: Mapped[list["MessageAttachment"]] = relationship(
+        back_populates="message",
+        cascade="all, delete-orphan",
+        order_by="MessageAttachment.created_at",
+    )
 
     __table_args__ = (
         Index("ix_messages_conversation_sequence", "conversation_id", "sequence"),
+    )
+
+
+class MessageAttachment(Base):
+    """User-uploaded file bound to a chat message."""
+
+    __tablename__ = "message_attachments"
+
+    id: Mapped[UUID] = mapped_column(primary_key=True, default=uuid4)
+    message_id: Mapped[UUID | None] = mapped_column(
+        ForeignKey("messages.id", ondelete="CASCADE"), nullable=True, default=None
+    )
+    conversation_id: Mapped[UUID] = mapped_column(
+        ForeignKey("conversations.id", ondelete="CASCADE"), nullable=False
+    )
+    s3_key: Mapped[str] = mapped_column(String(1024), nullable=False)
+    filename: Mapped[str] = mapped_column(String(500), nullable=False)
+    content_type: Mapped[str] = mapped_column(String(255), nullable=False)
+    size_bytes: Mapped[int] = mapped_column(Integer, nullable=False)
+    extracted_text: Mapped[str | None] = mapped_column(Text, default=None)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        server_default=text("NOW()"),
+    )
+
+    message: Mapped["Message | None"] = relationship(back_populates="attachments")
+    conversation: Mapped["Conversation"] = relationship(back_populates="attachments")
+
+    __table_args__ = (
+        Index("ix_message_attachments_message_id", "message_id"),
+        Index("ix_message_attachments_conversation_id", "conversation_id"),
     )

--- a/api/src/routers/chat.py
+++ b/api/src/routers/chat.py
@@ -12,9 +12,10 @@ import json
 import logging
 from datetime import datetime, timezone
 from typing import Literal, cast
+from urllib.parse import quote
 from uuid import UUID, uuid4
 
-from fastapi import APIRouter, HTTPException, status
+from fastapi import APIRouter, File, HTTPException, Response, UploadFile, status
 from sqlalchemy import func, select
 from sqlalchemy.orm import selectinload
 
@@ -23,18 +24,48 @@ from src.core.db_deps import DbSession
 from src.models.contracts.agents import (
     ChatRequest,
     ChatResponse,
+    ChatModelTierPublic,
+    ChatModelTiersResponse,
     ConversationCreate,
     ConversationPublic,
     ConversationSummary,
     MessagePublic,
+    AttachmentPublic,
+    AttachmentUploadResponse,
     ToolCall,
 )
-from src.models.orm import Agent, Conversation, Message
+from src.models.orm import Agent, Conversation, Message, MessageAttachment
 from src.services.agent_executor import AgentExecutor
+from src.services.chat_attachments import (
+    MAX_FILES_PER_MESSAGE,
+    ChatAttachmentError,
+    ChatAttachmentService,
+)
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/chat", tags=["Chat"])
+
+
+@router.get("/model-tiers")
+async def get_model_tiers(db: DbSession, user: CurrentActiveUser) -> ChatModelTiersResponse:
+    """Return only the administrator-governed model choices available in Chat."""
+    from src.services.llm_config_service import LLMConfigService
+
+    config = await LLMConfigService(db).get_config()
+    if config is None:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="LLM provider is not configured",
+        )
+
+    tiers: list[ChatModelTierPublic] = []
+    if config.chat_fast_model:
+        tiers.append(ChatModelTierPublic(id="fast", label=config.chat_fast_label))
+    tiers.append(ChatModelTierPublic(id="balanced", label=config.chat_balanced_label))
+    if config.chat_pro_model:
+        tiers.append(ChatModelTierPublic(id="pro", label=config.chat_pro_label))
+    return ChatModelTiersResponse(tiers=tiers, default_tier="balanced")
 
 
 # =============================================================================
@@ -240,6 +271,123 @@ async def delete_conversation(
 # =============================================================================
 
 
+@router.post("/conversations/{conversation_id}/attachments")
+async def upload_attachments(
+    conversation_id: UUID,
+    db: DbSession,
+    user: CurrentActiveUser,
+    files: list[UploadFile] = File(...),
+) -> AttachmentUploadResponse:
+    """Validate and store files for the next message in this conversation."""
+    conversation = (
+        await db.execute(
+            select(Conversation)
+            .where(Conversation.id == conversation_id)
+            .where(Conversation.user_id == user.user_id)
+        )
+    ).scalar_one_or_none()
+    if conversation is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Conversation not found")
+    if len(files) > MAX_FILES_PER_MESSAGE:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Attach no more than {MAX_FILES_PER_MESSAGE} files per message.",
+        )
+
+    service = ChatAttachmentService(db)
+    stored: list[MessageAttachment] = []
+    try:
+        for upload in files:
+            stored.append(
+                await service.store(
+                    conversation_id=conversation_id,
+                    filename=upload.filename or "attachment",
+                    content_type=upload.content_type or "application/octet-stream",
+                    content=await upload.read(),
+                )
+            )
+    except ChatAttachmentError as exc:
+        from src.services.file_storage.service import get_file_storage_service
+
+        storage = get_file_storage_service(db)
+        for attachment in stored:
+            await storage.delete_raw_from_s3(attachment.s3_key)
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+    return AttachmentUploadResponse(
+        attachments=[AttachmentPublic.model_validate(attachment) for attachment in stored]
+    )
+
+
+@router.delete(
+    "/conversations/{conversation_id}/attachments/{attachment_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+)
+async def delete_unbound_attachment(
+    conversation_id: UUID,
+    attachment_id: UUID,
+    db: DbSession,
+    user: CurrentActiveUser,
+) -> Response:
+    """Delete an uploaded attachment that was never bound to a message."""
+    attachment = (
+        await db.execute(
+            select(MessageAttachment)
+            .join(Conversation, Conversation.id == MessageAttachment.conversation_id)
+            .where(MessageAttachment.id == attachment_id)
+            .where(MessageAttachment.conversation_id == conversation_id)
+            .where(MessageAttachment.message_id.is_(None))
+            .where(Conversation.user_id == user.user_id)
+        )
+    ).scalar_one_or_none()
+    if attachment is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Attachment not found")
+
+    from src.services.file_storage.service import get_file_storage_service
+
+    await get_file_storage_service(db).delete_raw_from_s3(attachment.s3_key)
+    await db.delete(attachment)
+    await db.flush()
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+@router.get("/conversations/{conversation_id}/attachments/{attachment_id}/content")
+async def get_attachment_content(
+    conversation_id: UUID,
+    attachment_id: UUID,
+    db: DbSession,
+    user: CurrentActiveUser,
+    download: bool = False,
+) -> Response:
+    """Preview or download an attachment after enforcing conversation ownership."""
+    attachment = (
+        await db.execute(
+            select(MessageAttachment)
+            .join(Conversation, Conversation.id == MessageAttachment.conversation_id)
+            .where(MessageAttachment.id == attachment_id)
+            .where(MessageAttachment.conversation_id == conversation_id)
+            .where(Conversation.user_id == user.user_id)
+        )
+    ).scalar_one_or_none()
+    if attachment is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Attachment not found")
+
+    from src.services.file_storage.service import get_file_storage_service
+
+    content = await get_file_storage_service(db).read_uploaded_file(attachment.s3_key)
+    disposition = "attachment" if download else "inline"
+    encoded_filename = quote(attachment.filename, safe="")
+    return Response(
+        content=content,
+        media_type=attachment.content_type,
+        headers={
+            "Content-Disposition": (
+                f"{disposition}; filename*=UTF-8''{encoded_filename}"
+            ),
+            "X-Content-Type-Options": "nosniff",
+        },
+    )
+
+
 @router.get("/conversations/{conversation_id}/messages")
 async def get_messages(
     conversation_id: UUID,
@@ -277,12 +425,28 @@ async def get_messages(
     result = await db.execute(stmt)
     messages = result.scalars().all()
 
+    attachments_by_message: dict[UUID, list[MessageAttachment]] = {}
+    message_ids = [message.id for message in messages]
+    if message_ids:
+        attachment_result = await db.execute(
+            select(MessageAttachment)
+            .where(MessageAttachment.message_id.in_(message_ids))
+            .order_by(MessageAttachment.created_at)
+        )
+        for attachment in attachment_result.scalars().all():
+            if attachment.message_id is not None:
+                attachments_by_message.setdefault(attachment.message_id, []).append(attachment)
+
     return [
         MessagePublic(
             id=m.id,
             conversation_id=m.conversation_id,
             role=m.role,
             content=m.content,
+            attachments=[
+                AttachmentPublic.model_validate(attachment)
+                for attachment in attachments_by_message.get(m.id, [])
+            ],
             tool_calls=[
                 ToolCall(
                     id=tc["id"],
@@ -366,6 +530,8 @@ async def send_message(
         user_message=request.message,
         stream=False,
         user=user,
+        attachment_ids=request.attachment_ids,
+        model_tier=request.model_tier,
     ):
         if chunk.type == "delta" and chunk.content:
             final_content += chunk.content

--- a/api/src/routers/llm_config.py
+++ b/api/src/routers/llm_config.py
@@ -68,6 +68,12 @@ async def get_llm_config(
         default_system_prompt=config.default_system_prompt,
         summarization_model=config.summarization_model,
         tuning_model=config.tuning_model,
+        chat_fast_label=config.chat_fast_label,
+        chat_fast_model=config.chat_fast_model,
+        chat_balanced_label=config.chat_balanced_label,
+        chat_balanced_model=config.chat_balanced_model,
+        chat_pro_label=config.chat_pro_label,
+        chat_pro_model=config.chat_pro_model,
         is_configured=config.is_configured,
         api_key_set=config.api_key_set,
     )
@@ -97,6 +103,12 @@ async def set_llm_config(
             default_system_prompt=request.default_system_prompt,
             summarization_model=request.summarization_model,
             tuning_model=request.tuning_model,
+            chat_fast_label=request.chat_fast_label,
+            chat_fast_model=request.chat_fast_model,
+            chat_balanced_label=request.chat_balanced_label,
+            chat_balanced_model=request.chat_balanced_model,
+            chat_pro_label=request.chat_pro_label,
+            chat_pro_model=request.chat_pro_model,
             updated_by=user.email,
         )
     except ValueError as e:
@@ -150,6 +162,12 @@ async def set_llm_config(
         default_system_prompt=request.default_system_prompt,
         summarization_model=request.summarization_model,
         tuning_model=request.tuning_model,
+        chat_fast_label=request.chat_fast_label,
+        chat_fast_model=request.chat_fast_model,
+        chat_balanced_label=request.chat_balanced_label,
+        chat_balanced_model=request.chat_balanced_model,
+        chat_pro_label=request.chat_pro_label,
+        chat_pro_model=request.chat_pro_model,
         is_configured=True,
         api_key_set=api_key_set,
     )

--- a/api/src/routers/websocket.py
+++ b/api/src/routers/websocket.py
@@ -27,6 +27,7 @@ from src.core.database import get_db_context
 from src.core.log_safety import log_safe
 from src.core.pubsub import manager
 from src.models import Conversation, Execution
+from src.models.contracts.agents import ChatModelTierId, ChatRequest
 from src.models.contracts.policies import Expr, TablePolicies
 from src.models.contracts.policies import FileAction
 from src.models.orm import Agent
@@ -951,7 +952,9 @@ async def websocket_connect(
 
     # Track active chat tasks per conversation so they can be cancelled
     active_chat_tasks: dict[str, asyncio.Task] = {}
-    pending_messages: dict[str, tuple[str, str | None]] = {}  # conversation_id -> (message, local_id)
+    pending_messages: dict[
+        str, tuple[str, str | None, list[UUID], ChatModelTierId]
+    ] = {}
 
     # Per-connection state for policy-driven table subscriptions.
     # Populated by `_authorize_table_subscribe`; consulted by the dispatcher.
@@ -1222,11 +1225,23 @@ async def websocket_connect(
                 conversation_id = data.get("conversation_id")
                 message_text = data.get("message", "")
                 local_id = data.get("local_id")  # Client-generated ID for dedup
-
-                if not conversation_id or not message_text:
+                try:
+                    request = ChatRequest.model_validate({
+                        "message": message_text,
+                        "attachment_ids": data.get("attachment_ids", []),
+                        "model_tier": data.get("model_tier", "balanced"),
+                    })
+                except ValueError as exc:
                     await websocket.send_json({
                         "type": "error",
-                        "error": "Missing conversation_id or message"
+                        "error": str(exc),
+                    })
+                    continue
+
+                if not conversation_id:
+                    await websocket.send_json({
+                        "type": "error",
+                        "error": "Missing conversation_id"
                     })
                     continue
 
@@ -1244,11 +1259,22 @@ async def websocket_connect(
                 # interleaved messages that break the Anthropic API contract.
                 existing_task = active_chat_tasks.get(conversation_id)
                 if existing_task and not existing_task.done():
-                    pending_messages[conversation_id] = (message_text, local_id)
+                    pending_messages[conversation_id] = (
+                        request.message,
+                        local_id,
+                        request.attachment_ids,
+                        request.model_tier,
+                    )
                     continue
 
                 # No running task — process immediately
-                def _start_chat_task(cid: str, msg: str, lid: str | None) -> asyncio.Task:
+                def _start_chat_task(
+                    cid: str,
+                    msg: str,
+                    lid: str | None,
+                    attachment_ids: list[UUID],
+                    model_tier: ChatModelTierId,
+                ) -> asyncio.Task:
                     t = asyncio.create_task(
                         _process_chat_message(
                             websocket=websocket,
@@ -1256,6 +1282,8 @@ async def websocket_connect(
                             conversation_id=cid,
                             message=msg,
                             local_id=lid,
+                            attachment_ids=attachment_ids,
+                            model_tier=model_tier,
                         )
                     )
                     active_chat_tasks[cid] = t
@@ -1264,13 +1292,21 @@ async def websocket_connect(
                         active_chat_tasks.pop(_cid, None)
                         queued = pending_messages.pop(_cid, None)
                         if queued:
-                            q_msg, q_lid = queued
-                            _start_chat_task(_cid, q_msg, q_lid)
+                            q_msg, q_lid, q_attachments, q_tier = queued
+                            _start_chat_task(
+                                _cid, q_msg, q_lid, q_attachments, q_tier
+                            )
 
                     t.add_done_callback(_on_task_done)
                     return t
 
-                _start_chat_task(conversation_id, message_text, local_id)
+                _start_chat_task(
+                    conversation_id,
+                    request.message,
+                    local_id,
+                    request.attachment_ids,
+                    request.model_tier,
+                )
 
             elif data.get("type") == "chat_stop":
                 conversation_id = data.get("conversation_id")
@@ -1397,6 +1433,8 @@ async def _process_chat_message(
     conversation_id: str,
     message: str,
     local_id: str | None = None,
+    attachment_ids: list[UUID] | None = None,
+    model_tier: ChatModelTierId = "balanced",
 ) -> None:
     """
     Process a chat message and stream the response.
@@ -1479,6 +1517,8 @@ async def _process_chat_message(
                 stream=True,
                 local_id=local_id,
                 user=user,
+                attachment_ids=attachment_ids or [],
+                model_tier=model_tier,
             ):
                 # Track partial content from deltas
                 if chunk.type == "delta" and chunk.content:

--- a/api/src/services/agent_executor.py
+++ b/api/src/services/agent_executor.py
@@ -37,6 +37,7 @@ from sqlalchemy.orm import selectinload
 from src.core.principal import UserPrincipal
 from src.models.contracts.agents import (
     AgentSwitch,
+    ChatModelTierId,
     ChatStreamChunk,
     ContextWarning,
     ToolCall,
@@ -48,6 +49,7 @@ from src.models.orm import Agent, Conversation, Message, Workflow
 from src.repositories.agents import AgentRepository
 from src.services.llm import (
     LLMMessage,
+    LLMInputFile,
     ToolCallRequest,
     ToolDefinition,
     get_llm_client,
@@ -221,6 +223,8 @@ class AgentExecutor:
         enable_routing: bool = True,
         local_id: str | None = None,
         user: UserPrincipal | None = None,
+        attachment_ids: list[UUID] | None = None,
+        model_tier: ChatModelTierId = "balanced",
     ) -> AsyncIterator[ChatStreamChunk]:
         """
         Process a user message and generate a response.
@@ -240,6 +244,7 @@ class AgentExecutor:
             ChatStreamChunk objects with response content, tool calls, etc.
         """
         from src.services.agent_router import AgentRouter
+        from src.services.llm_config_service import LLMConfigService
 
         start_time = time.time()
         self._knowledge_search_budget.reset()
@@ -252,6 +257,12 @@ class AgentExecutor:
         )
 
         try:
+            async with self._db() as session:
+                llm_config = await LLMConfigService(session).get_config()
+            if llm_config is None:
+                raise ValueError("LLM provider is not configured.")
+            model_override = llm_config.resolve_chat_model(model_tier)
+
             # 1. Check for @mention agent switching
             if enable_routing:
                 mentioned_agent = await router.parse_mention(user_message)
@@ -295,6 +306,7 @@ class AgentExecutor:
                 role=MessageRole.USER,
                 content=user_message,
                 local_id=local_id,
+                attachment_ids=attachment_ids,
             )
 
             # 3b. Generate assistant message ID upfront and send message_start
@@ -371,9 +383,8 @@ IMPORTANT: When the user's request can be fulfilled using one of your tools, you
             # for authorization, persistence, and its stable stream contract;
             # the runtime owns history replay, tool/result sequencing, context
             # compaction, and budget enforcement.
-            model_override = agent.llm_model if agent else None
             max_tokens_override = agent.llm_max_tokens if agent else None
-            model_name = model_override or llm_client.model_name
+            model_name = model_override
             budget = AgentRunBudget(
                 max_requests=agent.max_iterations if agent else None,
                 max_total_tokens=agent.max_token_budget if agent else None,
@@ -468,7 +479,9 @@ IMPORTANT: When the user's request can be fulfilled using one of your tools, you
             history_messages = messages[1:]
             current_prompt = user_message
             if history_messages and history_messages[-1].role == "user":
-                current_prompt = history_messages.pop().content or user_message
+                current_prompt = PydanticAIClient.convert_user_content(
+                    history_messages.pop()
+                )
 
             observed_model = ObservedModel(
                 create_agent_model(llm_client.config, model=model_name),
@@ -757,10 +770,43 @@ IMPORTANT: When the user's request can be fulfilled using one of your tools, you
         async with self._db() as session:
             result = await session.execute(
                 select(Message)
+                .options(selectinload(Message.attachments))
                 .where(Message.conversation_id == conversation.id)
                 .order_by(Message.sequence)
             )
             db_messages = result.scalars().all()
+
+            from src.services.chat_attachments import (
+                ChatAttachmentService,
+                is_binary_model_input,
+            )
+
+            attachment_service = ChatAttachmentService(session)
+            user_inputs: dict[UUID, tuple[str | None, list[LLMInputFile]]] = {}
+            for db_message in db_messages:
+                if db_message.role != MessageRole.USER or not db_message.attachments:
+                    continue
+                text_parts = [db_message.content] if db_message.content else []
+                input_files: list[LLMInputFile] = []
+                for attachment in db_message.attachments:
+                    if is_binary_model_input(attachment.content_type):
+                        loaded = await attachment_service.load_binary_input(attachment)
+                        input_files.append(
+                            LLMInputFile(
+                                filename=loaded.filename,
+                                media_type=loaded.content_type,
+                                data=loaded.data,
+                            )
+                        )
+                    elif attachment.extracted_text:
+                        text_parts.append(
+                            f"[Attached file: {attachment.filename}]\n"
+                            f"{attachment.extracted_text}"
+                        )
+                user_inputs[db_message.id] = (
+                    "\n\n".join(text_parts) if text_parts else None,
+                    input_files,
+                )
 
         # Track seen tool_call IDs to handle providers (e.g. Minimax) that
         # reuse the same IDs across turns. When a collision is detected, remap
@@ -770,10 +816,14 @@ IMPORTANT: When the user's request can be fulfilled using one of your tools, you
 
         for msg in db_messages:
             if msg.role == MessageRole.USER:
+                content, input_files = user_inputs.get(
+                    msg.id, (msg.content, [])
+                )
                 messages.append(
                     LLMMessage(
                         role="user",
-                        content=msg.content,
+                        content=content,
+                        input_files=input_files,
                     )
                 )
             elif msg.role == MessageRole.ASSISTANT:
@@ -960,6 +1010,7 @@ IMPORTANT: When the user's request can be fulfilled using one of your tools, you
         tool_input: dict[str, Any] | None = None,
         # Client-generated ID for optimistic update reconciliation
         local_id: str | None = None,
+        attachment_ids: list[UUID] | None = None,
     ) -> Message:
         """Save a message to the conversation."""
         msg_id = message_id if message_id else uuid4()
@@ -995,6 +1046,14 @@ IMPORTANT: When the user's request can be fulfilled using one of your tools, you
                 local_id=local_id,
             )
             session.add(message)
+            if attachment_ids:
+                from src.services.chat_attachments import ChatAttachmentService
+
+                await ChatAttachmentService(session).bind(
+                    attachment_ids=attachment_ids,
+                    message_id=message.id,
+                    conversation_id=conversation_id,
+                )
 
             # Update conversation updated_at
             conversation_result = await session.execute(

--- a/api/src/services/chat_attachments.py
+++ b/api/src/services/chat_attachments.py
@@ -1,0 +1,217 @@
+"""Validation, storage, and message binding for chat file attachments."""
+
+from __future__ import annotations
+
+import csv
+import io
+from pathlib import Path
+from dataclasses import dataclass
+from itertools import islice
+from uuid import UUID, uuid4
+
+from PIL import Image, UnidentifiedImageError
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.models.orm import MessageAttachment
+from src.services.file_storage.service import get_file_storage_service
+
+MAX_FILE_SIZE_BYTES = 25 * 1024 * 1024
+MAX_FILES_PER_MESSAGE = 5
+MAX_CONVERSATION_BYTES = 500 * 1024 * 1024
+MAX_IMAGE_PIXELS = 40_000_000
+MAX_EXTRACTED_TEXT_CHARS = 200_000
+
+IMAGE_CONTENT_TYPES = {
+    "image/png",
+    "image/jpeg",
+    "image/jpg",
+    "image/webp",
+    "image/gif",
+}
+PDF_CONTENT_TYPES = {"application/pdf"}
+TEXT_CONTENT_TYPES = {
+    "text/plain",
+    "text/markdown",
+    "text/csv",
+    "application/csv",
+    "application/json",
+    "text/json",
+    "application/x-yaml",
+    "text/yaml",
+    "text/x-yaml",
+}
+EXTENSION_CONTENT_TYPES = {
+    ".txt": "text/plain",
+    ".md": "text/markdown",
+    ".markdown": "text/markdown",
+    ".csv": "text/csv",
+    ".json": "application/json",
+    ".yaml": "text/yaml",
+    ".yml": "text/yaml",
+}
+
+
+class ChatAttachmentError(ValueError):
+    """Raised when a chat attachment cannot be accepted or bound."""
+
+
+@dataclass(frozen=True)
+class ChatInputFile:
+    """Provider-neutral binary input loaded from attachment storage."""
+
+    filename: str
+    content_type: str
+    data: bytes
+
+
+def is_binary_model_input(content_type: str) -> bool:
+    """Return whether Pydantic AI should receive the original bytes."""
+    return content_type in IMAGE_CONTENT_TYPES or content_type in PDF_CONTENT_TYPES
+
+
+def _is_text(content_type: str) -> bool:
+    return content_type in TEXT_CONTENT_TYPES or content_type.startswith("text/")
+
+
+def _normalize_content_type(filename: str, content_type: str) -> str:
+    if content_type and content_type != "application/octet-stream":
+        return content_type
+    return EXTENSION_CONTENT_TYPES.get(Path(filename).suffix.lower(), content_type)
+
+
+def _validate_image(content: bytes) -> None:
+    try:
+        with Image.open(io.BytesIO(content)) as image:
+            if image.width * image.height > MAX_IMAGE_PIXELS:
+                raise ChatAttachmentError(
+                    f"Image exceeds the {MAX_IMAGE_PIXELS:,}-pixel limit."
+                )
+            image.verify()
+    except ChatAttachmentError:
+        raise
+    except (UnidentifiedImageError, OSError, ValueError) as exc:
+        raise ChatAttachmentError("Attachment is not a valid image.") from exc
+
+
+def _extract_text(content: bytes, content_type: str) -> str | None:
+    if not _is_text(content_type):
+        return None
+    decoded = content.decode("utf-8", errors="replace")
+    if content_type in {"text/csv", "application/csv"}:
+        rows = csv.reader(io.StringIO(decoded))
+        preview = list(islice(rows, 21))
+        output = "\n".join(",".join(cell for cell in row) for row in preview)
+        if next(rows, None) is not None:
+            output += "\n… (more rows)"
+        return output[:MAX_EXTRACTED_TEXT_CHARS]
+    return decoded[:MAX_EXTRACTED_TEXT_CHARS]
+
+
+class ChatAttachmentService:
+    """Store, retrieve, and bind user-provided chat files."""
+
+    def __init__(self, db: AsyncSession) -> None:
+        self.db = db
+
+    @staticmethod
+    def _storage_key(conversation_id: UUID, attachment_id: UUID, filename: str) -> str:
+        safe_name = filename.replace("/", "_").replace("\\", "_")
+        return f"_attachments/{conversation_id}/{attachment_id}_{safe_name}"
+
+    async def store(
+        self,
+        *,
+        conversation_id: UUID,
+        filename: str,
+        content_type: str,
+        content: bytes,
+    ) -> MessageAttachment:
+        content_type = _normalize_content_type(filename, content_type)
+        if not filename:
+            raise ChatAttachmentError("Attachment filename is required.")
+        if not content:
+            raise ChatAttachmentError(f"{filename} is empty.")
+        if len(content) > MAX_FILE_SIZE_BYTES:
+            raise ChatAttachmentError(f"{filename} is too large (maximum 25 MB).")
+        if not (
+            content_type in IMAGE_CONTENT_TYPES
+            or content_type in PDF_CONTENT_TYPES
+            or _is_text(content_type)
+        ):
+            raise ChatAttachmentError(
+                "Unsupported file type. Attach an image, PDF, CSV, or text file."
+            )
+        if content_type in IMAGE_CONTENT_TYPES:
+            _validate_image(content)
+        if content_type in PDF_CONTENT_TYPES and not content.startswith(b"%PDF-"):
+            raise ChatAttachmentError("Attachment is not a valid PDF.")
+
+        total_result = await self.db.execute(
+            select(func.coalesce(func.sum(MessageAttachment.size_bytes), 0)).where(
+                MessageAttachment.conversation_id == conversation_id
+            )
+        )
+        if int(total_result.scalar() or 0) + len(content) > MAX_CONVERSATION_BYTES:
+            raise ChatAttachmentError("This conversation's 500 MB file limit was reached.")
+
+        attachment_id = uuid4()
+        s3_key = self._storage_key(conversation_id, attachment_id, filename)
+        storage = get_file_storage_service(self.db)
+        await storage.write_raw_to_s3(s3_key, content)
+
+        attachment = MessageAttachment(
+            id=attachment_id,
+            message_id=None,
+            conversation_id=conversation_id,
+            s3_key=s3_key,
+            filename=filename,
+            content_type=content_type,
+            size_bytes=len(content),
+            extracted_text=_extract_text(content, content_type),
+        )
+        try:
+            self.db.add(attachment)
+            await self.db.flush()
+        except Exception:
+            await storage.delete_raw_from_s3(s3_key)
+            raise
+        return attachment
+
+    async def bind(
+        self,
+        *,
+        attachment_ids: list[UUID],
+        message_id: UUID,
+        conversation_id: UUID,
+    ) -> list[MessageAttachment]:
+        if len(attachment_ids) > MAX_FILES_PER_MESSAGE:
+            raise ChatAttachmentError("Attach no more than 5 files per message.")
+        if not attachment_ids:
+            return []
+
+        result = await self.db.execute(
+            select(MessageAttachment).where(MessageAttachment.id.in_(attachment_ids))
+        )
+        found = {attachment.id: attachment for attachment in result.scalars().all()}
+        if len(found) != len(set(attachment_ids)):
+            raise ChatAttachmentError("One or more attachments were not found.")
+        attachments: list[MessageAttachment] = []
+        for attachment_id in attachment_ids:
+            attachment = found[attachment_id]
+            if attachment.conversation_id != conversation_id:
+                raise ChatAttachmentError("Attachment belongs to another conversation.")
+            if attachment.message_id not in (None, message_id):
+                raise ChatAttachmentError("Attachment is already bound to another message.")
+            attachment.message_id = message_id
+            attachments.append(attachment)
+        await self.db.flush()
+        return attachments
+
+    async def load_binary_input(self, attachment: MessageAttachment) -> ChatInputFile:
+        storage = get_file_storage_service(self.db)
+        return ChatInputFile(
+            filename=attachment.filename,
+            content_type=attachment.content_type,
+            data=await storage.read_uploaded_file(attachment.s3_key),
+        )

--- a/api/src/services/llm/__init__.py
+++ b/api/src/services/llm/__init__.py
@@ -17,6 +17,7 @@ Usage:
 from src.services.llm.base import (
     BaseLLMClient,
     LLMMessage,
+    LLMInputFile,
     LLMResponse,
     LLMStreamChunk,
     ToolCallRequest,
@@ -27,6 +28,7 @@ from src.services.llm.factory import get_llm_client
 __all__ = [
     "BaseLLMClient",
     "LLMMessage",
+    "LLMInputFile",
     "LLMResponse",
     "LLMStreamChunk",
     "ToolCallRequest",

--- a/api/src/services/llm/base.py
+++ b/api/src/services/llm/base.py
@@ -28,6 +28,15 @@ class ToolCallRequest:
     arguments: dict[str, Any]
 
 
+@dataclass(frozen=True)
+class LLMInputFile:
+    """Binary user input kept provider-neutral until the Pydantic adapter."""
+
+    filename: str
+    media_type: str
+    data: bytes
+
+
 @dataclass
 class LLMMessage:
     """
@@ -38,6 +47,7 @@ class LLMMessage:
 
     role: Literal["user", "assistant", "system", "tool"]
     content: str | None = None
+    input_files: list[LLMInputFile] = field(default_factory=list)
 
     # For assistant messages that request tool calls
     tool_calls: list[ToolCallRequest] | None = None

--- a/api/src/services/llm/pydantic_client.py
+++ b/api/src/services/llm/pydantic_client.py
@@ -11,6 +11,7 @@ from collections.abc import AsyncGenerator
 
 from pydantic_ai.direct import model_request_stream
 from pydantic_ai.messages import (
+    BinaryContent,
     ModelMessage,
     ModelRequest,
     ModelResponse,
@@ -22,6 +23,7 @@ from pydantic_ai.messages import (
     ToolCallPart,
     ToolReturnPart,
     UserPromptPart,
+    UserContent,
 )
 from pydantic_ai.models import ModelRequestParameters
 from pydantic_ai.settings import ModelSettings
@@ -133,7 +135,26 @@ class PydanticAIClient(BaseLLMClient):
         )
 
     @staticmethod
-    def convert_messages(messages: list[LLMMessage]) -> list[ModelMessage]:
+    def convert_user_content(message: LLMMessage) -> str | list[UserContent]:
+        """Convert one Bifrost user message into Pydantic multimodal content."""
+        if not message.input_files:
+            return message.content or ""
+        parts: list[UserContent] = []
+        if message.content:
+            parts.append(message.content)
+        for input_file in message.input_files:
+            parts.append(f"Attached file: {input_file.filename}")
+            parts.append(
+                BinaryContent(
+                    data=input_file.data,
+                    media_type=input_file.media_type,
+                    identifier=input_file.filename,
+                )
+            )
+        return parts
+
+    @classmethod
+    def convert_messages(cls, messages: list[LLMMessage]) -> list[ModelMessage]:
         """Convert Bifrost's stable message DTOs to provider-neutral history."""
         converted: list[ModelMessage] = []
         for message in messages:
@@ -171,7 +192,7 @@ class PydanticAIClient(BaseLLMClient):
                     continue
                 request_parts = [tool_return]
             else:
-                request_parts = [UserPromptPart(message.content or "")]
+                request_parts = [UserPromptPart(cls.convert_user_content(message))]
             converted.append(ModelRequest(parts=request_parts))
         return converted
 

--- a/api/src/services/llm_config_service.py
+++ b/api/src/services/llm_config_service.py
@@ -40,8 +40,28 @@ class LLMProviderConfig:
     default_system_prompt: str | None = None  # Default system prompt for agentless chat
     summarization_model: str | None = None  # Override for post-run summarization
     tuning_model: str | None = None  # Override for tuning chat + dry-run
+    chat_fast_label: str = "Fast"
+    chat_fast_model: str | None = None
+    chat_balanced_label: str = "Balanced"
+    chat_balanced_model: str | None = None
+    chat_pro_label: str = "Pro"
+    chat_pro_model: str | None = None
     is_configured: bool = False
     api_key_set: bool = False  # Indicates if API key is configured (never return actual key)
+
+    def resolve_chat_model(
+        self, tier: Literal["fast", "balanced", "pro"]
+    ) -> str:
+        """Resolve an enabled Chat tier without exposing provider model IDs."""
+        if tier == "balanced":
+            return self.chat_balanced_model or self.model
+        model = {
+            "fast": self.chat_fast_model,
+            "pro": self.chat_pro_model,
+        }[tier]
+        if not model:
+            raise ValueError(f"The {tier} Chat model tier is not enabled.")
+        return model
 
 
 @dataclass
@@ -118,6 +138,12 @@ class LLMConfigService:
             default_system_prompt=config_data.get("default_system_prompt"),
             summarization_model=config_data.get("summarization_model"),
             tuning_model=config_data.get("tuning_model"),
+            chat_fast_label=config_data.get("chat_fast_label", "Fast"),
+            chat_fast_model=config_data.get("chat_fast_model"),
+            chat_balanced_label=config_data.get("chat_balanced_label", "Balanced"),
+            chat_balanced_model=config_data.get("chat_balanced_model"),
+            chat_pro_label=config_data.get("chat_pro_label", "Pro"),
+            chat_pro_model=config_data.get("chat_pro_model"),
             is_configured=True,
             api_key_set=bool(config_data.get("encrypted_api_key")),
         )
@@ -132,6 +158,12 @@ class LLMConfigService:
         default_system_prompt: str | None = None,
         summarization_model: str | None = None,
         tuning_model: str | None = None,
+        chat_fast_label: str = "Fast",
+        chat_fast_model: str | None = None,
+        chat_balanced_label: str = "Balanced",
+        chat_balanced_model: str | None = None,
+        chat_pro_label: str = "Pro",
+        chat_pro_model: str | None = None,
         updated_by: str = "system",
     ) -> None:
         """
@@ -179,6 +211,12 @@ class LLMConfigService:
             "default_system_prompt": default_system_prompt,
             "summarization_model": summarization_model,
             "tuning_model": tuning_model,
+            "chat_fast_label": chat_fast_label,
+            "chat_fast_model": chat_fast_model,
+            "chat_balanced_label": chat_balanced_label,
+            "chat_balanced_model": chat_balanced_model,
+            "chat_pro_label": chat_pro_label,
+            "chat_pro_model": chat_pro_model,
         }
 
         if existing:

--- a/api/tests/e2e/api/test_agent_delegation_lifecycle.py
+++ b/api/tests/e2e/api/test_agent_delegation_lifecycle.py
@@ -27,6 +27,7 @@ from src.services.execution.agent_helpers import agent_delegation_slug
 from src.services.execution.autonomous_agent_executor import AutonomousAgentExecutor
 from src.services.llm.base import LLMConfig, ToolCallRequest
 from src.services.llm.pydantic_client import PydanticAIClient
+from src.services.llm_config_service import LLMProviderConfig
 
 
 pytestmark = pytest.mark.asyncio
@@ -301,6 +302,15 @@ async def test_chat_executor_receives_durable_child_callback(
                 "src.services.agent_executor.get_llm_client",
                 new_callable=AsyncMock,
                 return_value=parent_llm,
+            ),
+            patch(
+                "src.services.llm_config_service.LLMConfigService.get_config",
+                new=AsyncMock(
+                    return_value=LLMProviderConfig(
+                        provider="openai",
+                        model="test-parent",
+                    )
+                ),
             ),
             patch(
                 "src.services.agent_executor.create_agent_model",

--- a/api/tests/e2e/api/test_chat.py
+++ b/api/tests/e2e/api/test_chat.py
@@ -153,6 +153,55 @@ class TestConversationsCRUD:
         assert test_conversation["id"] not in conv_ids
 
 
+class TestChatAttachments:
+    """Files can be uploaded, previewed, downloaded, and remain owner-scoped."""
+
+    def test_attachment_upload_and_content_access(
+        self,
+        e2e_client,
+        platform_admin,
+        org1_user,
+        test_conversation,
+    ):
+        auth_headers = {"Authorization": platform_admin.headers["Authorization"]}
+        upload = e2e_client.post(
+            f"/api/chat/conversations/{test_conversation['id']}/attachments",
+            files=[("files", ("notes.txt", b"attachment preview", "text/plain"))],
+            headers=auth_headers,
+        )
+        assert upload.status_code == 200, upload.text
+        attachment = upload.json()["attachments"][0]
+        assert attachment["filename"] == "notes.txt"
+        assert attachment["content_type"] == "text/plain"
+
+        content_url = (
+            f"/api/chat/conversations/{test_conversation['id']}"
+            f"/attachments/{attachment['id']}/content"
+        )
+        preview = e2e_client.get(content_url, headers=platform_admin.headers)
+        assert preview.status_code == 200
+        assert preview.content == b"attachment preview"
+        assert preview.headers["content-disposition"].startswith("inline;")
+
+        download = e2e_client.get(
+            f"{content_url}?download=true", headers=platform_admin.headers
+        )
+        assert download.status_code == 200
+        assert download.headers["content-disposition"].startswith("attachment;")
+
+        forbidden = e2e_client.get(content_url, headers=org1_user.headers)
+        assert forbidden.status_code == 404
+
+        discard = e2e_client.delete(
+            f"/api/chat/conversations/{test_conversation['id']}"
+            f"/attachments/{attachment['id']}",
+            headers=platform_admin.headers,
+        )
+        assert discard.status_code == 204
+        missing = e2e_client.get(content_url, headers=platform_admin.headers)
+        assert missing.status_code == 404
+
+
 # =============================================================================
 # Conversation Access Control Tests
 # =============================================================================

--- a/api/tests/e2e/platform/test_withdrawn_builder_migrations.py
+++ b/api/tests/e2e/platform/test_withdrawn_builder_migrations.py
@@ -13,7 +13,7 @@ async def test_fresh_database_does_not_install_withdrawn_builder_schema(
     revision = (
         await db_session.execute(text("SELECT version_num FROM alembic_version"))
     ).scalar_one()
-    assert revision == "20260815_optional_agent_limits"
+    assert revision == "20260815_chat_attachments"
 
     builder_tables = (
         await db_session.execute(

--- a/api/tests/unit/services/test_agent_executor_runtime.py
+++ b/api/tests/unit/services/test_agent_executor_runtime.py
@@ -15,6 +15,7 @@ from src.services.agent_executor import AgentExecutor
 from src.services.llm import LLMMessage, ToolDefinition
 from src.services.llm.base import LLMConfig
 from src.services.llm.pydantic_client import PydanticAIClient
+from src.services.llm_config_service import LLMProviderConfig
 
 
 class CountingTestModel(TestModel):
@@ -32,6 +33,17 @@ class CountingTestModel(TestModel):
 @pytest.fixture
 def executor() -> AgentExecutor:
     return AgentExecutor(MagicMock())
+
+
+@pytest.fixture(autouse=True)
+def configured_chat_model():
+    """Keep these runtime-contract tests focused on the Pydantic event loop."""
+    config = LLMProviderConfig(provider="openai", model="test-model")
+    with patch(
+        "src.services.llm_config_service.LLMConfigService.get_config",
+        new=AsyncMock(return_value=config),
+    ):
+        yield
 
 
 @pytest.fixture

--- a/api/tests/unit/services/test_agent_runtime.py
+++ b/api/tests/unit/services/test_agent_runtime.py
@@ -10,6 +10,7 @@ from pydantic_ai.exceptions import UsageLimitExceeded
 from pydantic_ai_harness.compaction import LimitWarner, TieredCompaction
 from pydantic_ai_harness.overflowing_tool_output import OverflowingToolOutput
 from pydantic_ai.messages import (
+    BinaryContent,
     ModelMessage,
     ModelRequest,
     ModelResponse,
@@ -32,7 +33,7 @@ from src.services.agent_runtime import (
     build_runtime_capabilities,
     create_agent_model,
 )
-from src.services.llm.base import LLMConfig, ToolDefinition
+from src.services.llm.base import LLMConfig, LLMInputFile, ToolDefinition
 from src.services.llm.base import LLMMessage, ToolCallRequest
 from src.services.llm.factory import create_llm_client
 from src.services.llm.pydantic_client import PydanticAIClient
@@ -301,6 +302,34 @@ def test_legacy_history_groups_consecutive_tool_results_for_provider_compatibili
     assert len(messages) == 2
     assert isinstance(messages[1], ModelRequest)
     assert [part.tool_call_id for part in messages[1].parts] == ["call-1", "call-2"]
+
+
+def test_legacy_history_preserves_multimodal_user_files() -> None:
+    messages = PydanticAIClient.convert_messages(
+        [
+            LLMMessage(
+                role="user",
+                content="Describe this image",
+                input_files=[
+                    LLMInputFile(
+                        filename="diagram.png",
+                        media_type="image/png",
+                        data=b"image-bytes",
+                    )
+                ],
+            )
+        ]
+    )
+
+    assert isinstance(messages[0], ModelRequest)
+    prompt = messages[0].parts[0]
+    assert isinstance(prompt, UserPromptPart)
+    assert isinstance(prompt.content, list)
+    assert prompt.content[0] == "Describe this image"
+    assert prompt.content[1] == "Attached file: diagram.png"
+    assert isinstance(prompt.content[2], BinaryContent)
+    assert prompt.content[2].data == b"image-bytes"
+    assert prompt.content[2].media_type == "image/png"
 
 
 @pytest.mark.asyncio

--- a/api/tests/unit/services/test_llm_config_service.py
+++ b/api/tests/unit/services/test_llm_config_service.py
@@ -117,6 +117,24 @@ class TestLLMConfigService:
         # API key should NOT be returned
         assert not hasattr(result, "api_key") or result.api_key_set is True
 
+    def test_chat_model_tiers_are_governed_by_configuration(self):
+        config = LLMProviderConfig(
+            provider="openai",
+            model="balanced-default",
+            chat_fast_model="fast-model",
+            chat_pro_model="pro-model",
+        )
+
+        assert config.resolve_chat_model("fast") == "fast-model"
+        assert config.resolve_chat_model("balanced") == "balanced-default"
+        assert config.resolve_chat_model("pro") == "pro-model"
+
+    def test_disabled_optional_chat_tier_is_rejected(self):
+        config = LLMProviderConfig(provider="openai", model="balanced-default")
+
+        with pytest.raises(ValueError, match="fast Chat model tier is not enabled"):
+            config.resolve_chat_model("fast")
+
     @pytest.mark.asyncio
     async def test_save_config_creates_new_config(
         self, mock_session, mock_settings

--- a/api/tests/unit/test_chat_attachments.py
+++ b/api/tests/unit/test_chat_attachments.py
@@ -1,0 +1,132 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from src.models.orm import MessageAttachment
+from src.services.chat_attachments import (
+    MAX_FILE_SIZE_BYTES,
+    ChatAttachmentError,
+    ChatAttachmentService,
+)
+
+
+def _db_with_total(total: int = 0) -> MagicMock:
+    db = MagicMock()
+    result = MagicMock()
+    result.scalar.return_value = total
+    db.execute = AsyncMock(return_value=result)
+    db.flush = AsyncMock()
+    return db
+
+
+@pytest.mark.asyncio
+async def test_store_text_attachment_extracts_content_and_writes_s3() -> None:
+    db = _db_with_total()
+    storage = AsyncMock()
+    conversation_id = uuid4()
+
+    with patch(
+        "src.services.chat_attachments.get_file_storage_service",
+        return_value=storage,
+    ):
+        attachment = await ChatAttachmentService(db).store(
+            conversation_id=conversation_id,
+            filename="notes.md",
+            content_type="text/markdown",
+            content=b"# Notes\nHello",
+        )
+
+    assert attachment.extracted_text == "# Notes\nHello"
+    assert attachment.s3_key.startswith(f"_attachments/{conversation_id}/")
+    assert attachment.s3_key.endswith("_notes.md")
+    storage.write_raw_to_s3.assert_awaited_once_with(
+        attachment.s3_key, b"# Notes\nHello"
+    )
+
+
+@pytest.mark.asyncio
+async def test_store_infers_known_text_type_when_browser_omits_it() -> None:
+    db = _db_with_total()
+    storage = AsyncMock()
+
+    with patch(
+        "src.services.chat_attachments.get_file_storage_service",
+        return_value=storage,
+    ):
+        attachment = await ChatAttachmentService(db).store(
+            conversation_id=uuid4(),
+            filename="notes.md",
+            content_type="application/octet-stream",
+            content=b"# Notes",
+        )
+
+    assert attachment.content_type == "text/markdown"
+    assert attachment.extracted_text == "# Notes"
+
+
+@pytest.mark.asyncio
+async def test_store_rejects_unsupported_and_oversized_files() -> None:
+    service = ChatAttachmentService(_db_with_total())
+    with pytest.raises(ChatAttachmentError, match="Unsupported file type"):
+        await service.store(
+            conversation_id=uuid4(),
+            filename="archive.zip",
+            content_type="application/zip",
+            content=b"not a zip",
+        )
+    with pytest.raises(ChatAttachmentError, match="too large"):
+        await service.store(
+            conversation_id=uuid4(),
+            filename="large.txt",
+            content_type="text/plain",
+            content=b"x" * (MAX_FILE_SIZE_BYTES + 1),
+        )
+
+
+@pytest.mark.asyncio
+async def test_store_removes_s3_object_when_persistence_fails() -> None:
+    db = _db_with_total()
+    db.flush.side_effect = RuntimeError("database unavailable")
+    storage = AsyncMock()
+
+    with patch(
+        "src.services.chat_attachments.get_file_storage_service",
+        return_value=storage,
+    ):
+        with pytest.raises(RuntimeError, match="database unavailable"):
+            await ChatAttachmentService(db).store(
+                conversation_id=uuid4(),
+                filename="notes.txt",
+                content_type="text/plain",
+                content=b"hello",
+            )
+
+    storage.delete_raw_from_s3.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_bind_rejects_cross_conversation_attachment() -> None:
+    attachment = MessageAttachment(
+        id=uuid4(),
+        message_id=None,
+        conversation_id=uuid4(),
+        s3_key="_attachments/file",
+        filename="file.txt",
+        content_type="text/plain",
+        size_bytes=4,
+    )
+    db = MagicMock()
+    result = MagicMock()
+    scalars = MagicMock()
+    scalars.all.return_value = [attachment]
+    result.scalars.return_value = scalars
+    db.execute = AsyncMock(return_value=result)
+    db.flush = AsyncMock()
+
+    with pytest.raises(ChatAttachmentError, match="another conversation"):
+        await ChatAttachmentService(db).bind(
+            attachment_ids=[attachment.id],
+            message_id=uuid4(),
+            conversation_id=uuid4(),
+        )

--- a/api/tests/unit/test_chat_model_tiers.py
+++ b/api/tests/unit/test_chat_model_tiers.py
@@ -1,0 +1,46 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.routers.chat import get_model_tiers
+from src.services.llm_config_service import LLMProviderConfig
+
+
+@pytest.mark.asyncio
+async def test_model_tiers_expose_labels_without_provider_model_ids() -> None:
+    config = LLMProviderConfig(
+        provider="openai",
+        model="provider-balanced-model",
+        chat_fast_label="Quick",
+        chat_fast_model="provider-fast-model",
+        chat_balanced_label="Everyday",
+        chat_pro_label="Deep",
+        chat_pro_model="provider-pro-model",
+    )
+    with patch(
+        "src.services.llm_config_service.LLMConfigService.get_config",
+        new=AsyncMock(return_value=config),
+    ):
+        response = await get_model_tiers(MagicMock(), MagicMock())
+
+    assert response.model_dump() == {
+        "tiers": [
+            {"id": "fast", "label": "Quick"},
+            {"id": "balanced", "label": "Everyday"},
+            {"id": "pro", "label": "Deep"},
+        ],
+        "default_tier": "balanced",
+    }
+    assert "provider-" not in response.model_dump_json()
+
+
+@pytest.mark.asyncio
+async def test_disabled_optional_model_tiers_are_hidden() -> None:
+    config = LLMProviderConfig(provider="openai", model="balanced-model")
+    with patch(
+        "src.services.llm_config_service.LLMConfigService.get_config",
+        new=AsyncMock(return_value=config),
+    ):
+        response = await get_model_tiers(MagicMock(), MagicMock())
+
+    assert [tier.id for tier in response.tiers] == ["balanced"]

--- a/client/e2e/chat-attachments.admin.spec.ts
+++ b/client/e2e/chat-attachments.admin.spec.ts
@@ -1,0 +1,75 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("Chat attachments and model tiers", () => {
+	test("uploads a file with the selected tier and previews it", async ({ page }) => {
+		await page.route("**/api/admin/llm/config", async (route) => {
+			await route.fulfill({
+				json: {
+					provider: "openai",
+					model: "balanced-model",
+					max_tokens: 16384,
+					is_configured: true,
+					api_key_set: true,
+				},
+			});
+		});
+		await page.route("**/api/chat/model-tiers", async (route) => {
+			await route.fulfill({
+				json: {
+					tiers: [
+						{ id: "fast", label: "Fast" },
+						{ id: "balanced", label: "Balanced" },
+						{ id: "pro", label: "Pro" },
+					],
+					default_tier: "balanced",
+				},
+			});
+		});
+
+		let resolveChat!: (payload: Record<string, unknown>) => void;
+		const chatPayload = new Promise<Record<string, unknown>>((resolve) => {
+			resolveChat = resolve;
+		});
+		await page.routeWebSocket(/\/ws\/connect/, (socket) => {
+			socket.onMessage((raw) => {
+				const payload = JSON.parse(String(raw)) as Record<string, unknown>;
+				if (payload.type === "chat") resolveChat(payload);
+				if (payload.type === "ping") socket.send(JSON.stringify({ type: "pong" }));
+			});
+		});
+
+		await page.goto("/chat");
+		await page.getByRole("combobox", { name: "Response model" }).click();
+		await page.getByRole("option", { name: "Pro" }).click();
+
+		const chooser = page.waitForEvent("filechooser");
+		await page.getByRole("button", { name: "Attach files" }).click();
+		await (await chooser).setFiles({
+			name: "notes.txt",
+			mimeType: "text/plain",
+			buffer: Buffer.from("attachment preview"),
+		});
+		await expect(page.getByText("notes.txt")).toBeVisible();
+
+		await page.getByLabel("Chat input").fill("Summarize this file");
+		await page.getByRole("button", { name: "Send message" }).click();
+
+		const payload = await chatPayload;
+		expect(payload.message).toBe("Summarize this file");
+		expect(payload.model_tier).toBe("pro");
+		expect(payload.attachment_ids).toEqual([expect.any(String)]);
+
+		await page
+			.getByRole("button", { name: /^notes\.txt \d+ B$/ })
+			.click();
+		await expect(page.getByRole("dialog")).toContainText("attachment preview");
+		await expect(page.getByRole("link", { name: "Download" })).toHaveAttribute(
+			"href",
+			/\/content\?download=true$/,
+		);
+
+		await page.setViewportSize({ width: 390, height: 844 });
+		await expect(page.getByRole("dialog")).toBeVisible();
+		await expect(page.getByRole("link", { name: "Download" })).toBeVisible();
+	});
+});

--- a/client/src/components/chat/ChatAttachmentList.tsx
+++ b/client/src/components/chat/ChatAttachmentList.tsx
@@ -1,0 +1,162 @@
+import { useEffect, useState } from "react";
+import { Download, FileText, Loader2 } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogHeader,
+	DialogTitle,
+} from "@/components/ui/dialog";
+import { authFetch } from "@/lib/api-client";
+import {
+	attachmentContentUrl,
+	isImageAttachment,
+	type AttachmentPublic,
+} from "@/services/chatAttachments";
+
+function formatBytes(bytes: number): string {
+	if (bytes < 1024) return `${bytes} B`;
+	if (bytes < 1024 * 1024) return `${Math.round(bytes / 1024)} KB`;
+	return `${(bytes / 1024 / 1024).toFixed(1)} MB`;
+}
+
+function TextPreview({ url }: { url: string }) {
+	const [text, setText] = useState<string | null>(null);
+	const [error, setError] = useState(false);
+
+	useEffect(() => {
+		let cancelled = false;
+		authFetch(url)
+			.then((response) => {
+				if (!response.ok) throw new Error("Preview failed");
+				return response.text();
+			})
+			.then((content) => {
+				if (!cancelled) setText(content);
+			})
+			.catch(() => {
+				if (!cancelled) setError(true);
+			});
+		return () => {
+			cancelled = true;
+		};
+	}, [url]);
+
+	if (error) {
+		return <p className="p-6 text-sm text-muted-foreground">Preview unavailable.</p>;
+	}
+	if (text === null) {
+		return (
+			<div className="flex min-h-48 items-center justify-center">
+				<Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+			</div>
+		);
+	}
+	return (
+		<pre className="max-h-[65vh] overflow-auto whitespace-pre-wrap p-4 text-xs">
+			{text}
+		</pre>
+	);
+}
+
+function AttachmentPreview({
+	conversationId,
+	attachment,
+}: {
+	conversationId: string;
+	attachment: AttachmentPublic;
+}) {
+	const url = attachmentContentUrl(conversationId, attachment.id);
+	if (isImageAttachment(attachment.content_type)) {
+		return (
+			<div className="flex max-h-[70vh] items-center justify-center overflow-auto bg-muted/30 p-3">
+				<img
+					src={url}
+					alt={attachment.filename}
+					className="max-h-[65vh] max-w-full rounded-lg object-contain"
+				/>
+			</div>
+		);
+	}
+	if (attachment.content_type === "application/pdf") {
+		return <iframe title={attachment.filename} src={url} className="h-[70vh] w-full" />;
+	}
+	return <TextPreview url={url} />;
+}
+
+export function ChatAttachmentList({
+	conversationId,
+	attachments,
+}: {
+	conversationId: string;
+	attachments: AttachmentPublic[];
+}) {
+	const [preview, setPreview] = useState<AttachmentPublic | null>(null);
+	if (attachments.length === 0) return null;
+
+	return (
+		<>
+			<div className="mb-2 flex flex-wrap justify-end gap-2">
+				{attachments.map((attachment) => {
+					const previewUrl = attachmentContentUrl(conversationId, attachment.id);
+					return (
+						<button
+							type="button"
+							key={attachment.id}
+							onClick={() => setPreview(attachment)}
+							className="flex max-w-64 items-center gap-2 rounded-xl border border-primary-foreground/20 bg-primary-foreground/10 p-2 text-left transition-colors hover:bg-primary-foreground/15"
+						>
+							{isImageAttachment(attachment.content_type) ? (
+								<img
+									src={previewUrl}
+									alt=""
+									className="h-12 w-12 rounded-lg object-cover"
+								/>
+							) : (
+								<span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-primary-foreground/10">
+									<FileText className="h-5 w-5" />
+								</span>
+							)}
+							<span className="min-w-0">
+								<span className="block truncate text-xs font-medium">
+									{attachment.filename}
+								</span>
+								<span className="block text-[10px] opacity-70">
+									{formatBytes(attachment.size_bytes)}
+								</span>
+							</span>
+						</button>
+					);
+				})}
+			</div>
+
+			<Dialog open={preview !== null} onOpenChange={(open) => !open && setPreview(null)}>
+				<DialogContent className="max-w-4xl overflow-hidden p-0">
+					{preview && (
+						<>
+							<DialogHeader className="flex-row items-center justify-between gap-4 border-b px-5 py-4 text-left">
+								<div className="min-w-0">
+									<DialogTitle className="truncate">{preview.filename}</DialogTitle>
+									<DialogDescription>{formatBytes(preview.size_bytes)}</DialogDescription>
+								</div>
+								<Button asChild variant="outline" size="sm" className="mr-7 shrink-0">
+									<a
+										href={attachmentContentUrl(conversationId, preview.id, {
+											download: true,
+										})}
+									>
+										<Download className="mr-2 h-4 w-4" />
+										Download
+									</a>
+								</Button>
+							</DialogHeader>
+							<AttachmentPreview conversationId={conversationId} attachment={preview} />
+						</>
+					)}
+				</DialogContent>
+			</Dialog>
+		</>
+	);
+}

--- a/client/src/components/chat/ChatInput.test.tsx
+++ b/client/src/components/chat/ChatInput.test.tsx
@@ -60,7 +60,7 @@ describe("ChatInput — send behavior", () => {
 		// Press Enter to submit.
 		await user.type(textarea, "{Enter}");
 
-		expect(onSend).toHaveBeenCalledWith("hello world");
+		expect(onSend).toHaveBeenCalledWith("hello world", [], "balanced");
 		// Textarea is cleared post-send.
 		expect(textarea.value).toBe("");
 	});
@@ -139,7 +139,23 @@ describe("ChatInput — @ mentions", () => {
 		await user.click(textarea);
 		await user.keyboard("{Enter}");
 
-		expect(onSend).toHaveBeenCalledWith("@[SupportBot]");
+		expect(onSend).toHaveBeenCalledWith("@[SupportBot]", [], "balanced");
+	});
+});
+
+describe("ChatInput — attachments and model tier", () => {
+	it("sends a staged file without requiring message text", async () => {
+		const onSend = vi.fn();
+		const { user, container } = renderWithProviders(
+			<ChatInput onSend={onSend} />,
+		);
+		const file = new File(["hello"], "notes.txt", { type: "text/plain" });
+		const input = container.querySelector('input[type="file"]') as HTMLInputElement;
+		fireEvent.change(input, { target: { files: [file] } });
+
+		expect(screen.getByText("notes.txt")).toBeInTheDocument();
+		await user.click(screen.getByRole("button", { name: /send message/i }));
+		expect(onSend).toHaveBeenCalledWith("", [file], "balanced");
 	});
 });
 

--- a/client/src/components/chat/ChatInput.tsx
+++ b/client/src/components/chat/ChatInput.tsx
@@ -1,330 +1,429 @@
-/**
- * ChatInput Component
- *
- * Modern floating chat input with send button inside.
- * Supports Enter to send, auto-resize textarea, and @mention agent switching.
- */
-
-import { useState, useRef, useCallback, useEffect } from "react";
+import {
+	useCallback,
+	useEffect,
+	useRef,
+	useState,
+	type ChangeEvent,
+	type ClipboardEvent,
+	type DragEvent,
+	type KeyboardEvent,
+} from "react";
 import {
 	ArrowUp,
 	Bot,
+	FileText,
 	Loader2,
 	Paperclip,
-	Plus,
 	Square,
 	X,
 } from "lucide-react";
+import { toast } from "sonner";
+
 import { Button } from "@/components/ui/button";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui/select";
 import { cn } from "@/lib/utils";
-import { MentionPicker } from "./MentionPicker";
 import type { components } from "@/lib/v1";
+import {
+	MAX_ATTACHMENTS_PER_MESSAGE,
+	isImageAttachment,
+	validateAttachment,
+} from "@/services/chatAttachments";
+import type {
+	ChatModelTierId,
+	ChatModelTierOption,
+} from "@/services/chatModels";
+import { MentionPicker } from "./MentionPicker";
 
 type AgentSummary = components["schemas"]["AgentSummary"];
-
 interface MentionChip {
 	name: string;
-	position: number; // Where in the message this mention starts
+}
+
+interface AttachmentDraft {
+	file: File;
+	previewUrl: string | null;
 }
 
 interface ChatInputProps {
-	onSend: (message: string) => void;
+	onSend: (
+		message: string,
+		files: File[],
+		modelTier: ChatModelTierId,
+	) => void | Promise<void>;
 	disabled?: boolean;
 	isLoading?: boolean;
 	placeholder?: string;
 	onStop?: () => void;
+	modelTiers?: ChatModelTierOption[];
+	modelTier?: ChatModelTierId;
+	onModelTierChange?: (tier: ChatModelTierId) => void;
 }
 
 export function ChatInput({
 	onSend,
 	disabled = false,
 	isLoading = false,
-	placeholder = "Reply...",
+	placeholder = "Reply…",
 	onStop,
+	modelTiers = [{ id: "balanced", label: "Balanced" }],
+	modelTier = "balanced",
+	onModelTierChange,
 }: ChatInputProps) {
 	const [message, setMessage] = useState("");
 	const [mentions, setMentions] = useState<MentionChip[]>([]);
+	const [attachments, setAttachments] = useState<AttachmentDraft[]>([]);
+	const [isSubmitting, setIsSubmitting] = useState(false);
+	const [isDragging, setIsDragging] = useState(false);
 	const textareaRef = useRef<HTMLTextAreaElement>(null);
-	const containerRef = useRef<HTMLDivElement>(null);
+	const fileInputRef = useRef<HTMLInputElement>(null);
+	const attachmentsRef = useRef(attachments);
 
-	// Mention picker state
 	const [mentionOpen, setMentionOpen] = useState(false);
 	const [mentionSearch, setMentionSearch] = useState("");
-	const [mentionPosition, setMentionPosition] = useState({ x: 0, y: 0 });
 	const [mentionStart, setMentionStart] = useState<number | null>(null);
 
-	const handleSend = useCallback(() => {
-		const trimmedMessage = message.trim();
-		if (!trimmedMessage && mentions.length === 0) return;
-		if (disabled || isLoading) return;
+	useEffect(() => {
+		attachmentsRef.current = attachments;
+	}, [attachments]);
 
-		// Build final message with mentions prepended
-		const mentionPrefixes = mentions.map((m) => `@[${m.name}]`).join(" ");
+	useEffect(
+		() => () => {
+			for (const draft of attachmentsRef.current) {
+				if (draft.previewUrl) URL.revokeObjectURL(draft.previewUrl);
+			}
+		},
+		[],
+	);
+
+	const addFiles = useCallback((files: File[]) => {
+		setAttachments((current) => {
+			const slots = MAX_ATTACHMENTS_PER_MESSAGE - current.length;
+			if (slots <= 0) {
+				toast.error("You can attach up to 5 files per message.");
+				return current;
+			}
+			const accepted: AttachmentDraft[] = [];
+			for (const file of files.slice(0, slots)) {
+				const error = validateAttachment(file);
+				if (error) {
+					toast.error(error);
+					continue;
+				}
+				accepted.push({
+					file,
+					previewUrl: isImageAttachment(file.type)
+						? URL.createObjectURL(file)
+						: null,
+				});
+			}
+			return [...current, ...accepted];
+		});
+	}, []);
+
+	const removeAttachment = useCallback((index: number) => {
+		setAttachments((current) => {
+			const draft = current[index];
+			if (draft?.previewUrl) URL.revokeObjectURL(draft.previewUrl);
+			return current.filter((_, draftIndex) => draftIndex !== index);
+		});
+	}, []);
+
+	const handleSend = useCallback(async () => {
+		const trimmedMessage = message.trim();
+		if (!trimmedMessage && mentions.length === 0 && attachments.length === 0) {
+			return;
+		}
+		if (disabled || isLoading || isSubmitting) return;
+
+		const mentionPrefixes = mentions.map((mention) => `@[${mention.name}]`).join(" ");
 		const finalMessage = mentionPrefixes
 			? `${mentionPrefixes} ${trimmedMessage}`.trim()
 			: trimmedMessage;
-
-		onSend(finalMessage);
-		setMessage("");
-		setMentions([]);
-
-		// Reset textarea height
-		if (textareaRef.current) {
-			textareaRef.current.style.height = "auto";
+		setIsSubmitting(true);
+		try {
+			await onSend(
+				finalMessage,
+				attachments.map((draft) => draft.file),
+				modelTier,
+			);
+			for (const draft of attachments) {
+				if (draft.previewUrl) URL.revokeObjectURL(draft.previewUrl);
+			}
+			setMessage("");
+			setMentions([]);
+			setAttachments([]);
+			if (textareaRef.current) textareaRef.current.style.height = "auto";
+		} finally {
+			setIsSubmitting(false);
 		}
-	}, [message, mentions, disabled, isLoading, onSend]);
+	}, [
+		attachments,
+		disabled,
+		isLoading,
+		isSubmitting,
+		mentions,
+		message,
+		modelTier,
+		onSend,
+	]);
 
 	const handleKeyDown = useCallback(
-		(e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-			// If mention picker is open, let it handle navigation
-			if (mentionOpen) {
-				if (
-					["ArrowUp", "ArrowDown", "Enter", "Escape"].includes(e.key)
-				) {
-					// These are handled by MentionPicker
-					return;
-				}
+		(event: KeyboardEvent<HTMLTextAreaElement>) => {
+			if (mentionOpen && ["ArrowUp", "ArrowDown", "Enter", "Escape"].includes(event.key)) {
+				return;
 			}
-
-			// Send on Enter (without Shift) when mention picker is closed
-			if (e.key === "Enter" && !e.shiftKey && !mentionOpen) {
-				e.preventDefault();
-				handleSend();
+			if (event.key === "Enter" && !event.shiftKey && !mentionOpen) {
+				event.preventDefault();
+				void handleSend();
 			}
 		},
 		[handleSend, mentionOpen],
 	);
 
-	// Detect @ mentions while typing
-	const handleInputChange = useCallback(
-		(e: React.ChangeEvent<HTMLTextAreaElement>) => {
-			const value = e.target.value;
-			const cursorPos = e.target.selectionStart;
-			setMessage(value);
-
-			// Find @ before cursor
-			const textBeforeCursor = value.slice(0, cursorPos);
-			const lastAtIndex = textBeforeCursor.lastIndexOf("@");
-
-			if (lastAtIndex !== -1) {
-				// Check if @ is at start or preceded by whitespace
-				const charBefore =
-					lastAtIndex > 0 ? value[lastAtIndex - 1] : " ";
-				if (/\s/.test(charBefore) || lastAtIndex === 0) {
-					const searchText = textBeforeCursor.slice(lastAtIndex + 1);
-					// Check if there's no space in the search text (would close mention)
-					if (!searchText.includes(" ")) {
-						setMentionSearch(searchText);
-						setMentionStart(lastAtIndex);
-						setMentionOpen(true);
-
-						// Position for mention picker (above the textarea)
-						setMentionPosition({ x: 16, y: 0 });
-						return;
-					}
-				}
+	const handleInputChange = useCallback((event: ChangeEvent<HTMLTextAreaElement>) => {
+		const value = event.target.value;
+		const cursor = event.target.selectionStart;
+		setMessage(value);
+		const beforeCursor = value.slice(0, cursor);
+		const at = beforeCursor.lastIndexOf("@");
+		if (at >= 0 && (at === 0 || /\s/.test(value[at - 1]))) {
+			const search = beforeCursor.slice(at + 1);
+			if (!search.includes(" ")) {
+				setMentionSearch(search);
+				setMentionStart(at);
+				setMentionOpen(true);
+				return;
 			}
+		}
+		setMentionOpen(false);
+		setMentionStart(null);
+	}, []);
 
-			// Close mention picker if no valid @ mention
-			setMentionOpen(false);
-			setMentionStart(null);
-		},
-		[],
-	);
-
-	// Handle agent selection from mention picker
 	const handleMentionSelect = useCallback(
 		(agent: AgentSummary) => {
 			if (mentionStart === null) return;
-
-			// Remove the @search from message text (mention will show as chip)
-			const beforeMention = message.slice(0, mentionStart);
-			const afterCursor = message.slice(
-				mentionStart + 1 + mentionSearch.length,
+			const before = message.slice(0, mentionStart);
+			const after = message.slice(mentionStart + 1 + mentionSearch.length);
+			setMessage(`${before}${after}`.trim());
+			setMentions((current) =>
+				current.some((mention) => mention.name === agent.name)
+					? current
+					: [...current, { name: agent.name }],
 			);
-			const newMessage = `${beforeMention}${afterCursor}`.trim();
-
-			// Add mention as a chip (avoid duplicates)
-			setMentions((prev) => {
-				if (prev.some((m) => m.name === agent.name)) {
-					return prev;
-				}
-				return [
-					...prev,
-					{
-						name: agent.name,
-						position: mentionStart,
-					},
-				];
-			});
-
-			setMessage(newMessage);
 			setMentionOpen(false);
 			setMentionStart(null);
 			setMentionSearch("");
-
-			// Focus back on textarea
-			if (textareaRef.current) {
-				textareaRef.current.focus();
-				// Move cursor to where the @ was
-				const newCursorPos = beforeMention.length;
-				setTimeout(() => {
-					textareaRef.current?.setSelectionRange(
-						newCursorPos,
-						newCursorPos,
-					);
-				}, 0);
-			}
+			textareaRef.current?.focus();
 		},
-		[message, mentionStart, mentionSearch],
+		[mentionSearch.length, mentionStart, message],
 	);
 
-	// Remove a mention chip
-	const handleRemoveMention = useCallback((name: string) => {
-		setMentions((prev) => prev.filter((m) => m.name !== name));
-	}, []);
+	const handlePaste = useCallback(
+		(event: ClipboardEvent<HTMLTextAreaElement>) => {
+			const files = Array.from(event.clipboardData.items)
+				.filter((item) => item.kind === "file")
+				.map((item) => item.getAsFile())
+				.filter((file): file is File => file !== null);
+			if (files.length) {
+				event.preventDefault();
+				addFiles(files);
+			}
+		},
+		[addFiles],
+	);
 
-	// Auto-resize textarea
+	const handleDrop = useCallback(
+		(event: DragEvent<HTMLDivElement>) => {
+			event.preventDefault();
+			setIsDragging(false);
+			addFiles(Array.from(event.dataTransfer.files));
+		},
+		[addFiles],
+	);
+
 	useEffect(() => {
 		const textarea = textareaRef.current;
 		if (!textarea) return;
-
 		textarea.style.height = "auto";
 		textarea.style.height = `${Math.min(textarea.scrollHeight, 200)}px`;
 	}, [message]);
 
+	const busy = disabled || isLoading || isSubmitting;
 	const canSend =
-		(message.trim().length > 0 || mentions.length > 0) &&
-		!disabled &&
-		!isLoading;
+		(message.trim().length > 0 || mentions.length > 0 || attachments.length > 0) &&
+		!busy;
 
 	return (
-		<div className="p-4 pt-2">
-			<div className="max-w-4xl mx-auto">
-				{/* Floating input container */}
+		<div className="px-3 pb-3 pt-2 sm:px-4 sm:pb-4">
+			<div className="mx-auto max-w-3xl">
 				<div
-					ref={containerRef}
+					onDrop={handleDrop}
+					onDragOver={(event) => {
+						event.preventDefault();
+						setIsDragging(true);
+					}}
+					onDragLeave={() => setIsDragging(false)}
 					className={cn(
-						"relative rounded-2xl bg-muted/50 shadow-lg ring-1 ring-foreground/5 dark:ring-foreground/10",
-						"transition-all duration-200",
-						"focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2 focus-within:ring-offset-background",
+						"relative rounded-2xl border bg-background shadow-sm transition-colors",
+						"focus-within:border-ring focus-within:ring-2 focus-within:ring-ring/20",
+						isDragging && "border-primary bg-primary/5",
 					)}
 				>
-					{/* Mention picker */}
 					<MentionPicker
 						open={mentionOpen}
 						onOpenChange={setMentionOpen}
 						onSelect={handleMentionSelect}
 						searchTerm={mentionSearch}
-						position={mentionPosition}
+						position={{ x: 16, y: 0 }}
 					/>
 
-					{/* Top row: mention chips + textarea */}
-					<div className="px-4 pt-3 pb-2">
-						{/* Mention chips */}
-						{mentions.length > 0 && (
-							<div className="flex flex-wrap gap-1.5 mb-2">
-								{mentions.map((mention) => (
-									<span
-										key={mention.name}
-										className="inline-flex items-center gap-1 pl-2 pr-1 py-0.5 rounded-full bg-primary/15 text-primary text-sm font-medium"
+					{attachments.length > 0 && (
+						<div className="flex gap-2 overflow-x-auto px-3 pt-3">
+							{attachments.map((draft, index) => (
+								<div
+									key={`${draft.file.name}-${draft.file.lastModified}-${index}`}
+									className="group relative flex h-16 min-w-40 max-w-56 items-center gap-2 rounded-xl border bg-muted/40 p-2"
+								>
+									{draft.previewUrl ? (
+										<img
+											src={draft.previewUrl}
+											alt=""
+											className="h-12 w-12 rounded-lg object-cover"
+										/>
+									) : (
+										<div className="flex h-12 w-12 items-center justify-center rounded-lg bg-background">
+											<FileText className="h-5 w-5 text-muted-foreground" />
+										</div>
+									)}
+									<span className="truncate text-xs font-medium">{draft.file.name}</span>
+									<Button
+										type="button"
+										variant="secondary"
+										size="icon-sm"
+										aria-label={`Remove ${draft.file.name}`}
+										className="absolute -right-1.5 -top-1.5 h-6 w-6 rounded-full"
+										onClick={() => removeAttachment(index)}
 									>
-										<Bot className="h-3 w-3 shrink-0" />
-										{mention.name}
-										<button
-											type="button"
-											onClick={() =>
-												handleRemoveMention(
-													mention.name,
-												)
-											}
-											className="ml-0.5 p-0.5 rounded-full hover:bg-primary/20 transition-colors"
-											aria-label={`Remove ${mention.name}`}
-										>
-											<X className="h-3 w-3" />
-										</button>
-									</span>
-								))}
-							</div>
-						)}
-						<textarea
-							ref={textareaRef}
-							aria-label="Chat input"
-							value={message}
-							onChange={handleInputChange}
-							onKeyDown={handleKeyDown}
-							placeholder={
-								mentions.length > 0
-									? "Add a message..."
-									: placeholder
-							}
-							disabled={disabled}
-							className={cn(
-								"w-full bg-transparent resize-none outline-none",
-								"text-base placeholder:text-muted-foreground",
-								"min-h-[24px] max-h-[200px]",
-								"disabled:opacity-50 disabled:cursor-not-allowed",
-							)}
-							rows={1}
-						/>
-					</div>
+										<X className="h-3 w-3" />
+									</Button>
+								</div>
+							))}
+						</div>
+					)}
 
-					{/* Bottom row: actions and send */}
-					<div className="flex items-center justify-between px-3 pb-3">
-						{/* Left side actions */}
-						<div className="flex items-center gap-1">
+					{mentions.length > 0 && (
+						<div className="flex flex-wrap gap-1.5 px-3 pt-3">
+							{mentions.map((mention) => (
+								<span
+									key={mention.name}
+									className="inline-flex items-center gap-1 rounded-full bg-primary/10 px-2 py-1 text-xs font-medium text-primary"
+								>
+									<Bot className="h-3 w-3" />
+									{mention.name}
+									<button
+										type="button"
+										aria-label={`Remove ${mention.name}`}
+										onClick={() =>
+											setMentions((current) =>
+												current.filter((item) => item.name !== mention.name),
+											)
+										}
+									>
+										<X className="h-3 w-3" />
+									</button>
+								</span>
+							))}
+						</div>
+					)}
+
+					<textarea
+						ref={textareaRef}
+						aria-label="Chat input"
+						value={message}
+						onChange={handleInputChange}
+						onKeyDown={handleKeyDown}
+						onPaste={handlePaste}
+						placeholder={placeholder}
+						disabled={disabled}
+						rows={1}
+						className="max-h-[200px] min-h-12 w-full resize-none bg-transparent px-4 py-3 text-base outline-none placeholder:text-muted-foreground disabled:opacity-50"
+					/>
+
+					<div className="flex items-center justify-between gap-2 px-2.5 pb-2.5">
+						<div className="flex min-w-0 items-center gap-1">
+							<input
+								ref={fileInputRef}
+								type="file"
+								multiple
+								className="hidden"
+								accept="image/png,image/jpeg,image/webp,image/gif,application/pdf,text/*,application/json,application/csv"
+								onChange={(event) => {
+									addFiles(Array.from(event.target.files ?? []));
+									event.target.value = "";
+								}}
+							/>
 							<Button
 								type="button"
 								variant="ghost"
-								size="icon"
-								className="h-8 w-8 rounded-full text-muted-foreground/50 cursor-not-allowed"
-								disabled
-								title="Coming soon"
-							>
-								<Plus className="h-5 w-5" />
-							</Button>
-							<Button
-								type="button"
-								variant="ghost"
-								size="icon"
-								className="h-8 w-8 rounded-full text-muted-foreground/50 cursor-not-allowed"
-								disabled
-								title="Coming soon"
+								size="icon-sm"
+								aria-label="Attach files"
+								title="Attach files"
+								disabled={busy || attachments.length >= MAX_ATTACHMENTS_PER_MESSAGE}
+								onClick={() => fileInputRef.current?.click()}
 							>
 								<Paperclip className="h-4 w-4" />
 							</Button>
+							{modelTiers.length > 0 && (
+								<Select
+									value={modelTier}
+									onValueChange={(value) =>
+										onModelTierChange?.(value as ChatModelTierId)
+									}
+									disabled={busy}
+								>
+									<SelectTrigger
+										aria-label="Response model"
+										className="h-8 w-auto min-w-24 border-0 bg-transparent px-2 text-xs shadow-none"
+									>
+										<SelectValue />
+									</SelectTrigger>
+									<SelectContent>
+										{modelTiers.map((tier) => (
+											<SelectItem key={tier.id} value={tier.id}>
+												{tier.label}
+											</SelectItem>
+										))}
+									</SelectContent>
+								</Select>
+							)}
 						</div>
 
-						{/* Right side: stop or send button */}
 						{isLoading && onStop ? (
 							<Button
 								onClick={onStop}
-								size="icon"
+								size="icon-sm"
 								variant="destructive"
 								aria-label="Stop generation"
-								className={cn(
-									"h-8 w-8 rounded-full shrink-0",
-									"transition-all duration-200",
-								)}
 								title="Stop generation"
+								className="rounded-full"
 							>
 								<Square className="h-3 w-3 fill-current" />
 							</Button>
 						) : (
 							<Button
-								onClick={handleSend}
+								onClick={() => void handleSend()}
 								disabled={!canSend}
-								size="icon"
+								size="icon-sm"
 								aria-label="Send message"
-								className={cn(
-									"h-8 w-8 rounded-full shrink-0",
-									"transition-all duration-200",
-									canSend
-										? "bg-primary text-primary-foreground hover:bg-primary/90"
-										: "bg-muted-foreground/20 text-muted-foreground",
-								)}
+								className="rounded-full"
 							>
-								{isLoading ? (
+								{isSubmitting ? (
 									<Loader2 className="h-4 w-4 animate-spin" />
 								) : (
 									<ArrowUp className="h-4 w-4" />
@@ -333,11 +432,8 @@ export function ChatInput({
 						)}
 					</div>
 				</div>
-
-				{/* Disclaimer */}
-				<p className="text-center text-xs text-muted-foreground mt-2">
-					Claude is AI and can make mistakes. Please double-check
-					responses.
+				<p className="mt-2 text-center text-[11px] text-muted-foreground">
+					AI can make mistakes. Check important results.
 				</p>
 			</div>
 		</div>

--- a/client/src/components/chat/ChatMessage.test.tsx
+++ b/client/src/components/chat/ChatMessage.test.tsx
@@ -41,6 +41,26 @@ describe("ChatMessage — user messages", () => {
 		expect(container.querySelector(".justify-end")).not.toBeNull();
 	});
 
+	it("renders attached files as preview controls", () => {
+		renderWithProviders(
+			<ChatMessage
+				message={makeMessage({
+					role: "user",
+					content: "Review this",
+					attachments: [
+						{
+							id: "attachment-1",
+							filename: "notes.txt",
+							content_type: "text/plain",
+							size_bytes: 12,
+						},
+					],
+				})}
+			/>,
+		);
+		expect(screen.getByRole("button", { name: /notes.txt/i })).toBeInTheDocument();
+	});
+
 	it("renders @[AgentName] mentions as an inline badge for user messages", () => {
 		renderWithProviders(
 			<ChatMessage

--- a/client/src/components/chat/ChatMessage.tsx
+++ b/client/src/components/chat/ChatMessage.tsx
@@ -14,6 +14,7 @@ import remarkGfm from "remark-gfm";
 import rehypeRaw from "rehype-raw";
 import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
 import { oneDark } from "react-syntax-highlighter/dist/esm/styles/prism";
+import { ChatAttachmentList } from "./ChatAttachmentList";
 
 type MessagePublic = components["schemas"]["MessagePublic"];
 
@@ -90,6 +91,10 @@ export function ChatMessage({
 		return (
 			<div className="flex justify-end py-2 px-4">
 				<div className="max-w-[80%] bg-primary text-primary-foreground rounded-2xl px-4 py-2.5 overflow-x-auto break-words">
+					<ChatAttachmentList
+						conversationId={message.conversation_id}
+						attachments={message.attachments ?? []}
+					/>
 					<div className="prose prose-invert prose-sm max-w-none prose-p:my-1 prose-p:leading-relaxed prose-p:text-primary-foreground prose-headings:text-primary-foreground prose-strong:text-primary-foreground prose-code:text-primary-foreground prose-pre:my-2 prose-pre:p-0 prose-pre:bg-transparent">
 						<ReactMarkdown
 							remarkPlugins={[remarkGfm]}

--- a/client/src/components/chat/ChatWindow.test.tsx
+++ b/client/src/components/chat/ChatWindow.test.tsx
@@ -14,7 +14,7 @@
 
 import React from "react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { renderWithProviders, screen, fireEvent } from "@/test-utils";
+import { renderWithProviders, screen, fireEvent, waitFor } from "@/test-utils";
 
 // --- mocks --------------------------------------------------------------
 
@@ -32,7 +32,7 @@ const streamRef = {
 };
 
 const createConversationRef = {
-	mutate: vi.fn(),
+	mutateAsync: vi.fn(),
 	isPending: false,
 };
 
@@ -42,6 +42,12 @@ vi.mock("@/hooks/useChat", () => ({
 		isLoading: messagesRef.isLoading,
 	}),
 	useCreateConversation: () => createConversationRef,
+	useChatModelTiers: () => ({
+		data: {
+			tiers: [{ id: "balanced", label: "Balanced" }],
+			default_tier: "balanced",
+		},
+	}),
 }));
 
 vi.mock("@/hooks/useChatStream", () => ({
@@ -87,7 +93,7 @@ vi.mock("./ChatInput", () => ({
 		onSend,
 		placeholder,
 	}: {
-		onSend: (m: string) => void;
+		onSend: (m: string, files: File[], tier: "balanced") => void;
 		placeholder?: string;
 	}) => (
 		<div>
@@ -96,7 +102,7 @@ vi.mock("./ChatInput", () => ({
 				placeholder={placeholder}
 				onKeyDown={(e) => {
 					if (e.key === "Enter") {
-						onSend((e.target as HTMLInputElement).value);
+						onSend((e.target as HTMLInputElement).value, [], "balanced");
 					}
 				}}
 			/>
@@ -144,7 +150,7 @@ beforeEach(() => {
 	streamRef.isStreaming = false;
 	streamRef.pendingQuestion = null;
 	streamRef.stopStreaming = vi.fn();
-	createConversationRef.mutate = vi.fn();
+	createConversationRef.mutateAsync = vi.fn();
 	createConversationRef.isPending = false;
 	storeSelectors.setActiveConversation.mockReset();
 	storeSelectors.setActiveAgent.mockReset();
@@ -212,7 +218,7 @@ describe("ChatWindow — messages render & send", () => {
 		expect(screen.getByText("pong")).toBeInTheDocument();
 	});
 
-	it("forwards a typed message to the stream's sendMessage", () => {
+	it("forwards a typed message to the stream's sendMessage", async () => {
 		messagesRef.data = [
 			{
 				id: "m-1",
@@ -230,12 +236,20 @@ describe("ChatWindow — messages render & send", () => {
 		fireEvent.change(input, { target: { value: "hello" } });
 		fireEvent.keyDown(input, { key: "Enter" });
 
-		expect(streamRef.sendMessage).toHaveBeenCalledWith("hello");
+		await waitFor(() =>
+			expect(streamRef.sendMessage).toHaveBeenCalledWith(
+				"hello",
+				"c-1",
+				[],
+				"balanced",
+			),
+		);
 	});
 
-	it("creates a conversation from the blank draft and sends the first message", () => {
-		createConversationRef.mutate.mockImplementation((_variables, options) => {
-			options?.onSuccess?.({ id: "new-conversation-id" });
+	it("creates a conversation from the blank draft and sends the first message", async () => {
+		createConversationRef.mutateAsync.mockResolvedValue({
+			id: "new-conversation-id",
+			agent_id: null,
 		});
 
 		renderWithProviders(<ChatWindow conversationId={undefined} />);
@@ -246,9 +260,10 @@ describe("ChatWindow — messages render & send", () => {
 		fireEvent.change(input, { target: { value: "hello from draft" } });
 		fireEvent.keyDown(input, { key: "Enter" });
 
-		expect(createConversationRef.mutate).toHaveBeenCalledWith(
-			{ body: { channel: "chat" } },
-			expect.objectContaining({ onSuccess: expect.any(Function) }),
+		await waitFor(() =>
+			expect(createConversationRef.mutateAsync).toHaveBeenCalledWith({
+				body: { channel: "chat" },
+			}),
 		);
 		expect(storeSelectors.setActiveConversation).toHaveBeenCalledWith(
 			"new-conversation-id",
@@ -258,6 +273,8 @@ describe("ChatWindow — messages render & send", () => {
 		expect(streamRef.sendMessage).toHaveBeenCalledWith(
 			"hello from draft",
 			"new-conversation-id",
+			[],
+			"balanced",
 		);
 	});
 });

--- a/client/src/components/chat/ChatWindow.tsx
+++ b/client/src/components/chat/ChatWindow.tsx
@@ -18,11 +18,22 @@ import { AskUserQuestionCard } from "./AskUserQuestionCard";
 import { NeedsReauthCard, extractNeedsReauth } from "./NeedsReauthCard";
 import { TodoList } from "./TodoList";
 import { useChatStore, useTodos } from "@/stores/chatStore";
-import { useCreateConversation, useMessages } from "@/hooks/useChat";
+import {
+	useChatModelTiers,
+	useCreateConversation,
+	useMessages,
+} from "@/hooks/useChat";
 import { useChatStream } from "@/hooks/useChatStream";
 import { Skeleton } from "@/components/ui/skeleton";
 import type { components } from "@/lib/v1";
 import { integrateMessages, type UnifiedMessage } from "@/lib/chat-utils";
+import {
+	deleteUnboundChatAttachment,
+	uploadChatAttachments,
+	type AttachmentPublic,
+} from "@/services/chatAttachments";
+import type { ChatModelTierId } from "@/services/chatModels";
+import { toast } from "sonner";
 
 type MessagePublic = components["schemas"]["MessagePublic"];
 
@@ -214,6 +225,17 @@ export function ChatWindow({
 	);
 	const setActiveAgent = useChatStore((state) => state.setActiveAgent);
 	const createConversation = useCreateConversation();
+	const { data: modelTierData } = useChatModelTiers();
+	const [selectedModelTier, setSelectedModelTier] =
+		useState<ChatModelTierId>("balanced");
+	const modelTiers = modelTierData?.tiers ?? [
+		{ id: "balanced" as const, label: "Balanced" },
+	];
+	const effectiveModelTier = modelTiers.some(
+		(tier) => tier.id === selectedModelTier,
+	)
+		? selectedModelTier
+		: (modelTierData?.default_tier ?? "balanced");
 
 	// Use WebSocket streaming
 	const {
@@ -316,25 +338,49 @@ export function ChatWindow({
 	}, [messages, systemEvents, pendingQuestion, isAtBottom]);
 
 	// Handle send message
-	const handleSendMessage = (message: string) => {
-		if (!conversationId) {
-			createConversation.mutate(
-				{
+	const handleSendMessage = async (
+		message: string,
+		files: File[],
+		modelTier: ChatModelTierId,
+	) => {
+		let uploaded: AttachmentPublic[] = [];
+		let targetConversationId = conversationId;
+		try {
+			if (!targetConversationId) {
+				const data = await createConversation.mutateAsync({
 					body: { channel: "chat" },
-				},
-				{
-					onSuccess: (data) => {
-						setActiveConversation(data.id);
-						setActiveAgent(data.agent_id ?? null);
-						navigate(`/chat/${data.id}`);
-						sendMessage(message, data.id);
-					},
-				},
-			);
-			return;
-		}
+				});
+				targetConversationId = data.id;
+				setActiveConversation(data.id);
+				setActiveAgent(data.agent_id ?? null);
+				navigate(`/chat/${data.id}`);
+			}
 
-		sendMessage(message);
+			if (files.length > 0) {
+				uploaded = (
+					await uploadChatAttachments(targetConversationId, files)
+				).attachments;
+			}
+			await sendMessage(
+				message,
+				targetConversationId,
+				uploaded,
+				modelTier,
+			);
+		} catch (error) {
+			if (targetConversationId && uploaded.length > 0) {
+				const cleanupConversationId = targetConversationId;
+				await Promise.allSettled(
+					uploaded.map((attachment) =>
+						deleteUnboundChatAttachment(cleanupConversationId, attachment.id),
+					),
+				);
+			}
+			const description =
+				error instanceof Error ? error.message : "Could not send this message.";
+			toast.error("Message not sent", { description });
+			throw error;
+		}
 	};
 
 	// Empty state
@@ -355,6 +401,9 @@ export function ChatWindow({
 					onSend={handleSendMessage}
 					disabled={createConversation.isPending}
 					placeholder="Send a message..."
+					modelTiers={modelTiers}
+					modelTier={effectiveModelTier}
+					onModelTierChange={setSelectedModelTier}
 				/>
 			</div>
 		);
@@ -375,7 +424,13 @@ export function ChatWindow({
 						</div>
 					))}
 				</div>
-				<ChatInput onSend={handleSendMessage} disabled />
+				<ChatInput
+					onSend={handleSendMessage}
+					disabled
+					modelTiers={modelTiers}
+					modelTier={effectiveModelTier}
+					onModelTierChange={setSelectedModelTier}
+				/>
 			</div>
 		);
 	}
@@ -401,6 +456,9 @@ export function ChatWindow({
 				<ChatInput
 					onSend={handleSendMessage}
 					placeholder="Send a message..."
+					modelTiers={modelTiers}
+					modelTier={effectiveModelTier}
+					onModelTierChange={setSelectedModelTier}
 				/>
 			</div>
 		);
@@ -513,6 +571,9 @@ export function ChatWindow({
 				placeholder={
 					agentName ? `Message ${agentName}...` : "Send a message..."
 				}
+				modelTiers={modelTiers}
+				modelTier={effectiveModelTier}
+				onModelTierChange={setSelectedModelTier}
 			/>
 		</div>
 	);

--- a/client/src/hooks/useChat.ts
+++ b/client/src/hooks/useChat.ts
@@ -13,6 +13,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { $api, apiClient } from "@/lib/api-client";
 import { toast } from "sonner";
 import type { components } from "@/lib/v1";
+import type { ChatModelTierId } from "@/services/chatModels";
 import { useChatStore } from "@/stores/chatStore";
 
 // Re-export types for convenience
@@ -129,12 +130,19 @@ export async function getMessages(
 export async function sendMessage(
 	conversationId: string,
 	message: string,
+	attachmentIds: string[] = [],
+	modelTier: ChatModelTierId = "balanced",
 ): Promise<ChatResponse> {
 	const { data, error } = await apiClient.POST(
 		"/api/chat/conversations/{conversation_id}/messages",
 		{
 			params: { path: { conversation_id: conversationId } },
-			body: { message, stream: false },
+			body: {
+				message,
+				stream: false,
+				attachment_ids: attachmentIds,
+				model_tier: modelTier,
+			},
 		},
 	);
 	if (error)
@@ -182,6 +190,13 @@ export function useMessages(conversationId: string | undefined) {
 		{ params: { path: { conversation_id: conversationId ?? "" } } },
 		{ enabled: !!conversationId },
 	);
+}
+
+/** Hook to fetch the administrator-governed Chat model choices. */
+export function useChatModelTiers() {
+	return $api.useQuery("get", "/api/chat/model-tiers", undefined, {
+		staleTime: 5 * 60 * 1000,
+	});
 }
 
 // ==================== Mutation Hooks ====================

--- a/client/src/hooks/useChatStream.ts
+++ b/client/src/hooks/useChatStream.ts
@@ -16,6 +16,8 @@ import {
 	type AskUserQuestion,
 } from "@/services/websocket";
 import { generateMessageId, type UnifiedMessage } from "@/lib/chat-utils";
+import type { AttachmentPublic } from "@/services/chatAttachments";
+import type { ChatModelTierId } from "@/services/chatModels";
 
 export interface PendingQuestion {
 	questions: AskUserQuestion[];
@@ -29,7 +31,12 @@ export interface UseChatStreamOptions {
 }
 
 export interface UseChatStreamReturn {
-	sendMessage: (message: string, conversationIdOverride?: string) => void;
+	sendMessage: (
+		message: string,
+		conversationIdOverride?: string,
+		attachments?: AttachmentPublic[],
+		modelTier?: ChatModelTierId,
+	) => Promise<void>;
 	isConnected: boolean;
 	isStreaming: boolean;
 	// AskUserQuestion support
@@ -410,7 +417,12 @@ export function useChatStream({
 
 	// Send message via WebSocket
 	const sendMessage = useCallback(
-		async (message: string, conversationIdOverride?: string) => {
+		async (
+			message: string,
+			conversationIdOverride?: string,
+			attachments: AttachmentPublic[] = [],
+			modelTier: ChatModelTierId = "balanced",
+		) => {
 			const targetConversationId = conversationIdOverride ?? conversationId;
 			if (!targetConversationId) {
 				toast.error("No conversation selected");
@@ -432,6 +444,7 @@ export function useChatStream({
 				conversation_id: targetConversationId,
 				role: "user",
 				content: message,
+				attachments,
 				sequence: Date.now(),
 				created_at: now,
 				isOptimistic: true,
@@ -447,15 +460,20 @@ export function useChatStream({
 				targetConversationId,
 				message,
 				userMessageId,
+				attachments.map((attachment) => attachment.id),
+				modelTier,
 			);
 			if (!sent) {
 				try {
 					await webSocketService.connectToChat(targetConversationId);
-					webSocketService.sendChatMessage(
+					const retried = webSocketService.sendChatMessage(
 						targetConversationId,
 						message,
 						userMessageId,
+						attachments.map((attachment) => attachment.id),
+						modelTier,
 					);
+					if (!retried) throw new Error("WebSocket is not connected");
 				} catch (error) {
 					console.error(
 						"[useChatStream] Failed to send message:",
@@ -463,6 +481,7 @@ export function useChatStream({
 					);
 					setStreamError("Failed to send message");
 					resetStream();
+					throw error;
 				}
 			}
 		},

--- a/client/src/lib/v1.d.ts
+++ b/client/src/lib/v1.d.ts
@@ -5846,6 +5846,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/chat/model-tiers": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Model Tiers
+         * @description Return only the administrator-governed model choices available in Chat.
+         */
+        get: operations["get_model_tiers_api_chat_model_tiers_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/chat/conversations": {
         parameters: {
             query?: never;
@@ -5889,6 +5909,66 @@ export interface paths {
          * @description Delete a conversation (soft delete).
          */
         delete: operations["delete_conversation_api_chat_conversations__conversation_id__delete"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/chat/conversations/{conversation_id}/attachments": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Upload Attachments
+         * @description Validate and store files for the next message in this conversation.
+         */
+        post: operations["upload_attachments_api_chat_conversations__conversation_id__attachments_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/chat/conversations/{conversation_id}/attachments/{attachment_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /**
+         * Delete Unbound Attachment
+         * @description Delete an uploaded attachment that was never bound to a message.
+         */
+        delete: operations["delete_unbound_attachment_api_chat_conversations__conversation_id__attachments__attachment_id__delete"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/chat/conversations/{conversation_id}/attachments/{attachment_id}/content": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Attachment Content
+         * @description Preview or download an attachment after enforcing conversation ownership.
+         */
+        get: operations["get_attachment_content_api_chat_conversations__conversation_id__attachments__attachment_id__content_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
         options?: never;
         head?: never;
         patch?: never;
@@ -6016,7 +6096,7 @@ export interface paths {
          * List Llm Models
          * @description List available models from the configured LLM provider.
          *
-         *     Works with OpenAI and Anthropic (both support model listing).
+         *     Works with OpenAI, Anthropic, and Google.
          *     Requires platform admin access.
          */
         get: operations["list_llm_models_api_admin_llm_models_get"];
@@ -11399,6 +11479,28 @@ export interface components {
             at?: string;
         };
         /**
+         * AttachmentPublic
+         * @description Metadata for a file attached to a chat message.
+         */
+        AttachmentPublic: {
+            /** Id */
+            id: string;
+            /** Filename */
+            filename: string;
+            /** Content Type */
+            content_type: string;
+            /** Size Bytes */
+            size_bytes: number;
+        };
+        /**
+         * AttachmentUploadResponse
+         * @description Files accepted for the next message in a conversation.
+         */
+        AttachmentUploadResponse: {
+            /** Attachments */
+            attachments: components["schemas"]["AttachmentPublic"][];
+        };
+        /**
          * AuditLogActor
          * @description Who performed the action.
          */
@@ -11819,6 +11921,11 @@ export interface components {
              */
             file: string;
         };
+        /** Body_upload_attachments_api_chat_conversations__conversation_id__attachments_post */
+        Body_upload_attachments_api_chat_conversations__conversation_id__attachments_post: {
+            /** Files */
+            files: string[];
+        };
         /** Body_upload_avatar_api_profile_avatar_post */
         Body_upload_avatar_api_profile_avatar_post: {
             /** File */
@@ -12028,7 +12135,7 @@ export interface components {
         CLIAIInfoResponse: {
             /**
              * Provider
-             * @description LLM provider (openai, anthropic)
+             * @description LLM provider (openai, anthropic, google)
              */
             provider: string;
             /**
@@ -12526,11 +12633,40 @@ export interface components {
             logs?: components["schemas"]["CLISessionLogRequest"][];
         };
         /**
+         * ChatModelTierPublic
+         * @description One administrator-governed model choice exposed in Chat.
+         */
+        ChatModelTierPublic: {
+            /**
+             * Id
+             * @enum {string}
+             */
+            id: "fast" | "balanced" | "pro";
+            /** Label */
+            label: string;
+        };
+        /**
+         * ChatModelTiersResponse
+         * @description Enabled Chat model tiers and the default selection.
+         */
+        ChatModelTiersResponse: {
+            /** Tiers */
+            tiers: components["schemas"]["ChatModelTierPublic"][];
+            /**
+             * Default Tier
+             * @enum {string}
+             */
+            default_tier: "fast" | "balanced" | "pro";
+        };
+        /**
          * ChatRequest
          * @description Request for sending a chat message.
          */
         ChatRequest: {
-            /** Message */
+            /**
+             * Message
+             * @default
+             */
             message: string;
             /**
              * Stream
@@ -12538,6 +12674,14 @@ export interface components {
              * @default true
              */
             stream: boolean;
+            /** Attachment Ids */
+            attachment_ids?: string[];
+            /**
+             * Model Tier
+             * @default balanced
+             * @enum {string}
+             */
+            model_tier: "fast" | "balanced" | "pro";
         };
         /**
          * ChatResponse
@@ -17943,6 +18087,36 @@ export interface components {
              * @description Model override for tuning chat + dry-run. Falls back to primary model if unset.
              */
             tuning_model?: string | null;
+            /**
+             * Chat Fast Label
+             * @default Fast
+             */
+            chat_fast_label: string;
+            /**
+             * Chat Fast Model
+             * @description Optional model exposed as the Fast Chat tier.
+             */
+            chat_fast_model?: string | null;
+            /**
+             * Chat Balanced Label
+             * @default Balanced
+             */
+            chat_balanced_label: string;
+            /**
+             * Chat Balanced Model
+             * @description Optional Balanced model; the primary model is used when unset.
+             */
+            chat_balanced_model?: string | null;
+            /**
+             * Chat Pro Label
+             * @default Pro
+             */
+            chat_pro_label: string;
+            /**
+             * Chat Pro Model
+             * @description Optional model exposed as the Pro Chat tier.
+             */
+            chat_pro_model?: string | null;
         };
         /**
          * LLMConfigResponse
@@ -17969,6 +18143,27 @@ export interface components {
             summarization_model?: string | null;
             /** Tuning Model */
             tuning_model?: string | null;
+            /**
+             * Chat Fast Label
+             * @default Fast
+             */
+            chat_fast_label: string;
+            /** Chat Fast Model */
+            chat_fast_model?: string | null;
+            /**
+             * Chat Balanced Label
+             * @default Balanced
+             */
+            chat_balanced_label: string;
+            /** Chat Balanced Model */
+            chat_balanced_model?: string | null;
+            /**
+             * Chat Pro Label
+             * @default Pro
+             */
+            chat_pro_label: string;
+            /** Chat Pro Model */
+            chat_pro_model?: string | null;
             /**
              * Is Configured
              * @default true
@@ -19144,6 +19339,8 @@ export interface components {
             role: components["schemas"]["MessageRole"];
             /** Content */
             content?: string | null;
+            /** Attachments */
+            attachments?: components["schemas"]["AttachmentPublic"][];
             /** Tool Calls */
             tool_calls?: components["schemas"]["ToolCall"][] | null;
             /** Tool Call Id */
@@ -36009,6 +36206,26 @@ export interface operations {
             };
         };
     };
+    get_model_tiers_api_chat_model_tiers_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ChatModelTiersResponse"];
+                };
+            };
+        };
+    };
     list_conversations_api_chat_conversations_get: {
         parameters: {
             query?: {
@@ -36124,6 +36341,105 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    upload_attachments_api_chat_conversations__conversation_id__attachments_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                conversation_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "multipart/form-data": components["schemas"]["Body_upload_attachments_api_chat_conversations__conversation_id__attachments_post"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AttachmentUploadResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    delete_unbound_attachment_api_chat_conversations__conversation_id__attachments__attachment_id__delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                conversation_id: string;
+                attachment_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_attachment_content_api_chat_conversations__conversation_id__attachments__attachment_id__content_get: {
+        parameters: {
+            query?: {
+                download?: boolean;
+            };
+            header?: never;
+            path: {
+                conversation_id: string;
+                attachment_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
             };
             /** @description Validation Error */
             422: {

--- a/client/src/pages/settings/LLMConfig.tsx
+++ b/client/src/pages/settings/LLMConfig.tsx
@@ -115,6 +115,12 @@ export function LLMConfig() {
 	const [defaultSystemPrompt, setDefaultSystemPrompt] = useState("");
 	const [summarizationModel, setSummarizationModel] = useState("");
 	const [tuningModel, setTuningModel] = useState("");
+	const [chatFastLabel, setChatFastLabel] = useState("Fast");
+	const [chatFastModel, setChatFastModel] = useState("");
+	const [chatBalancedLabel, setChatBalancedLabel] = useState("Balanced");
+	const [chatBalancedModel, setChatBalancedModel] = useState("");
+	const [chatProLabel, setChatProLabel] = useState("Pro");
+	const [chatProModel, setChatProModel] = useState("");
 
 	// Models state (loaded dynamically after test)
 	const [availableModels, setAvailableModels] = useState<ModelInfo[]>([]);
@@ -161,6 +167,12 @@ export function LLMConfig() {
 		setEndpoint(config.endpoint || DEFAULT_ENDPOINTS[p] || DEFAULT_ENDPOINTS.openai);
 		setSummarizationModel(config.summarization_model ?? "");
 		setTuningModel(config.tuning_model ?? "");
+		setChatFastLabel(config.chat_fast_label ?? "Fast");
+		setChatFastModel(config.chat_fast_model ?? "");
+		setChatBalancedLabel(config.chat_balanced_label ?? "Balanced");
+		setChatBalancedModel(config.chat_balanced_model ?? "");
+		setChatProLabel(config.chat_pro_label ?? "Pro");
+		setChatProModel(config.chat_pro_model ?? "");
 	}
 
 	// Track if we've already fetched models for this config
@@ -292,6 +304,12 @@ export function LLMConfig() {
 					default_system_prompt: defaultSystemPrompt || null,
 					summarization_model: summarizationModel || null,
 					tuning_model: tuningModel || null,
+					chat_fast_label: chatFastLabel.trim() || "Fast",
+					chat_fast_model: chatFastModel.trim() || null,
+					chat_balanced_label: chatBalancedLabel.trim() || "Balanced",
+					chat_balanced_model: chatBalancedModel.trim() || null,
+					chat_pro_label: chatProLabel.trim() || "Pro",
+					chat_pro_model: chatProModel.trim() || null,
 				},
 			});
 
@@ -332,6 +350,12 @@ export function LLMConfig() {
 			setDefaultSystemPrompt("");
 			setSummarizationModel("");
 			setTuningModel("");
+			setChatFastLabel("Fast");
+			setChatFastModel("");
+			setChatBalancedLabel("Balanced");
+			setChatBalancedModel("");
+			setChatProLabel("Pro");
+			setChatProModel("");
 			setTestResult(null);
 			setAvailableModels([]);
 			setModelsLoaded(false);
@@ -656,6 +680,87 @@ export function LLMConfig() {
 								specific agent. Leave empty to use the built-in
 								default.
 							</p>
+						</div>
+
+						<div className="space-y-3 rounded-lg border p-4">
+							<div>
+								<h5 className="text-sm font-medium">Chat model choices</h5>
+								<p className="mt-1 text-xs text-muted-foreground">
+									Choose the models users may select in Chat. Balanced uses the
+									primary model when left blank; blank Fast or Pro models hide
+									those choices.
+								</p>
+							</div>
+							{[
+								{
+									id: "fast",
+									label: chatFastLabel,
+									setLabel: setChatFastLabel,
+									model: chatFastModel,
+									setModel: setChatFastModel,
+									placeholder: "Optional fast model",
+								},
+								{
+									id: "balanced",
+									label: chatBalancedLabel,
+									setLabel: setChatBalancedLabel,
+									model: chatBalancedModel,
+									setModel: setChatBalancedModel,
+									placeholder: `Primary model (${model})`,
+								},
+								{
+									id: "pro",
+									label: chatProLabel,
+									setLabel: setChatProLabel,
+									model: chatProModel,
+									setModel: setChatProModel,
+									placeholder: "Optional pro model",
+								},
+							].map((tier) => (
+								<div key={tier.id} className="grid gap-2 sm:grid-cols-[10rem_1fr]">
+									<div className="space-y-1">
+										<Label htmlFor={`chat-${tier.id}-label`}>
+											{tier.id[0].toUpperCase() + tier.id.slice(1)} label
+										</Label>
+										<Input
+											id={`chat-${tier.id}-label`}
+											value={tier.label}
+											onChange={(event) => tier.setLabel(event.target.value)}
+											maxLength={30}
+										/>
+									</div>
+									<div className="space-y-1">
+										<Label htmlFor={`chat-${tier.id}-model`}>
+											{tier.id[0].toUpperCase() + tier.id.slice(1)} model
+										</Label>
+										{hasModels ? (
+											<Combobox
+												id={`chat-${tier.id}-model`}
+												value={tier.model}
+												onValueChange={tier.setModel}
+												placeholder={tier.placeholder}
+												searchPlaceholder="Search models..."
+												emptyText="No models found."
+												options={availableModels.map((availableModel) => ({
+													value: availableModel.id,
+													label: availableModel.display_name,
+													description:
+														availableModel.id !== availableModel.display_name
+															? availableModel.id
+															: undefined,
+												}))}
+											/>
+										) : (
+											<Input
+												id={`chat-${tier.id}-model`}
+												value={tier.model}
+												onChange={(event) => tier.setModel(event.target.value)}
+												placeholder={tier.placeholder}
+											/>
+										)}
+									</div>
+								</div>
+							))}
 						</div>
 
 						{/* Summarization Model Override */}

--- a/client/src/services/chatAttachments.test.ts
+++ b/client/src/services/chatAttachments.test.ts
@@ -1,0 +1,81 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const authFetch = vi.hoisted(() => vi.fn());
+vi.mock("@/lib/api-client", () => ({ authFetch }));
+
+import {
+	MAX_ATTACHMENT_SIZE_BYTES,
+	attachmentContentUrl,
+	deleteUnboundChatAttachment,
+	isImageAttachment,
+	uploadChatAttachments,
+	validateAttachment,
+} from "./chatAttachments";
+
+describe("chatAttachments", () => {
+	beforeEach(() => authFetch.mockReset());
+
+	it("validates supported files and size limits", () => {
+		expect(
+			validateAttachment(
+				new File(["hello"], "notes.txt", { type: "text/plain" }),
+			),
+		).toBeNull();
+		expect(validateAttachment(new File(["hello"], "notes.md"))).toBeNull();
+		expect(
+			validateAttachment(
+				new File(["x"], "archive.zip", { type: "application/zip" }),
+			),
+		).toMatch(/not a supported/i);
+		const oversized = {
+			name: "large.pdf",
+			type: "application/pdf",
+			size: MAX_ATTACHMENT_SIZE_BYTES + 1,
+		} as File;
+		expect(validateAttachment(oversized)).toMatch(/too large/i);
+	});
+
+	it("builds owner-scoped preview and download URLs", () => {
+		expect(attachmentContentUrl("conversation", "attachment")).toBe(
+			"/api/chat/conversations/conversation/attachments/attachment/content",
+		);
+		expect(
+			attachmentContentUrl("conversation", "attachment", { download: true }),
+		).toMatch(/download=true$/);
+		expect(isImageAttachment("image/webp")).toBe(true);
+	});
+
+	it("uploads files as multipart and discards unbound uploads", async () => {
+		authFetch
+			.mockResolvedValueOnce(
+				new Response(
+					JSON.stringify({
+						attachments: [
+							{
+								id: "attachment-1",
+								filename: "notes.txt",
+								content_type: "text/plain",
+								size_bytes: 5,
+							},
+						],
+					}),
+					{ status: 200 },
+				),
+			)
+			.mockResolvedValueOnce(new Response(null, { status: 204 }));
+
+		const file = new File(["hello"], "notes.txt", { type: "text/plain" });
+		const uploaded = await uploadChatAttachments("conversation-1", [file]);
+		expect(uploaded.attachments[0].id).toBe("attachment-1");
+		expect(authFetch.mock.calls[0][1]).toMatchObject({
+			method: "POST",
+			body: expect.any(FormData),
+		});
+
+		await deleteUnboundChatAttachment("conversation-1", "attachment-1");
+		expect(authFetch).toHaveBeenLastCalledWith(
+			"/api/chat/conversations/conversation-1/attachments/attachment-1",
+			{ method: "DELETE" },
+		);
+	});
+});

--- a/client/src/services/chatAttachments.ts
+++ b/client/src/services/chatAttachments.ts
@@ -1,0 +1,102 @@
+import { authFetch } from "@/lib/api-client";
+import type { components } from "@/lib/v1";
+
+export type AttachmentPublic = components["schemas"]["AttachmentPublic"];
+export type AttachmentUploadResponse =
+	components["schemas"]["AttachmentUploadResponse"];
+
+export const MAX_ATTACHMENT_SIZE_BYTES = 25 * 1024 * 1024;
+export const MAX_ATTACHMENTS_PER_MESSAGE = 5;
+
+const ALLOWED_TYPES = new Set([
+	"image/png",
+	"image/jpeg",
+	"image/webp",
+	"image/gif",
+	"application/pdf",
+	"text/plain",
+	"text/markdown",
+	"text/csv",
+	"application/csv",
+	"application/json",
+	"text/json",
+	"application/x-yaml",
+	"text/yaml",
+	"text/x-yaml",
+]);
+const ALLOWED_TEXT_EXTENSIONS = new Set([
+	"txt",
+	"md",
+	"markdown",
+	"csv",
+	"json",
+	"yaml",
+	"yml",
+]);
+
+export function isImageAttachment(contentType: string): boolean {
+	return contentType.startsWith("image/");
+}
+
+export function validateAttachment(file: File): string | null {
+	if (file.size <= 0) return `${file.name} is empty.`;
+	if (file.size > MAX_ATTACHMENT_SIZE_BYTES) {
+		return `${file.name} is too large (maximum 25 MB).`;
+	}
+	const extension = file.name.split(".").pop()?.toLowerCase() ?? "";
+	const knownTextFile = !file.type && ALLOWED_TEXT_EXTENSIONS.has(extension);
+	if (
+		!knownTextFile &&
+		!ALLOWED_TYPES.has(file.type) &&
+		!file.type.startsWith("text/")
+	) {
+		return `${file.name} is not a supported image, PDF, CSV, or text file.`;
+	}
+	return null;
+}
+
+export async function uploadChatAttachments(
+	conversationId: string,
+	files: File[],
+): Promise<AttachmentUploadResponse> {
+	if (files.length > MAX_ATTACHMENTS_PER_MESSAGE) {
+		throw new Error(
+			`Attach no more than ${MAX_ATTACHMENTS_PER_MESSAGE} files per message.`,
+		);
+	}
+	const formData = new FormData();
+	for (const file of files) formData.append("files", file);
+	const response = await authFetch(
+		`/api/chat/conversations/${conversationId}/attachments`,
+		{ method: "POST", body: formData },
+	);
+	if (!response.ok) {
+		const body = (await response.json().catch(() => ({}))) as {
+			detail?: string;
+		};
+		throw new Error(body.detail || "Could not upload the attached files.");
+	}
+	return response.json() as Promise<AttachmentUploadResponse>;
+}
+
+export async function deleteUnboundChatAttachment(
+	conversationId: string,
+	attachmentId: string,
+): Promise<void> {
+	const response = await authFetch(
+		`/api/chat/conversations/${conversationId}/attachments/${attachmentId}`,
+		{ method: "DELETE" },
+	);
+	if (!response.ok && response.status !== 404) {
+		throw new Error("Could not discard the uploaded file.");
+	}
+}
+
+export function attachmentContentUrl(
+	conversationId: string,
+	attachmentId: string,
+	options?: { download?: boolean },
+): string {
+	const base = `/api/chat/conversations/${conversationId}/attachments/${attachmentId}/content`;
+	return options?.download ? `${base}?download=true` : base;
+}

--- a/client/src/services/chatModels.ts
+++ b/client/src/services/chatModels.ts
@@ -1,0 +1,4 @@
+import type { components } from "@/lib/v1";
+
+export type ChatModelTierOption = components["schemas"]["ChatModelTierPublic"];
+export type ChatModelTierId = ChatModelTierOption["id"];

--- a/client/src/services/websocket.test.ts
+++ b/client/src/services/websocket.test.ts
@@ -52,3 +52,33 @@ describe("platform-job WebSocket contract", () => {
 		unsubscribe();
 	});
 });
+
+describe("chat WebSocket contract", () => {
+	it("sends attachment ids and the governed model tier", () => {
+		const send = vi.fn();
+		const service = webSocketService as unknown as {
+			ws: { readyState: number; send: typeof send } | null;
+		};
+		service.ws = { readyState: WebSocket.OPEN, send };
+
+		expect(
+			webSocketService.sendChatMessage(
+				"conversation-1",
+				"Summarize this",
+				"local-1",
+				["attachment-1"],
+				"pro",
+			),
+		).toBe(true);
+		expect(JSON.parse(send.mock.calls[0][0])).toEqual({
+			type: "chat",
+			conversation_id: "conversation-1",
+			message: "Summarize this",
+			local_id: "local-1",
+			attachment_ids: ["attachment-1"],
+			model_tier: "pro",
+		});
+
+		service.ws = null;
+	});
+});

--- a/client/src/services/websocket.ts
+++ b/client/src/services/websocket.ts
@@ -1477,7 +1477,13 @@ class WebSocketService {
 	/**
 	 * Send a chat message to a conversation
 	 */
-	sendChatMessage(conversationId: string, message: string, localId?: string): boolean {
+	sendChatMessage(
+		conversationId: string,
+		message: string,
+		localId?: string,
+		attachmentIds: string[] = [],
+		modelTier: "fast" | "balanced" | "pro" = "balanced",
+	): boolean {
 		if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
 			return false;
 		}
@@ -1488,6 +1494,8 @@ class WebSocketService {
 				conversation_id: conversationId,
 				message,
 				local_id: localId,
+				attachment_ids: attachmentIds,
+				model_tier: modelTier,
 			}),
 		);
 		return true;

--- a/plugins/bifrost/skills/bifrost-build/generated/openapi-digest.md
+++ b/plugins/bifrost/skills/bifrost-build/generated/openapi-digest.md
@@ -104,8 +104,12 @@
 | POST | `/api/chat/conversations` |
 | DELETE | `/api/chat/conversations/{conversation_id}` |
 | GET | `/api/chat/conversations/{conversation_id}` |
+| POST | `/api/chat/conversations/{conversation_id}/attachments` |
+| DELETE | `/api/chat/conversations/{conversation_id}/attachments/{attachment_id}` |
+| GET | `/api/chat/conversations/{conversation_id}/attachments/{attachment_id}/content` |
 | GET | `/api/chat/conversations/{conversation_id}/messages` |
 | POST | `/api/chat/conversations/{conversation_id}/messages` |
+| GET | `/api/chat/model-tiers` |
 | GET | `/api/claims` |
 | POST | `/api/claims` |
 | DELETE | `/api/claims/{name}` |


### PR DESCRIPTION
Closes #139

## Summary

- distill the Chat composer around messaging, governed model selection, and attachments
- add configurable Fast, Balanced, and Pro labels with administrator-controlled model mappings
- persist owner-scoped attachments with preview, download, validation, storage limits, and cleanup
- pass images and PDFs to Pydantic AI as binary content and bounded text or CSV content as prompt context
- retain staged files when a synchronous send fails and clean up unbound uploads
- regenerate the OpenAPI client contract

## Scope intentionally omitted

- Workspaces
- manual compaction controls
- Chat-specific delegation UI
- Toolbox
- message editing and retry branching
- generated artifacts before Code Builder

## Verification

- API type checking and Ruff: passed
- 111 scoped backend and contract tests: passed
- 27 scoped Vitest tests: passed
- focused attachment regression rerun: 6 backend tests and 3 client service tests passed
- TypeScript type checking: passed
- ESLint: passed with one existing React Compiler warning in FormRenderer
- Playwright desktop and mobile attachment journey: passed on the first attempt
- Impeccable UI detector: no findings

Broader full backend, full Vitest, and full Playwright suites were not run.