### PR TITLE
Fix agent and application list loading

### DIFF
--- a/api/src/models/contracts/agents.py
+++ b/api/src/models/contracts/agents.py
@@ -8,6 +8,8 @@ from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, Field, field_serializer, model_validator
 
+from src.models.contracts.agent_stats import AgentStatsResponse
+
 from src.models.contracts.refs import WorkflowRef
 from src.models.enums import AgentAccessLevel, AgentChannel, MessageRole
 
@@ -222,6 +224,10 @@ class AgentSummary(BaseModel):
         description="Versioned presentation-logo URL, or null when no logo is set.",
     )
     logo_version: str | None = Field(default=None, description="Presentation-logo content hash.")
+    stats: AgentStatsResponse | None = Field(
+        default=None,
+        description="Per-agent run stats when explicitly requested by the list caller.",
+    )
     is_solution_managed: bool = Field(default=False, description="True if managed by a deployed Solution (read-only on platform)")
     solution_id: UUID | None = Field(default=None, description="UUID of the owning Solution install (null if not solution-managed)")
 

--- a/api/src/routers/agents.py
+++ b/api/src/routers/agents.py
@@ -52,7 +52,7 @@ from shared.logo_processing import (
 from src.repositories.agents import AgentRepository
 from src.services.solutions.guard import assert_not_solution_managed
 from src.routers.tools import get_system_tool_ids
-from src.services.agent_stats import get_agent_stats, get_fleet_stats
+from src.services.agent_stats import get_agent_stats, get_agent_stats_batch, get_fleet_stats
 from src.services.workflow_role_service import sync_agent_roles_to_workflows
 
 logger = logging.getLogger(__name__)
@@ -210,10 +210,12 @@ def _logo_data_url(data: bytes | None, content_type: str | None) -> str | None:
 
 
 def _agent_logo_url(agent: Agent) -> str | None:
-    """Return a cache-busted URL only after a presentation copy exists."""
-    if not is_logo_thumbnail_version(agent.logo_thumbnail_version):
-        return None
-    return f"/api/agents/{agent.id}/logo?v={agent.logo_thumbnail_version}"
+    """Return a logo URL without hiding legacy images during thumbnail backfill."""
+    if is_logo_thumbnail_version(agent.logo_thumbnail_version):
+        return f"/api/agents/{agent.id}/logo?v={agent.logo_thumbnail_version}"
+    if agent.logo_content_type:
+        return f"/api/agents/{agent.id}/logo"
+    return None
 
 
 def _agent_to_public(agent: Agent) -> AgentPublic:
@@ -279,6 +281,10 @@ async def list_agents(
     ),
     category: str | None = None,
     active_only: bool = True,
+    include_stats: bool = Query(
+        False,
+        description="Include per-agent run stats in the list response.",
+    ),
 ) -> list[AgentSummary]:
     """
     List agents the user has access to.
@@ -341,6 +347,12 @@ async def list_agents(
         )
         mcp_counts = {row[0]: row[1] for row in mcp_count_result.all()}
 
+    stats_by_agent = (
+        await get_agent_stats_batch(agent_ids, db)
+        if include_stats and agent_ids
+        else {}
+    )
+
     result = []
     for a in agents:
         summary = AgentSummary.model_validate(a)
@@ -353,6 +365,7 @@ async def list_agents(
             if is_logo_thumbnail_version(a.logo_thumbnail_version)
             else None
         )
+        summary.stats = stats_by_agent.get(a.id)
         result.append(summary)
 
     return result

--- a/api/src/routers/applications.py
+++ b/api/src/routers/applications.py
@@ -119,10 +119,12 @@ def _logo_data_url(data: bytes | None, content_type: str | None) -> str | None:
 
 
 def _application_logo_url(application: Application) -> str | None:
-    """Return a cache-busted URL only after a presentation copy exists."""
-    if not is_logo_thumbnail_version(application.logo_thumbnail_version):
-        return None
-    return f"/api/applications/{application.id}/logo?v={application.logo_thumbnail_version}"
+    """Return a logo URL without hiding legacy images during thumbnail backfill."""
+    if is_logo_thumbnail_version(application.logo_thumbnail_version):
+        return f"/api/applications/{application.id}/logo?v={application.logo_thumbnail_version}"
+    if application.logo_content_type:
+        return f"/api/applications/{application.id}/logo"
+    return None
 
 
 async def application_to_public(

--- a/api/src/services/agent_stats.py
+++ b/api/src/services/agent_stats.py
@@ -12,6 +12,145 @@ from src.models.orm.agents import Agent, Conversation
 from src.models.orm.ai_usage import AIUsage
 
 
+async def get_agent_stats_batch(
+    agent_ids: list[UUID],
+    db: AsyncSession,
+    *,
+    window_days: int = 7,
+) -> dict[UUID, AgentStatsResponse]:
+    """Compute the list-card stats for many agents in four bounded queries."""
+    if not agent_ids:
+        return {}
+
+    cutoff = datetime.now(timezone.utc) - timedelta(days=window_days)
+    now = datetime.now(timezone.utc)
+    unique_agent_ids = list(dict.fromkeys(agent_ids))
+
+    runs = (
+        (
+            await db.execute(
+                select(AgentRun).where(
+                    AgentRun.agent_id.in_(unique_agent_ids),
+                    AgentRun.created_at >= cutoff,
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+
+    run_ids = [run.id for run in runs]
+    costs_by_agent: dict[UUID, Decimal] = {}
+    if run_ids:
+        cost_rows = (
+            await db.execute(
+                select(
+                    AgentRun.agent_id,
+                    func.coalesce(func.sum(AIUsage.cost), 0),
+                )
+                .join(AIUsage, AIUsage.agent_run_id == AgentRun.id)
+                .where(AgentRun.id.in_(run_ids))
+                .group_by(AgentRun.agent_id)
+            )
+        ).all()
+        costs_by_agent = {
+            agent_id: cost if isinstance(cost, Decimal) else Decimal(cost)
+            for agent_id, cost in cost_rows
+        }
+
+    chat_rows = (
+        await db.execute(
+            select(
+                Conversation.agent_id,
+                func.count(Conversation.id),
+                func.max(Conversation.updated_at),
+            )
+            .where(
+                Conversation.agent_id.in_(unique_agent_ids),
+                Conversation.updated_at >= cutoff,
+            )
+            .group_by(Conversation.agent_id)
+        )
+    ).all()
+    chat_by_agent = {
+        agent_id: (count, last_at) for agent_id, count, last_at in chat_rows
+    }
+
+    chat_cost_rows = (
+        await db.execute(
+            select(
+                Conversation.agent_id,
+                func.coalesce(func.sum(AIUsage.cost), 0),
+            )
+            .join(AIUsage, AIUsage.conversation_id == Conversation.id)
+            .where(
+                Conversation.agent_id.in_(unique_agent_ids),
+                AIUsage.timestamp >= cutoff,
+            )
+            .group_by(Conversation.agent_id)
+        )
+    ).all()
+    chat_costs_by_agent = {
+        agent_id: cost if isinstance(cost, Decimal) else Decimal(cost)
+        for agent_id, cost in chat_cost_rows
+    }
+
+    runs_by_agent: dict[UUID, list[AgentRun]] = {
+        agent_id: [] for agent_id in unique_agent_ids
+    }
+    for run in runs:
+        runs_by_agent[run.agent_id].append(run)
+
+    result: dict[UUID, AgentStatsResponse] = {}
+    for agent_id in unique_agent_ids:
+        agent_runs = runs_by_agent[agent_id]
+        run_count = len(agent_runs)
+        completed = sum(1 for run in agent_runs if run.status == "completed")
+        durations = [
+            run.duration_ms for run in agent_runs if run.duration_ms is not None
+        ]
+        last_run_at = max(
+            (run.created_at for run in agent_runs),
+            default=None,
+        )
+        buckets = [0] * window_days
+        for run in agent_runs:
+            day_offset = (now - run.created_at).days
+            if 0 <= day_offset < window_days:
+                buckets[window_days - 1 - day_offset] += 1
+
+        chat_count, last_chat_at = chat_by_agent.get(agent_id, (0, None))
+        if last_chat_at is not None:
+            last_run_at = (
+                last_chat_at
+                if last_run_at is None
+                else max(last_run_at, last_chat_at)
+            )
+
+        result[agent_id] = AgentStatsResponse(
+            agent_id=agent_id,
+            runs_7d=run_count + chat_count,
+            success_rate=(completed / run_count) if run_count else 0.0,
+            avg_duration_ms=(
+                int(sum(durations) / len(durations)) if durations else 0
+            ),
+            total_cost_7d=(
+                costs_by_agent.get(agent_id, Decimal("0"))
+                + chat_costs_by_agent.get(agent_id, Decimal("0"))
+            ),
+            last_run_at=last_run_at,
+            runs_by_day=buckets,
+            needs_review=sum(1 for run in agent_runs if run.verdict == "down"),
+            unreviewed=sum(
+                1
+                for run in agent_runs
+                if run.verdict is None and run.status == "completed"
+            ),
+        )
+
+    return result
+
+
 async def get_agent_stats(
     agent_id: UUID,
     db: AsyncSession,
@@ -37,90 +176,13 @@ async def get_agent_stats(
     ``AgentRun`` only — the deferred "tuning + chat conversations"
     follow-up will revisit those.
     """
