### PR TITLE
Fail closed on exact merge-candidate proof

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,9 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Check GitHub Action pins
-        run: python3 api/scripts/check_github_action_pins.py
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: python3 api/scripts/check_github_action_pins.py --verify-versions
 
       # Codex skill mirrors (plugins/bifrost/skills/, .codex/skills/) are
       # generated from the canonical .claude/skills/ source. Regenerate and fail
@@ -314,7 +316,7 @@ jobs:
 
       - name: Build production client under test (cached)
         if: github.event_name != 'merge_group'
-        uses: docker/build-push-action@53b7df96c91f9d12dcc8a07bcb9ccacbed38856a # v7.3.0
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: ./client
           file: ./client/Dockerfile
@@ -337,7 +339,7 @@ jobs:
             bifrost-test-client-e2e:latest
 
       - name: Build Playwright runner (cached)
-        uses: docker/build-push-action@53b7df96c91f9d12dcc8a07bcb9ccacbed38856a # v7.3.0
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: ./client
           file: ./client/Dockerfile.playwright
@@ -361,7 +363,7 @@ jobs:
 
       - name: Upload browser diagnostics
         if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656f7c1c64a875d1fc6a0a # v7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: critical-browser-smoke-${{ github.run_attempt }}
           path: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -483,6 +483,7 @@ jobs:
   test-e2e-gate:
     if: >-
       always() && (
+        github.event_name == 'pull_request' ||
         github.event_name == 'merge_group' ||
         github.event_name == 'workflow_dispatch' ||
         startsWith(github.ref, 'refs/tags/v')
@@ -493,6 +494,16 @@ jobs:
     steps:
       - name: Check shard results
         run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            if [ "${{ needs.test-client-unit.result }}" != "success" ]; then
+              echo "Client unit tests failed or were cancelled (result: ${{ needs.test-client-unit.result }})"
+              exit 1
+            fi
+            echo "Full E2E is deferred to the merge queue's exact merge candidate."
+            echo "A successful merge_group E2E Tests check is required before main and :dev images."
+            exit 0
+          fi
+
           if [ "${{ needs.test-e2e.result }}" != "success" ] || \
              [ "${{ needs.test-client-unit.result }}" != "success" ] || \
              [ "${{ needs.test-client-smoke.result }}" != "success" ] || \
@@ -505,25 +516,6 @@ jobs:
             exit 1
           fi
           echo "All exact-candidate suites and required artifact builds passed."
-
-  # Ordinary PRs retain the existing required check name while deferring the
-  # complete E2E suite to merge_group. Lint, backend unit, and client unit tests
-  # still run on the PR. The static workflow contract exercised by Unit Tests
-  # prevents this check from being used without the full exact-candidate gate.
-  test-e2e-pr:
-    if: always() && github.event_name == 'pull_request'
-    needs: [test-client-unit]
-    runs-on: ubuntu-latest
-    name: E2E Tests
-    steps:
-      - name: Report exact-candidate E2E gate
-        run: |
-          if [ "${{ needs.test-client-unit.result }}" != "success" ]; then
-            echo "Client unit tests failed or were cancelled (result: ${{ needs.test-client-unit.result }})"
-            exit 1
-          fi
-          echo "Full E2E is deferred to the merge queue's exact merge candidate."
-          echo "A successful merge_group E2E Tests check is required before main and :dev images."
 
   # =============================================================================
   # Dev Promotion - main may only publish the already-built exact candidate.
@@ -543,6 +535,14 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+
+      - name: Verify exact merge candidate gate
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: >-
+          python3 api/scripts/verify_merge_candidate.py
+          --repository "$GITHUB_REPOSITORY"
+          --sha "$GITHUB_SHA"
 
       - name: Compute version
         id: version
@@ -765,9 +765,9 @@ jobs:
       - name: Smoke deployed API and client services
         run: |
           set -euo pipefail
-          kubectl -n bifrost port-forward service/bifrost-api 18000:8000 > /tmp/bifrost-api-port-forward.log 2>&1 &
+          kubectl -n bifrost port-forward service/api 18000:8000 > /tmp/bifrost-api-port-forward.log 2>&1 &
           API_FORWARD_PID=$!
-          kubectl -n bifrost port-forward service/bifrost-client 18080:80 > /tmp/bifrost-client-port-forward.log 2>&1 &
+          kubectl -n bifrost port-forward service/client 18080:80 > /tmp/bifrost-client-port-forward.log 2>&1 &
           CLIENT_FORWARD_PID=$!
           cleanup() {
             kill "$API_FORWARD_PID" "$CLIENT_FORWARD_PID" 2>/dev/null || true

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -25,7 +25,7 @@ jobs:
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Build API dev image (cached)
-        uses: docker/build-push-action@53b7df96c91f9d12dcc8a07bcb9ccacbed38856a # v7.3.0
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           file: ./api/Dockerfile.dev
@@ -35,7 +35,7 @@ jobs:
           cache-to: type=gha,scope=test-api-dev,mode=max
 
       - name: Build production client under test (cached)
-        uses: docker/build-push-action@53b7df96c91f9d12dcc8a07bcb9ccacbed38856a # v7.3.0
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: ./client
           file: ./client/Dockerfile
@@ -47,7 +47,7 @@ jobs:
           cache-to: type=gha,scope=test-client-e2e,mode=max
 
       - name: Build Playwright runner (cached)
-        uses: docker/build-push-action@53b7df96c91f9d12dcc8a07bcb9ccacbed38856a # v7.3.0
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: ./client
           file: ./client/Dockerfile.playwright
@@ -71,7 +71,7 @@ jobs:
 
       - name: Upload browser diagnostics
         if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656f7c1c64a875d1fc6a0a # v7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: nightly-product-browser-${{ github.run_attempt }}
           path: |
@@ -92,7 +92,7 @@ jobs:
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Build API dev image (cached)
-        uses: docker/build-push-action@53b7df96c91f9d12dcc8a07bcb9ccacbed38856a # v7.3.0
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           file: ./api/Dockerfile.dev
@@ -116,7 +116,7 @@ jobs:
 
       - name: Upload backend diagnostics
         if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656f7c1c64a875d1fc6a0a # v7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: nightly-slow-backend-${{ github.run_attempt }}
           path: /tmp/bifrost-*/
@@ -135,7 +135,7 @@ jobs:
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Build API dev image (cached)
-        uses: docker/build-push-action@53b7df96c91f9d12dcc8a07bcb9ccacbed38856a # v7.3.0
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           file: ./api/Dockerfile.dev
@@ -187,7 +187,7 @@ jobs:
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Build API production image without cache
-        uses: docker/build-push-action@53b7df96c91f9d12dcc8a07bcb9ccacbed38856a # v7.3.0
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           file: ./api/Dockerfile
@@ -197,7 +197,7 @@ jobs:
           build-args: BIFROST_VERSION=nightly-${{ github.sha }}
 
       - name: Build client production image without cache
-        uses: docker/build-push-action@53b7df96c91f9d12dcc8a07bcb9ccacbed38856a # v7.3.0
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: ./client
           file: ./client/Dockerfile

--- a/api/scripts/check_github_action_pins.py
+++ b/api/scripts/check_github_action_pins.py
@@ -4,15 +4,22 @@
 from __future__ import annotations
 
 import argparse
+import json
+import os
 import re
 import sys
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Callable
+from urllib.error import HTTPError, URLError
+from urllib.parse import quote
+from urllib.request import Request, urlopen
 
 
 FULL_SHA_RE = re.compile(r"^[0-9a-f]{40}$", re.IGNORECASE)
 USES_RE = re.compile(r"^\s*(?:-\s*)?uses:\s*(?P<value>.+?)\s*$")
 WORKFLOW_SUFFIXES = {".yml", ".yaml"}
+VERSION_COMMENT_RE = re.compile(r"#\s*(?P<version>v[0-9][^\s#]*)\s*$")
 
 
 @dataclass(frozen=True)
@@ -79,6 +86,103 @@ def find_unpinned_actions(paths: list[Path]) -> list[Violation]:
     return violations
 
 
+def find_mismatched_action_versions(
+    paths: list[Path],
+    resolve_version: Callable[[str, str], str],
+) -> list[Violation]:
+    """Verify each readable version comment resolves to the pinned commit."""
+    violations: list[Violation] = []
+    resolved: dict[tuple[str, str], str] = {}
+    for path in _iter_workflow_files(paths):
+        for line_number, line in enumerate(
+            path.read_text(encoding="utf-8").splitlines(), start=1
+        ):
+            match = USES_RE.match(line)
+            if not match:
+                continue
+
+            action = _strip_optional_quotes(
+                _strip_inline_comment(match.group("value"))
+            )
+            if _is_local_or_non_github_action(action) or "@" not in action:
+                continue
+
+            action_path, pinned_sha = action.rsplit("@", 1)
+            if not FULL_SHA_RE.fullmatch(pinned_sha):
+                continue
+
+            version_match = VERSION_COMMENT_RE.search(line)
+            if not version_match:
+                violations.append(
+                    Violation(
+                        path,
+                        line_number,
+                        action,
+                        "SHA-pinned external action needs a readable version comment",
+                    )
+                )
+                continue
+
+            parts = action_path.split("/")
+            if len(parts) < 2:
+                continue
+            repository = "/".join(parts[:2])
+            version = version_match.group("version")
+            key = (repository, version)
+            try:
+                if key not in resolved:
+                    resolved[key] = resolve_version(repository, version)
+                resolved_sha = resolved[key]
+            except (HTTPError, URLError, RuntimeError, ValueError) as exc:
+                violations.append(
+                    Violation(
+                        path,
+                        line_number,
+                        action,
+                        f"could not resolve {repository}@{version}: {exc}",
+                    )
+                )
+                continue
+
+            if resolved_sha.lower() != pinned_sha.lower():
+                violations.append(
+                    Violation(
+                        path,
+                        line_number,
+                        action,
+                        (
+                            f"{repository}@{version} resolves to {resolved_sha}, "
+                            f"not {pinned_sha}"
+                        ),
+                    )
+                )
+
+    return violations
+
+
+def resolve_github_action_version(repository: str, version: str) -> str:
+    """Resolve an action tag through GitHub's commits API."""
+    url = (
+        "https://api.github.com/repos/"
+        f"{quote(repository, safe='/')}/commits/{quote(version, safe='')}"
+    )
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "User-Agent": "bifrost-action-pin-check",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    token = os.environ.get("GITHUB_TOKEN")
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+
+    with urlopen(Request(url, headers=headers), timeout=15) as response:  # noqa: S310
+        payload = json.load(response)
+    sha = payload.get("sha")
+    if not isinstance(sha, str) or not FULL_SHA_RE.fullmatch(sha):
+        raise ValueError("GitHub returned no full commit SHA")
+    return sha
+
+
 def _iter_workflow_files(paths: list[Path]) -> list[Path]:
     files: list[Path] = []
     for path in paths:
@@ -104,9 +208,21 @@ def main(argv: list[str] | None = None) -> int:
         default=[Path(".github/workflows"), Path(".github/actions")],
         help="Workflow files or directories to scan.",
     )
+    parser.add_argument(
+        "--verify-versions",
+        action="store_true",
+        help="Resolve readable version comments and verify their pinned SHAs.",
+    )
     args = parser.parse_args(argv)
 
     violations = find_unpinned_actions(args.paths)
+    if args.verify_versions:
+        violations.extend(
+            find_mismatched_action_versions(
+                args.paths,
+                resolve_github_action_version,
+            )
+        )
     if not violations:
         return 0
 

--- a/api/scripts/verify_merge_candidate.py
+++ b/api/scripts/verify_merge_candidate.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Fail closed unless an exact SHA passed Bifrost's merge-candidate gate."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from collections.abc import Callable
+from typing import Any
+from urllib.parse import quote, urlencode
+from urllib.request import Request, urlopen
+
+
+REQUIRED_JOBS = {
+    "Lint & Type Check",
+    "Unit Tests",
+    "Client Unit Tests",
+    "E2E Tests (shard 1/2)",
+    "E2E Tests (shard 2/2)",
+    "Critical Browser Smoke",
+    "Build Dev Candidate",
+    "E2E Tests",
+}
+CI_WORKFLOW_PATH = ".github/workflows/ci.yml"
+
+
+def _github_json(url: str) -> dict[str, Any]:
+    if not url.startswith("https://api.github.com/"):
+        raise ValueError(f"refusing non-GitHub API URL: {url}")
+
+    token = os.environ.get("GITHUB_TOKEN")
+    if not token:
+        raise RuntimeError("GITHUB_TOKEN is required")
+    request = Request(
+        url,
+        headers={
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {token}",
+            "User-Agent": "bifrost-merge-candidate-verifier",
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+    )
+    with urlopen(request, timeout=15) as response:  # noqa: S310
+        payload = json.load(response)
+    if not isinstance(payload, dict):
+        raise ValueError("GitHub returned a non-object response")
+    return payload
+
+
+def verify_merge_candidate(
+    repository: str,
+    sha: str,
+    fetch_json: Callable[[str], dict[str, Any]],
+) -> list[str]:
+    """Return invariant violations for the merge-group run at ``sha``."""
+    query = urlencode(
+        {
+            "event": "merge_group",
+            "head_sha": sha,
+            "per_page": 100,
+        }
+    )
+    runs_url = (
+        "https://api.github.com/repos/"
+        f"{quote(repository, safe='/')}/actions/runs?{query}"
+    )
+    runs = fetch_json(runs_url).get("workflow_runs", [])
+    candidates = [
+        run
+        for run in runs
+        if run.get("head_sha") == sha
+        and run.get("event") == "merge_group"
+        and run.get("path") == CI_WORKFLOW_PATH
+    ]
+    if len(candidates) != 1:
+        return [
+            f"expected exactly one {CI_WORKFLOW_PATH} merge_group run for {sha}, "
+            f"found {len(candidates)}"
+        ]
+
+    run = candidates[0]
+    jobs_url = run.get("jobs_url")
+    if not isinstance(jobs_url, str):
+        return ["merge-group run did not provide a jobs URL"]
+    separator = "&" if "?" in jobs_url else "?"
+    jobs = fetch_json(f"{jobs_url}{separator}per_page=100").get("jobs", [])
+
+    conclusions: dict[str, list[str | None]] = {}
+    for job in jobs:
+        name = job.get("name")
+        if isinstance(name, str) and name in REQUIRED_JOBS:
+            conclusions.setdefault(name, []).append(job.get("conclusion"))
+
+    violations: list[str] = []
+    for name in sorted(REQUIRED_JOBS):
+        observed = conclusions.get(name, [])
+        if observed != ["success"]:
+            violations.append(
+                f"required exact-candidate job {name!r} must appear once and pass; "
+                f"observed {observed or 'missing'}"
+            )
+    return violations
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Verify the exact SHA passed every merge-candidate gate job."
+    )
+    parser.add_argument("--repository", required=True, help="GitHub owner/repository")
+    parser.add_argument("--sha", required=True, help="Exact candidate commit SHA")
+    args = parser.parse_args(argv)
+
+    violations = verify_merge_candidate(
+        args.repository,
+        args.sha,
+        _github_json,
+    )
+    if not violations:
+        print(f"Exact merge candidate {args.sha} passed every required gate job.")
+        return 0
+
+    print("Refusing dev-image promotion:", file=sys.stderr)
+    for violation in violations:
+        print(f"  - {violation}", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/api/tests/unit/test_ci_workflow_contract.py
+++ b/api/tests/unit/test_ci_workflow_contract.py
@@ -55,7 +55,8 @@ def test_full_suite_gates_exact_merge_candidate_before_dev_image() -> None:
         assert "github.event_name == 'merge_group'" in condition
         assert "github.event_name == 'workflow_dispatch'" in condition
         assert "startsWith(github.ref, 'refs/tags/v')" in condition
-        assert "pull_request" not in condition
+    assert "pull_request" not in full_e2e_condition
+    assert "github.event_name == 'pull_request'" in full_e2e_gate_condition
 
     assert set(jobs["test-e2e-gate"]["needs"]) == {
         "test-e2e",
@@ -64,6 +65,9 @@ def test_full_suite_gates_exact_merge_candidate_before_dev_image() -> None:
         "build-dev-candidate",
     }
     assert jobs["test-e2e-gate"]["name"] == "E2E Tests"
+    assert [
+        name for name, job in jobs.items() if job.get("name") == "E2E Tests"
+    ] == ["test-e2e-gate"]
 
     for job_name in ("lint", "test-unit", "test-client-unit"):
         condition = _normalized(jobs[job_name]["if"])
@@ -75,6 +79,13 @@ def test_full_suite_gates_exact_merge_candidate_before_dev_image() -> None:
         "github.event_name == 'push' && github.ref == 'refs/heads/main'"
     )
     assert "needs" not in build_dev
+    verification = next(
+        step
+        for step in build_dev["steps"]
+        if step.get("name") == "Verify exact merge candidate gate"
+    )
+    assert "verify_merge_candidate.py" in verification["run"]
+    assert '--sha "$GITHUB_SHA"' in verification["run"]
     assert jobs["deploy-dev"]["needs"] == ["build-dev"]
 
 
@@ -192,6 +203,8 @@ def test_dev_artifact_is_built_on_merge_candidate_and_promoted_without_rebuild()
     deploy = jobs["deploy-dev"]
     assert deploy["needs"] == ["build-dev"]
     deploy_source = "\n".join(step.get("run", "") for step in deploy["steps"])
+    assert "port-forward service/api" in deploy_source
+    assert "port-forward service/client" in deploy_source
     assert "http://127.0.0.1:18000/health/ready" in deploy_source
     assert "http://127.0.0.1:18080/" in deploy_source
 
@@ -199,17 +212,13 @@ def test_dev_artifact_is_built_on_merge_candidate_and_promoted_without_rebuild()
 def test_pull_request_reports_required_e2e_context_without_running_full_suite() -> None:
     jobs = _load_workflow(CI_WORKFLOW)["jobs"]
 
-    pr_gate = jobs["test-e2e-pr"]
-    assert _normalized(pr_gate["if"]) == (
-        "always() && github.event_name == 'pull_request'"
-    )
-    assert pr_gate["needs"] == ["test-client-unit"]
-    assert pr_gate["name"] == "E2E Tests"
-
-    # The ordinary PR and exact-candidate jobs share the required check name but
-    # their event conditions are mutually exclusive.
-    assert jobs["test-e2e-gate"]["name"] == pr_gate["name"]
-    assert "pull_request" not in _normalized(jobs["test-e2e-gate"]["if"])
+    gate = jobs["test-e2e-gate"]
+    assert gate["name"] == "E2E Tests"
+    assert "github.event_name == 'pull_request'" in _normalized(gate["if"])
+    source = "\n".join(step.get("run", "") for step in gate["steps"])
+    assert 'github.event_name }}" = "pull_request"' in source
+    assert "needs.test-client-unit.result" in source
+    assert "Full E2E is deferred" in source
 
 
 def test_docs_only_inverse_workflow_covers_the_same_paths_and_check_names() -> None:

--- a/api/tests/unit/test_github_action_pins.py
+++ b/api/tests/unit/test_github_action_pins.py
@@ -45,3 +45,45 @@ def test_allows_sha_pinned_local_and_docker_actions(tmp_path: Path) -> None:
     violations = check_github_action_pins.find_unpinned_actions([workflow])
 
     assert violations == []
+
+
+def test_flags_sha_that_does_not_match_version_comment(tmp_path: Path) -> None:
+    workflow = tmp_path / "workflow.yml"
+    workflow.write_text(
+        "steps:\n"
+        "  - uses: owner/action@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa # v1.2.3\n",
+        encoding="utf-8",
+    )
+
+    violations = check_github_action_pins.find_mismatched_action_versions(
+        [workflow],
+        lambda repository, version: "b" * 40,
+    )
+
+    assert len(violations) == 1
+    assert "owner/action@v1.2.3 resolves to" in violations[0].reason
+
+
+def test_allows_sha_matching_version_comment_and_caches_resolution(
+    tmp_path: Path,
+) -> None:
+    workflow = tmp_path / "workflow.yml"
+    sha = "a" * 40
+    workflow.write_text(
+        "steps:\n"
+        f"  - uses: owner/action@{sha} # v1.2.3\n"
+        f"  - uses: owner/action/subpath@{sha} # v1.2.3\n",
+        encoding="utf-8",
+    )
+    calls: list[tuple[str, str]] = []
+
+    def resolve(repository: str, version: str) -> str:
+        calls.append((repository, version))
+        return sha
+
+    violations = check_github_action_pins.find_mismatched_action_versions(
+        [workflow], resolve
+    )
+
+    assert violations == []
+    assert calls == [("owner/action", "v1.2.3")]

--- a/api/tests/unit/test_verify_merge_candidate.py
+++ b/api/tests/unit/test_verify_merge_candidate.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from typing import Any
+
+from scripts.verify_merge_candidate import (
+    CI_WORKFLOW_PATH,
+    REQUIRED_JOBS,
+    verify_merge_candidate,
+)
+
+
+SHA = "a" * 40
+
+
+def _fetcher(
+    conclusions: dict[str, str],
+):
+    def fetch(url: str) -> dict[str, Any]:
+        if url.endswith("/jobs?per_page=100"):
+            return {
+                "jobs": [
+                    {"name": name, "conclusion": conclusion}
+                    for name, conclusion in conclusions.items()
+                ]
+            }
+        return {
+            "workflow_runs": [
+                {
+                    "head_sha": SHA,
+                    "event": "merge_group",
+                    "path": CI_WORKFLOW_PATH,
+                    "jobs_url": "https://api.github.com/runs/1/jobs",
+                }
+            ]
+        }
+
+    return fetch
+
+
+def test_accepts_exact_candidate_only_when_every_gate_job_passed() -> None:
+    conclusions = {name: "success" for name in REQUIRED_JOBS}
+
+    assert verify_merge_candidate("gobifrost/bifrost", SHA, _fetcher(conclusions)) == []
+
+
+def test_rejects_failed_or_missing_gate_jobs() -> None:
+    conclusions = {name: "success" for name in REQUIRED_JOBS}
+    conclusions["Critical Browser Smoke"] = "failure"
+    del conclusions["E2E Tests (shard 2/2)"]
+
+    violations = verify_merge_candidate(
+        "gobifrost/bifrost", SHA, _fetcher(conclusions)
+    )
+
+    assert any("Critical Browser Smoke" in violation for violation in violations)
+    assert any("E2E Tests (shard 2/2)" in violation for violation in violations)
+
+
+def test_rejects_ambiguous_duplicate_required_context() -> None:
+    conclusions = {name: "success" for name in REQUIRED_JOBS}
+    fetch = _fetcher(conclusions)
+
+    def with_duplicate(url: str) -> dict[str, Any]:
+        payload = fetch(url)
+        if "jobs?" in url:
+            payload["jobs"].append(
+                {"name": "E2E Tests", "conclusion": "skipped"}
+            )
+        return payload
+
+    violations = verify_merge_candidate("gobifrost/bifrost", SHA, with_duplicate)
+
+    assert any("E2E Tests" in violation and "twice" not in violation for violation in violations)

--- a/docs/plans/2026-08-15-ci-reliability-and-latency.md
+++ b/docs/plans/2026-08-15-ci-reliability-and-latency.md
@@ -464,19 +464,33 @@ not merge.
 
 ### First queue validation incident
 
-The first exact-candidate run exposed a deterministic harness defect before any
-shared image promotion: `Critical Browser Smoke` failed during job setup because
-the pinned SHAs for `actions/upload-artifact@v7.0.1` and
-`docker/build-push-action@v7.3.0` each contained a one-character transcription
-error. GitHub could not resolve either action, so the browser test never ran.
-This was not a Docker failure or a flaky product test.
+The first exact-candidate run exposed two deterministic harness defects. First,
+`Critical Browser Smoke` failed during job setup because the pinned SHAs for
+`actions/upload-artifact@v7.0.1` and `docker/build-push-action@v7.3.0` each
+contained a one-character transcription error. GitHub could not resolve either
+action, so the browser test never ran. This was not a Docker failure or a flaky
+product test.
 
-The repair uses the official tag commit SHAs in every CI and nightly reference.
-The existing action-pin check now also resolves each readable version comment
-through GitHub's commits API and requires it to equal the pinned SHA. That moves
-this class of workflow setup failure into the ordinary PR lint job instead of
-discovering it after entering the merge queue. The failed candidate was not
-rerun; the repair requires a new commit and therefore a new exact candidate.
+More importantly, the workflow had two mutually exclusive jobs named `E2E
+Tests`: the real aggregate exact-candidate gate and the ordinary-PR reporting
+job. On `merge_group`, GitHub marked the PR-only job skipped and accepted that
+duplicate skipped context as satisfying the repository's required `E2E Tests`
+name. It merged while both backend shards were still running and while browser
+smoke had failed. The main workflow then promoted and rolled out the candidate
+before its deploy smoke exposed a separate incorrect Kubernetes service name.
+This violated the intended dev-image invariant. The last previously successful
+main workflow was deliberately rerun to restore the shared `:dev` tags and
+deployments to fully gated commit `f1b519f4e`.
+
+The repair uses the official action tag SHAs everywhere and resolves every
+readable version comment in the ordinary PR lint job. A single `E2E Tests` job
+now handles both PR reporting and the full exact-candidate result, eliminating
+the duplicate skipped context. Main promotion also queries GitHub for the exact
+SHA and independently requires one successful instance of every merge-group
+job (both backend shards, unit suites, lint, critical browser smoke, candidate
+build, and aggregate gate) before it can mutate any shared tag. The deployment
+smoke uses the actual `api` and `client` Kubernetes Service names. A new commit
+must pass the corrected merge queue; the failed candidate is not rerun.
 
 ## Limitations
 

--- a/docs/plans/2026-08-15-ci-reliability-and-latency.md
+++ b/docs/plans/2026-08-15-ci-reliability-and-latency.md
@@ -462,6 +462,22 @@ resulting `merge_group` run must execute and pass lint/type, backend unit,
 client unit, and both E2E shards. If any condition is absent, this change must
 not merge.
 
+### First queue validation incident
+
+The first exact-candidate run exposed a deterministic harness defect before any
+shared image promotion: `Critical Browser Smoke` failed during job setup because
+the pinned SHAs for `actions/upload-artifact@v7.0.1` and
+`docker/build-push-action@v7.3.0` each contained a one-character transcription
+error. GitHub could not resolve either action, so the browser test never ran.
+This was not a Docker failure or a flaky product test.
+
+The repair uses the official tag commit SHAs in every CI and nightly reference.
+The existing action-pin check now also resolves each readable version comment
+through GitHub's commits API and requires it to equal the pinned SHA. That moves
+this class of workflow setup failure into the ordinary PR lint job instead of
+discovering it after entering the merge queue. The failed candidate was not
+rerun; the repair requires a new commit and therefore a new exact candidate.
+
 ## Limitations
 
 - GitHub retains current run/job metadata more reliably than every historical


### PR DESCRIPTION
## Incident

PR #610's first merge-group run exposed two deterministic workflow defects:

1. The pinned SHAs for `actions/upload-artifact@v7.0.1` and `docker/build-push-action@v7.3.0` each had a one-character transcription error, so `Critical Browser Smoke` failed during job setup.
2. More seriously, two mutually exclusive jobs shared the required name `E2E Tests`. On `merge_group`, GitHub treated the skipped PR-only job as satisfying the required context and merged while both backend E2E shards were still running and browser smoke had failed.

The main workflow promoted and rolled out that candidate before deploy smoke failed on incorrect Kubernetes Service names. The last successful main workflow was deliberately rerun to restore `:dev` and the shared deployment to fully gated commit `f1b519f4e`.

## Repair

- Use the official immutable action SHAs in CI and nightly.
- Resolve every readable action version comment against GitHub's commits API during ordinary PR lint and require it to equal the pinned SHA.
- Emit the required `E2E Tests` context from exactly one job. It reports scoped PR feedback on `pull_request` and evaluates all exact-candidate dependencies on `merge_group`.
- Before touching any shared tag, main independently queries GitHub for its exact SHA and requires exactly one successful instance of lint, unit, client unit, both backend E2E shards, critical browser smoke, candidate build, and the aggregate gate.
- Use the actual Kubernetes Services (`api` and `client`) for post-rollout smoke.
- Record the incident and rollback in the durable reliability report.

## Safety invariant

This PR strengthens the invariant: shared `:dev` publication now fails closed unless the exact main SHA has objective job-level proof from a `merge_group` run. It does not depend solely on mutable branch-protection context matching. There is no retry, fallback rebuild, skip, quarantine, timeout increase, branch-protection mutation, or release/production configuration change.

## Verification

- Official action-version resolution across all workflows: passed.
- `./test.sh tests/unit/test_github_action_pins.py tests/unit/test_ci_workflow_contract.py tests/unit/test_verify_merge_candidate.py -v`: 15 passed.
- `./test.sh quality api`: Pyright 0 errors/warnings; Ruff passed.
- `git diff --check`: passed.

Follow-up to #603 and #610.
