### PR TITLE
test(migrations): expect AI usage pricing head

### DIFF
--- a/api/tests/e2e/platform/test_withdrawn_builder_migrations.py
+++ b/api/tests/e2e/platform/test_withdrawn_builder_migrations.py
@@ -13,7 +13,7 @@ async def test_fresh_database_does_not_install_withdrawn_builder_schema(
     revision = (
         await db_session.execute(text("SELECT version_num FROM alembic_version"))
     ).scalar_one()
-    assert revision == "20260815_chat_attachments"
+    assert revision == "20260815_ai_usage_cache_cost"
 
     builder_tables = (
         await db_session.execute(


### PR DESCRIPTION
Follow-up to #607. The new cache-aware AI usage migration correctly advanced the Alembic head, but the withdrawn-Builder-schema regression test still expected the prior chat-attachments head.

This updates only that pinned revision; the test continues to verify the withdrawn Builder tables and roles are absent.

Verification:
- `./test.sh tests/e2e/platform/test_withdrawn_builder_migrations.py -vv` (1 passed)

Fixes #604