### PR TITLE
fix(agent-runtime): preserve OpenRouter provider usage

### DIFF
--- a/api/src/services/agent_runtime/model_factory.py
+++ b/api/src/services/agent_runtime/model_factory.py
@@ -4,23 +4,73 @@ Provider SDK imports stay inside the selected branch. This preserves the worker 
 scheduler import boundary while giving every agent surface one model abstraction.
 """
 
+from urllib.parse import urlparse
+
 from pydantic_ai.models import Model
+from pydantic_ai.usage import RequestUsage
 
 from src.services.llm.base import LLMConfig
+
+
+def _is_openrouter_endpoint(endpoint: str | None) -> bool:
+    """Return whether an OpenAI-compatible endpoint is OpenRouter itself."""
+
+    if not endpoint:
+        return False
+    hostname = urlparse(endpoint).hostname
+    return hostname == "openrouter.ai" or bool(
+        hostname and hostname.endswith(".openrouter.ai")
+    )
+
+
+def _openrouter_usage(response: object, fallback: RequestUsage) -> RequestUsage:
+    """Map counts OpenRouter returned even when Pydantic's price lookup misses."""
+
+    provider_usage = getattr(response, "usage", None)
+    if provider_usage is None:
+        return fallback
+
+    prompt_details = getattr(provider_usage, "prompt_tokens_details", None)
+    cached_tokens = getattr(prompt_details, "cached_tokens", 0) or 0
+    return RequestUsage(
+        input_tokens=provider_usage.prompt_tokens,
+        output_tokens=provider_usage.completion_tokens,
+        cache_read_tokens=cached_tokens,
+        cache_write_tokens=fallback.cache_write_tokens,
+        input_audio_tokens=fallback.input_audio_tokens,
+        cache_audio_read_tokens=fallback.cache_audio_read_tokens,
+        output_audio_tokens=fallback.output_audio_tokens,
+        details=fallback.details,
+    )
 
 
 def create_agent_model(config: LLMConfig, *, model: str | None = None) -> Model:
     """Build the configured Pydantic AI model.
 
-    OpenAI-compatible endpoints (including OpenRouter) deliberately use the Chat
-    Completions adapter because that is the compatibility contract Bifrost exposes
-    today. Native OpenAI can move to Responses independently without changing this
-    runtime boundary.
+    Bifrost's public configuration remains provider-neutral. Known compatible
+    services use their native Pydantic adapter internally so provider-specific
+    response metadata, especially usage accounting, is preserved. Other custom
+    OpenAI-compatible endpoints continue through the generic Chat Completions
+    adapter.
     """
 
     model_name = model or config.model
 
     if config.provider == "openai":
+        if _is_openrouter_endpoint(config.endpoint):
+            from pydantic_ai.models.openrouter import OpenRouterModel
+            from pydantic_ai.providers.openrouter import OpenRouterProvider
+
+            class BifrostOpenRouterModel(OpenRouterModel):
+                def _map_usage(self, response: object) -> RequestUsage:
+                    return _openrouter_usage(response, super()._map_usage(response))  # type: ignore[arg-type]
+
+            return BifrostOpenRouterModel(
+                model_name,
+                provider=OpenRouterProvider(api_key=config.api_key),
+                settings={"openrouter_usage": {"include": True}},
+            )
+
         from pydantic_ai.models.openai import OpenAIChatModel
         from pydantic_ai.providers.openai import OpenAIProvider
 

--- a/api/src/services/agent_runtime/observed_model.py
+++ b/api/src/services/agent_runtime/observed_model.py
@@ -5,7 +5,7 @@ import math
 import time
 from collections.abc import AsyncGenerator, Awaitable, Callable
 from contextlib import asynccontextmanager
-from dataclasses import dataclass, replace
+from dataclasses import dataclass
 from typing import Literal
 
 import pydantic_core
@@ -157,29 +157,6 @@ class ObservedModel(WrapperModel):
                 input_tokens=int(breakdown["estimated_input_tokens"]),
             )
 
