### PR TITLE
Improve detail route loading transitions

### DIFF
--- a/api/tests/unit/jobs/schedulers/test_platform_jobs.py
+++ b/api/tests/unit/jobs/schedulers/test_platform_jobs.py
@@ -150,12 +150,24 @@ async def test_concurrent_replicas_claim_each_row_once(
 @pytest.mark.asyncio
 async def test_expired_lease_requeues_then_fails_at_attempt_limit(
     db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    # Keep the lease valid to the live scheduler container while advancing only
+    # this test process beyond it. Otherwise the live scheduler can recover the
+    # deliberately expired row before the function under test sees it.
+    wall_clock_now = datetime.now(timezone.utc)
+    lease_deadline = wall_clock_now + timedelta(days=1)
+    monkeypatch.setattr(
+        scheduler,
+        "_now",
+        lambda: wall_clock_now + timedelta(days=2),
+    )
+
     job = await _queued_job(db_session)
     job.status = "running"
     job.attempt = 1
     job.lease_token = uuid4()
-    job.lease_expires_at = datetime.now(timezone.utc) - timedelta(seconds=1)
+    job.lease_expires_at = lease_deadline
     await db_session.commit()
 
     recovered, failed = await scheduler.recover_expired_platform_jobs()
@@ -167,7 +179,7 @@ async def test_expired_lease_requeues_then_fails_at_attempt_limit(
     job.status = "running"
     job.attempt = job.max_attempts
     job.lease_token = uuid4()
-    job.lease_expires_at = datetime.now(timezone.utc) - timedelta(seconds=1)
+    job.lease_expires_at = lease_deadline
     await db_session.commit()
     recovered, failed = await scheduler.recover_expired_platform_jobs()
     assert (recovered, failed) == (1, 1)

--- a/client/e2e/detail-route-loading.admin.spec.ts
+++ b/client/e2e/detail-route-loading.admin.spec.ts
@@ -1,0 +1,87 @@
+import { expect, test } from "./fixtures/api-fixture";
+
+test.describe("Detail route loading", () => {
+	test("keeps navigation continuous and gives direct loads immediate feedback", async ({
+		page,
+		api,
+	}, testInfo) => {
+		const name = `Route Ready Agent ${Date.now()}`;
+		const createResponse = await api.post("/api/agents", {
+			data: {
+				name,
+				description: "Exercises the route-ready loading boundary.",
+				system_prompt: "You are a route loading test agent.",
+				channels: ["chat"],
+				access_level: "authenticated",
+			},
+		});
+		expect(createResponse.ok(), await createResponse.text()).toBe(true);
+		const agent = (await createResponse.json()) as { id: string };
+		const detailPattern = `**/api/agents/${agent.id}`;
+
+		try {
+			await page.goto("/agents");
+			const fleetHeading = page
+				.getByRole("heading", { name: /agents/i })
+				.first();
+			await expect(fleetHeading).toBeVisible();
+			const card = page.getByRole("link").filter({ hasText: name });
+			await expect(card).toBeVisible();
+
+			let releaseNavigation!: () => void;
+			const navigationGate = new Promise<void>((resolve) => {
+				releaseNavigation = resolve;
+			});
+			let detailRequests = 0;
+			await page.route(detailPattern, async (route) => {
+				detailRequests += 1;
+				await navigationGate;
+				await route.continue();
+			});
+
+			const click = card.click();
+			await expect(
+				page.getByRole("progressbar", { name: "Loading page" }),
+			).toBeVisible();
+			await expect(fleetHeading).toBeVisible();
+			expect(new URL(page.url()).pathname).toBe("/agents");
+
+			releaseNavigation();
+			await click;
+			await expect(page).toHaveURL(new RegExp(`/agents/${agent.id}$`));
+			await expect(page.getByRole("heading", { name })).toBeVisible();
+			await expect(page.getByText("Loading…")).toHaveCount(0);
+			expect(detailRequests).toBe(1);
+
+			await page.unroute(detailPattern);
+			let releaseDirectLoad!: () => void;
+			const directLoadGate = new Promise<void>((resolve) => {
+				releaseDirectLoad = resolve;
+			});
+			await page.route(detailPattern, async (route) => {
+				await directLoadGate;
+				await route.continue();
+			});
+
+			const reload = page.reload({ waitUntil: "domcontentloaded" });
+			await expect(
+				page.getByRole("status", { name: "Opening agent…" }),
+			).toBeVisible();
+			await testInfo.attach("detail-route-opening", {
+				body: await page.screenshot({ fullPage: true }),
+				contentType: "image/png",
+			});
+
+			releaseDirectLoad();
+			await reload;
+			await expect(page.getByRole("heading", { name })).toBeVisible();
+			await testInfo.attach("detail-route-ready", {
+				body: await page.screenshot({ fullPage: true }),
+				contentType: "image/png",
+			});
+		} finally {
+			await page.unroute(detailPattern);
+			await api.delete(`/api/agents/${agent.id}`);
+		}
+	});
+});

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,9 +1,11 @@
 import { Suspense, useEffect } from "react";
 import {
-	BrowserRouter,
-	Routes,
 	Route,
+	RouterProvider,
+	createBrowserRouter,
+	createRoutesFromElements,
 	useLocation,
+	Outlet,
 	matchPath,
 } from "react-router-dom";
 import { Layout } from "@/components/layout/Layout";
@@ -28,6 +30,13 @@ import {
 } from "@/contexts/KeyboardContext";
 import { lazyWithReload } from "@/lib/lazy-with-reload";
 import { RunFormRoute } from "@/pages/run-form-route";
+import { RouteOpeningState } from "@/components/layout/RouteOpeningState";
+import { RouteReadyReveal } from "@/components/layout/RouteReadyReveal";
+import { RouteLoadError } from "@/components/layout/RouteLoadError";
+import {
+	agentDetailLoader,
+	applicationDetailLoader,
+} from "@/lib/detail-route-loaders";
 
 // Lazy load all page components for code splitting
 const Dashboard = lazyWithReload(() =>
@@ -216,7 +225,7 @@ const MCPConnectionEdit = lazyWithReload(() =>
 	})),
 );
 
-function AppRoutes() {
+function AppFrame() {
 	const { brandingLoaded } = useOrgScope();
 	const applicationName = useApplicationName();
 	const location = useLocation();
@@ -281,530 +290,554 @@ function AppRoutes() {
 			<UnifiedDock />
 
 			<Suspense fallback={<PageLoader />}>
-				<Routes>
-					{/* Public routes - no auth required */}
-					<Route path="login" element={<Login />} />
-					<Route path="setup" element={<Setup />} />
-					<Route path="accept-invite" element={<Register />} />
-					<Route path="mfa-setup" element={<MFASetup />} />
-					<Route
-						path="auth/callback/:provider"
-						element={<AuthCallback />}
-					/>
-					<Route path="mcp/callback" element={<MCPCallback />} />
-
-					{/* Device authorization - requires auth, handles redirect internally */}
-					<Route path="device" element={<DevicePage />} />
-
-					{/* OAuth Callback - Public (no auth, no layout) */}
-					<Route
-						path="oauth/callback/:integrationId"
-						element={<OAuthCallback />}
-					/>
-
-					{/* Application Preview - Full screen for developers */}
-					<Route
-						path="apps/:applicationId/preview/*"
-						element={
-							<ProtectedRoute requirePlatformAdmin>
-								<ApplicationPreview />
-							</ProtectedRoute>
-						}
-					/>
-
-					{/* Application Runner - Published apps (full screen) */}
-					<Route
-						path="apps/:applicationId/*"
-						element={
-							<ProtectedRoute requireOrgUser>
-								<ApplicationRunner />
-							</ProtectedRoute>
-						}
-					/>
-					<Route
-						path="embedded/forms/public/:publicKey"
-						element={
-							<ProtectedRoute requireOrgUser>
-								<RunFormRoute />
-							</ProtectedRoute>
-						}
-					/>
-					<Route
-						path="embedded/forms/hmac/:formId"
-						element={
-							<ProtectedRoute requireOrgUser>
-								<RunFormRoute />
-							</ProtectedRoute>
-						}
-					/>
-
-					<Route path="/" element={<Layout />}>
-						{/* Dashboard - PlatformAdmin only (OrgUsers redirected to /forms) */}
-						<Route index element={<Dashboard />} />
-
-						{/* Workflows - PlatformAdmin only */}
-						<Route
-							path="workflows"
-							element={
-								<ProtectedRoute requirePlatformAdmin>
-									<Workflows />
-								</ProtectedRoute>
-							}
-						/>
-						<Route
-							path="workflows/:workflowName/execute"
-							element={
-								<ProtectedRoute requirePlatformAdmin>
-									<ExecuteWorkflow />
-								</ProtectedRoute>
-							}
-						/>
-
-						{/* Forms - PlatformAdmin or OrgUser */}
-						<Route
-							path="forms"
-							element={
-								<ProtectedRoute requireOrgUser>
-									<Forms />
-								</ProtectedRoute>
-							}
-						/>
-						<Route
-							path="execute/:formId"
-							element={
-								<ProtectedRoute requireOrgUser>
-									<RunFormRoute />
-								</ProtectedRoute>
-							}
-						/>
-
-						{/* Form Builder - PlatformAdmin only */}
-						<Route
-							path="forms/new"
-							element={
-								<ProtectedRoute requirePlatformAdmin>
-									<FormBuilder />
-								</ProtectedRoute>
-							}
-						/>
-						<Route
-							path="forms/:formId/edit"
-							element={
-								<ProtectedRoute requirePlatformAdmin>
-									<FormBuilder />
-								</ProtectedRoute>
-							}
-						/>
-
-						{/* History - PlatformAdmin or OrgUser */}
-						<Route
-							path="history"
-							element={
-								<ProtectedRoute requireOrgUser>
-									<ExecutionHistory />
-								</ProtectedRoute>
-							}
-						/>
-
-						{/* Organizations - PlatformAdmin only */}
-						<Route
-							path="organizations"
-							element={
-								<ProtectedRoute requirePlatformAdmin>
-									<Organizations />
-								</ProtectedRoute>
-							}
-						/>
-
-						{/* Users - PlatformAdmin only */}
-						<Route
-							path="users"
-							element={
-								<ProtectedRoute requirePlatformAdmin>
-									<Users />
-								</ProtectedRoute>
-							}
-						/>
-						<Route
-							path="users/:userId"
-							element={
-								<ProtectedRoute requirePlatformAdmin>
-									<Users />
-								</ProtectedRoute>
-							}
-						/>
-
-						{/* Roles - PlatformAdmin only */}
-						<Route
-							path="roles"
-							element={
-								<ProtectedRoute requirePlatformAdmin>
-									<Roles />
-								</ProtectedRoute>
-							}
-						/>
-						<Route
-							path="roles/:roleId"
-							element={
-								<ProtectedRoute requirePlatformAdmin>
-									<RoleDetail />
-								</ProtectedRoute>
-							}
-						/>
-						<Route
-							path="roles/:roleId/:tab"
-							element={
-								<ProtectedRoute requirePlatformAdmin>
-									<RoleDetail />
-								</ProtectedRoute>
-							}
-						/>
-
-						{/* Solutions - PlatformAdmin only */}
-						<Route
-							path="solutions"
-							element={
-								<ProtectedRoute requirePlatformAdmin>
-									<Solutions />
-								</ProtectedRoute>
-							}
-						/>
-						<Route
-							path="solutions/:solutionId"
-							element={
-								<ProtectedRoute requirePlatformAdmin>
-									<SolutionDetail />
-								</ProtectedRoute>
-							}
-						/>
-
-						{/* Config - PlatformAdmin only */}
-						<Route
-							path="config"
-							element={
-								<ProtectedRoute requirePlatformAdmin>
-									<Config />
-								</ProtectedRoute>
-							}
-						/>
-
-						{/* Data Tables - PlatformAdmin only */}
-						<Route
-							path="tables"
-							element={
-								<ProtectedRoute requirePlatformAdmin>
-									<Tables />
-								</ProtectedRoute>
-							}
-						/>
-						<Route
-							path="tables/:tableId"
-							element={
-								<ProtectedRoute requirePlatformAdmin>
-									<TableDetail />
-								</ProtectedRoute>
-							}
-						/>
-
-						{/* Files - PlatformAdmin only */}
-						<Route
-							path="files"
-							element={
-								<ProtectedRoute requirePlatformAdmin>
-									<Files />
-								</ProtectedRoute>
-							}
-						/>
-
-						{/* Applications List - OrgUser access (with sidebar) */}
-						<Route
-							path="apps"
-							element={
-								<ProtectedRoute requireOrgUser>
-									<Applications />
-								</ProtectedRoute>
-							}
-						/>
-						<Route
-							path="apps/new"
-							element={
-								<ProtectedRoute requirePlatformAdmin>
-									<AppCodeEditorPage />
-								</ProtectedRoute>
-							}
-						/>
-						<Route
-							path="apps/:applicationId/edit/*"
-							element={
-								<ProtectedRoute requirePlatformAdmin>
-									<AppCodeEditorPage />
-								</ProtectedRoute>
-							}
-						/>
-
-						{/* Agents - All authenticated users */}
-						<Route
-							path="agents"
-							element={
-								<ProtectedRoute>
-									<FleetPage />
-								</ProtectedRoute>
-							}
-						/>
-						<Route
-							path="agents/new"
-							element={
-								<ProtectedRoute>
-									<AgentDetailPage />
-								</ProtectedRoute>
-							}
-						/>
-						<Route
-							path="agents/:id"
-							element={
-								<ProtectedRoute>
-									<AgentDetailPage />
-								</ProtectedRoute>
-							}
-						/>
-						<Route
-							path="agents/:id/review"
-							element={
-								<ProtectedRoute>
-									<AgentReviewPage />
-								</ProtectedRoute>
-							}
-						/>
-						<Route
-							path="agents/:id/tune"
-							element={
-								<ProtectedRoute>
-									<AgentTuneWorkbench />
-								</ProtectedRoute>
-							}
-						/>
-						<Route
-							path="agents/:agentId/runs/:runId"
-							element={
-								<ProtectedRoute>
-									<AgentRunDetailPage />
-								</ProtectedRoute>
-							}
-						/>
-						{/* Knowledge - PlatformAdmin only */}
-						<Route
-							path="knowledge"
-							element={
-								<ProtectedRoute requirePlatformAdmin>
-									<Knowledge />
-								</ProtectedRoute>
-							}
-						/>
-
-						{/* Entity Management - PlatformAdmin only */}
-						<Route
-							path="entity-management"
-							element={
-								<ProtectedRoute requirePlatformAdmin>
-									<EntityManagement />
-								</ProtectedRoute>
-							}
-						/>
-
-						{/* Integrations - PlatformAdmin only */}
-						<Route
-							path="integrations"
-							element={
-								<ProtectedRoute requirePlatformAdmin>
-									<Integrations />
-								</ProtectedRoute>
-							}
-						/>
-						<Route
-							path="integrations/:id"
-							element={
-								<ProtectedRoute requirePlatformAdmin>
-									<IntegrationDetail />
-								</ProtectedRoute>
-							}
-						/>
-
-						{/* MCP Servers - PlatformAdmin only */}
-						<Route
-							path="mcp-servers"
-							element={
-								<ProtectedRoute requirePlatformAdmin>
-									<MCPServers />
-								</ProtectedRoute>
-							}
-						/>
-						<Route
-							path="mcp-servers/:id"
-							element={
-								<ProtectedRoute requirePlatformAdmin>
-									<MCPServerDetail />
-								</ProtectedRoute>
-							}
-						/>
-						<Route
-							path="mcp-servers/:serverId/connections/:connectionId/edit"
-							element={
-								<ProtectedRoute requirePlatformAdmin>
-									<MCPConnectionEdit />
-								</ProtectedRoute>
-							}
-						/>
-
-						{/* Event Sources - PlatformAdmin only */}
-						<Route
-							path="event-sources"
-							element={
-								<ProtectedRoute requirePlatformAdmin>
-									<Events />
-								</ProtectedRoute>
-							}
-						/>
-						<Route
-							path="event-sources/:sourceId"
-							element={
-								<ProtectedRoute requirePlatformAdmin>
-									<Events />
-								</ProtectedRoute>
-							}
-						/>
-						<Route
-							path="event-sources/:sourceId/events/:eventId"
-							element={
-								<ProtectedRoute requirePlatformAdmin>
-									<Events />
-								</ProtectedRoute>
-							}
-						/>
-
-						{/* Settings - PlatformAdmin only */}
-						<Route
-							path="settings"
-							element={
-								<ProtectedRoute requirePlatformAdmin>
-									<Settings />
-								</ProtectedRoute>
-							}
-						/>
-						<Route
-							path="settings/:tab"
-							element={
-								<ProtectedRoute requirePlatformAdmin>
-									<Settings />
-								</ProtectedRoute>
-							}
-						/>
-
-						{/* Diagnostics - PlatformAdmin only */}
-						<Route
-							path="diagnostics"
-							element={
-								<ProtectedRoute requirePlatformAdmin>
-									<DiagnosticsPage />
-								</ProtectedRoute>
-							}
-						/>
-
-						{/* Audit Log - PlatformAdmin only */}
-						<Route
-							path="audit"
-							element={
-								<ProtectedRoute requirePlatformAdmin>
-									<AuditLogPage />
-								</ProtectedRoute>
-							}
-						/>
-
-						{/* Reports - PlatformAdmin only */}
-						<Route
-							path="reports/roi"
-							element={
-								<ProtectedRoute requirePlatformAdmin>
-									<ROIReports />
-								</ProtectedRoute>
-							}
-						/>
-						<Route
-							path="reports/usage"
-							element={
-								<ProtectedRoute requirePlatformAdmin>
-									<UsageReports />
-								</ProtectedRoute>
-							}
-						/>
-
-						{/* User Settings - All authenticated users */}
-						<Route
-							path="user-settings"
-							element={
-								<ProtectedRoute>
-									<UserSettings />
-								</ProtectedRoute>
-							}
-						/>
-						<Route
-							path="user-settings/:tab"
-							element={
-								<ProtectedRoute>
-									<UserSettings />
-								</ProtectedRoute>
-							}
-						/>
-					</Route>
-
-					{/* ContentLayout - Pages without default padding */}
-					<Route path="/" element={<ContentLayout />}>
-						{/* Chat - All authenticated users */}
-						<Route
-							path="chat"
-							element={
-								<ProtectedRoute>
-									<Chat />
-								</ProtectedRoute>
-							}
-						/>
-						<Route
-							path="chat/:conversationId"
-							element={
-								<ProtectedRoute>
-									<Chat />
-								</ProtectedRoute>
-							}
-						/>
-						{/* Execution Details - PlatformAdmin or OrgUser */}
-						<Route
-							path="history/:executionId"
-							element={
-								<ProtectedRoute requireOrgUser>
-									<ExecutionDetails />
-								</ProtectedRoute>
-							}
-						/>
-					</Route>
-				</Routes>
+				<RouteReadyReveal key={location.key}>
+					<Outlet />
+				</RouteReadyReveal>
 			</Suspense>
 		</>
 	);
 }
 
+const routeElements = (
+	<>
+		{/* Public routes - no auth required */}
+		<Route path="login" element={<Login />} />
+		<Route path="setup" element={<Setup />} />
+		<Route path="accept-invite" element={<Register />} />
+		<Route path="mfa-setup" element={<MFASetup />} />
+		<Route path="auth/callback/:provider" element={<AuthCallback />} />
+		<Route path="mcp/callback" element={<MCPCallback />} />
+
+		{/* Device authorization - requires auth, handles redirect internally */}
+		<Route path="device" element={<DevicePage />} />
+
+		{/* OAuth Callback - Public (no auth, no layout) */}
+		<Route
+			path="oauth/callback/:integrationId"
+			element={<OAuthCallback />}
+		/>
+
+		{/* Application Preview - Full screen for developers */}
+		<Route
+			path="apps/:applicationId/preview/*"
+			loader={applicationDetailLoader(true)}
+			errorElement={<RouteLoadError />}
+			element={
+				<ProtectedRoute requirePlatformAdmin>
+					<ApplicationPreview />
+				</ProtectedRoute>
+			}
+		/>
+
+		{/* Application Runner - Published apps (full screen) */}
+		<Route
+			path="apps/:applicationId/*"
+			loader={applicationDetailLoader(false)}
+			errorElement={<RouteLoadError />}
+			element={
+				<ProtectedRoute requireOrgUser>
+					<ApplicationRunner />
+				</ProtectedRoute>
+			}
+		/>
+		<Route
+			path="embedded/forms/public/:publicKey"
+			element={
+				<ProtectedRoute requireOrgUser>
+					<RunFormRoute />
+				</ProtectedRoute>
+			}
+		/>
+		<Route
+			path="embedded/forms/hmac/:formId"
+			element={
+				<ProtectedRoute requireOrgUser>
+					<RunFormRoute />
+				</ProtectedRoute>
+			}
+		/>
+
+		<Route path="/" element={<Layout />}>
+			{/* Dashboard - PlatformAdmin only (OrgUsers redirected to /forms) */}
+			<Route index element={<Dashboard />} />
+
+			{/* Workflows - PlatformAdmin only */}
+			<Route
+				path="workflows"
+				element={
+					<ProtectedRoute requirePlatformAdmin>
+						<Workflows />
+					</ProtectedRoute>
+				}
+			/>
+			<Route
+				path="workflows/:workflowName/execute"
+				element={
+					<ProtectedRoute requirePlatformAdmin>
+						<ExecuteWorkflow />
+					</ProtectedRoute>
+				}
+			/>
+
+			{/* Forms - PlatformAdmin or OrgUser */}
+			<Route
+				path="forms"
+				element={
+					<ProtectedRoute requireOrgUser>
+						<Forms />
+					</ProtectedRoute>
+				}
+			/>
+			<Route
+				path="execute/:formId"
+				element={
+					<ProtectedRoute requireOrgUser>
+						<RunFormRoute />
+					</ProtectedRoute>
+				}
+			/>
+
+			{/* Form Builder - PlatformAdmin only */}
+			<Route
+				path="forms/new"
+				element={
+					<ProtectedRoute requirePlatformAdmin>
+						<FormBuilder />
+					</ProtectedRoute>
+				}
+			/>
+			<Route
+				path="forms/:formId/edit"
+				element={
+					<ProtectedRoute requirePlatformAdmin>
+						<FormBuilder />
+					</ProtectedRoute>
+				}
+			/>
+
+			{/* History - PlatformAdmin or OrgUser */}
+			<Route
+				path="history"
+				element={
+					<ProtectedRoute requireOrgUser>
+						<ExecutionHistory />
+					</ProtectedRoute>
+				}
+			/>
+
+			{/* Organizations - PlatformAdmin only */}
+			<Route
+				path="organizations"
+				element={
+					<ProtectedRoute requirePlatformAdmin>
+						<Organizations />
+					</ProtectedRoute>
+				}
+			/>
+
+			{/* Users - PlatformAdmin only */}
+			<Route
+				path="users"
+				element={
+					<ProtectedRoute requirePlatformAdmin>
+						<Users />
+					</ProtectedRoute>
+				}
+			/>
+			<Route
+				path="users/:userId"
+				element={
+					<ProtectedRoute requirePlatformAdmin>
+						<Users />
+					</ProtectedRoute>
+				}
+			/>
+
+			{/* Roles - PlatformAdmin only */}
+			<Route
+				path="roles"
+				element={
+					<ProtectedRoute requirePlatformAdmin>
+						<Roles />
+					</ProtectedRoute>
+				}
+			/>
+			<Route
+				path="roles/:roleId"
+				element={
+					<ProtectedRoute requirePlatformAdmin>
+						<RoleDetail />
+					</ProtectedRoute>
+				}
+			/>
+			<Route
+				path="roles/:roleId/:tab"
+				element={
+					<ProtectedRoute requirePlatformAdmin>
+						<RoleDetail />
+					</ProtectedRoute>
+				}
+			/>
+
+			{/* Solutions - PlatformAdmin only */}
+			<Route
+				path="solutions"
+				element={
+					<ProtectedRoute requirePlatformAdmin>
+						<Solutions />
+					</ProtectedRoute>
+				}
+			/>
+			<Route
+				path="solutions/:solutionId"
+				element={
+					<ProtectedRoute requirePlatformAdmin>
+						<SolutionDetail />
+					</ProtectedRoute>
+				}
+			/>
+
+			{/* Config - PlatformAdmin only */}
+			<Route
+				path="config"
+				element={
+					<ProtectedRoute requirePlatformAdmin>
+						<Config />
+					</ProtectedRoute>
+				}
+			/>
+
+			{/* Data Tables - PlatformAdmin only */}
+			<Route
+				path="tables"
+				element={
+					<ProtectedRoute requirePlatformAdmin>
+						<Tables />
+					</ProtectedRoute>
+				}
+			/>
+			<Route
+				path="tables/:tableId"
+				element={
+					<ProtectedRoute requirePlatformAdmin>
+						<TableDetail />
+					</ProtectedRoute>
+				}
+			/>
+
+			{/* Files - PlatformAdmin only */}
+			<Route
+				path="files"
+				element={
+					<ProtectedRoute requirePlatformAdmin>
+						<Files />
+					</ProtectedRoute>
+				}
+			/>
+
+			{/* Applications List - OrgUser access (with sidebar) */}
+			<Route
+				path="apps"
+				element={
+					<ProtectedRoute requireOrgUser>
+						<Applications />
+					</ProtectedRoute>
+				}
+			/>
+			<Route
+				path="apps/new"
+				element={
+					<ProtectedRoute requirePlatformAdmin>
+						<AppCodeEditorPage />
+					</ProtectedRoute>
+				}
+			/>
+			<Route
+				path="apps/:applicationId/edit/*"
+				element={
+					<ProtectedRoute requirePlatformAdmin>
+						<AppCodeEditorPage />
+					</ProtectedRoute>
+				}
+			/>
+
+			{/* Agents - All authenticated users */}
+			<Route
+				path="agents"
+				element={
+					<ProtectedRoute>
+						<FleetPage />
+					</ProtectedRoute>
+				}
+			/>
+			<Route
+				path="agents/new"
+				element={
+					<ProtectedRoute>
+						<AgentDetailPage />
+					</ProtectedRoute>
+				}
+			/>
+			<Route
+				path="agents/:id"
+				loader={agentDetailLoader}
+				errorElement={<RouteLoadError />}
+				element={
+					<ProtectedRoute>
+						<AgentDetailPage />
+					</ProtectedRoute>
+				}
+			/>
+			<Route
+				path="agents/:id/review"
+				element={
+					<ProtectedRoute>
+						<AgentReviewPage />
+					</ProtectedRoute>
+				}
+			/>
+			<Route
+				path="agents/:id/tune"
+				element={
+					<ProtectedRoute>
+						<AgentTuneWorkbench />
+					</ProtectedRoute>
+				}
+			/>
+			<Route
+				path="agents/:agentId/runs/:runId"
+				element={
+					<ProtectedRoute>
+						<AgentRunDetailPage />
+					</ProtectedRoute>
+				}
+			/>
+			{/* Knowledge - PlatformAdmin only */}
+			<Route
+				path="knowledge"
+				element={
+					<ProtectedRoute requirePlatformAdmin>
+						<Knowledge />
+					</ProtectedRoute>
+				}
+			/>
+
+			{/* Entity Management - PlatformAdmin only */}
+			<Route
+				path="entity-management"
+				element={
+					<ProtectedRoute requirePlatformAdmin>
+						<EntityManagement />
+					</ProtectedRoute>
+				}
+			/>
+
+			{/* Integrations - PlatformAdmin only */}
+			<Route
+				path="integrations"
+				element={
+					<ProtectedRoute requirePlatformAdmin>
+						<Integrations />
+					</ProtectedRoute>
+				}
+			/>
+			<Route
+				path="integrations/:id"
+				element={
+					<ProtectedRoute requirePlatformAdmin>
+						<IntegrationDetail />
+					</ProtectedRoute>
+				}
+			/>
+
+			{/* MCP Servers - PlatformAdmin only */}
+			<Route
+				path="mcp-servers"
+				element={
+					<ProtectedRoute requirePlatformAdmin>
+						<MCPServers />
+					</ProtectedRoute>
+				}
+			/>
+			<Route
+				path="mcp-servers/:id"
+				element={
+					<ProtectedRoute requirePlatformAdmin>
+						<MCPServerDetail />
+					</ProtectedRoute>
+				}
+			/>
+			<Route
+				path="mcp-servers/:serverId/connections/:connectionId/edit"
+				element={
+					<ProtectedRoute requirePlatformAdmin>
+						<MCPConnectionEdit />
+					</ProtectedRoute>
+				}
+			/>
+
+			{/* Event Sources - PlatformAdmin only */}
+			<Route
+				path="event-sources"
+				element={
+					<ProtectedRoute requirePlatformAdmin>
+						<Events />
+					</ProtectedRoute>
+				}
+			/>
+			<Route
+				path="event-sources/:sourceId"
+				element={
+					<ProtectedRoute requirePlatformAdmin>
+						<Events />
+					</ProtectedRoute>
+				}
+			/>
+			<Route
+				path="event-sources/:sourceId/events/:eventId"
+				element={
+					<ProtectedRoute requirePlatformAdmin>
+						<Events />
+					</ProtectedRoute>
+				}
+			/>
+
+			{/* Settings - PlatformAdmin only */}
+			<Route
+				path="settings"
+				element={
+					<ProtectedRoute requirePlatformAdmin>
+						<Settings />
+					</ProtectedRoute>
+				}
+			/>
+			<Route
+				path="settings/:tab"
+				element={
+					<ProtectedRoute requirePlatformAdmin>
+						<Settings />
+					</ProtectedRoute>
+				}
+			/>
+
+			{/* Diagnostics - PlatformAdmin only */}
+			<Route
+				path="diagnostics"
+				element={
+					<ProtectedRoute requirePlatformAdmin>
+						<DiagnosticsPage />
+					</ProtectedRoute>
+				}
+			/>
+
+			{/* Audit Log - PlatformAdmin only */}
+			<Route
+				path="audit"
+				element={
+					<ProtectedRoute requirePlatformAdmin>
+						<AuditLogPage />
+					</ProtectedRoute>
+				}
+			/>
+
+			{/* Reports - PlatformAdmin only */}
+			<Route
+				path="reports/roi"
+				element={
+					<ProtectedRoute requirePlatformAdmin>
+						<ROIReports />
+					</ProtectedRoute>
+				}
+			/>
+			<Route
+				path="reports/usage"
+				element={
+					<ProtectedRoute requirePlatformAdmin>
+						<UsageReports />
+					</ProtectedRoute>
+				}
+			/>
+
+			{/* User Settings - All authenticated users */}
+			<Route
+				path="user-settings"
+				element={
+					<ProtectedRoute>
+						<UserSettings />
+					</ProtectedRoute>
+				}
+			/>
+			<Route
+				path="user-settings/:tab"
+				element={
+					<ProtectedRoute>
+						<UserSettings />
+					</ProtectedRoute>
+				}
+			/>
+		</Route>
+
+		{/* ContentLayout - Pages without default padding */}
+		<Route path="/" element={<ContentLayout />}>
+			{/* Chat - All authenticated users */}
+			<Route
+				path="chat"
+				element={
+					<ProtectedRoute>
+						<Chat />
+					</ProtectedRoute>
+				}
+			/>
+			<Route
+				path="chat/:conversationId"
+				element={
+					<ProtectedRoute>
+						<Chat />
+					</ProtectedRoute>
+				}
+			/>
+			{/* Execution Details - PlatformAdmin or OrgUser */}
+			<Route
+				path="history/:executionId"
+				element={
+					<ProtectedRoute requireOrgUser>
+						<ExecutionDetails />
+					</ProtectedRoute>
+				}
+			/>
+		</Route>
+	</>
+);
+
+function AppProviders() {
+	return (
+		<AuthProvider>
+			<OrgScopeProvider>
+				<KeyboardProvider>
+					<RouteTransitionProgress />
+					<AppFrame />
+				</KeyboardProvider>
+			</OrgScopeProvider>
+		</AuthProvider>
+	);
+}
+
+const router = createBrowserRouter(
+	createRoutesFromElements(
+		<Route
+			element={<AppProviders />}
+			hydrateFallbackElement={<RouteOpeningState />}
+		>
+			{routeElements}
+		</Route>,
+	),
+);
+
 function App() {
 	return (
 		<ApplicationUpdateGate>
 			<ErrorBoundary>
-				<BrowserRouter>
-					<RouteTransitionProgress />
-					<AuthProvider>
-						<OrgScopeProvider>
-							<KeyboardProvider>
-								<AppRoutes />
-							</KeyboardProvider>
-						</OrgScopeProvider>
-					</AuthProvider>
-				</BrowserRouter>
+				<RouterProvider router={router} />
 			</ErrorBoundary>
 		</ApplicationUpdateGate>
 	);

--- a/client/src/components/EntityLogo.test.tsx
+++ b/client/src/components/EntityLogo.test.tsx
@@ -63,6 +63,23 @@ describe("EntityLogo", () => {
 		expect(img.getAttribute("src")).toBe(dataUrl);
 	});
 
+	it("crossfades a fetched logo over its fallback", () => {
+		render(
+			<EntityLogo
+				entityType="app"
+				entityId="11111111-1111-1111-1111-111111111111"
+				logo="/images/app-logo.png"
+				fallback={<span data-testid="fallback">F</span>}
+				size={32}
+			/>,
+		);
+		const img = screen.getByTestId("entity-logo");
+		expect(img).toHaveClass("opacity-0");
+		expect(screen.getByTestId("fallback")).toBeInTheDocument();
+		fireEvent.load(img);
+		expect(img).toHaveClass("opacity-100");
+	});
+
 	it("falls back when a list-provided logo URL fails", () => {
 		render(
 			<EntityLogo

--- a/client/src/components/EntityLogo.tsx
+++ b/client/src/components/EntityLogo.tsx
@@ -1,4 +1,5 @@
 import { useState, type ReactNode } from "react";
+
 import { useEntityLogoVersion } from "./entityLogoVersions";
 
 export type EntityLogoProps = {
@@ -9,12 +10,9 @@ export type EntityLogoProps = {
 	cacheKey?: string;
 	className?: string;
 	/**
-	 * Logo source (data URL or versioned endpoint URL) from the list/detail
-	 * response. When provided as a string, renders it directly. When explicitly
-	 * `null`, renders
-	 * the fallback without hitting the per-entity endpoint. When `undefined`,
-	 * falls back to fetching /api/{type}/{id}/logo (preserves the upload
-	 * dialog's live-preview behavior).
+	 * Logo source from the list/detail response. A string is rendered directly,
+	 * null means there is no logo, and undefined retains the endpoint behavior
+	 * used by upload surfaces.
 	 */
 	logo?: string | null;
 };
@@ -35,48 +33,37 @@ export function EntityLogo({
 	logo,
 }: EntityLogoProps) {
 	const [erroredSource, setErroredSource] = useState<string | null>(null);
+	const [loadedSource, setLoadedSource] = useState<string | null>(null);
 	const globalVersion = useEntityLogoVersion(entityType, entityId);
-
-	if (logo === null) {
-		return <>{fallback}</>;
-	}
-
-	if (typeof logo === "string") {
-		if (erroredSource === logo) {
-			return <>{fallback}</>;
-		}
-		return (
-			<img
-				data-testid="entity-logo"
-				src={logo}
-				alt=""
-				width={size}
-				height={size}
-				className={className}
-				onError={() => setErroredSource(logo)}
-			/>
-		);
-	}
-
 	const base = `${PATHS[entityType]}/${entityId}/logo`;
 	const effectiveKey = cacheKey ?? globalVersion?.toString() ?? null;
-	const src = effectiveKey
+	const endpointSource = effectiveKey
 		? `${base}?v=${encodeURIComponent(effectiveKey)}`
 		: base;
-
-	if (erroredSource === src) {
-		return <>{fallback}</>;
-	}
+	const src = logo === null ? null : (logo ?? endpointSource);
+	const hasUsableSource = src !== null && erroredSource !== src;
+	const imageLoaded = src !== null && loadedSource === src;
 
 	return (
-		<img
-			data-testid="entity-logo"
-			src={src}
-			alt=""
-			width={size}
-			height={size}
-			className={className}
-			onError={() => setErroredSource(src)}
-		/>
+		<span
+			className={`relative inline-grid place-items-center overflow-hidden ${className ?? ""}`}
+			style={{ width: size, height: size }}
+		>
+			<span className="absolute inset-0 grid place-items-center">
+				{fallback}
+			</span>
+			{hasUsableSource ? (
+				<img
+					data-testid="entity-logo"
+					src={src}
+					alt=""
+					width={size}
+					height={size}
+					className={`absolute inset-0 h-full w-full object-cover transition-opacity duration-150 motion-reduce:transition-none ${imageLoaded ? "opacity-100" : "opacity-0"}`}
+					onLoad={() => setLoadedSource(src)}
+					onError={() => setErroredSource(src)}
+				/>
+			) : null}
+		</span>
 	);
 }

--- a/client/src/components/LogoDropZone.test.tsx
+++ b/client/src/components/LogoDropZone.test.tsx
@@ -34,7 +34,10 @@ describe("LogoDropZone", () => {
 	it("renders the preview img pointing at previewUrl", () => {
 		render(<LogoDropZone {...baseProps} />);
 		const img = screen.getByTestId("logo-drop-zone-img");
-		expect(img.getAttribute("src")).toContain(baseProps.previewUrl);
+		expect(img.getAttribute("src")).toBe(baseProps.previewUrl);
+		expect(img).toHaveClass("opacity-0");
+		fireEvent.load(img);
+		expect(img).toHaveClass("opacity-100");
 	});
 
 	it("shows the fallback when the preview img errors", () => {
@@ -45,7 +48,9 @@ describe("LogoDropZone", () => {
 	});
 
 	it("POSTs the dropped file via authFetch", async () => {
-		mockAuthFetch.mockResolvedValueOnce(new Response(null, { status: 200 }));
+		mockAuthFetch.mockResolvedValueOnce(
+			new Response(null, { status: 200 }),
+		);
 		const onChange = vi.fn();
 		render(<LogoDropZone {...baseProps} onChange={onChange} />);
 		const zone = screen.getByTestId("logo-drop-zone");
@@ -72,7 +77,9 @@ describe("LogoDropZone", () => {
 	});
 
 	it("DELETEs via authFetch when Remove is clicked", async () => {
-		mockAuthFetch.mockResolvedValueOnce(new Response(null, { status: 204 }));
+		mockAuthFetch.mockResolvedValueOnce(
+			new Response(null, { status: 204 }),
+		);
 		const onChange = vi.fn();
 		render(<LogoDropZone {...baseProps} onChange={onChange} />);
 		// Remove button only shows once an image has actually loaded

--- a/client/src/components/LogoDropZone.tsx
+++ b/client/src/components/LogoDropZone.tsx
@@ -42,7 +42,7 @@ export function LogoDropZone({
 	onChange,
 }: LogoDropZoneProps) {
 	const fileInputRef = useRef<HTMLInputElement>(null);
-	const [cacheKey, setCacheKey] = useState(() => String(Date.now()));
+	const [cacheKey, setCacheKey] = useState<string | null>(null);
 	const [isDragging, setIsDragging] = useState(false);
 	const [imageLoaded, setImageLoaded] = useState(false);
 	const [isErrored, setIsErrored] = useState(false);
@@ -70,7 +70,10 @@ export function LogoDropZone({
 		try {
 			const fd = new FormData();
 			fd.append("file", file);
-			const resp = await authFetch(uploadUrl, { method: "POST", body: fd });
+			const resp = await authFetch(uploadUrl, {
+				method: "POST",
+				body: fd,
+			});
 			if (!resp.ok) {
 				const err = await resp.json().catch(() => ({}));
 				throw new Error(err.detail || `Upload failed (${resp.status})`);
@@ -126,7 +129,9 @@ export function LogoDropZone({
 	);
 
 	const rounded = shape === "circle" ? "rounded-full" : "rounded-md";
-	const src = `${previewUrl}?v=${encodeURIComponent(cacheKey)}`;
+	const src = cacheKey
+		? `${previewUrl}${previewUrl.includes("?") ? "&" : "?"}v=${encodeURIComponent(cacheKey)}`
+		: previewUrl;
 
 	return (
 		<div
@@ -150,6 +155,9 @@ export function LogoDropZone({
 				isDragging ? "ring-2 ring-primary ring-offset-2" : ""
 			}`}
 		>
+			<div className="absolute inset-0 flex items-center justify-center text-muted-foreground">
+				{fallback}
+			</div>
 			{!isErrored && (
 				<img
 					data-testid="logo-drop-zone-img"
@@ -157,18 +165,13 @@ export function LogoDropZone({
 					alt=""
 					width={size}
 					height={size}
-					className="h-full w-full object-cover"
+					className={`absolute inset-0 h-full w-full object-cover transition-opacity duration-150 motion-reduce:transition-none ${imageLoaded ? "opacity-100" : "opacity-0"}`}
 					onLoad={() => setImageLoaded(true)}
 					onError={() => {
 						setIsErrored(true);
 						setImageLoaded(false);
 					}}
 				/>
-			)}
-			{(isErrored || !imageLoaded) && (
-				<div className="absolute inset-0 flex items-center justify-center text-muted-foreground">
-					{fallback}
-				</div>
 			)}
 			<div
 				className={`absolute inset-0 flex items-center justify-center bg-black/50 ${rounded} transition-opacity ${

--- a/client/src/components/applications/ApplicationListSurface.tsx
+++ b/client/src/components/applications/ApplicationListSurface.tsx
@@ -25,6 +25,7 @@ import {
 } from "@/components/ui/data-table";
 import { term, useTerminology } from "@/lib/terminology";
 import type { components } from "@/lib/v1";
+import { prefetchApplicationDetail } from "@/lib/detail-route-loaders";
 
 export type ApplicationListItem = components["schemas"]["ApplicationPublic"] & {
 	app_model?: string | null;
@@ -131,156 +132,190 @@ export function ApplicationListSurface({
 						</DataTableRow>
 					</DataTableHeader>
 					<DataTableBody>
-						{apps.map((app) => (
-							<DataTableRow key={app.id}>
-								{isPlatformAdmin && (
-									<DataTableCell className="w-0 whitespace-nowrap">
-										{app.organization_id ? (
-											<Badge
-												variant="outline"
-												className="text-xs"
-											>
-												<Building2 className="mr-1 h-3 w-3" />
-												{getOrgName(
-													app.organization_id,
-												)}
-											</Badge>
-										) : (
-											<Badge
-												variant="default"
-												className="text-xs"
-											>
-												<Globe className="mr-1 h-3 w-3" />
-												Global
-											</Badge>
-										)}
-									</DataTableCell>
-								)}
-								<DataTableCell className="font-medium">
-									{app.name}
-								</DataTableCell>
-								<DataTableCell className="max-w-xs truncate text-muted-foreground">
-									{app.description || (
-										<span className="italic">
-											No description
-										</span>
-									)}
-								</DataTableCell>
-								<DataTableCell className="w-0 whitespace-nowrap">
-									<div className="flex gap-1">
-										{app.is_published && (
-											<Badge
-												variant="default"
-												className="text-xs"
-											>
-												Published
-											</Badge>
-										)}
-										{app.has_unpublished_changes && (
-											<Badge
-												variant="outline"
-												className="text-xs"
-											>
-												Draft
-											</Badge>
-										)}
-										{!app.is_published &&
-											!app.has_unpublished_changes && (
+						{apps.map((app) => {
+							const opensPreview =
+								!canLaunchApp(app) && Boolean(onPreview);
+							return (
+								<DataTableRow
+									key={app.id}
+									onPointerEnter={() =>
+										prefetchApplicationDetail(
+											app,
+											opensPreview,
+										)
+									}
+									onFocus={() =>
+										prefetchApplicationDetail(
+											app,
+											opensPreview,
+										)
+									}
+								>
+									{isPlatformAdmin && (
+										<DataTableCell className="w-0 whitespace-nowrap">
+											{app.organization_id ? (
 												<Badge
-													variant="secondary"
+													variant="outline"
 													className="text-xs"
 												>
-													{isV2App(app)
-														? "V2"
-														: "Empty"}
+													<Building2 className="mr-1 h-3 w-3" />
+													{getOrgName(
+														app.organization_id,
+													)}
+												</Badge>
+											) : (
+												<Badge
+													variant="default"
+													className="text-xs"
+												>
+													<Globe className="mr-1 h-3 w-3" />
+													Global
 												</Badge>
 											)}
-									</div>
-								</DataTableCell>
-								<DataTableCell className="w-0 whitespace-nowrap">
-									{app.is_published ? "Published" : "-"}
-								</DataTableCell>
-								<DataTableCell className="w-0 whitespace-nowrap text-right">
-									<div className="flex gap-1 justify-end">
-										<Button
-											size="sm"
-											onClick={() => onLaunch(app)}
-											disabled={!canLaunchApp(app)}
-											title={
-												!canLaunchApp(app)
-													? "No published version"
-													: `Open ${term(terminology, "app", "formalSingularLower")}`
-											}
-										>
-											<PlayCircle className="h-4 w-4" />
-										</Button>
-										{canManageApps &&
-											!isV2App(app) &&
-											app.has_unpublished_changes &&
-											onPreview && (
-												<Button
-													variant="ghost"
-													size="sm"
-													onClick={() =>
-														onPreview(app)
-													}
-													title="Preview draft"
-												>
-													<Eye className="h-4 w-4" />
-												</Button>
-											)}
-										{app.is_solution_managed && (
-											<SolutionManagedBadge
-												solutionId={app.solution_id}
+										</DataTableCell>
+									)}
+									<DataTableCell className="font-medium">
+										<div className="flex items-center gap-2">
+											<EntityLogo
+												entityType="app"
+												entityId={app.id}
+												logo={app.logo_url ?? null}
+												fallback={
+													<AppWindow className="h-3.5 w-3.5 text-muted-foreground" />
+												}
+												size={20}
+												className="h-5 w-5 shrink-0 rounded object-cover"
 											/>
+											<span>{app.name}</span>
+										</div>
+									</DataTableCell>
+									<DataTableCell className="max-w-xs truncate text-muted-foreground">
+										{app.description || (
+											<span className="italic">
+												No description
+											</span>
 										)}
-										{canManageApps &&
-											!app.is_solution_managed && (
-												<>
-													{onOpenSettings && (
-														<Button
-															variant="ghost"
-															size="sm"
-															onClick={() =>
-																onOpenSettings(
-																	app,
-																)
-															}
-															title="Settings"
-														>
-															<Pencil className="h-4 w-4" />
-														</Button>
-													)}
-													{onOpenCode && (
-														<Button
-															variant="ghost"
-															size="sm"
-															onClick={() =>
-																onOpenCode(app)
-															}
-															title="Code editor"
-														>
-															<Code2 className="h-4 w-4" />
-														</Button>
-													)}
-													{onDelete && (
-														<Button
-															variant="ghost"
-															size="sm"
-															onClick={() =>
-																onDelete(app)
-															}
-															title={`Delete ${term(terminology, "app", "formalSingularLower")}`}
-														>
-															<Trash2 className="h-4 w-4" />
-														</Button>
-													)}
-												</>
+									</DataTableCell>
+									<DataTableCell className="w-0 whitespace-nowrap">
+										<div className="flex gap-1">
+											{app.is_published && (
+												<Badge
+													variant="default"
+													className="text-xs"
+												>
+													Published
+												</Badge>
 											)}
-									</div>
-								</DataTableCell>
-							</DataTableRow>
-						))}
+											{app.has_unpublished_changes && (
+												<Badge
+													variant="outline"
+													className="text-xs"
+												>
+													Draft
+												</Badge>
+											)}
+											{!app.is_published &&
+												!app.has_unpublished_changes && (
+													<Badge
+														variant="secondary"
+														className="text-xs"
+													>
+														{isV2App(app)
+															? "V2"
+															: "Empty"}
+													</Badge>
+												)}
+										</div>
+									</DataTableCell>
+									<DataTableCell className="w-0 whitespace-nowrap">
+										{app.is_published ? "Published" : "-"}
+									</DataTableCell>
+									<DataTableCell className="w-0 whitespace-nowrap text-right">
+										<div className="flex gap-1 justify-end">
+											<Button
+												size="sm"
+												onClick={() => onLaunch(app)}
+												disabled={!canLaunchApp(app)}
+												title={
+													!canLaunchApp(app)
+														? "No published version"
+														: `Open ${term(terminology, "app", "formalSingularLower")}`
+												}
+											>
+												<PlayCircle className="h-4 w-4" />
+											</Button>
+											{canManageApps &&
+												!isV2App(app) &&
+												app.has_unpublished_changes &&
+												onPreview && (
+													<Button
+														variant="ghost"
+														size="sm"
+														onClick={() =>
+															onPreview(app)
+														}
+														title="Preview draft"
+													>
+														<Eye className="h-4 w-4" />
+													</Button>
+												)}
+											{app.is_solution_managed && (
+												<SolutionManagedBadge
+													solutionId={app.solution_id}
+												/>
+											)}
+											{canManageApps &&
+												!app.is_solution_managed && (
+													<>
+														{onOpenSettings && (
+															<Button
+																variant="ghost"
+																size="sm"
+																onClick={() =>
+																	onOpenSettings(
+																		app,
+																	)
+																}
+																title="Settings"
+															>
+																<Pencil className="h-4 w-4" />
+															</Button>
+														)}
+														{onOpenCode && (
+															<Button
+																variant="ghost"
+																size="sm"
+																onClick={() =>
+																	onOpenCode(
+																		app,
+																	)
+																}
+																title="Code editor"
+															>
+																<Code2 className="h-4 w-4" />
+															</Button>
+														)}
+														{onDelete && (
+															<Button
+																variant="ghost"
+																size="sm"
+																onClick={() =>
+																	onDelete(
+																		app,
+																	)
+																}
+																title={`Delete ${term(terminology, "app", "formalSingularLower")}`}
+															>
+																<Trash2 className="h-4 w-4" />
+															</Button>
+														)}
+													</>
+												)}
+										</div>
+									</DataTableCell>
+								</DataTableRow>
+							);
+						})}
 					</DataTableBody>
 				</DataTable>
 			</div>
@@ -290,6 +325,7 @@ export function ApplicationListSurface({
 	return (
 		<div className="grid grid-cols-1 gap-4 sm:grid-cols-[repeat(auto-fill,minmax(320px,1fr))]">
 			{apps.map((app) => {
+				const opensPreview = !canLaunchApp(app) && Boolean(onPreview);
 				const defaultTarget = canLaunchApp(app)
 					? () => onLaunch(app)
 					: onPreview
@@ -305,6 +341,12 @@ export function ApplicationListSurface({
 						key={app.id}
 						role="button"
 						tabIndex={0}
+						onPointerEnter={() =>
+							prefetchApplicationDetail(app, opensPreview)
+						}
+						onFocus={() =>
+							prefetchApplicationDetail(app, opensPreview)
+						}
 						onClick={defaultTarget}
 						onKeyDown={(e) => {
 							if (

--- a/client/src/components/jsx-app/BundledAppShell.test.tsx
+++ b/client/src/components/jsx-app/BundledAppShell.test.tsx
@@ -15,7 +15,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { renderWithProviders, screen, waitFor } from "@/test-utils";
+import { fireEvent, renderWithProviders, screen, waitFor } from "@/test-utils";
 
 const { mockStandaloneV2App } = vi.hoisted(() => ({
 	mockStandaloneV2App: vi.fn(),
@@ -120,7 +120,11 @@ afterEach(() => {
 async function renderShell({ isPreview = true }: { isPreview?: boolean } = {}) {
 	const { BundledAppShell } = await import("./BundledAppShell");
 	return renderWithProviders(
-		<BundledAppShell appId="app-1" appSlug="my-app" isPreview={isPreview} />,
+		<BundledAppShell
+			appId="app-1"
+			appSlug="my-app"
+			isPreview={isPreview}
+		/>,
 	);
 }
 
@@ -140,9 +144,7 @@ describe("BundledAppShell — loading", () => {
 
 		await renderShell();
 
-		expect(
-			screen.getByText(/loading application/i),
-		).toBeInTheDocument();
+		expect(screen.getByText(/loading application/i)).toBeInTheDocument();
 
 		// Clean up the hanging promise so the test doesn't leak.
 		resolveFetch({
@@ -209,6 +211,40 @@ describe("BundledAppShell — websocket subscription", () => {
 });
 
 describe("BundledAppShell — app_model render branch", () => {
+	it("uses a route-prepared bundle without fetching its manifest again", async () => {
+		mockManifestOk({
+			app_model: "standalone_v2",
+			entry: "assets/main-prepared.js",
+			base_url: "/api/applications/app-prepared/dist",
+			runtime_contract: "mount-v1",
+		});
+		const { BundledAppShell, prepareAppBundle } =
+			await import("./BundledAppShell");
+		const preparation = prepareAppBundle({
+			appId: "app-prepared",
+			isPreview: false,
+		});
+		await waitFor(() => {
+			const preload = document.querySelector('link[rel="modulepreload"]');
+			expect(preload).not.toBeNull();
+			fireEvent.load(preload!);
+		});
+		await preparation;
+
+		renderWithProviders(
+			<BundledAppShell
+				appId="app-prepared"
+				appSlug="prepared"
+				isPreview={false}
+			/>,
+		);
+
+		expect(
+			await screen.findByTestId("solution-v2-app-root"),
+		).toBeInTheDocument();
+		expect(mockAuthFetch).toHaveBeenCalledTimes(1);
+	});
+
 	it("mounts the standalone v2 app same-document (no iframe) and injects auth", async () => {
 		mockManifestOk({
 			app_model: "standalone_v2",
@@ -255,7 +291,9 @@ describe("BundledAppShell — app_model render branch", () => {
 		const { rerender } = renderWithProviders(
 			<BundledAppShell appId="app-v2" appSlug="v2" isPreview />,
 		);
-		expect(await screen.findByTestId("solution-v2-app-root")).toBeInTheDocument();
+		expect(
+			await screen.findByTestId("solution-v2-app-root"),
+		).toBeInTheDocument();
 
 		// Navigate to a different, inline_v1 app: the v2 container must go away
 		// (the shell re-fetches and resets the model). The inline dynamic import
@@ -289,7 +327,9 @@ describe("BundledAppShell — app_model render branch", () => {
 		);
 
 		// Navigate to app B; B's manifest fetch is PENDING (never resolves here).
-		mockAuthFetch.mockImplementationOnce(() => new Promise<Response>(() => {}));
+		mockAuthFetch.mockImplementationOnce(
+			() => new Promise<Response>(() => {}),
+		);
 		rerender(<BundledAppShell appId="app-B" appSlug="bbb" isPreview />);
 
 		// During the pending window the stale A v2 mount must be cleared — NOT

--- a/client/src/components/jsx-app/BundledAppShell.tsx
+++ b/client/src/components/jsx-app/BundledAppShell.tsx
@@ -38,7 +38,8 @@ import {
 
 // jsDelivr — JSPM's CDN 404s on floating tags (`@2`), only exact versions
 // resolve. Pinned to an exact version for reproducible loads.
-const ESM_SHIMS_URL = "https://cdn.jsdelivr.net/npm/es-module-shims@2.8.0/dist/es-module-shims.js";
+const ESM_SHIMS_URL =
+	"https://cdn.jsdelivr.net/npm/es-module-shims@2.8.0/dist/es-module-shims.js";
 // Force esm.sh to leave React/Router as bare specifiers in its own response so
 // they resolve back through our static import map to the host's copies. Same
 // instance everywhere -> no "two Reacts" hooks failure when a user dep calls
@@ -71,7 +72,11 @@ function ensureEsModuleShimsLoaded(): Promise<void> {
 		script.src = ESM_SHIMS_URL;
 		script.onload = () => resolve();
 		script.onerror = () =>
-			reject(new Error(`Failed to load es-module-shims from ${ESM_SHIMS_URL}`));
+			reject(
+				new Error(
+					`Failed to load es-module-shims from ${ESM_SHIMS_URL}`,
+				),
+			);
 		document.head.appendChild(script);
 	});
 	return esModuleShimsPromise;
@@ -87,7 +92,7 @@ function registerUserDepImportMap(dependencies: Record<string, string>): void {
 	// Always include the platform keys in the shim-mode map too — shim-mode
 	// modules can't see the native importmap, so they need their own copy.
 	const imports: Record<string, string> = {
-		"react": "/__bifrost_modules/react.js",
+		react: "/__bifrost_modules/react.js",
 		"react-dom": "/__bifrost_modules/react-dom.js",
 		"react-dom/client": "/__bifrost_modules/react-dom-client.js",
 		"react/jsx-runtime": "/__bifrost_modules/react-jsx-runtime.js",
@@ -96,7 +101,8 @@ function registerUserDepImportMap(dependencies: Record<string, string>): void {
 		"lucide-react": "/__bifrost_modules/lucide-react.js",
 	};
 	for (const [name, version] of Object.entries(dependencies)) {
-		imports[name] = `https://esm.sh/${name}@${version}?external=${REACT_EXTERNALS}`;
+		imports[name] =
+			`https://esm.sh/${name}@${version}?external=${REACT_EXTERNALS}`;
 	}
 
 	const key = JSON.stringify(imports);
@@ -109,7 +115,7 @@ function registerUserDepImportMap(dependencies: Record<string, string>): void {
 	document.head.appendChild(script);
 }
 
-interface BundleManifest {
+export interface BundleManifest {
 	// null for a standalone_v2 app with no built dist yet; a string otherwise.
 	entry: string | null;
 	css: string | null;
@@ -142,19 +148,183 @@ interface BundledAppShellProps {
 // React component type exported by the bundled entry.
 type BundledAppComponent = React.ComponentType<Record<string, never>>;
 
-export function BundledAppShell({ appId, appSlug, isPreview }: BundledAppShellProps) {
+interface PreparedAppBundle {
+	manifest: BundleManifest;
+	component: BundledAppComponent | null;
+	entry: string | null;
+	cssHref: string | null;
+}
+
+const preparedBundles = new Map<string, PreparedAppBundle>();
+const preparingBundles = new Map<string, Promise<PreparedAppBundle>>();
+const PREPARED_BUNDLE_TTL_MS = 10_000;
+
+function preparedBundleKey(appId: string, isPreview: boolean): string {
+	return `${appId}:${isPreview ? "draft" : "live"}`;
+}
+
+function invalidatePreparedAppBundle(appId: string, isPreview: boolean): void {
+	preparedBundles.delete(preparedBundleKey(appId, isPreview));
+}
+
+export function getPreparedAppBundle(
+	appId: string,
+	isPreview: boolean,
+): PreparedAppBundle | undefined {
+	return preparedBundles.get(preparedBundleKey(appId, isPreview));
+}
+
+export function prepareAppBundle({
+	appId,
+	isPreview,
+	signal,
+}: {
+	appId: string;
+	isPreview: boolean;
+	signal?: AbortSignal;
+}): Promise<PreparedAppBundle> {
+	const key = preparedBundleKey(appId, isPreview);
+	const prepared = preparedBundles.get(key);
+	if (prepared) return Promise.resolve(prepared);
+
+	const pending = preparingBundles.get(key);
+	if (pending) return pending;
+
+	const load = (async () => {
+		const mode = isPreview ? "draft" : "live";
+		const response = await authFetch(
+			`/api/applications/${appId}/bundle-manifest?mode=${mode}`,
+			{ signal },
+		);
+		if (!response.ok) {
+			const text = await response.text();
+			throw new Error(
+				`Bundle manifest fetch failed: ${response.status} ${text}`,
+			);
+		}
+
+		const manifest: BundleManifest = await response.json();
+		if (manifest.app_model === "standalone_v2") {
+			if (!manifest.entry) {
+				throw new Error(
+					"This v2 app has no built bundle yet (deploy it first).",
+				);
+			}
+
+			await Promise.all([
+				preloadModule(`${manifest.base_url}/${manifest.entry}`, signal),
+				manifest.css
+					? preloadStylesheet(
+							`${manifest.base_url}/${manifest.css}`,
+							signal,
+						)
+					: Promise.resolve(),
+			]);
+
+			return {
+				manifest,
+				component: null,
+				entry: manifest.entry,
+				cssHref: manifest.css
+					? `${manifest.base_url}/${manifest.css}`
+					: null,
+			};
+		}
+
+		if (!manifest.entry) {
+			throw new Error("Bundle manifest did not include an entry module.");
+		}
+
+		const entryUrl = `${manifest.base_url}/${manifest.entry}?mode=${mode}`;
+		const cssHref = manifest.css
+			? `${manifest.base_url}/${manifest.css}?mode=${mode}`
+			: null;
+		const dependencies = manifest.dependencies ?? {};
+		const hasUserDependencies = Object.keys(dependencies).length > 0;
+		let dynamicImport: (url: string) => Promise<{ default?: unknown }>;
+		if (hasUserDependencies) {
+			await ensureEsModuleShimsLoaded();
+			registerUserDepImportMap(dependencies);
+			const runtime = window as unknown as ImportShimWindow;
+			if (typeof runtime.importShim !== "function") {
+				throw new Error(
+					"es-module-shims loaded but importShim is undefined",
+				);
+			}
+			const importShim = runtime.importShim;
+			dynamicImport = (url) =>
+				importShim(url) as Promise<{ default?: unknown }>;
+		} else {
+			dynamicImport = (url) =>
+				import(/* @vite-ignore */ url) as Promise<{
+					default?: unknown;
+				}>;
+		}
+
+		const [module] = await Promise.all([
+			dynamicImport(entryUrl),
+			cssHref ? preloadStylesheet(cssHref, signal) : Promise.resolve(),
+		]);
+		if (typeof module.default !== "function") {
+			throw new Error(
+				"Bundle does not have a default export (expected a React component)",
+			);
+		}
+
+		return {
+			manifest,
+			component: module.default as BundledAppComponent,
+			entry: manifest.entry,
+			cssHref,
+		};
+	})();
+	preparingBundles.set(key, load);
+
+	return load
+		.then((result) => {
+			preparedBundles.set(key, result);
+			preparingBundles.delete(key);
+			window.setTimeout(() => {
+				if (preparedBundles.get(key) === result) {
+					preparedBundles.delete(key);
+				}
+			}, PREPARED_BUNDLE_TTL_MS);
+			return result;
+		})
+		.catch((error: unknown) => {
+			preparingBundles.delete(key);
+			throw error;
+		});
+}
+
+export function BundledAppShell({
+	appId,
+	appSlug,
+	isPreview,
+}: BundledAppShellProps) {
+	const initiallyPrepared = getPreparedAppBundle(appId, isPreview);
 	// The bundle's default export is a React component. We render it INLINE
 	// via React.createElement so the bundled subtree inherits all of the
 	// host's context providers (AuthContext, QueryClientProvider, theme, etc.).
 	// Earlier we used `createRoot(container).render(...)` inside the bundle's
 	// `mount()` — that created a sibling root with no provider inheritance
 	// and broke every hook that read host context (e.g. useUser → useAuth).
-	const [BundledApp, setBundledApp] = useState<BundledAppComponent | null>(null);
-	const [loadedEntry, setLoadedEntry] = useState<string | null>(null);
-	const [cssHref, setCssHref] = useState<string | null>(null);
+	const [BundledApp, setBundledApp] = useState<BundledAppComponent | null>(
+		() => initiallyPrepared?.component ?? null,
+	);
+	const [loadedEntry, setLoadedEntry] = useState<string | null>(
+		initiallyPrepared?.entry ?? null,
+	);
+	const [cssHref, setCssHref] = useState<string | null>(
+		initiallyPrepared?.cssHref ?? null,
+	);
 	// Render model from the manifest. 'standalone_v2' apps are NOT loaded inline
 	// here — they are mounted same-document by <StandaloneV2App>.
-	const [appModel, setAppModel] = useState<"inline_v1" | "standalone_v2">("inline_v1");
+	const [appModel, setAppModel] = useState<"inline_v1" | "standalone_v2">(
+		initiallyPrepared?.manifest.app_model === "standalone_v2"
+			? "standalone_v2"
+			: "inline_v1",
+	);
 	// For standalone_v2: the hashed entry/css + dist base from the manifest, used
 	// to mount the app same-document (replaces the old iframe).
 	const [v2Mount, setV2Mount] = useState<{
@@ -162,7 +332,18 @@ export function BundledAppShell({ appId, appSlug, isPreview }: BundledAppShellPr
 		css: string | null;
 		baseUrl: string;
 		runtimeContract: StandaloneV2RuntimeContract;
-	} | null>(null);
+	} | null>(() => {
+		const manifest = initiallyPrepared?.manifest;
+		if (manifest?.app_model !== "standalone_v2" || !manifest.entry) {
+			return null;
+		}
+		return {
+			entry: manifest.entry,
+			css: manifest.css,
+			baseUrl: manifest.base_url,
+			runtimeContract: manifest.runtime_contract ?? null,
+		};
+	});
 	// Reset the v2 mount DURING RENDER when the app changes (React's "adjust
 	// state on prop change" pattern). This shell instance is reused across app
 	// routes; without this, the render below would pair the NEW appId with the
@@ -179,12 +360,16 @@ export function BundledAppShell({ appId, appSlug, isPreview }: BundledAppShellPr
 	// Org-scoped app: tells the table SDK to default `scope` to the app's
 	// org for `tables.*` and `useTable` calls inside the bundle. Captured
 	// from the first successful manifest fetch.
-	const [appOrgId, setAppOrgId] = useState<string | null>(null);
+	const [appOrgId, setAppOrgId] = useState<string | null>(
+		initiallyPrepared?.manifest.organization_id ?? null,
+	);
 
 	const [loadError, setLoadError] = useState<string | null>(null);
 	// Build errors from hot-reload rebuilds. The last-good bundle keeps
 	// rendering underneath; this banner sits on top.
-	const [buildErrors, setBuildErrors] = useState<BundleMessage[] | null>(null);
+	const [buildErrors, setBuildErrors] = useState<BundleMessage[] | null>(
+		null,
+	);
 	const [buildErrorDismissed, setBuildErrorDismissed] = useState(false);
 
 	// Auto-migration notice shown when the first-view bundle-manifest fetch
@@ -192,16 +377,16 @@ export function BundledAppShell({ appId, appSlug, isPreview }: BundledAppShellPr
 	// Persisted-dismissed via localStorage so it doesn't re-appear on every
 	// navigation within the same app.
 	const migrateDismissKey = `bifrost.automigrate-dismissed.${appId}`;
-	const [migrateNotice, setMigrateNotice] = useState(false);
-	const [migrateNoticeDismissed, setMigrateNoticeDismissed] = useState(
-		() => {
-			try {
-				return localStorage.getItem(migrateDismissKey) === "1";
-			} catch {
-				return false;
-			}
-		},
+	const [migrateNotice, setMigrateNotice] = useState(
+		initiallyPrepared?.manifest.migrated ?? false,
 	);
+	const [migrateNoticeDismissed, setMigrateNoticeDismissed] = useState(() => {
+		try {
+			return localStorage.getItem(migrateDismissKey) === "1";
+		} catch {
+			return false;
+		}
+	});
 
 	const setAppContext = useAppBuilderStore((state) => state.setAppContext);
 
@@ -234,6 +419,33 @@ export function BundledAppShell({ appId, appSlug, isPreview }: BundledAppShellPr
 			cssOverride?: string | null,
 		): Promise<"inline_v1" | "standalone_v2" | undefined> {
 			try {
+				if (entryOverride === undefined) {
+					const prepared = getPreparedAppBundle(appId, isPreview);
+					if (prepared) {
+						const manifest = prepared.manifest;
+						setAppOrgId(manifest.organization_id ?? null);
+						if (manifest.migrated) setMigrateNotice(true);
+						if (manifest.app_model === "standalone_v2") {
+							if (!manifest.entry) return undefined;
+							setV2Mount({
+								entry: manifest.entry,
+								css: manifest.css,
+								baseUrl: manifest.base_url,
+								runtimeContract:
+									manifest.runtime_contract ?? null,
+							});
+							setAppModel("standalone_v2");
+							return "standalone_v2";
+						}
+
+						setCssHref(prepared.cssHref);
+						setBundledApp(() => prepared.component);
+						setLoadedEntry(prepared.entry);
+						setAppModel("inline_v1");
+						return "inline_v1";
+					}
+				}
+
 				const mode = isPreview ? "draft" : "live";
 				let entry: string;
 				let css: string | null;
@@ -255,7 +467,9 @@ export function BundledAppShell({ appId, appSlug, isPreview }: BundledAppShellPr
 					);
 					if (!resp.ok) {
 						const txt = await resp.text();
-						throw new Error(`Bundle manifest fetch failed: ${resp.status} ${txt}`);
+						throw new Error(
+							`Bundle manifest fetch failed: ${resp.status} ${txt}`,
+						);
 					}
 					const manifest: BundleManifest = await resp.json();
 					// inline_v1 always has an entry; a v2 app may have null (handled
@@ -299,30 +513,39 @@ export function BundledAppShell({ appId, appSlug, isPreview }: BundledAppShellPr
 				}
 
 				if (controller.signal.aborted) return;
-				if (loadedEntry === entry) return;
+				if (entryOverride === undefined && loadedEntry === entry)
+					return;
 
 				const entryUrl = `${baseUrl}/${entry}?mode=${mode}`;
-				const nextCssHref = css ? `${baseUrl}/${css}?mode=${mode}` : null;
+				const nextCssHref = css
+					? `${baseUrl}/${css}?mode=${mode}`
+					: null;
 
 				// User-dep apps go through es-module-shims so that the user-dep
 				// importmap can be registered after page load. Apps with only
 				// platform externals use the native dynamic import, which
 				// resolves through the static map in index.html.
 				const hasUserDeps = Object.keys(dependencies).length > 0;
-				let dynamicImport: (url: string) => Promise<{ default?: unknown }>;
+				let dynamicImport: (
+					url: string,
+				) => Promise<{ default?: unknown }>;
 				if (hasUserDeps) {
 					await ensureEsModuleShimsLoaded();
 					registerUserDepImportMap(dependencies);
 					const w = window as unknown as ImportShimWindow;
 					if (typeof w.importShim !== "function") {
-						throw new Error("es-module-shims loaded but importShim is undefined");
+						throw new Error(
+							"es-module-shims loaded but importShim is undefined",
+						);
 					}
 					const importShim = w.importShim;
 					dynamicImport = (url) =>
 						importShim(url) as Promise<{ default?: unknown }>;
 				} else {
 					dynamicImport = (url) =>
-						import(/* @vite-ignore */ url) as Promise<{ default?: unknown }>;
+						import(/* @vite-ignore */ url) as Promise<{
+							default?: unknown;
+						}>;
 				}
 
 				// Load JS and CSS in parallel, but don't commit either until
@@ -330,7 +553,9 @@ export function BundledAppShell({ appId, appSlug, isPreview }: BundledAppShellPr
 				// tick before the <link> attaches and we get a FOUC.
 				const [module] = await Promise.all([
 					dynamicImport(entryUrl),
-					nextCssHref ? preloadStylesheet(nextCssHref, controller.signal) : Promise.resolve(),
+					nextCssHref
+						? preloadStylesheet(nextCssHref, controller.signal)
+						: Promise.resolve(),
 				]);
 
 				if (controller.signal.aborted) return;
@@ -359,11 +584,16 @@ export function BundledAppShell({ appId, appSlug, isPreview }: BundledAppShellPr
 				// show a full-screen error; otherwise it's a failed hot-reload
 				// and we surface it via the banner while keeping last-good live.
 				if (!BundledApp) {
-					setLoadError(err instanceof Error ? err.message : String(err));
+					setLoadError(
+						err instanceof Error ? err.message : String(err),
+					);
 				} else {
 					setBuildErrors([
 						{
-							text: err instanceof Error ? err.message : String(err),
+							text:
+								err instanceof Error
+									? err.message
+									: String(err),
 							file: null,
 							line: null,
 							column: null,
@@ -393,16 +623,26 @@ export function BundledAppShell({ appId, appSlug, isPreview }: BundledAppShellPr
 					unsub = webSocketService.onAppCodeFileUpdate(
 						appId,
 						(update: AppCodeFileUpdate) => {
-							if (update.error && update.error.messages.length > 0) {
+							if (
+								update.error &&
+								update.error.messages.length > 0
+							) {
 								setBuildErrors(update.error.messages);
 								setBuildErrorDismissed(false);
 							} else if (update.bundle) {
-								loadBundle(update.bundle.entry, update.bundle.css);
+								invalidatePreparedAppBundle(appId, isPreview);
+								loadBundle(
+									update.bundle.entry,
+									update.bundle.css,
+								);
 							}
 						},
 					);
 				} catch (e) {
-					console.warn("[Bifrost] Failed to subscribe to app updates:", e);
+					console.warn(
+						"[Bifrost] Failed to subscribe to app updates:",
+						e,
+					);
 				}
 			})();
 		}
@@ -490,7 +730,7 @@ export function BundledAppShell({ appId, appSlug, isPreview }: BundledAppShellPr
  * Warm the browser cache for a stylesheet before we mount the bundled
  * component, so the <link> that BundleStyles appends applies on first paint.
  */
-function preloadStylesheet(href: string, signal: AbortSignal): Promise<void> {
+function preloadStylesheet(href: string, signal?: AbortSignal): Promise<void> {
 	return new Promise((resolve, reject) => {
 		const el = document.createElement("link");
 		el.rel = "preload";
@@ -498,7 +738,7 @@ function preloadStylesheet(href: string, signal: AbortSignal): Promise<void> {
 		el.href = href;
 		const cleanup = () => {
 			el.remove();
-			signal.removeEventListener("abort", onAbort);
+			signal?.removeEventListener("abort", onAbort);
 		};
 		const onAbort = () => {
 			cleanup();
@@ -514,12 +754,37 @@ function preloadStylesheet(href: string, signal: AbortSignal): Promise<void> {
 			// sees *something* instead of a hang.
 			resolve();
 		};
-		if (signal.aborted) {
+		if (signal?.aborted) {
 			onAbort();
 			return;
 		}
-		signal.addEventListener("abort", onAbort);
+		signal?.addEventListener("abort", onAbort);
 		document.head.appendChild(el);
+	});
+}
+
+function preloadModule(href: string, signal?: AbortSignal): Promise<void> {
+	return new Promise((resolve) => {
+		const element = document.createElement("link");
+		element.rel = "modulepreload";
+		element.href = href;
+		const cleanup = () => {
+			element.remove();
+			signal?.removeEventListener("abort", onAbort);
+		};
+		const finish = () => {
+			cleanup();
+			resolve();
+		};
+		const onAbort = () => finish();
+		element.onload = finish;
+		element.onerror = finish;
+		if (signal?.aborted) {
+			finish();
+			return;
+		}
+		signal?.addEventListener("abort", onAbort);
+		document.head.appendChild(element);
 	});
 }
 
@@ -565,8 +830,8 @@ function AutoMigrateNotice({ onDismiss }: { onDismiss: () => void }) {
 						</button>
 					</div>
 					<p className="text-sm text-blue-800 dark:text-blue-200">
-						Your app was automatically updated to the new runtime. Review the
-						changes in your workspace on your next{" "}
+						Your app was automatically updated to the new runtime.
+						Review the changes in your workspace on your next{" "}
 						<code className="rounded bg-blue-100 px-1 dark:bg-blue-900/60">
 							bifrost pull
 						</code>
@@ -614,7 +879,9 @@ function BuildErrorBanner({
 									<span className="font-semibold">
 										{e.file}
 										{e.line !== null ? `:${e.line}` : ""}
-										{e.column !== null ? `:${e.column}` : ""}
+										{e.column !== null
+											? `:${e.column}`
+											: ""}
 										{" — "}
 									</span>
 								)}
@@ -622,7 +889,9 @@ function BuildErrorBanner({
 							</li>
 						))}
 						{errors.length > 5 && (
-							<li className="italic">… and {errors.length - 5} more</li>
+							<li className="italic">
+								… and {errors.length - 5} more
+							</li>
 						)}
 					</ul>
 				</div>

--- a/client/src/components/layout/RouteLoadError.test.tsx
+++ b/client/src/components/layout/RouteLoadError.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen } from "@testing-library/react";
+import { createMemoryRouter, RouterProvider } from "react-router-dom";
+import { describe, expect, it } from "vitest";
+
+import { RouteLoadError } from "./RouteLoadError";
+
+describe("RouteLoadError", () => {
+	it("offers recovery when an agent loader fails", async () => {
+		window.history.replaceState({}, "", "/agents/broken");
+		const router = createMemoryRouter(
+			[
+				{
+					path: "/agents/broken",
+					loader: () => {
+						throw new Error("Agent request failed");
+					},
+					element: <div>Agent</div>,
+					errorElement: <RouteLoadError />,
+				},
+			],
+			{ initialEntries: ["/agents/broken"] },
+		);
+
+		render(<RouterProvider router={router} />);
+
+		expect(
+			await screen.findByRole("heading", {
+				name: "Couldn't open this agent",
+			}),
+		).toBeInTheDocument();
+		expect(screen.getByText("Agent request failed")).toBeInTheDocument();
+		expect(screen.getByRole("link", { name: /back/i })).toHaveAttribute(
+			"href",
+			"/agents",
+		);
+	});
+});

--- a/client/src/components/layout/RouteLoadError.tsx
+++ b/client/src/components/layout/RouteLoadError.tsx
@@ -1,0 +1,39 @@
+import { AlertTriangle, ArrowLeft, RefreshCw } from "lucide-react";
+import { Link, useRouteError } from "react-router-dom";
+
+import { Button } from "@/components/ui/button";
+
+export function RouteLoadError() {
+	const error = useRouteError();
+	const isAgent = window.location.pathname.startsWith("/agents/");
+	const entity = isAgent ? "agent" : "application";
+	const returnPath = isAgent ? "/agents" : "/apps";
+	const detail =
+		error instanceof Error
+			? error.message
+			: `The ${entity} could not be loaded.`;
+
+	return (
+		<div className="flex h-full min-h-[420px] w-full items-center justify-center p-6">
+			<div className="w-full max-w-md text-center">
+				<div className="mx-auto grid h-12 w-12 place-items-center rounded-2xl bg-destructive/10 text-destructive">
+					<AlertTriangle aria-hidden="true" className="h-5 w-5" />
+				</div>
+				<h1 className="mt-4 text-xl font-semibold">
+					Couldn&apos;t open this {entity}
+				</h1>
+				<p className="mt-2 text-sm text-muted-foreground">{detail}</p>
+				<div className="mt-5 flex justify-center gap-2">
+					<Button variant="outline" asChild>
+						<Link to={returnPath}>
+							<ArrowLeft className="h-4 w-4" /> Back
+						</Link>
+					</Button>
+					<Button onClick={() => window.location.reload()}>
+						<RefreshCw className="h-4 w-4" /> Try again
+					</Button>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/client/src/components/layout/RouteOpeningState.test.tsx
+++ b/client/src/components/layout/RouteOpeningState.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { RouteOpeningState, openingKind } from "./RouteOpeningState";
+
+describe("RouteOpeningState", () => {
+	afterEach(() => window.history.replaceState({}, "", "/"));
+
+	it("identifies detail routes for specific loading copy", () => {
+		expect(openingKind("/agents/agent-1")).toBe("agent");
+		expect(openingKind("/apps/my-app/preview")).toBe("application");
+		expect(openingKind("/forms")).toBe("page");
+	});
+
+	it("shows immediate feedback for a direct agent load", () => {
+		window.history.replaceState({}, "", "/agents/agent-1");
+		render(<RouteOpeningState />);
+
+		expect(
+			screen.getByRole("status", { name: "Opening agent…" }),
+		).toBeInTheDocument();
+	});
+});

--- a/client/src/components/layout/RouteOpeningState.tsx
+++ b/client/src/components/layout/RouteOpeningState.tsx
@@ -1,0 +1,45 @@
+import { AppWindow, Bot } from "lucide-react";
+
+type OpeningKind = "agent" | "application" | "page";
+
+function openingKind(pathname: string): OpeningKind {
+	if (pathname.startsWith("/agents/")) return "agent";
+	if (pathname.startsWith("/apps/")) return "application";
+	return "page";
+}
+
+export function RouteOpeningState() {
+	const kind = openingKind(window.location.pathname);
+	const Icon = kind === "agent" ? Bot : AppWindow;
+	const label =
+		kind === "agent"
+			? "Opening agent…"
+			: kind === "application"
+				? "Opening application…"
+				: "Opening page…";
+
+	return (
+		<div
+			className="flex h-dvh w-screen items-center justify-center bg-background"
+			role="status"
+			aria-live="polite"
+			aria-label={label}
+		>
+			<div className="flex flex-col items-center gap-3 text-muted-foreground">
+				<div className="relative grid h-12 w-12 place-items-center rounded-2xl bg-muted/70 ring-1 ring-foreground/10">
+					<span
+						aria-hidden="true"
+						className="absolute inset-1 rounded-xl border-2 border-transparent border-t-primary motion-safe:animate-spin"
+					/>
+					<Icon
+						aria-hidden="true"
+						className="h-5 w-5 text-foreground"
+					/>
+				</div>
+				<p className="text-sm font-medium">{label}</p>
+			</div>
+		</div>
+	);
+}
+
+export { openingKind };

--- a/client/src/components/layout/RouteReadyReveal.tsx
+++ b/client/src/components/layout/RouteReadyReveal.tsx
@@ -1,0 +1,5 @@
+import type { ReactNode } from "react";
+
+export function RouteReadyReveal({ children }: { children: ReactNode }) {
+	return <div className="route-ready-reveal h-full w-full">{children}</div>;
+}

--- a/client/src/components/layout/RouteTransitionProgress.test.tsx
+++ b/client/src/components/layout/RouteTransitionProgress.test.tsx
@@ -1,110 +1,64 @@
-import { Link, MemoryRouter, Route, Routes } from "react-router-dom";
-import { describe, expect, it, vi } from "vitest";
 import { act, fireEvent, render, screen } from "@testing-library/react";
+import {
+	Link,
+	Outlet,
+	RouterProvider,
+	createMemoryRouter,
+} from "react-router-dom";
+import { describe, expect, it } from "vitest";
+
 import { RouteTransitionProgress } from "./RouteTransitionProgress";
 
-function TestRoutes() {
+function deferred<T>() {
+	let resolve!: (value: T) => void;
+	const promise = new Promise<T>((next) => {
+		resolve = next;
+	});
+	return { promise, resolve };
+}
+
+function Shell() {
 	return (
 		<>
 			<RouteTransitionProgress />
-			<Link to="/chat">Chat</Link>
-			<a href="https://example.com/docs">External docs</a>
-			<Routes>
-				<Route path="/" element={<div>Dashboard</div>} />
-				<Route path="/chat" element={<div>Chat page</div>} />
-			</Routes>
+			<Link to="/agent">Agent</Link>
+			<Outlet />
 		</>
 	);
 }
 
 describe("RouteTransitionProgress", () => {
-	it("shows progress immediately for same-origin route clicks", async () => {
-		vi.useFakeTimers();
-
-		try {
-			render(
-				<MemoryRouter initialEntries={["/"]}>
-					<TestRoutes />
-				</MemoryRouter>,
-			);
-
-			fireEvent.click(screen.getByRole("link", { name: "Chat" }));
-
-			expect(
-				screen.getByRole("progressbar", { name: "Loading page" }),
-			).toBeInTheDocument();
-			const fill = screen
-				.getByRole("progressbar", { name: "Loading page" })
-				.querySelector(".route-transition-progress-fill");
-			expect(fill).toBeInTheDocument();
-			expect(fill).toHaveAttribute("data-state");
-			expect(screen.getByText("Chat page")).toBeInTheDocument();
-
-			act(() => {
-				vi.advanceTimersByTime(220);
-			});
-
-			expect(
-				screen.queryByRole("progressbar", { name: "Loading page" }),
-			).not.toBeInTheDocument();
-		} finally {
-			vi.useRealTimers();
-		}
-	});
-
-	it("ignores external links", () => {
-		render(
-			<MemoryRouter initialEntries={["/"]}>
-				<TestRoutes />
-			</MemoryRouter>,
+	it("stays visible until the destination loader settles", async () => {
+		const loader = deferred<null>();
+		const router = createMemoryRouter(
+			[
+				{
+					element: <Shell />,
+					children: [
+						{ index: true, element: <div>Fleet</div> },
+						{
+							path: "agent",
+							loader: () => loader.promise,
+							element: <div>Agent detail</div>,
+						},
+					],
+				},
+			],
+			{ initialEntries: ["/"] },
 		);
 
-		fireEvent.click(screen.getByRole("link", { name: "External docs" }));
+		render(<RouterProvider router={router} />);
+		fireEvent.click(screen.getByRole("link", { name: "Agent" }));
 
+		expect(screen.getByText("Fleet")).toBeInTheDocument();
+		expect(
+			screen.getByRole("progressbar", { name: "Loading page" }),
+		).toBeInTheDocument();
+
+		await act(async () => loader.resolve(null));
+		expect(screen.getByText("Agent detail")).toBeInTheDocument();
 		expect(
 			screen.queryByRole("progressbar", { name: "Loading page" }),
 		).not.toBeInTheDocument();
-	});
-
-	it("ignores navigation inside a mounted application", () => {
-		// A standalone app under /apps/<id> runs its own router; the platform
-		// router never sees those pushes, so the bar would start and never finish.
-		window.history.pushState({}, "", "/apps/app-1/documents");
-		try {
-			render(
-				<MemoryRouter initialEntries={["/apps/app-1/documents"]}>
-					<RouteTransitionProgress />
-					<a href="/apps/app-1/staff/users">Portal Users</a>
-				</MemoryRouter>,
-			);
-
-			fireEvent.click(screen.getByRole("link", { name: "Portal Users" }));
-
-			expect(
-				screen.queryByRole("progressbar", { name: "Loading page" }),
-			).not.toBeInTheDocument();
-		} finally {
-			window.history.pushState({}, "", "/");
-		}
-	});
-
-	it("tracks navigation leaving a mounted application", () => {
-		window.history.pushState({}, "", "/apps/app-1/documents");
-		try {
-			render(
-				<MemoryRouter initialEntries={["/apps/app-1/documents"]}>
-					<RouteTransitionProgress />
-					<a href="/forms">Back to Bifrost</a>
-				</MemoryRouter>,
-			);
-
-			fireEvent.click(screen.getByRole("link", { name: "Back to Bifrost" }));
-
-			expect(
-				screen.getByRole("progressbar", { name: "Loading page" }),
-			).toBeInTheDocument();
-		} finally {
-			window.history.pushState({}, "", "/");
-		}
 	});
 });

--- a/client/src/components/layout/RouteTransitionProgress.tsx
+++ b/client/src/components/layout/RouteTransitionProgress.tsx
@@ -1,118 +1,9 @@
-import { useCallback, useEffect, useRef, useState } from "react";
-import { useLocation } from "react-router-dom";
-
-type ProgressState = "idle" | "loading" | "finishing";
-
-const FINISH_DELAY_MS = 220;
-
-function shouldTrackClick(event: MouseEvent): boolean {
-	if (
-		event.defaultPrevented ||
-		event.button !== 0 ||
-		event.metaKey ||
-		event.altKey ||
-		event.ctrlKey ||
-		event.shiftKey
-	) {
-		return false;
-	}
-
-	const target = event.target;
-	if (!(target instanceof Element)) {
-		return false;
-	}
-
-	const anchor = target.closest<HTMLAnchorElement>("a[href]");
-	if (!anchor || anchor.target === "_blank" || anchor.hasAttribute("download")) {
-		return false;
-	}
-
-	const targetUrl = new URL(anchor.href, window.location.href);
-	if (targetUrl.origin !== window.location.origin) {
-		return false;
-	}
-
-	const currentUrl = new URL(window.location.href);
-
-	// Navigation that stays inside a mounted application (/apps/<id>/...) is
-	// handled by the app's own router — the platform router never observes it,
-	// so the bar would start and never finish.
-	const appMount = currentUrl.pathname.match(/^\/apps\/[^/]+/)?.[0];
-	if (
-		appMount &&
-		(targetUrl.pathname === appMount ||
-			targetUrl.pathname.startsWith(`${appMount}/`))
-	) {
-		return false;
-	}
-
-	return (
-		targetUrl.pathname !== currentUrl.pathname ||
-		targetUrl.search !== currentUrl.search
-	);
-}
+import { useNavigation } from "react-router-dom";
 
 export function RouteTransitionProgress() {
-	const location = useLocation();
-	const routeKey = `${location.pathname}${location.search}${location.hash}`;
-	const lastRouteKey = useRef(routeKey);
-	const finishTimer = useRef<number | null>(null);
-	const isTrackingNavigation = useRef(false);
-	const [progressState, setProgressState] = useState<ProgressState>("idle");
+	const navigation = useNavigation();
 
-	const clearFinishTimer = useCallback(() => {
-		if (finishTimer.current === null) {
-			return;
-		}
-		window.clearTimeout(finishTimer.current);
-		finishTimer.current = null;
-	}, []);
-
-	const finish = useCallback(() => {
-		if (!isTrackingNavigation.current) {
-			return;
-		}
-
-		clearFinishTimer();
-		setProgressState("finishing");
-		finishTimer.current = window.setTimeout(() => {
-			isTrackingNavigation.current = false;
-			setProgressState("idle");
-			finishTimer.current = null;
-		}, FINISH_DELAY_MS);
-	}, [clearFinishTimer]);
-
-	const start = useCallback(() => {
-		clearFinishTimer();
-		isTrackingNavigation.current = true;
-		setProgressState("loading");
-	}, [clearFinishTimer]);
-
-	useEffect(() => {
-		const handleClick = (event: MouseEvent) => {
-			if (shouldTrackClick(event)) {
-				start();
-			}
-		};
-
-		document.addEventListener("click", handleClick, true);
-		return () => {
-			document.removeEventListener("click", handleClick, true);
-		};
-	}, [start]);
-
-	useEffect(() => {
-		if (lastRouteKey.current === routeKey) {
-			return;
-		}
-
-		lastRouteKey.current = routeKey;
-		finish();
-	}, [finish, routeKey]);
-
-	useEffect(() => clearFinishTimer, [clearFinishTimer]);
-
-	if (progressState === "idle") {
+	if (navigation.state === "idle") {
 		return null;
 	}
 
@@ -123,7 +14,7 @@ export function RouteTransitionProgress() {
 			className="route-transition-progress-track pointer-events-none fixed inset-x-0 top-0 z-[100] h-0.5 overflow-hidden"
 		>
 			<div
-				data-state={progressState}
+				data-state="loading"
 				className="route-transition-progress-fill h-full w-full transition-transform duration-200 ease-out"
 			/>
 		</div>

--- a/client/src/hooks/useAgents.ts
+++ b/client/src/hooks/useAgents.ts
@@ -85,7 +85,7 @@ export function useAgent(agentId: string | undefined) {
 		"get",
 		"/api/agents/{agent_id}",
 		{ params: { path: { agent_id: agentId ?? "" } } },
-		{ enabled: !!agentId },
+		{ enabled: !!agentId, staleTime: 60_000 },
 	);
 }
 

--- a/client/src/hooks/useApplications.ts
+++ b/client/src/hooks/useApplications.ts
@@ -85,7 +85,7 @@ export function useApplication(slug: string | undefined) {
 				path: { slug: slug ?? "" },
 			},
 		},
-		{ enabled: !!slug },
+		{ enabled: !!slug, staleTime: 60_000 },
 	);
 }
 

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -378,6 +378,21 @@
 		}
 	}
 
+	@keyframes routeReadyReveal {
+		from {
+			opacity: 0.72;
+			filter: blur(2px);
+			clip-path: inset(0 0 6px 0 round 8px);
+			transform: translateY(4px);
+		}
+		to {
+			opacity: 1;
+			filter: blur(0);
+			clip-path: inset(0 round 0);
+			transform: translateY(0);
+		}
+	}
+
 	.route-transition-progress-track {
 		background: oklch(from var(--primary) l c h / 0.12);
 	}
@@ -392,13 +407,14 @@
 		transform-origin: left center;
 	}
 
-	.route-transition-progress-fill[data-state="finishing"] {
-		transform: translateX(0) scaleX(1);
+	.route-ready-reveal {
+		animation: routeReadyReveal 220ms cubic-bezier(0.16, 1, 0.3, 1);
 	}
 
-	/* Apply fade-in animation to main content */
-	main > * {
-		animation: fadeIn 0.3s ease-out;
+	@media (prefers-reduced-motion: reduce) {
+		.route-ready-reveal {
+			animation: none;
+		}
 	}
 
 	/* Button press effect */

--- a/client/src/lib/detail-route-loaders.test.ts
+++ b/client/src/lib/detail-route-loaders.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const { prepareAppBundle } = vi.hoisted(() => ({
+	prepareAppBundle: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@/components/jsx-app/BundledAppShell", () => ({
+	prepareAppBundle,
+}));
+
+import { queryClient } from "@/lib/queryClient";
+import {
+	agentDetailLoader,
+	applicationDetailLoader,
+} from "./detail-route-loaders";
+
+class LoadedImage {
+	complete = false;
+	onload: (() => void) | null = null;
+	onerror: (() => void) | null = null;
+
+	set src(_value: string) {
+		queueMicrotask(() => this.onload?.());
+	}
+}
+
+describe("detail route loaders", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+		prepareAppBundle.mockClear();
+		vi.unstubAllGlobals();
+	});
+
+	it("waits for agent metadata and its primary image", async () => {
+		vi.stubGlobal("Image", LoadedImage);
+		const ensure = vi
+			.spyOn(queryClient, "ensureQueryData")
+			.mockResolvedValue({ logo_url: "/agent-logo.png" });
+
+		const request = new Request("http://localhost/agents/agent-1");
+		await agentDetailLoader({
+			params: { id: "agent-1" },
+			request,
+			url: new URL(request.url),
+			pattern: "/agents/:id",
+			context: {},
+		});
+
+		expect(ensure).toHaveBeenCalledOnce();
+		expect(ensure.mock.calls[0]?.[0].queryKey).toEqual([
+			"get",
+			"/api/agents/{agent_id}",
+			{ params: { path: { agent_id: "agent-1" } } },
+		]);
+	});
+
+	it("waits for application metadata, image, and bundle readiness", async () => {
+		vi.stubGlobal("Image", LoadedImage);
+		vi.spyOn(queryClient, "ensureQueryData").mockResolvedValue({
+			id: "app-1",
+			slug: "portal",
+			logo_url: "/app-logo.png",
+		});
+		const request = new Request("http://localhost/apps/portal");
+
+		await applicationDetailLoader(false)({
+			params: { applicationId: "portal", "*": "" },
+			request,
+			url: new URL(request.url),
+			pattern: "/apps/:applicationId/*",
+			context: {},
+		});
+
+		expect(prepareAppBundle).toHaveBeenCalledWith({
+			appId: "app-1",
+			isPreview: false,
+			signal: request.signal,
+		});
+	});
+});

--- a/client/src/lib/detail-route-loaders.ts
+++ b/client/src/lib/detail-route-loaders.ts
@@ -1,0 +1,90 @@
+import type { LoaderFunctionArgs } from "react-router-dom";
+
+import { prepareAppBundle } from "@/components/jsx-app/BundledAppShell";
+import { $api } from "@/lib/api-client";
+import { queryClient } from "@/lib/queryClient";
+import type { ApplicationPublic } from "@/hooks/useApplications";
+
+export const DETAIL_STALE_TIME_MS = 60_000;
+
+export function agentDetailQueryOptions(agentId: string) {
+	return $api.queryOptions(
+		"get",
+		"/api/agents/{agent_id}",
+		{ params: { path: { agent_id: agentId } } },
+		{ staleTime: DETAIL_STALE_TIME_MS },
+	);
+}
+
+export function applicationDetailQueryOptions(slug: string) {
+	return $api.queryOptions(
+		"get",
+		"/api/applications/{slug}",
+		{ params: { path: { slug } } },
+		{ staleTime: DETAIL_STALE_TIME_MS },
+	);
+}
+
+async function decodeImage(src: string | null | undefined): Promise<void> {
+	if (!src) return;
+
+	await new Promise<void>((resolve) => {
+		const image = new Image();
+		image.onload = () => resolve();
+		image.onerror = () => resolve();
+		image.src = src;
+		if (image.complete) resolve();
+	});
+}
+
+export async function agentDetailLoader({ params }: LoaderFunctionArgs) {
+	const agentId = params.id;
+	if (!agentId) return null;
+
+	const agent = await queryClient.ensureQueryData(
+		agentDetailQueryOptions(agentId),
+	);
+	await decodeImage(agent.logo_url);
+	return null;
+}
+
+export function prefetchAgentDetail(agentId: string): void {
+	void queryClient
+		.ensureQueryData(agentDetailQueryOptions(agentId))
+		.then((agent) => decodeImage(agent.logo_url))
+		.catch(() => undefined);
+}
+
+export function prefetchApplicationDetail(
+	application: ApplicationPublic,
+	preview: boolean,
+): void {
+	queryClient.setQueryData(
+		applicationDetailQueryOptions(application.slug).queryKey,
+		application,
+	);
+	void Promise.all([
+		decodeImage(application.logo_url),
+		prepareAppBundle({ appId: application.id, isPreview: preview }),
+	]).catch(() => undefined);
+}
+
+export function applicationDetailLoader(preview: boolean) {
+	return async ({ params, request }: LoaderFunctionArgs) => {
+		const slug = params.applicationId;
+		if (!slug) return null;
+
+		const application = await queryClient.ensureQueryData(
+			applicationDetailQueryOptions(slug),
+		);
+		await Promise.all([
+			decodeImage(application.logo_url),
+			prepareAppBundle({
+				appId: application.id,
+				isPreview: preview,
+				signal: request.signal,
+			}),
+		]);
+		return null;
+	};
+}

--- a/client/src/pages/Applications.test.tsx
+++ b/client/src/pages/Applications.test.tsx
@@ -23,8 +23,12 @@ vi.mock("@/hooks/useOrganizations", () => ({
 	useOrganizations: () => ({ data: [] }),
 }));
 
-// Heavy children that aren't relevant to the badge behaviour.
-vi.mock("@/components/EntityLogo", () => ({ EntityLogo: () => null }));
+// Keep the icon contract observable without loading image resources in happy-dom.
+vi.mock("@/components/EntityLogo", () => ({
+	EntityLogo: ({ logo }: { logo?: string | null }) => (
+		<span data-testid="entity-logo" data-logo={logo ?? ""} />
+	),
+}));
 vi.mock("@/components/app-builder/AppInfoDialog", () => ({
 	AppInfoDialog: () => null,
 }));
@@ -44,7 +48,7 @@ function makeApp(overrides: Partial<Record<string, unknown>> = {}) {
 		has_unpublished_changes: false,
 		is_solution_managed: false,
 		solution_id: null,
-		logo: null,
+		logo_url: "/api/applications/app-1/logo",
 		app_model: "legacy",
 		...overrides,
 	};
@@ -188,6 +192,10 @@ describe("Applications — solution-managed badge (table view)", () => {
 	it("shows Delete and no badge on a non-managed app row", async () => {
 		await renderTable([makeApp()]);
 		const table = document.querySelector("table")!;
+		expect(within(table).getByTestId("entity-logo")).toHaveAttribute(
+			"data-logo",
+			"/api/applications/app-1/logo",
+		);
 		expect(
 			within(table).queryByTestId("solution-managed-badge"),
 		).not.toBeInTheDocument();

--- a/client/src/pages/agents/AgentDetailPage.test.tsx
+++ b/client/src/pages/agents/AgentDetailPage.test.tsx
@@ -235,13 +235,3 @@ describe("AgentDetailPage — solution back-nav", () => {
 		expect(back).toHaveAttribute("href", "/agents");
 	});
 });
-
-describe("AgentDetailPage — loading state in edit mode", () => {
-	it("renders 'Loading…' while the agent is being fetched", async () => {
-		mockUseAgent.mockReturnValue({ data: undefined, isLoading: true });
-		await renderAtRoute("/agents/agent-1");
-		expect(
-			screen.getByRole("heading", { name: /loading/i }),
-		).toBeInTheDocument();
-	});
-});

--- a/client/src/pages/agents/AgentDetailPage.tsx
+++ b/client/src/pages/agents/AgentDetailPage.tsx
@@ -30,7 +30,6 @@ import {
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { Skeleton } from "@/components/ui/skeleton";
 import {
 	Tooltip,
 	TooltipContent,
@@ -77,7 +76,7 @@ export function AgentDetailPage() {
 
 	const isCreate = !id || id === "new";
 	const agentId = isCreate ? undefined : id;
-	const { data: agent, isLoading } = useAgent(agentId);
+	const { data: agent } = useAgent(agentId);
 	const { data: runsList } = useAgentRuns({
 		agentId: agentId ?? "",
 		limit: 1,
@@ -176,7 +175,9 @@ export function AgentDetailPage() {
 						<LogoDropZone
 							uploadUrl={`/api/agents/${agent.id}/logo`}
 							deleteUrl={`/api/agents/${agent.id}/logo`}
-							previewUrl={`/api/agents/${agent.id}/logo`}
+							previewUrl={
+								agent.logo_url ?? `/api/agents/${agent.id}/logo`
+							}
 							fallback={<Bot className="h-5 w-5" />}
 							size={48}
 							onChange={() =>
@@ -194,9 +195,7 @@ export function AgentDetailPage() {
 							<span className="truncate">
 								{isCreate
 									? "New agent"
-									: isLoading
-										? "Loading…"
-										: (agent?.name ?? "Unknown agent")}
+									: (agent?.name ?? "Unknown agent")}
 							</span>
 							{!isCreate && agent ? (
 								isActive ? (
@@ -369,8 +368,6 @@ export function AgentDetailPage() {
 			{tab === "settings" ? (
 				isCreate ? (
 					<AgentSettingsTab mode="create" onCreated={handleCreated} />
-				) : isLoading ? (
-					<Skeleton className="h-64 w-full" />
 				) : (
 					<AgentSettingsTab mode="edit" agent={agent ?? null} />
 				)

--- a/client/src/pages/agents/FleetPage.test.tsx
+++ b/client/src/pages/agents/FleetPage.test.tsx
@@ -68,6 +68,7 @@ function makeAgent(overrides: Partial<Record<string, unknown>> = {}) {
 		owner_user_id: null,
 		created_at: "2026-04-01T00:00:00Z",
 		dependency_count: 0,
+		logo_url: null,
 		stats: baseStats,
 		...overrides,
 	};
@@ -370,6 +371,24 @@ describe("FleetPage — view toggle", () => {
 		// Header cells from AgentTable
 		expect(within(table!).getByText(/runs \(7d\)/i)).toBeInTheDocument();
 		expect(within(table!).getByText("Alpha")).toBeInTheDocument();
+	});
+
+	it("keeps the agent icon in table view", async () => {
+		mockUseAgents.mockReturnValue({
+			data: [
+				makeAgent({
+					id: "a",
+					name: "Alpha",
+					logo_url: "/api/agents/a/logo",
+				}),
+			],
+			isLoading: false,
+		});
+		const { user } = await renderPage();
+		await user.click(screen.getByLabelText(/table view/i));
+		expect(
+			document.querySelector('img[src="/api/agents/a/logo"]'),
+		).not.toBeNull();
 	});
 });
 

--- a/client/src/pages/agents/FleetPage.tsx
+++ b/client/src/pages/agents/FleetPage.tsx
@@ -8,7 +8,7 @@
  */
 
 import { type MouseEvent, useMemo, useState } from "react";
-import { Link } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import {
 	AlertTriangle,
 	Bot,
@@ -80,6 +80,7 @@ import {
 	formatNumber,
 	formatRelativeTime,
 } from "@/lib/utils";
+import { prefetchAgentDetail } from "@/lib/detail-route-loaders";
 
 type ViewMode = "grid" | "table";
 type Organization = components["schemas"]["OrganizationPublic"];
@@ -468,6 +469,8 @@ function AgentGridCard({
 	return (
 		<Link
 			to={`/agents/${agent.id}`}
+			onPointerEnter={() => prefetchAgentDetail(agent.id)}
+			onFocus={() => prefetchAgentDetail(agent.id)}
 			className={cn(
 				"group flex flex-col overflow-hidden",
 				CARD_SURFACE,
@@ -702,14 +705,22 @@ function AgentTableRow({
 	showOrg: boolean;
 	orgName: string;
 }) {
+	const navigate = useNavigate();
 	const stats = agent.stats;
 	const hasRuns = (stats?.runs_7d ?? 0) > 0;
 
 	return (
 		<DataTableRow
-			className="cursor-pointer hover:bg-accent/40"
-			onClick={() => {
-				window.location.href = `/agents/${agent.id}`;
+			className="cursor-pointer hover:bg-accent/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
+			tabIndex={0}
+			onPointerEnter={() => prefetchAgentDetail(agent.id)}
+			onFocus={() => prefetchAgentDetail(agent.id)}
+			onClick={() => navigate(`/agents/${agent.id}`)}
+			onKeyDown={(event) => {
+				if (event.key === "Enter" || event.key === " ") {
+					event.preventDefault();
+					navigate(`/agents/${agent.id}`);
+				}
 			}}
 		>
 			{showOrg && (
@@ -719,7 +730,16 @@ function AgentTableRow({
 			)}
 			<DataTableCell>
 				<div className="flex items-center gap-2">
-					<Bot className="h-3.5 w-3.5 text-muted-foreground" />
+					<EntityLogo
+						entityType="agent"
+						entityId={agent.id}
+						logo={agent.logo_url ?? null}
+						fallback={
+							<Bot className="h-3.5 w-3.5 text-muted-foreground" />
+						}
+						size={20}
+						className="h-5 w-5 shrink-0 rounded object-cover"
+					/>
 					<span className="font-medium">{agent.name}</span>
 					{agent.is_solution_managed ? (
 						<SolutionManagedBadge solutionId={agent.solution_id} />


### PR DESCRIPTION
## Summary

- keep list pages mounted while agent and application detail data, logos, and bundles become ready
- add animated route progress, direct-load opening states, restrained ready reveals, and route error recovery
- crossfade stable entity logos and prefetch detail routes without duplicate requests
- preserve app preview hot reload and publish/live behavior

## Verification

- Targeted client unit suite: 68 passed
- Detail-route Playwright spec passed with screenshots
- Existing app preview/hot-reload/publish Playwright smoke spec passed
- TypeScript passed
- ESLint passed with one pre-existing FormRenderer warning
- Git diff check passed

Broader full Vitest, Playwright, and backend suites were not run locally; the merge queue will run the repository gates.