-    cutoff = datetime.now(timezone.utc) - timedelta(days=window_days)
-    runs_q = select(AgentRun).where(
-        AgentRun.agent_id == agent_id,
-        AgentRun.created_at >= cutoff,
-    )
-    runs = (await db.execute(runs_q)).scalars().all()
-
-    runs_count = len(runs)
-    completed = [r for r in runs if r.status == "completed"]
-    success_rate = (len(completed) / runs_count) if runs_count else 0.0
-    durations = [r.duration_ms for r in runs if r.duration_ms is not None]
-    avg_duration_ms = int(sum(durations) / len(durations)) if durations else 0
-
-    if runs:
-        cost_q = select(func.coalesce(func.sum(AIUsage.cost), 0)).where(
-            AIUsage.agent_run_id.in_([r.id for r in runs])
+    return (
+        await get_agent_stats_batch(
+            [agent_id],
+            db,
+            window_days=window_days,
         )
-        total_cost = (await db.execute(cost_q)).scalar() or Decimal("0")
-    else:
-        total_cost = Decimal("0")
-
-    last_run_at = max((r.created_at for r in runs), default=None)
-
-    # Per-day bucket counts (oldest first; index 0 = window_days days ago,
-    # index -1 = today).
-    buckets = [0] * window_days
-    now = datetime.now(timezone.utc)
-    for r in runs:
-        day_offset = (now - r.created_at).days
-        if 0 <= day_offset < window_days:
-            buckets[window_days - 1 - day_offset] += 1
-
-    total_cost_decimal = (
-        total_cost if isinstance(total_cost, Decimal) else Decimal(total_cost)
-    )
-
-    # Chat-channel rollup. Both queries hit ix_conversations_agent_id +
-    # ix_ai_usage_conversation; the cost query also benefits from
-    # ix_ai_usage_timestamp.
-    chat_count_q = select(func.count(Conversation.id)).where(
-        Conversation.agent_id == agent_id,
-        Conversation.updated_at >= cutoff,
-    )
-    chat_runs_count = (await db.execute(chat_count_q)).scalar() or 0
-
-    chat_cost_q = (
-        select(func.coalesce(func.sum(AIUsage.cost), 0))
-        .join(Conversation, Conversation.id == AIUsage.conversation_id)
-        .where(
-            Conversation.agent_id == agent_id,
-            AIUsage.timestamp >= cutoff,
-        )
-    )
-    chat_cost = (await db.execute(chat_cost_q)).scalar() or Decimal("0")
-    chat_cost_decimal = (
-        chat_cost if isinstance(chat_cost, Decimal) else Decimal(chat_cost)
-    )
-
-    last_chat_q = select(func.max(Conversation.updated_at)).where(
-        Conversation.agent_id == agent_id,
-        Conversation.updated_at >= cutoff,
-    )
-    last_chat_at = (await db.execute(last_chat_q)).scalar()
-
-    runs_count += chat_runs_count
-    total_cost_decimal += chat_cost_decimal
-    if last_chat_at is not None:
-        last_run_at = (
-            last_chat_at if last_run_at is None else max(last_run_at, last_chat_at)
-        )
-
-    return AgentStatsResponse(
-        agent_id=agent_id,
-        runs_7d=runs_count,
-        success_rate=success_rate,
-        avg_duration_ms=avg_duration_ms,
-        total_cost_7d=total_cost_decimal,
-        last_run_at=last_run_at,
-        runs_by_day=buckets,
-        needs_review=sum(1 for r in runs if r.verdict == "down"),
-        unreviewed=sum(
-            1 for r in runs if r.verdict is None and r.status == "completed"
-        ),
-    )
+    )[agent_id]
 
 
 async def get_fleet_stats(

--- a/api/tests/e2e/api/test_entity_logos.py
+++ b/api/tests/e2e/api/test_entity_logos.py
@@ -185,7 +185,10 @@ class TestAgentLogo:
             assert len(got.content) <= 20 * 1024
             assert got.headers["cache-control"] == "private, max-age=31536000, immutable"
 
-            listed = e2e_client.get("/api/agents", headers=platform_admin.headers)
+            listed = e2e_client.get(
+                "/api/agents?include_stats=true",
+                headers=platform_admin.headers,
+            )
             listed_agent = next(
                 row for row in listed.json() if row["id"] == agent_id
             )
@@ -193,6 +196,7 @@ class TestAgentLogo:
             assert listed_agent["logo_url"].startswith(
                 f"/api/agents/{agent_id}/logo?v="
             )
+            assert listed_agent["stats"]["runs_7d"] == 0
 
             deleted = e2e_client.delete(
                 f"/api/agents/{agent_id}/logo",

--- a/api/tests/unit/routers/test_entity_logo_urls.py
+++ b/api/tests/unit/routers/test_entity_logo_urls.py
@@ -1,0 +1,39 @@
+"""List logo URLs stay usable while legacy thumbnail backfill drains."""
+
+from types import SimpleNamespace
+from uuid import uuid4
+
+from src.routers.agents import _agent_logo_url
+from src.routers.applications import _application_logo_url
+
+
+def _entity(**overrides):
+    values = {
+        "id": uuid4(),
+        "logo_content_type": None,
+        "logo_thumbnail_version": None,
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def test_legacy_agent_logo_uses_uncached_endpoint_during_backfill() -> None:
+    agent = _entity(logo_content_type="image/png")
+    assert _agent_logo_url(agent) == f"/api/agents/{agent.id}/logo"
+
+
+def test_legacy_application_logo_uses_uncached_endpoint_during_backfill() -> None:
+    application = _entity(logo_content_type="image/svg+xml")
+    assert _application_logo_url(application) == (
+        f"/api/applications/{application.id}/logo"
+    )
+
+
+def test_thumbnail_logo_keeps_immutable_versioned_url() -> None:
+    agent = _entity(
+        logo_content_type="image/png",
+        logo_thumbnail_version="a" * 64,
+    )
+    assert _agent_logo_url(agent) == (
+        f"/api/agents/{agent.id}/logo?v={'a' * 64}"
+    )

--- a/api/tests/unit/test_agent_stats_service.py
+++ b/api/tests/unit/test_agent_stats_service.py
@@ -11,7 +11,11 @@ from src.models.enums import AgentAccessLevel
 from src.models.orm.agent_runs import AgentRun
 from src.models.orm.agents import Agent, Conversation
 from src.models.orm.ai_usage import AIUsage
-from src.services.agent_stats import get_agent_stats, get_fleet_stats
+from src.services.agent_stats import (
+    get_agent_stats,
+    get_agent_stats_batch,
+    get_fleet_stats,
+)
 
 
 @pytest_asyncio.fixture
@@ -125,6 +129,23 @@ async def test_per_agent_stats(db_session, seed_agent, seed_runs_for_agent):
     # Unreviewed: completed runs with verdict=None
     # 4 completed, 1 has 'up', 1 has 'down', 2 unreviewed
     assert stats.unreviewed == 2
+
+
+@pytest.mark.asyncio
+async def test_agent_stats_batch_matches_single_agent_rollup(
+    db_session, seed_agent, seed_runs_for_agent
+):
+    empty_agent_id = uuid4()
+    batch = await get_agent_stats_batch(
+        [seed_agent.id, empty_agent_id],
+        db_session,
+        window_days=7,
+    )
+    single = await get_agent_stats(seed_agent.id, db_session, window_days=7)
+
+    assert batch[seed_agent.id] == single
+    assert batch[empty_agent_id].runs_7d == 0
+    assert batch[empty_agent_id].runs_by_day == [0] * 7
 
 
 @pytest.mark.asyncio

--- a/client/e2e/entity-logos.admin.spec.ts
+++ b/client/e2e/entity-logos.admin.spec.ts
@@ -125,7 +125,22 @@ test.describe("Entity logos", () => {
 
 			await expect(page.getByText("Image updated")).toBeVisible();
 
+			const perAgentStatsRequests: string[] = [];
+			page.on("request", (request) => {
+				if (/\/api\/agents\/[0-9a-f-]+\/stats$/.test(new URL(request.url()).pathname)) {
+					perAgentStatsRequests.push(request.url());
+				}
+			});
+			const listWithStats = page.waitForResponse((response) => {
+				const url = new URL(response.url());
+				return (
+					url.pathname === "/api/agents" &&
+					url.searchParams.get("include_stats") === "true"
+				);
+			});
+
 			await page.goto("/agents");
+			await listWithStats;
 
 			const card = page.getByRole("link", {
 				name: new RegExp(AGENT_NAME),
@@ -136,6 +151,7 @@ test.describe("Entity logos", () => {
 				"src",
 				new RegExp(`^/api/agents/${agentId}/logo\\?v=[0-9a-f]{64}$`),
 			);
+			expect(perAgentStatsRequests).toEqual([]);
 		});
 	});
 });

--- a/client/src/components/EntityLogo.test.tsx
+++ b/client/src/components/EntityLogo.test.tsx
@@ -63,6 +63,20 @@ describe("EntityLogo", () => {
 		expect(img.getAttribute("src")).toBe(dataUrl);
 	});
 
+	it("falls back when a list-provided logo URL fails", () => {
+		render(
+			<EntityLogo
+				entityType="agent"
+				entityId="22222222-2222-2222-2222-222222222222"
+				logo="/api/agents/22222222-2222-2222-2222-222222222222/logo"
+				fallback={<span data-testid="fallback">F</span>}
+				size={32}
+			/>,
+		);
+		fireEvent.error(screen.getByTestId("entity-logo"));
+		expect(screen.getByTestId("fallback")).toBeInTheDocument();
+	});
+
 	it("renders fallback without making any request when logo is explicitly null", () => {
 		render(
 			<EntityLogo

--- a/client/src/components/EntityLogo.tsx
+++ b/client/src/components/EntityLogo.tsx
@@ -34,7 +34,7 @@ export function EntityLogo({
 	className,
 	logo,
 }: EntityLogoProps) {
-	const [erroredVersion, setErroredVersion] = useState<string | null>(null);
+	const [erroredSource, setErroredSource] = useState<string | null>(null);
 	const globalVersion = useEntityLogoVersion(entityType, entityId);
 
 	if (logo === null) {
@@ -42,6 +42,9 @@ export function EntityLogo({
 	}
 
 	if (typeof logo === "string") {
+		if (erroredSource === logo) {
+			return <>{fallback}</>;
+		}
 		return (
 			<img
 				data-testid="entity-logo"
@@ -50,6 +53,7 @@ export function EntityLogo({
 				width={size}
 				height={size}
 				className={className}
+				onError={() => setErroredSource(logo)}
 			/>
 		);
 	}
@@ -60,7 +64,7 @@ export function EntityLogo({
 		? `${base}?v=${encodeURIComponent(effectiveKey)}`
 		: base;
 
-	if (erroredVersion !== null && erroredVersion === (effectiveKey ?? "")) {
+	if (erroredSource === src) {
 		return <>{fallback}</>;
 	}
 
@@ -72,7 +76,7 @@ export function EntityLogo({
 			width={size}
 			height={size}
 			className={className}
-			onError={() => setErroredVersion(effectiveKey ?? "")}
+			onError={() => setErroredSource(src)}
 		/>
 	);
 }

--- a/client/src/components/PageLoader.test.tsx
+++ b/client/src/components/PageLoader.test.tsx
@@ -1,0 +1,18 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { PageLoader } from "./PageLoader";
+
+describe("PageLoader", () => {
+	it("announces progress and renders a reduced-motion-safe spinner", () => {
+		const { container } = render(<PageLoader message="Loading agents…" />);
+
+		expect(
+			screen.getByRole("status", { name: "Loading agents…" }),
+		).toHaveAttribute("aria-live", "polite");
+		expect(container.querySelector("svg")).toHaveClass(
+			"animate-spin",
+			"motion-reduce:animate-none",
+		);
+	});
+});

--- a/client/src/components/PageLoader.tsx
+++ b/client/src/components/PageLoader.tsx
@@ -22,10 +22,16 @@ export function PageLoader({
 		: "flex min-h-[400px] h-full w-full items-center justify-center";
 
 	return (
-		<div className={containerClasses}>
+		<div
+			className={containerClasses}
+			role="status"
+			aria-live="polite"
+			aria-label={message}
+		>
 			<div className="flex flex-col items-center gap-4">
 				<Loader2
-					className={`${sizeClasses[size]} animate-spin text-primary`}
+					aria-hidden="true"
+					className={`${sizeClasses[size]} animate-spin text-primary motion-reduce:animate-none`}
 				/>
 				<p className="text-sm text-muted-foreground">{message}</p>
 			</div>

--- a/client/src/components/applications/ApplicationListSurface.tsx
+++ b/client/src/components/applications/ApplicationListSurface.tsx
@@ -10,6 +10,7 @@ import {
 } from "lucide-react";
 
 import { EntityLogo } from "@/components/EntityLogo";
+import { PageLoader } from "@/components/PageLoader";
 import { SolutionManagedBadge } from "@/components/solutions/SolutionManagedBadge";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -22,7 +23,6 @@ import {
 	DataTableHeader,
 	DataTableRow,
 } from "@/components/ui/data-table";
-import { Skeleton } from "@/components/ui/skeleton";
 import { term, useTerminology } from "@/lib/terminology";
 import type { components } from "@/lib/v1";
 
@@ -74,19 +74,7 @@ export function ApplicationListSurface({
 	const terminology = useTerminology();
 
 	if (isLoading) {
-		return viewMode === "grid" || !canManageApps ? (
-			<div className="grid grid-cols-1 gap-4 sm:grid-cols-[repeat(auto-fill,minmax(320px,1fr))]">
-				{[...Array(6)].map((_, i) => (
-					<Skeleton key={i} className="h-48 w-full" />
-				))}
-			</div>
-		) : (
-			<div className="space-y-2">
-				{[...Array(3)].map((_, i) => (
-					<Skeleton key={i} className="h-12 w-full" />
-				))}
-			</div>
-		);
+		return <PageLoader message="Loading applications…" size="sm" />;
 	}
 
 	if (apps.length === 0) {
@@ -100,10 +88,10 @@ export function ApplicationListSurface({
 							: `No ${term(terminology, "app", "formalPluralLower")} found`}
 					</h3>
 					<p className="mt-2 text-sm text-muted-foreground">
-							{emptySearchActive
-								? "Try adjusting your search term or clear the filter"
-								: `No ${term(terminology, "app", "formalPluralLower")} are currently available`}
-						</p>
+						{emptySearchActive
+							? "Try adjusting your search term or clear the filter"
+							: `No ${term(terminology, "app", "formalPluralLower")} are currently available`}
+					</p>
 					{canManageApps && !emptySearchActive && onCreateEmpty && (
 						<Button
 							variant="outline"
@@ -133,8 +121,12 @@ export function ApplicationListSurface({
 							)}
 							<DataTableHead>Name</DataTableHead>
 							<DataTableHead>Description</DataTableHead>
-							<DataTableHead className="w-0 whitespace-nowrap">Status</DataTableHead>
-							<DataTableHead className="w-0 whitespace-nowrap">Version</DataTableHead>
+							<DataTableHead className="w-0 whitespace-nowrap">
+								Status
+							</DataTableHead>
+							<DataTableHead className="w-0 whitespace-nowrap">
+								Version
+							</DataTableHead>
 							<DataTableHead className="w-0 whitespace-nowrap text-right" />
 						</DataTableRow>
 					</DataTableHeader>
@@ -144,12 +136,20 @@ export function ApplicationListSurface({
 								{isPlatformAdmin && (
 									<DataTableCell className="w-0 whitespace-nowrap">
 										{app.organization_id ? (
-											<Badge variant="outline" className="text-xs">
+											<Badge
+												variant="outline"
+												className="text-xs"
+											>
 												<Building2 className="mr-1 h-3 w-3" />
-												{getOrgName(app.organization_id)}
+												{getOrgName(
+													app.organization_id,
+												)}
 											</Badge>
 										) : (
-											<Badge variant="default" className="text-xs">
+											<Badge
+												variant="default"
+												className="text-xs"
+											>
 												<Globe className="mr-1 h-3 w-3" />
 												Global
 											</Badge>
@@ -161,26 +161,40 @@ export function ApplicationListSurface({
 								</DataTableCell>
 								<DataTableCell className="max-w-xs truncate text-muted-foreground">
 									{app.description || (
-										<span className="italic">No description</span>
+										<span className="italic">
+											No description
+										</span>
 									)}
 								</DataTableCell>
 								<DataTableCell className="w-0 whitespace-nowrap">
 									<div className="flex gap-1">
 										{app.is_published && (
-											<Badge variant="default" className="text-xs">
+											<Badge
+												variant="default"
+												className="text-xs"
+											>
 												Published
 											</Badge>
 										)}
 										{app.has_unpublished_changes && (
-											<Badge variant="outline" className="text-xs">
+											<Badge
+												variant="outline"
+												className="text-xs"
+											>
 												Draft
 											</Badge>
 										)}
-										{!app.is_published && !app.has_unpublished_changes && (
-											<Badge variant="secondary" className="text-xs">
-												{isV2App(app) ? "V2" : "Empty"}
-											</Badge>
-										)}
+										{!app.is_published &&
+											!app.has_unpublished_changes && (
+												<Badge
+													variant="secondary"
+													className="text-xs"
+												>
+													{isV2App(app)
+														? "V2"
+														: "Empty"}
+												</Badge>
+											)}
 									</div>
 								</DataTableCell>
 								<DataTableCell className="w-0 whitespace-nowrap">
@@ -207,49 +221,62 @@ export function ApplicationListSurface({
 												<Button
 													variant="ghost"
 													size="sm"
-													onClick={() => onPreview(app)}
+													onClick={() =>
+														onPreview(app)
+													}
 													title="Preview draft"
 												>
 													<Eye className="h-4 w-4" />
 												</Button>
 											)}
 										{app.is_solution_managed && (
-											<SolutionManagedBadge solutionId={app.solution_id} />
+											<SolutionManagedBadge
+												solutionId={app.solution_id}
+											/>
 										)}
-										{canManageApps && !app.is_solution_managed && (
-											<>
-												{onOpenSettings && (
-													<Button
-														variant="ghost"
-														size="sm"
-														onClick={() => onOpenSettings(app)}
-														title="Settings"
-													>
-														<Pencil className="h-4 w-4" />
-													</Button>
-												)}
-												{onOpenCode && (
-													<Button
-														variant="ghost"
-														size="sm"
-														onClick={() => onOpenCode(app)}
-														title="Code editor"
-													>
-														<Code2 className="h-4 w-4" />
-													</Button>
-												)}
-												{onDelete && (
-													<Button
-														variant="ghost"
-														size="sm"
-														onClick={() => onDelete(app)}
-														title={`Delete ${term(terminology, "app", "formalSingularLower")}`}
-													>
-														<Trash2 className="h-4 w-4" />
-													</Button>
-												)}
-											</>
-										)}
+										{canManageApps &&
+											!app.is_solution_managed && (
+												<>
+													{onOpenSettings && (
+														<Button
+															variant="ghost"
+															size="sm"
+															onClick={() =>
+																onOpenSettings(
+																	app,
+																)
+															}
+															title="Settings"
+														>
+															<Pencil className="h-4 w-4" />
+														</Button>
+													)}
+													{onOpenCode && (
+														<Button
+															variant="ghost"
+															size="sm"
+															onClick={() =>
+																onOpenCode(app)
+															}
+															title="Code editor"
+														>
+															<Code2 className="h-4 w-4" />
+														</Button>
+													)}
+													{onDelete && (
+														<Button
+															variant="ghost"
+															size="sm"
+															onClick={() =>
+																onDelete(app)
+															}
+															title={`Delete ${term(terminology, "app", "formalSingularLower")}`}
+														>
+															<Trash2 className="h-4 w-4" />
+														</Button>
+													)}
+												</>
+											)}
 									</div>
 								</DataTableCell>
 							</DataTableRow>
@@ -280,7 +307,10 @@ export function ApplicationListSurface({
 						tabIndex={0}
 						onClick={defaultTarget}
 						onKeyDown={(e) => {
-							if (defaultTarget && (e.key === "Enter" || e.key === " ")) {
+							if (
+								defaultTarget &&
+								(e.key === "Enter" || e.key === " ")
+							) {
 								e.preventDefault();
 								defaultTarget();
 							}
@@ -305,7 +335,9 @@ export function ApplicationListSurface({
 									</span>
 								</div>
 								{app.is_solution_managed ? (
-									<SolutionManagedBadge solutionId={app.solution_id} />
+									<SolutionManagedBadge
+										solutionId={app.solution_id}
+									/>
 								) : canManageApps ? (
 									<div className="flex shrink-0 gap-1">
 										{onOpenSettings && (
@@ -371,19 +403,21 @@ export function ApplicationListSurface({
 											Open Published
 										</button>
 									)}
-									{canManageApps && app.has_unpublished_changes && onPreview && (
-										<button
-											type="button"
-											className="pointer-events-auto text-left text-[13px] font-medium text-foreground hover:text-primary"
-											onClick={(e) => {
-												e.stopPropagation();
-												onPreview(app);
-											}}
-										>
-											<Eye className="-mt-0.5 mr-1.5 inline h-3.5 w-3.5" />
-											Open Preview
-										</button>
-									)}
+									{canManageApps &&
+										app.has_unpublished_changes &&
+										onPreview && (
+											<button
+												type="button"
+												className="pointer-events-auto text-left text-[13px] font-medium text-foreground hover:text-primary"
+												onClick={(e) => {
+													e.stopPropagation();
+													onPreview(app);
+												}}
+											>
+												<Eye className="-mt-0.5 mr-1.5 inline h-3.5 w-3.5" />
+												Open Preview
+											</button>
+										)}
 								</div>
 							)}
 						</div>
@@ -391,24 +425,35 @@ export function ApplicationListSurface({
 						<div className="flex items-center justify-between gap-2 border-t px-4 py-2.5">
 							<div className="flex items-center gap-1.5">
 								{app.is_published && (
-									<Badge variant="default" className="text-[10px] px-1.5 py-0">
+									<Badge
+										variant="default"
+										className="text-[10px] px-1.5 py-0"
+									>
 										Published
 									</Badge>
 								)}
 								{app.has_unpublished_changes && (
-									<Badge variant="outline" className="text-[10px] px-1.5 py-0">
+									<Badge
+										variant="outline"
+										className="text-[10px] px-1.5 py-0"
+									>
 										Draft
 									</Badge>
 								)}
-								{!app.is_published && !app.has_unpublished_changes && (
-									<span className="text-[11px] text-muted-foreground">
-										{isV2App(app) ? "V2" : "Empty"}
-									</span>
-								)}
+								{!app.is_published &&
+									!app.has_unpublished_changes && (
+										<span className="text-[11px] text-muted-foreground">
+											{isV2App(app) ? "V2" : "Empty"}
+										</span>
+									)}
 							</div>
 							{orgLabel ? (
 								<Badge
-									variant={app.organization_id ? "outline" : "default"}
+									variant={
+										app.organization_id
+											? "outline"
+											: "default"
+									}
 									className="text-[10px] px-1.5 py-0"
 								>
 									{app.organization_id ? (

--- a/client/src/hooks/useAgents.ts
+++ b/client/src/hooks/useAgents.ts
@@ -43,7 +43,7 @@ function getErrorMessage(error: unknown, fallback: string): string {
  */
 export function useAgents(
 	filterScope?: string | null,
-	options?: { includeInactive?: boolean },
+	options?: { includeInactive?: boolean; includeStats?: boolean },
 ) {
 	// Build query params - scope is the new filter parameter
 	const queryParams: Record<string, string | boolean | undefined> = {};
@@ -59,6 +59,9 @@ export function useAgents(
 		// Default server-side is active_only=true; opt in to paused agents too.
 		queryParams.active_only = false;
 	}
+	if (options?.includeStats) {
+		queryParams.include_stats = true;
+	}
 
 	return $api.useQuery("get", "/api/agents", {
 		params: {
@@ -69,6 +72,7 @@ export function useAgents(
 			query?: {
 				category?: string | null;
 				active_only?: boolean;
+				include_stats?: boolean;
 				scope?: string;
 			};
 		},

--- a/client/src/lib/v1.d.ts
+++ b/client/src/lib/v1.d.ts
@@ -10938,6 +10938,8 @@ export interface components {
              * @description Presentation-logo content hash.
              */
             logo_version?: string | null;
+            /** @description Per-agent run stats when explicitly requested by the list caller. */
+            stats?: components["schemas"]["AgentStatsResponse"] | null;
             /**
              * Is Solution Managed
              * @description True if managed by a deployed Solution (read-only on platform)
@@ -35105,6 +35107,8 @@ export interface operations {
                 scope?: string | null;
                 category?: string | null;
                 active_only?: boolean;
+                /** @description Include per-agent run stats in the list response. */
+                include_stats?: boolean;
             };
             header?: never;
             path?: never;

--- a/client/src/pages/Applications.test.tsx
+++ b/client/src/pages/Applications.test.tsx
@@ -69,6 +69,18 @@ async function renderPage() {
 }
 
 describe("Applications — app launch behavior", () => {
+	it("shows a loading indicator while the list loads", async () => {
+		mockUseApplications.mockReturnValue({
+			data: undefined,
+			isLoading: true,
+			refetch: vi.fn(),
+		});
+		await renderPage();
+		expect(
+			screen.getByRole("status", { name: /loading applications/i }),
+		).toBeInTheDocument();
+	});
+
 	it("does not expose the deprecated create code application action", async () => {
 		await renderPage();
 		expect(

--- a/client/src/pages/SolutionDetail.test.tsx
+++ b/client/src/pages/SolutionDetail.test.tsx
@@ -8,6 +8,9 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { renderWithProviders, screen, waitFor } from "@/test-utils";
 import { SolutionDetail } from "./SolutionDetail";
 
+const APP_LOGO_DATA_URL =
+	"data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciLz4=";
+
 const mockNavigate = vi.fn();
 vi.mock("react-router-dom", async () => {
 	const actual =
@@ -81,14 +84,17 @@ vi.mock("@/services/solutions", () => ({
 		mockGetSolutionDeletionSummary(...a),
 	setSolutionConfig: (...a: unknown[]) => mockSetSolutionConfig(...a),
 	exportSolution: (...a: unknown[]) => mockExportSolution(...a),
-	createSolutionExportJob: (...a: unknown[]) => mockCreateSolutionExportJob(...a),
-	listSolutionExportJobs: (...a: unknown[]) => mockListSolutionExportJobs(...a),
+	createSolutionExportJob: (...a: unknown[]) =>
+		mockCreateSolutionExportJob(...a),
+	listSolutionExportJobs: (...a: unknown[]) =>
+		mockListSolutionExportJobs(...a),
 	downloadSolutionExportJob: (...a: unknown[]) =>
 		mockDownloadSolutionExportJob(...a),
 	syncSolution: (...a: unknown[]) => mockSyncSolution(...a),
 	getSolutionCaptureCandidates: (...a: unknown[]) =>
 		mockGetSolutionCaptureCandidates(...a),
-	captureSolutionEntities: (...a: unknown[]) => mockCaptureSolutionEntities(...a),
+	captureSolutionEntities: (...a: unknown[]) =>
+		mockCaptureSolutionEntities(...a),
 }));
 
 vi.mock("@/services/workflowKeys", () => ({
@@ -123,27 +129,27 @@ function makeEntities(statusOverride = "active") {
 				function_name: "sync_tickets",
 			},
 		],
-			apps: [
-				{
-					id: "app-1",
-					name: "Solution App",
-					slug: "solution-app",
-					description: "Solution app",
-					app_model: "standalone_v2",
-					is_published: true,
-					has_unpublished_changes: false,
-					logo_url: "/api/applications/app-1/logo?v=thumb-v1",
-				},
-			],
-			forms: [
-				{
-					id: "form-1",
-					name: "Ticket Intake",
-					description: "Collect ticket context",
-					is_active: true,
-					organization_id: "org-1",
-				},
-			],
+		apps: [
+			{
+				id: "app-1",
+				name: "Solution App",
+				slug: "solution-app",
+				description: "Solution app",
+				app_model: "standalone_v2",
+				is_published: true,
+				has_unpublished_changes: false,
+				logo_url: APP_LOGO_DATA_URL,
+			},
+		],
+		forms: [
+			{
+				id: "form-1",
+				name: "Ticket Intake",
+				description: "Collect ticket context",
+				is_active: true,
+				organization_id: "org-1",
+			},
+		],
 		agents: [],
 		tables: [{ id: "tbl-1", name: "Customers" }],
 		claims: [
@@ -252,7 +258,9 @@ describe("SolutionDetail", () => {
 		expect(
 			await screen.findByText(/no setup instructions provided/i),
 		).toBeInTheDocument();
-		expect(screen.queryByText(/add setup instructions/i)).not.toBeInTheDocument();
+		expect(
+			screen.queryByText(/add setup instructions/i),
+		).not.toBeInTheDocument();
 		expect(
 			screen.queryByRole("button", { name: /write readme/i }),
 		).not.toBeInTheDocument();
@@ -277,7 +285,9 @@ describe("SolutionDetail", () => {
 		await renderPage();
 		await screen.findByTestId("solution-detail");
 
-		expect(screen.getByTestId("tab-overview")).toHaveTextContent("Overview");
+		expect(screen.getByTestId("tab-overview")).toHaveTextContent(
+			"Overview",
+		);
 
 		// Contents collapses the 6 entity inventories; its count is the total
 		// (1 workflow + 1 app + 1 form + 0 agents + 1 table + 1 claim = 5 in the
@@ -322,10 +332,16 @@ describe("SolutionDetail", () => {
 		await screen.findByTestId("solution-detail");
 
 		await waitFor(() =>
-			expect(screen.queryByTestId("continue-setup")).not.toBeInTheDocument(),
+			expect(
+				screen.queryByTestId("continue-setup"),
+			).not.toBeInTheDocument(),
 		);
-		expect(screen.queryByTestId("incomplete-badge")).not.toBeInTheDocument();
-		expect(screen.queryByTestId("config-tab-warning")).not.toBeInTheDocument();
+		expect(
+			screen.queryByTestId("incomplete-badge"),
+		).not.toBeInTheDocument();
+		expect(
+			screen.queryByTestId("config-tab-warning"),
+		).not.toBeInTheDocument();
 	});
 
 	it("returns to overview when completed setup is dismissed", async () => {
@@ -350,7 +366,9 @@ describe("SolutionDetail", () => {
 		await screen.findByTestId("solution-detail");
 
 		await user.click(screen.getByTestId("tab-configuration"));
-		expect(await screen.findByText(/all required setup is complete/i)).toBeInTheDocument();
+		expect(
+			await screen.findByText(/all required setup is complete/i),
+		).toBeInTheDocument();
 		await user.click(screen.getByRole("button", { name: /done/i }));
 
 		await waitFor(() =>
@@ -411,7 +429,9 @@ describe("SolutionDetail", () => {
 		await screen.findByTestId("solution-detail");
 
 		await user.click(screen.getByTestId("solution-actions"));
-		await user.click(await screen.findByRole("menuitem", { name: /export/i }));
+		await user.click(
+			await screen.findByRole("menuitem", { name: /export/i }),
+		);
 		await user.click(screen.getByLabelText(/^backup/i));
 		await user.type(screen.getByLabelText(/^password/i), "hunter2");
 		await user.click(screen.getByRole("button", { name: /queue backup/i }));
@@ -441,7 +461,9 @@ describe("SolutionDetail", () => {
 		const workflows = screen.getByTestId("chip-workflows");
 		expect(workflows).toHaveTextContent("Workflows");
 		expect(workflows).toHaveTextContent("1");
-		expect(screen.getByTestId("chip-claims")).toHaveTextContent("Custom Claims");
+		expect(screen.getByTestId("chip-claims")).toHaveTextContent(
+			"Custom Claims",
+		);
 	});
 
 	it("opens the requested Contents filter from an Overview entity count", async () => {
@@ -454,9 +476,13 @@ describe("SolutionDetail", () => {
 			"data-state",
 			"active",
 		);
-		expect(screen.getByTestId("chip-workflows")).toHaveTextContent("Workflows");
+		expect(screen.getByTestId("chip-workflows")).toHaveTextContent(
+			"Workflows",
+		);
 		expect(screen.getByText("Sync Tickets")).toBeInTheDocument();
-		expect(screen.queryByTestId("summary-workflows")).not.toBeInTheDocument();
+		expect(
+			screen.queryByTestId("summary-workflows"),
+		).not.toBeInTheDocument();
 	});
 
 	it("opens Files directly from the Overview Files count", async () => {
@@ -474,15 +500,18 @@ describe("SolutionDetail", () => {
 			"data-state",
 			"active",
 		);
-		expect(await screen.findByTestId("solution-files-explorer"))
-			.toHaveTextContent("Files Explorer sol-1 My Solution");
+		expect(
+			await screen.findByTestId("solution-files-explorer"),
+		).toHaveTextContent("Files Explorer sol-1 My Solution");
 	});
 
 	it("renders the update action and the overflow menu in the header", async () => {
 		const { user } = await renderPage();
 		await screen.findByTestId("solution-detail");
 
-		expect(screen.getByRole("button", { name: /update/i })).toBeInTheDocument();
+		expect(
+			screen.getByRole("button", { name: /update/i }),
+		).toBeInTheDocument();
 
 		// The secondary actions (Capture, Export, Edit, Delete) live behind the
 		// "⋯" overflow menu now, not as a flat row of buttons.
@@ -508,101 +537,109 @@ describe("SolutionDetail", () => {
 		await screen.findByTestId("solution-detail");
 
 		await user.click(screen.getByTestId("solution-actions"));
-		await user.click(await screen.findByRole("menuitem", { name: /capture/i }));
+		await user.click(
+			await screen.findByRole("menuitem", { name: /capture/i }),
+		);
 
 		expect(
-			await screen.findByRole("heading", { name: /capture existing entities/i }),
+			await screen.findByRole("heading", {
+				name: /capture existing entities/i,
+			}),
 		).toBeInTheDocument();
-		expect(await screen.findByLabelText(/capture orders/i)).toBeInTheDocument();
+		expect(
+			await screen.findByLabelText(/capture orders/i),
+		).toBeInTheDocument();
 	});
 
-		it("shows the setup-incomplete banner", async () => {
-			await renderPage();
-			expect(
-				await screen.findByTestId("required-config-warning"),
-			).toBeInTheDocument();
-			expect(
-				screen.getByText(/setup incomplete .* 1 required config needs a value/i),
-			).toBeInTheDocument();
+	it("shows the setup-incomplete banner", async () => {
+		await renderPage();
+		expect(
+			await screen.findByTestId("required-config-warning"),
+		).toBeInTheDocument();
+		expect(
+			screen.getByText(
+				/setup incomplete .* 1 required config needs a value/i,
+			),
+		).toBeInTheDocument();
+	});
+
+	it("uses the workflow list execute action instead of making the card open execution", async () => {
+		const { user } = await renderPage();
+		await screen.findByTestId("solution-detail");
+
+		await user.click(screen.getByTestId("tab-contents"));
+		await user.click(screen.getByTestId("chip-workflows"));
+		const execute = screen.getByRole("button", {
+			name: /execute workflow/i,
 		});
+		await user.click(execute);
 
-		it("uses the workflow list execute action instead of making the card open execution", async () => {
-			const { user } = await renderPage();
-			await screen.findByTestId("solution-detail");
+		expect(mockNavigate).toHaveBeenCalledWith(
+			"/workflows/Sync%20Tickets/execute?from=solution:sol-1",
+		);
+	});
 
-			await user.click(screen.getByTestId("tab-contents"));
-			await user.click(screen.getByTestId("chip-workflows"));
-			const execute = screen.getByRole("button", { name: /execute workflow/i });
-			await user.click(execute);
+	it("uses the forms list launch action without exposing edit controls", async () => {
+		const { user } = await renderPage();
+		await screen.findByTestId("solution-detail");
 
-			expect(mockNavigate).toHaveBeenCalledWith(
-				"/workflows/Sync%20Tickets/execute?from=solution:sol-1",
-			);
-		});
+		await user.click(screen.getByTestId("tab-contents"));
+		await user.click(screen.getByTestId("chip-forms"));
+		expect(screen.getByText("Ticket Intake")).toBeInTheDocument();
+		expect(
+			screen.queryByRole("button", { name: /edit form/i }),
+		).not.toBeInTheDocument();
 
-		it("uses the forms list launch action without exposing edit controls", async () => {
-			const { user } = await renderPage();
-			await screen.findByTestId("solution-detail");
+		await user.click(screen.getByRole("button", { name: /launch/i }));
+		expect(mockNavigate).toHaveBeenCalledWith(
+			"/execute/form-1?from=solution:sol-1",
+		);
+	});
 
-			await user.click(screen.getByTestId("tab-contents"));
-			await user.click(screen.getByTestId("chip-forms"));
-			expect(screen.getByText("Ticket Intake")).toBeInTheDocument();
-			expect(
-				screen.queryByRole("button", { name: /edit form/i }),
-			).not.toBeInTheDocument();
+	it("opens sharing for a solution-managed form without exposing edit controls", async () => {
+		const { user } = await renderPage();
+		await screen.findByTestId("solution-detail");
 
-			await user.click(screen.getByRole("button", { name: /launch/i }));
-			expect(mockNavigate).toHaveBeenCalledWith(
-				"/execute/form-1?from=solution:sol-1",
-			);
-		});
+		await user.click(screen.getByTestId("tab-contents"));
+		await user.click(screen.getByTestId("chip-forms"));
+		await user.click(
+			screen.getByRole("button", { name: "Ticket Intake actions" }),
+		);
 
-		it("opens sharing for a solution-managed form without exposing edit controls", async () => {
-			const { user } = await renderPage();
-			await screen.findByTestId("solution-detail");
+		expect(
+			screen.getByRole("menuitem", { name: "Share Form" }),
+		).toBeInTheDocument();
+		expect(
+			screen.queryByRole("menuitem", { name: "Edit Form" }),
+		).not.toBeInTheDocument();
 
-			await user.click(screen.getByTestId("tab-contents"));
-			await user.click(screen.getByTestId("chip-forms"));
-			await user.click(
-				screen.getByRole("button", { name: "Ticket Intake actions" }),
-			);
+		await user.click(screen.getByRole("menuitem", { name: "Share Form" }));
+		expect(screen.getByRole("dialog")).toHaveTextContent(
+			"Share Ticket Intake",
+		);
+	});
 
-			expect(
-				screen.getByRole("menuitem", { name: "Share Form" }),
-			).toBeInTheDocument();
-			expect(
-				screen.queryByRole("menuitem", { name: "Edit Form" }),
-			).not.toBeInTheDocument();
+	it("uses the applications list open behavior for solution apps", async () => {
+		const { user } = await renderPage();
+		await screen.findByTestId("solution-detail");
 
-			await user.click(
-				screen.getByRole("menuitem", { name: "Share Form" }),
-			);
-			expect(screen.getByRole("dialog")).toHaveTextContent(
-				"Share Ticket Intake",
-			);
-		});
+		await user.click(screen.getByTestId("tab-contents"));
+		await user.click(screen.getByTestId("chip-apps"));
+		expect(screen.queryByText(/open published/i)).not.toBeInTheDocument();
+		expect(screen.getByTestId("entity-logo")).toHaveAttribute(
+			"src",
+			APP_LOGO_DATA_URL,
+		);
+		await user.click(screen.getByRole("button", { name: /solution app/i }));
 
-		it("uses the applications list open behavior for solution apps", async () => {
-			const { user } = await renderPage();
-			await screen.findByTestId("solution-detail");
+		expect(mockNavigate).toHaveBeenCalledWith(
+			"/apps/solution-app?from=solution:sol-1",
+		);
+	});
 
-			await user.click(screen.getByTestId("tab-contents"));
-			await user.click(screen.getByTestId("chip-apps"));
-			expect(screen.queryByText(/open published/i)).not.toBeInTheDocument();
-			expect(screen.getByTestId("entity-logo")).toHaveAttribute(
-				"src",
-				"/api/applications/app-1/logo?v=thumb-v1",
-			);
-			await user.click(screen.getByRole("button", { name: /solution app/i }));
-
-			expect(mockNavigate).toHaveBeenCalledWith(
-				"/apps/solution-app?from=solution:sol-1",
-			);
-		});
-
-		it("navigates a table row to its entity page with ?from=solution:", async () => {
-			const { user } = await renderPage();
-			await screen.findByTestId("solution-detail");
+	it("navigates a table row to its entity page with ?from=solution:", async () => {
+		const { user } = await renderPage();
+		await screen.findByTestId("solution-detail");
 
 		await user.click(screen.getByTestId("tab-contents"));
 		await user.click(screen.getByTestId("chip-tables"));
@@ -620,12 +657,11 @@ describe("SolutionDetail", () => {
 
 		await user.click(screen.getByTestId("tab-contents"));
 		await user.click(screen.getByTestId("chip-tables"));
-		expect(screen.getByRole("row", { name: /customers/i })).toBeInTheDocument();
+		expect(
+			screen.getByRole("row", { name: /customers/i }),
+		).toBeInTheDocument();
 
-		await user.type(
-			screen.getByPlaceholderText("Search tables..."),
-			"zzz",
-		);
+		await user.type(screen.getByPlaceholderText("Search tables..."), "zzz");
 		// SearchBox debounces input before propagating it.
 		expect(await screen.findByText(/no tables match/i)).toBeInTheDocument();
 		expect(
@@ -730,7 +766,9 @@ describe("SolutionDetail", () => {
 		// On success the entities query refetches (clears the badge once the
 		// backend drops update_available_version).
 		await waitFor(() =>
-			expect(mockGetSolutionEntities.mock.calls.length).toBeGreaterThan(1),
+			expect(mockGetSolutionEntities.mock.calls.length).toBeGreaterThan(
+				1,
+			),
 		);
 	});
 
@@ -761,8 +799,9 @@ describe("SolutionDetail", () => {
 		await user.click(screen.getByTestId("tab-contents"));
 		await user.click(screen.getByTestId("chip-files"));
 
-		expect(await screen.findByTestId("solution-files-explorer"))
-			.toHaveTextContent("Files Explorer sol-1 My Solution");
+		expect(
+			await screen.findByTestId("solution-files-explorer"),
+		).toHaveTextContent("Files Explorer sol-1 My Solution");
 		expect(mockFilesExplorer).toHaveBeenCalledWith({
 			install: "sol-1",
 			installName: "My Solution",
@@ -775,7 +814,9 @@ describe("SolutionDetail", () => {
 		await screen.findByTestId("solution-detail");
 
 		await user.click(screen.getByTestId("solution-actions"));
-		expect(await screen.findByTestId("uninstall-solution")).toBeInTheDocument();
+		expect(
+			await screen.findByTestId("uninstall-solution"),
+		).toBeInTheDocument();
 		expect(screen.getByTestId("hard-delete-solution")).toBeInTheDocument();
 	});
 
@@ -808,7 +849,9 @@ describe("SolutionDetail", () => {
 
 		// Overflow menu has no Uninstall but still has Delete permanently.
 		await user.click(screen.getByTestId("solution-actions"));
-		expect(screen.queryByTestId("uninstall-solution")).not.toBeInTheDocument();
+		expect(
+			screen.queryByTestId("uninstall-solution"),
+		).not.toBeInTheDocument();
 		expect(screen.getByTestId("hard-delete-solution")).toBeInTheDocument();
 	});
 
@@ -831,7 +874,9 @@ describe("SolutionDetail", () => {
 		expect(screen.getByTestId("hard-delete-slug")).toHaveTextContent(
 			"my-solution",
 		);
-		expect(screen.getByText("Type the Solution slug to confirm")).toBeInTheDocument();
+		expect(
+			screen.getByText("Type the Solution slug to confirm"),
+		).toBeInTheDocument();
 
 		// Confirm is disabled until slug is typed.
 		const confirmBtn = screen.getByTestId("confirm-hard-delete");
@@ -870,7 +915,10 @@ describe("SolutionDetail", () => {
 		await user.click(screen.getByTestId("confirm-hard-delete"));
 
 		await waitFor(() =>
-			expect(mockDeleteSolution).toHaveBeenCalledWith("sol-1", "my-solution"),
+			expect(mockDeleteSolution).toHaveBeenCalledWith(
+				"sol-1",
+				"my-solution",
+			),
 		);
 		await waitFor(() =>
 			expect(mockNavigate).toHaveBeenCalledWith("/solutions"),

--- a/client/src/pages/SolutionDetail.test.tsx
+++ b/client/src/pages/SolutionDetail.test.tsx
@@ -84,17 +84,14 @@ vi.mock("@/services/solutions", () => ({
 		mockGetSolutionDeletionSummary(...a),
 	setSolutionConfig: (...a: unknown[]) => mockSetSolutionConfig(...a),
 	exportSolution: (...a: unknown[]) => mockExportSolution(...a),
-	createSolutionExportJob: (...a: unknown[]) =>
-		mockCreateSolutionExportJob(...a),
-	listSolutionExportJobs: (...a: unknown[]) =>
-		mockListSolutionExportJobs(...a),
+	createSolutionExportJob: (...a: unknown[]) => mockCreateSolutionExportJob(...a),
+	listSolutionExportJobs: (...a: unknown[]) => mockListSolutionExportJobs(...a),
 	downloadSolutionExportJob: (...a: unknown[]) =>
 		mockDownloadSolutionExportJob(...a),
 	syncSolution: (...a: unknown[]) => mockSyncSolution(...a),
 	getSolutionCaptureCandidates: (...a: unknown[]) =>
 		mockGetSolutionCaptureCandidates(...a),
-	captureSolutionEntities: (...a: unknown[]) =>
-		mockCaptureSolutionEntities(...a),
+	captureSolutionEntities: (...a: unknown[]) => mockCaptureSolutionEntities(...a),
 }));
 
 vi.mock("@/services/workflowKeys", () => ({
@@ -129,27 +126,27 @@ function makeEntities(statusOverride = "active") {
 				function_name: "sync_tickets",
 			},
 		],
-		apps: [
-			{
-				id: "app-1",
-				name: "Solution App",
-				slug: "solution-app",
-				description: "Solution app",
-				app_model: "standalone_v2",
-				is_published: true,
-				has_unpublished_changes: false,
-				logo_url: APP_LOGO_DATA_URL,
-			},
-		],
-		forms: [
-			{
-				id: "form-1",
-				name: "Ticket Intake",
-				description: "Collect ticket context",
-				is_active: true,
-				organization_id: "org-1",
-			},
-		],
+			apps: [
+				{
+					id: "app-1",
+					name: "Solution App",
+					slug: "solution-app",
+					description: "Solution app",
+					app_model: "standalone_v2",
+					is_published: true,
+					has_unpublished_changes: false,
+					logo_url: APP_LOGO_DATA_URL,
+				},
+			],
+			forms: [
+				{
+					id: "form-1",
+					name: "Ticket Intake",
+					description: "Collect ticket context",
+					is_active: true,
+					organization_id: "org-1",
+				},
+			],
 		agents: [],
 		tables: [{ id: "tbl-1", name: "Customers" }],
 		claims: [
@@ -258,9 +255,7 @@ describe("SolutionDetail", () => {
 		expect(
 			await screen.findByText(/no setup instructions provided/i),
 		).toBeInTheDocument();
-		expect(
-			screen.queryByText(/add setup instructions/i),
-		).not.toBeInTheDocument();
+		expect(screen.queryByText(/add setup instructions/i)).not.toBeInTheDocument();
 		expect(
 			screen.queryByRole("button", { name: /write readme/i }),
 		).not.toBeInTheDocument();
@@ -285,9 +280,7 @@ describe("SolutionDetail", () => {
 		await renderPage();
 		await screen.findByTestId("solution-detail");
 
-		expect(screen.getByTestId("tab-overview")).toHaveTextContent(
-			"Overview",
-		);
+		expect(screen.getByTestId("tab-overview")).toHaveTextContent("Overview");
 
 		// Contents collapses the 6 entity inventories; its count is the total
 		// (1 workflow + 1 app + 1 form + 0 agents + 1 table + 1 claim = 5 in the
@@ -332,16 +325,10 @@ describe("SolutionDetail", () => {
 		await screen.findByTestId("solution-detail");
 
 		await waitFor(() =>
-			expect(
-				screen.queryByTestId("continue-setup"),
-			).not.toBeInTheDocument(),
+			expect(screen.queryByTestId("continue-setup")).not.toBeInTheDocument(),
 		);
-		expect(
-			screen.queryByTestId("incomplete-badge"),
-		).not.toBeInTheDocument();
-		expect(
-			screen.queryByTestId("config-tab-warning"),
-		).not.toBeInTheDocument();
+		expect(screen.queryByTestId("incomplete-badge")).not.toBeInTheDocument();
+		expect(screen.queryByTestId("config-tab-warning")).not.toBeInTheDocument();
 	});
 
 	it("returns to overview when completed setup is dismissed", async () => {
@@ -366,9 +353,7 @@ describe("SolutionDetail", () => {
 		await screen.findByTestId("solution-detail");
 
 		await user.click(screen.getByTestId("tab-configuration"));
-		expect(
-			await screen.findByText(/all required setup is complete/i),
-		).toBeInTheDocument();
+		expect(await screen.findByText(/all required setup is complete/i)).toBeInTheDocument();
 		await user.click(screen.getByRole("button", { name: /done/i }));
 
 		await waitFor(() =>
@@ -429,9 +414,7 @@ describe("SolutionDetail", () => {
 		await screen.findByTestId("solution-detail");
 
 		await user.click(screen.getByTestId("solution-actions"));
-		await user.click(
-			await screen.findByRole("menuitem", { name: /export/i }),
-		);
+		await user.click(await screen.findByRole("menuitem", { name: /export/i }));
 		await user.click(screen.getByLabelText(/^backup/i));
 		await user.type(screen.getByLabelText(/^password/i), "hunter2");
 		await user.click(screen.getByRole("button", { name: /queue backup/i }));
@@ -461,9 +444,7 @@ describe("SolutionDetail", () => {
 		const workflows = screen.getByTestId("chip-workflows");
 		expect(workflows).toHaveTextContent("Workflows");
 		expect(workflows).toHaveTextContent("1");
-		expect(screen.getByTestId("chip-claims")).toHaveTextContent(
-			"Custom Claims",
-		);
+		expect(screen.getByTestId("chip-claims")).toHaveTextContent("Custom Claims");
 	});
 
 	it("opens the requested Contents filter from an Overview entity count", async () => {
@@ -476,13 +457,9 @@ describe("SolutionDetail", () => {
 			"data-state",
 			"active",
 		);
-		expect(screen.getByTestId("chip-workflows")).toHaveTextContent(
-			"Workflows",
-		);
+		expect(screen.getByTestId("chip-workflows")).toHaveTextContent("Workflows");
 		expect(screen.getByText("Sync Tickets")).toBeInTheDocument();
-		expect(
-			screen.queryByTestId("summary-workflows"),
-		).not.toBeInTheDocument();
+		expect(screen.queryByTestId("summary-workflows")).not.toBeInTheDocument();
 	});
 
 	it("opens Files directly from the Overview Files count", async () => {
@@ -500,18 +477,15 @@ describe("SolutionDetail", () => {
 			"data-state",
 			"active",
 		);
-		expect(
-			await screen.findByTestId("solution-files-explorer"),
-		).toHaveTextContent("Files Explorer sol-1 My Solution");
+		expect(await screen.findByTestId("solution-files-explorer"))
+			.toHaveTextContent("Files Explorer sol-1 My Solution");
 	});
 
 	it("renders the update action and the overflow menu in the header", async () => {
 		const { user } = await renderPage();
 		await screen.findByTestId("solution-detail");
 
-		expect(
-			screen.getByRole("button", { name: /update/i }),
-		).toBeInTheDocument();
+		expect(screen.getByRole("button", { name: /update/i })).toBeInTheDocument();
 
 		// The secondary actions (Capture, Export, Edit, Delete) live behind the
 		// "⋯" overflow menu now, not as a flat row of buttons.
@@ -537,109 +511,101 @@ describe("SolutionDetail", () => {
 		await screen.findByTestId("solution-detail");
 
 		await user.click(screen.getByTestId("solution-actions"));
-		await user.click(
-			await screen.findByRole("menuitem", { name: /capture/i }),
-		);
+		await user.click(await screen.findByRole("menuitem", { name: /capture/i }));
 
 		expect(
-			await screen.findByRole("heading", {
-				name: /capture existing entities/i,
-			}),
+			await screen.findByRole("heading", { name: /capture existing entities/i }),
 		).toBeInTheDocument();
-		expect(
-			await screen.findByLabelText(/capture orders/i),
-		).toBeInTheDocument();
+		expect(await screen.findByLabelText(/capture orders/i)).toBeInTheDocument();
 	});
 
-	it("shows the setup-incomplete banner", async () => {
-		await renderPage();
-		expect(
-			await screen.findByTestId("required-config-warning"),
-		).toBeInTheDocument();
-		expect(
-			screen.getByText(
-				/setup incomplete .* 1 required config needs a value/i,
-			),
-		).toBeInTheDocument();
-	});
-
-	it("uses the workflow list execute action instead of making the card open execution", async () => {
-		const { user } = await renderPage();
-		await screen.findByTestId("solution-detail");
-
-		await user.click(screen.getByTestId("tab-contents"));
-		await user.click(screen.getByTestId("chip-workflows"));
-		const execute = screen.getByRole("button", {
-			name: /execute workflow/i,
+		it("shows the setup-incomplete banner", async () => {
+			await renderPage();
+			expect(
+				await screen.findByTestId("required-config-warning"),
+			).toBeInTheDocument();
+			expect(
+				screen.getByText(/setup incomplete .* 1 required config needs a value/i),
+			).toBeInTheDocument();
 		});
-		await user.click(execute);
 
-		expect(mockNavigate).toHaveBeenCalledWith(
-			"/workflows/Sync%20Tickets/execute?from=solution:sol-1",
-		);
-	});
+		it("uses the workflow list execute action instead of making the card open execution", async () => {
+			const { user } = await renderPage();
+			await screen.findByTestId("solution-detail");
 
-	it("uses the forms list launch action without exposing edit controls", async () => {
-		const { user } = await renderPage();
-		await screen.findByTestId("solution-detail");
+			await user.click(screen.getByTestId("tab-contents"));
+			await user.click(screen.getByTestId("chip-workflows"));
+			const execute = screen.getByRole("button", { name: /execute workflow/i });
+			await user.click(execute);
 
-		await user.click(screen.getByTestId("tab-contents"));
-		await user.click(screen.getByTestId("chip-forms"));
-		expect(screen.getByText("Ticket Intake")).toBeInTheDocument();
-		expect(
-			screen.queryByRole("button", { name: /edit form/i }),
-		).not.toBeInTheDocument();
+			expect(mockNavigate).toHaveBeenCalledWith(
+				"/workflows/Sync%20Tickets/execute?from=solution:sol-1",
+			);
+		});
 
-		await user.click(screen.getByRole("button", { name: /launch/i }));
-		expect(mockNavigate).toHaveBeenCalledWith(
-			"/execute/form-1?from=solution:sol-1",
-		);
-	});
+		it("uses the forms list launch action without exposing edit controls", async () => {
+			const { user } = await renderPage();
+			await screen.findByTestId("solution-detail");
 
-	it("opens sharing for a solution-managed form without exposing edit controls", async () => {
-		const { user } = await renderPage();
-		await screen.findByTestId("solution-detail");
+			await user.click(screen.getByTestId("tab-contents"));
+			await user.click(screen.getByTestId("chip-forms"));
+			expect(screen.getByText("Ticket Intake")).toBeInTheDocument();
+			expect(
+				screen.queryByRole("button", { name: /edit form/i }),
+			).not.toBeInTheDocument();
 
-		await user.click(screen.getByTestId("tab-contents"));
-		await user.click(screen.getByTestId("chip-forms"));
-		await user.click(
-			screen.getByRole("button", { name: "Ticket Intake actions" }),
-		);
+			await user.click(screen.getByRole("button", { name: /launch/i }));
+			expect(mockNavigate).toHaveBeenCalledWith(
+				"/execute/form-1?from=solution:sol-1",
+			);
+		});
 
-		expect(
-			screen.getByRole("menuitem", { name: "Share Form" }),
-		).toBeInTheDocument();
-		expect(
-			screen.queryByRole("menuitem", { name: "Edit Form" }),
-		).not.toBeInTheDocument();
+		it("opens sharing for a solution-managed form without exposing edit controls", async () => {
+			const { user } = await renderPage();
+			await screen.findByTestId("solution-detail");
 
-		await user.click(screen.getByRole("menuitem", { name: "Share Form" }));
-		expect(screen.getByRole("dialog")).toHaveTextContent(
-			"Share Ticket Intake",
-		);
-	});
+			await user.click(screen.getByTestId("tab-contents"));
+			await user.click(screen.getByTestId("chip-forms"));
+			await user.click(
+				screen.getByRole("button", { name: "Ticket Intake actions" }),
+			);
 
-	it("uses the applications list open behavior for solution apps", async () => {
-		const { user } = await renderPage();
-		await screen.findByTestId("solution-detail");
+			expect(
+				screen.getByRole("menuitem", { name: "Share Form" }),
+			).toBeInTheDocument();
+			expect(
+				screen.queryByRole("menuitem", { name: "Edit Form" }),
+			).not.toBeInTheDocument();
 
-		await user.click(screen.getByTestId("tab-contents"));
-		await user.click(screen.getByTestId("chip-apps"));
-		expect(screen.queryByText(/open published/i)).not.toBeInTheDocument();
-		expect(screen.getByTestId("entity-logo")).toHaveAttribute(
-			"src",
-			APP_LOGO_DATA_URL,
-		);
-		await user.click(screen.getByRole("button", { name: /solution app/i }));
+			await user.click(
+				screen.getByRole("menuitem", { name: "Share Form" }),
+			);
+			expect(screen.getByRole("dialog")).toHaveTextContent(
+				"Share Ticket Intake",
+			);
+		});
 
-		expect(mockNavigate).toHaveBeenCalledWith(
-			"/apps/solution-app?from=solution:sol-1",
-		);
-	});
+		it("uses the applications list open behavior for solution apps", async () => {
+			const { user } = await renderPage();
+			await screen.findByTestId("solution-detail");
 
-	it("navigates a table row to its entity page with ?from=solution:", async () => {
-		const { user } = await renderPage();
-		await screen.findByTestId("solution-detail");
+			await user.click(screen.getByTestId("tab-contents"));
+			await user.click(screen.getByTestId("chip-apps"));
+			expect(screen.queryByText(/open published/i)).not.toBeInTheDocument();
+			expect(screen.getByTestId("entity-logo")).toHaveAttribute(
+				"src",
+				APP_LOGO_DATA_URL,
+			);
+			await user.click(screen.getByRole("button", { name: /solution app/i }));
+
+			expect(mockNavigate).toHaveBeenCalledWith(
+				"/apps/solution-app?from=solution:sol-1",
+			);
+		});
+
+		it("navigates a table row to its entity page with ?from=solution:", async () => {
+			const { user } = await renderPage();
+			await screen.findByTestId("solution-detail");
 
 		await user.click(screen.getByTestId("tab-contents"));
 		await user.click(screen.getByTestId("chip-tables"));
@@ -657,11 +623,12 @@ describe("SolutionDetail", () => {
 
 		await user.click(screen.getByTestId("tab-contents"));
 		await user.click(screen.getByTestId("chip-tables"));
-		expect(
-			screen.getByRole("row", { name: /customers/i }),
-		).toBeInTheDocument();
+		expect(screen.getByRole("row", { name: /customers/i })).toBeInTheDocument();
 
-		await user.type(screen.getByPlaceholderText("Search tables..."), "zzz");
+		await user.type(
+			screen.getByPlaceholderText("Search tables..."),
+			"zzz",
+		);
 		// SearchBox debounces input before propagating it.
 		expect(await screen.findByText(/no tables match/i)).toBeInTheDocument();
 		expect(
@@ -766,9 +733,7 @@ describe("SolutionDetail", () => {
 		// On success the entities query refetches (clears the badge once the
 		// backend drops update_available_version).
 		await waitFor(() =>
-			expect(mockGetSolutionEntities.mock.calls.length).toBeGreaterThan(
-				1,
-			),
+			expect(mockGetSolutionEntities.mock.calls.length).toBeGreaterThan(1),
 		);
 	});
 
@@ -799,9 +764,8 @@ describe("SolutionDetail", () => {
 		await user.click(screen.getByTestId("tab-contents"));
 		await user.click(screen.getByTestId("chip-files"));
 
-		expect(
-			await screen.findByTestId("solution-files-explorer"),
-		).toHaveTextContent("Files Explorer sol-1 My Solution");
+		expect(await screen.findByTestId("solution-files-explorer"))
+			.toHaveTextContent("Files Explorer sol-1 My Solution");
 		expect(mockFilesExplorer).toHaveBeenCalledWith({
 			install: "sol-1",
 			installName: "My Solution",
@@ -814,9 +778,7 @@ describe("SolutionDetail", () => {
 		await screen.findByTestId("solution-detail");
 
 		await user.click(screen.getByTestId("solution-actions"));
-		expect(
-			await screen.findByTestId("uninstall-solution"),
-		).toBeInTheDocument();
+		expect(await screen.findByTestId("uninstall-solution")).toBeInTheDocument();
 		expect(screen.getByTestId("hard-delete-solution")).toBeInTheDocument();
 	});
 
@@ -849,9 +811,7 @@ describe("SolutionDetail", () => {
 
 		// Overflow menu has no Uninstall but still has Delete permanently.
 		await user.click(screen.getByTestId("solution-actions"));
-		expect(
-			screen.queryByTestId("uninstall-solution"),
-		).not.toBeInTheDocument();
+		expect(screen.queryByTestId("uninstall-solution")).not.toBeInTheDocument();
 		expect(screen.getByTestId("hard-delete-solution")).toBeInTheDocument();
 	});
 
@@ -874,9 +834,7 @@ describe("SolutionDetail", () => {
 		expect(screen.getByTestId("hard-delete-slug")).toHaveTextContent(
 			"my-solution",
 		);
-		expect(
-			screen.getByText("Type the Solution slug to confirm"),
-		).toBeInTheDocument();
+		expect(screen.getByText("Type the Solution slug to confirm")).toBeInTheDocument();
 
 		// Confirm is disabled until slug is typed.
 		const confirmBtn = screen.getByTestId("confirm-hard-delete");
@@ -915,10 +873,7 @@ describe("SolutionDetail", () => {
 		await user.click(screen.getByTestId("confirm-hard-delete"));
 
 		await waitFor(() =>
-			expect(mockDeleteSolution).toHaveBeenCalledWith(
-				"sol-1",
-				"my-solution",
-			),
+			expect(mockDeleteSolution).toHaveBeenCalledWith("sol-1", "my-solution"),
 		);
 		await waitFor(() =>
 			expect(mockNavigate).toHaveBeenCalledWith("/solutions"),

--- a/client/src/pages/agents/FleetPage.test.tsx
+++ b/client/src/pages/agents/FleetPage.test.tsx
@@ -2,7 +2,8 @@
  * Tests for FleetPage.
  *
  * The page composes hooks from `@/hooks/useAgents` (list) and
- * `@/services/agents` (fleet + per-agent stats). We mock both at module
+ * `@/services/agents` (fleet stats). Per-agent stats arrive on each list item.
+ * We mock both modules at module
  * scope so we can control loading / data states deterministically.
  */
 
@@ -17,14 +18,12 @@ const mockUseAgents = vi.fn();
 vi.mock("@/hooks/useAgents", () => ({
 	useAgents: (
 		filterScope?: string | null,
-		options?: { includeInactive?: boolean },
+		options?: { includeInactive?: boolean; includeStats?: boolean },
 	) => mockUseAgents(filterScope, options),
 }));
 
-const mockUseAgentStats = vi.fn();
 const mockUseFleetStats = vi.fn();
 vi.mock("@/services/agents", () => ({
-	useAgentStats: (id: string | undefined) => mockUseAgentStats(id),
 	useFleetStats: () => mockUseFleetStats(),
 }));
 
@@ -69,6 +68,7 @@ function makeAgent(overrides: Partial<Record<string, unknown>> = {}) {
 		owner_user_id: null,
 		created_at: "2026-04-01T00:00:00Z",
 		dependency_count: 0,
+		stats: baseStats,
 		...overrides,
 	};
 }
@@ -88,7 +88,6 @@ const baseStats = {
 beforeEach(() => {
 	mockUseAgents.mockReturnValue({ data: [], isLoading: false });
 	mockUseFleetStats.mockReturnValue({ data: fleetStats, isLoading: false });
-	mockUseAgentStats.mockReturnValue({ data: baseStats, isLoading: false });
 	mockUseAuth.mockReturnValue({ isPlatformAdmin: false });
 });
 
@@ -179,6 +178,7 @@ describe("FleetPage — agent cards (grid)", () => {
 
 		expect(mockUseAgents).toHaveBeenLastCalledWith(undefined, {
 			includeInactive: false,
+			includeStats: true,
 		});
 
 		const toggle = screen.getByRole("switch", { name: "Show Inactive" });
@@ -186,6 +186,7 @@ describe("FleetPage — agent cards (grid)", () => {
 
 		expect(mockUseAgents).toHaveBeenLastCalledWith(undefined, {
 			includeInactive: true,
+			includeStats: true,
 		});
 	});
 
@@ -373,14 +374,17 @@ describe("FleetPage — view toggle", () => {
 });
 
 describe("FleetPage — loading state", () => {
-	it("renders skeletons while fleet stats and agents are loading", async () => {
+	it("shows a loading indicator while agents are loading", async () => {
 		mockUseAgents.mockReturnValue({ data: undefined, isLoading: true });
 		mockUseFleetStats.mockReturnValue({
 			data: undefined,
 			isLoading: true,
 		});
 		const { container } = await renderPage();
-		// Skeleton renders divs with the .animate-pulse class.
+		expect(
+			screen.getByRole("status", { name: /loading agents/i }),
+		).toBeInTheDocument();
+		// Fleet metrics retain compact placeholders while their separate request loads.
 		expect(
 			container.querySelectorAll(".animate-pulse").length,
 		).toBeGreaterThan(0);

--- a/client/src/pages/agents/FleetPage.tsx
+++ b/client/src/pages/agents/FleetPage.tsx
@@ -3,8 +3,8 @@
  *
  * Visual spec mirrors `/tmp/agent-mockup/src/pages/FleetPage.tsx`: stat row with
  * deltas, paired grid/table toggle, per-agent cards with mini-stat trio +
- * sparkline + footer row. Per-agent stats are fetched via `useAgentStats(id)`
- * (N+1; acceptable v1, TODO for a denormalized list endpoint).
+ * sparkline + footer row. Per-agent stats are included by the list endpoint so
+ * the page renders the fleet in one bounded request instead of one call/card.
  */
 
 import { type MouseEvent, useMemo, useState } from "react";
@@ -29,6 +29,7 @@ import {
 import { toast } from "sonner";
 
 import { EntityLogo } from "@/components/EntityLogo";
+import { PageLoader } from "@/components/PageLoader";
 import { SolutionManagedBadge } from "@/components/solutions/SolutionManagedBadge";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -71,7 +72,7 @@ import {
 } from "@/components/agents/design-tokens";
 
 import { useAgents, type AgentSummary } from "@/hooks/useAgents";
-import { useAgentStats, useFleetStats } from "@/services/agents";
+import { useFleetStats } from "@/services/agents";
 import {
 	cn,
 	formatCost,
@@ -95,7 +96,7 @@ export function FleetPage() {
 
 	const { data: agents, isLoading: agentsLoading } = useAgents(
 		isPlatformAdmin ? filterOrgId : undefined,
-		{ includeInactive: showInactive },
+		{ includeInactive: showInactive, includeStats: true },
 	);
 	const { data: fleetStats, isLoading: fleetLoading } = useFleetStats();
 
@@ -348,24 +349,10 @@ export function FleetPage() {
 			{/* Content */}
 			<div className="flex-1 min-h-0 overflow-auto">
 				{agentsLoading ? (
-					view === "grid" ? (
-						<div
-							className={cn(
-								"grid md:grid-cols-2 xl:grid-cols-3",
-								GAP_CARD,
-							)}
-						>
-							{[...Array(6)].map((_, i) => (
-								<Skeleton key={i} className="h-52 w-full" />
-							))}
-						</div>
-					) : (
-						<div className="space-y-2">
-							{[...Array(3)].map((_, i) => (
-								<Skeleton key={i} className="h-12 w-full" />
-							))}
-						</div>
-					)
+					<PageLoader
+						message={`Loading ${term(terminology, "agent", "pluralLower")}…`}
+						size="sm"
+					/>
 				) : filtered.length === 0 ? (
 					<EmptyState hasQuery={query.trim().length > 0} />
 				) : view === "grid" ? (
@@ -473,9 +460,7 @@ function AgentGridCard({
 	showOrg: boolean;
 	orgName: string;
 }) {
-	// TODO(plan-2): replace per-card useAgentStats N+1 with a denormalized
-	// list endpoint that returns fleet member stats in one round-trip.
-	const { data: stats, isLoading } = useAgentStats(agent.id ?? undefined);
+	const stats = agent.stats;
 	const successRate = stats?.success_rate ?? 0;
 	const colorClass = successRateTone(successRate);
 	const hasRuns = (stats?.runs_7d ?? 0) > 0;
@@ -496,7 +481,9 @@ function AgentGridCard({
 							entityType="agent"
 							entityId={agent.id}
 							logo={agent.logo_url ?? null}
-							fallback={<Bot className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />}
+							fallback={
+								<Bot className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+							}
 							size={20}
 							className="h-5 w-5 rounded shrink-0 object-cover"
 						/>
@@ -527,9 +514,7 @@ function AgentGridCard({
 				) : null}
 			</div>
 			<div className="flex-1 space-y-3 p-4">
-				{isLoading ? (
-					<Skeleton className="h-24 w-full" />
-				) : hasRuns ? (
+				{hasRuns ? (
 					<>
 						<div className="grid grid-cols-3 gap-3">
 							<MiniStat
@@ -717,7 +702,7 @@ function AgentTableRow({
 	showOrg: boolean;
 	orgName: string;
 }) {
-	const { data: stats } = useAgentStats(agent.id ?? undefined);
+	const stats = agent.stats;
 	const hasRuns = (stats?.runs_7d ?? 0) > 0;
 
 	return (


### PR DESCRIPTION
## Summary

- preserve agent and application icons while resized thumbnails are still being generated
- batch seven-day agent statistics into the list response instead of issuing one request per row
- use the shared spinning loading indicator for agent and application lists

## Verification

- `./test.sh tests/unit/test_agent_stats_service.py tests/unit/routers/test_entity_logo_urls.py tests/unit/test_contract_version.py tests/unit/test_dto_flags.py -v` — 78 passed
- targeted client Vitest — 34 passed after rebase
- `npm run tsc`
- `npm run lint -- --quiet`
- entity logo API E2E — 6 passed
- entity logo/list Playwright — 3 passed; screenshots inspected
- `./test.sh quality api`

Fixes #612