-    @staticmethod
-    def _usage_with_fallback(
-        usage: RequestUsage,
-        *,
-        context_breakdown: dict[str, int | str],
-        response: ModelResponse,
-    ) -> RequestUsage:
-        """Backfill only token fields omitted by an upstream provider."""
-
-        if usage.input_tokens > 0 and usage.output_tokens > 0:
-            return usage
-        estimated_output_tokens = max(
-            1,
-            math.ceil(len(pydantic_core.to_json(response.parts, fallback=str)) / 2),
-        )
-        return replace(
-            usage,
-            input_tokens=usage.input_tokens
-            or int(context_breakdown["estimated_input_tokens"]),
-            output_tokens=usage.output_tokens or estimated_output_tokens,
-            details={**usage.details, "bifrost_usage_estimated": 1},
-        )
-
     async def request(
         self,
         messages: list[ModelMessage],
@@ -215,14 +192,6 @@ class ObservedModel(WrapperModel):
                 )
             )
             raise
-
-        fallback_usage = self._usage_with_fallback(
-            response.usage,
-            context_breakdown=context_breakdown,
-            response=response,
-        )
-        if fallback_usage is not response.usage:
-            response = replace(response, usage=fallback_usage)
 
         await self._observer(
             ModelCallEvent(
@@ -266,18 +235,6 @@ class ObservedModel(WrapperModel):
             ) as response_stream:
                 yield response_stream
             response = response_stream.get()
-            fallback_usage = self._usage_with_fallback(
-                response.usage,
-                context_breakdown=context_breakdown,
-                response=response,
-            )
-            if fallback_usage is not response.usage:
-                # Pydantic exposes stream usage read-only. The pinned runtime's
-                # StreamedResponse stores that public value in `_usage`; update it
-                # before our context exits so the agent ledger receives the same
-                # conservative fallback as non-streaming requests.
-                response_stream._usage = fallback_usage
-                response = replace(response, usage=fallback_usage)
         except Exception as exc:
             await self._observer(
                 ModelCallEvent(

--- a/api/tests/unit/services/test_agent_runtime.py
+++ b/api/tests/unit/services/test_agent_runtime.py
@@ -2,9 +2,11 @@
 
 from contextlib import asynccontextmanager
 from dataclasses import replace
+from typing import cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from openai.types.chat import ChatCompletion
 from pydantic_ai import Agent as PydanticAgent
 from pydantic_ai.exceptions import UsageLimitExceeded
 from pydantic_ai_harness.compaction import LimitWarner, TieredCompaction
@@ -110,6 +112,63 @@ def test_create_agent_model_supports_every_configured_provider(
 
     assert model.model_name == "test-model"
     assert model.system == expected_system
+
+
+def test_create_agent_model_uses_native_openrouter_adapter() -> None:
+    from pydantic_ai.models.openrouter import OpenRouterModel, OpenRouterModelSettings
+
+    config = LLMConfig(
+        provider="openai",
+        model="~deepseek/deepseek-v4-flash-latest",
+        api_key="test-key",
+        endpoint="https://openrouter.ai/api/v1",
+    )
+
+    model = create_agent_model(config)
+
+    assert isinstance(model, OpenRouterModel)
+    assert model.model_name == "~deepseek/deepseek-v4-flash-latest"
+    assert model.system == "openrouter"
+    settings = cast(OpenRouterModelSettings, model.settings)
+    assert settings.get("openrouter_usage") == {"include": True}
+
+
+def test_native_openrouter_adapter_preserves_provider_reported_usage() -> None:
+    config = LLMConfig(
+        provider="openai",
+        model="~deepseek/deepseek-v4-flash-latest",
+        api_key="test-key",
+        endpoint="https://openrouter.ai/api/v1",
+    )
+    model = create_agent_model(config)
+    provider_response = ChatCompletion.model_validate(
+        {
+            "id": "generation-123",
+            "object": "chat.completion",
+            "created": 0,
+            "model": "deepseek/deepseek-v4-flash-0731",
+            "provider": "DeepSeek",
+            "choices": [
+                {
+                    "index": 0,
+                    "finish_reason": "stop",
+                    "message": {"role": "assistant", "content": "done"},
+                }
+            ],
+            "usage": {
+                "prompt_tokens": 12_345,
+                "completion_tokens": 678,
+                "total_tokens": 13_023,
+            },
+        }
+    )
+
+    validated_response = model._validate_completion(provider_response)  # type: ignore[attr-defined]
+    response = model._process_response(validated_response)  # type: ignore[attr-defined]
+
+    assert response.provider_response_id == "generation-123"
+    assert response.usage.input_tokens == 12_345
+    assert response.usage.output_tokens == 678
 
 
 def test_budget_is_enforced_before_requests_and_warns_before_hard_stop() -> None:
@@ -438,7 +497,7 @@ def test_request_observability_breaks_down_context_without_recording_contents() 
 
 
 @pytest.mark.asyncio
-async def test_missing_provider_usage_is_backfilled_for_requests_and_streams() -> None:
+async def test_missing_provider_usage_is_not_replaced_by_safety_estimates() -> None:
     messages = [ModelRequest(parts=[UserPromptPart(content="hello")])]
     parameters = ModelRequestParameters()
     observer = AsyncMock()
@@ -449,14 +508,14 @@ async def test_missing_provider_usage_is_backfilled_for_requests_and_streams() -
 
     response = await model.request(messages, None, parameters)
 
-    assert response.usage.input_tokens > 0
-    assert response.usage.output_tokens > 0
-    assert response.usage.details["bifrost_usage_estimated"] == 1
+    assert response.usage.input_tokens == 0
+    assert response.usage.output_tokens == 0
+    assert "bifrost_usage_estimated" not in response.usage.details
 
     async with model.request_stream(messages, None, parameters) as response_stream:
         async for _event in response_stream:
             pass
 
-    assert response_stream.usage.input_tokens > 0
-    assert response_stream.usage.output_tokens > 0
-    assert response_stream.usage.details["bifrost_usage_estimated"] == 1
+    assert response_stream.usage.input_tokens == 0
+    assert response_stream.usage.output_tokens == 0
+    assert "bifrost_usage_estimated" not in response_stream.usage.details

--- a/docs/plans/2026-08-14-pydantic-agent-runtime.md
+++ b/docs/plans/2026-08-14-pydantic-agent-runtime.md
@@ -51,7 +51,7 @@ The shared runtime is divided into narrow boundaries:
 - `agent_runtime/model_factory.py` selects native OpenAI/OpenAI-compatible, Anthropic, or Google Pydantic models. OpenRouter remains an OpenAI-compatible endpoint and model name.
 - `agent_runtime/toolset.py` exposes Bifrost's stored JSON schemas without regenerating them and delegates execution back to Bifrost's existing authorization-aware tool paths.
 - `agent_runtime/budgets.py` creates pre-request usage limits, a shared parent/child ledger, proactive wind-down warnings, oversized-tool spillover, deterministic tool-result clearing, and a sliding context window.
-- `agent_runtime/observed_model.py` records a privacy-safe request composition breakdown, uses native provider token counting when available, and conservatively estimates missing preflight or response usage without replacing nonzero provider usage.
+- `agent_runtime/observed_model.py` records a privacy-safe request composition breakdown, uses native provider token counting when available, and conservatively estimates the next request only for preflight budget protection.
 - `llm/pydantic_client.py` adapts the existing `BaseLLMClient` contract so non-agent consumers migrate provider transport without changing SDK or API contracts.
 - `agent_executor.py` and `execution/autonomous_agent_executor.py` now use Pydantic's native loop and event stream instead of maintaining independent model/tool loops.
 
@@ -59,7 +59,7 @@ The shared runtime is divided into narrow boundaries:
 
 The configured token budget is cumulative input plus output across the root run and every delegated descendant. Pydantic's `RunUsage` object is shared through the delegation tree. A child also receives a local ceiling derived from its own configured allowance, but that ceiling can never exceed the inherited parent ceiling.
 
-Limits are evaluated before a provider request with token counting enabled. When a provider cannot count locally, the observed-model boundary estimates serialized messages and tool schemas at two bytes per token plus structural overhead; this intentionally fails closed for ordinary prose and JSON. A provider's eventual output cannot be known in advance, so the preflight check counts accumulated usage plus the next input; the returned output is then charged before any later request. If an upstream route omits response usage, missing input/output fields are conservatively backfilled and tagged in usage details while any nonzero provider fields remain authoritative. Request count, the one allowed malformed-tool correction, and delegated model calls all consume the same ledger.
+Limits are evaluated before a provider request with token counting enabled. When a provider cannot count locally, the observed-model boundary estimates serialized messages and tool schemas at two bytes per token plus structural overhead; this intentionally fails closed for ordinary prose and JSON. The estimate is predictive only: it can trigger wind-down or prevent the next request, but it is never persisted as actual usage. A provider's eventual output cannot be known in advance, so the preflight check counts accumulated provider usage plus the estimated next input; the returned provider input and output counts are then charged before any later request. Request count, the one allowed malformed-tool correction, and delegated model calls all consume the same ledger.
 
 At 70% of either request or total-token budget, the model receives a wind-down instruction. With two requests remaining, the instruction becomes critical. The intended experience is a technician-style handoff: state what was tried, identify remaining blockers, finish notes, and leave resumable progress. If the hard guard still fires, chat returns a context warning and a resumable handoff rather than silently disappearing.
 
@@ -88,7 +88,7 @@ The Coding Agent branch can consume the same model factory, shared budget, obser
 4. Gate wider rollout on lower cumulative input per successful run, zero parent-budget escapes, preserved tool success rate, and no increase in incomplete handoffs.
 5. Merge the shared runtime into the Coding Agent worktree, then implement its coding capability profile there.
 
-The local OpenRouter gate completed against `deepseek/deepseek-v4-flash`: one Bifrost tool call completed across two model requests. That route omitted native token usage, exercising the fallback ledger, which recorded 3,074 input and 401 output tokens. The credential was injected transiently from the work 1Password vault and was not stored in source or runtime configuration.
+The original local OpenRouter gate completed against `deepseek/deepseek-v4-flash`, but its 3,074 input and 401 output totals were conservative Bifrost estimates rather than provider usage. A follow-up live trace proved that OpenRouter returned exact usage while Pydantic AI's generic usage extractor silently reduced it to zero. Bifrost now requests OpenRouter usage explicitly and preserves those returned fields directly. The patched factory's live canary recorded 9 input and 22 output tokens; the old local input estimate for the same request was 131 tokens. The credential was injected transiently from the work 1Password vault and was not stored in source or runtime configuration.
 
 Required production telemetry per model request:
 


### PR DESCRIPTION
## Summary
- select Pydantic AI’s native OpenRouter adapter behind the existing OpenAI-compatible configuration contract
- explicitly request OpenRouter usage and preserve provider input/output counts when Pydantic’s generic extractor returns zero
- keep the conservative estimator predictive-only for pre-request budget protection; never store it as actual usage
- document the corrected live canary and add regression coverage

## Verification
- `./test.sh tests/unit/services/test_agent_runtime.py tests/unit/services/test_agent_executor_runtime.py tests/unit/services/test_autonomous_agent_executor.py tests/unit/services/test_agent_runtime_delegated_wind_down.py tests/unit/services/test_agent_runtime_wind_down.py tests/unit/test_run_summarizer.py -q` — 79 passed
- `./test.sh tests/unit/test_contract_version.py tests/unit/test_dto_flags.py -q` — 64 passed
- `./test.sh quality api` — pyright and ruff passed
- live OpenRouter canary through patched Bifrost factory: 9 input, 22 output, 31 total; prior local estimator for the same input: 131

Fixes #599