### PR TITLE
Require a complete local pre-PR gate

### DIFF
--- a/.claude/skills/bifrost-issues/SKILL.md
+++ b/.claude/skills/bifrost-issues/SKILL.md
@@ -118,8 +118,8 @@ Debug stacks are per-worktree — `./debug.sh` derives its Compose project name 
 
 - Make the change in the worktree, not in main.
 - Use `./test.sh stack up` once per worktree, then `./test.sh` many times.
-- Run `./test.sh`, `pyright`, `ruff`, `npm run tsc`, `npm run lint`, `./test.sh client unit` before claiming done (CLAUDE.md's verification checklist).
-- `pyright`/`ruff` require a repo-root `.venv`: `python -m venv .venv && ./.venv/bin/pip install -r requirements.txt pyright ruff` (matches `.github/workflows/ci.yml`).
+- Use targeted tests and quality checks while iterating (CLAUDE.md's verification checklist).
+- Use `./test.sh quality api` for Dockerized pyright and ruff parity; do not depend on a host `.venv`.
 
 ### 5.5. CI bottleneck reducers before PR
 
@@ -139,6 +139,16 @@ python api/scripts/skill-truth/generate.py
 ```
 
 If host Python is missing API dependencies, run the generator in the API test image with writable `.claude/skills` and read-only source mounts. Do not hand-edit generated appendices.
+
+### 5.6. Required local gate before PR
+
+After targeted verification, commit the exact candidate and run:
+
+```bash
+./test.sh pre-pr
+```
+
+Do not open a PR or queue it for merge unless this passes for the current `HEAD`. The command rejects dirty worktrees and branches that do not contain current `origin/main`; rerun it after every commit, amend, rebase, or merge. It exercises every locally reproducible PR and merge-queue gate. GitHub-only boundaries such as the synthetic merge ref, registry publication, signing, and attestation remain remote checks.
 
 ### 6. PR linkage
 
@@ -210,6 +220,8 @@ gh pr view <N> --repo gobifrost/bifrost \
   --jq '.statusCheckRollup[] | select((.conclusion // "") == "FAILURE") | {name,workflowName,detailsUrl}'
 gh api repos/gobifrost/bifrost/actions/jobs/<job_id>/logs
 ```
+
+If the failure is locally reproducible and `./test.sh pre-pr` passed for the same SHA, the local gate is incomplete or non-equivalent. Fix that harness/guidance defect and preserve the exposing condition in `pre-pr` before rerunning or requeueing; do not accept CI as the routine first broad test run.
 
 Fix CI failures in the same worktree and branch. Prefer a normal follow-up commit once reviewers or other agents may have seen the PR; amending with `--force-with-lease` is acceptable for a fresh, unreviewed PR where you are the only actor. After any force-push, re-check whether auto-merge/queue state survived.
 

--- a/.claude/skills/bifrost-testing/SKILL.md
+++ b/.claude/skills/bifrost-testing/SKILL.md
@@ -63,10 +63,11 @@ If `DOWN` → `./test.sh stack up`. Each worktree runs its own isolated stack (C
 - React component behavior → `./test.sh client unit` (vitest on host, no stack needed)
 - Full user flow through UI → `./test.sh client e2e`
 - All available suites (manual broad run) → `./test.sh all` (backend) + `./test.sh client unit` + `./test.sh client e2e`
+- Exact clean commit before opening or queueing a PR → `./test.sh pre-pr`
 
 State is auto-reset before every test subcommand. If migrations changed, run `./test.sh stack reset` once — that rebuilds the template DB.
 
-### 3. Before declaring done: scoped verification
+### 3. Before declaring implementation done: scoped verification
 
 Run the smallest test set that gives direct evidence for the change:
 
@@ -75,11 +76,23 @@ Run the smallest test set that gives direct evidence for the change:
 - The relevant contract tripwires when DTOs, CLI/MCP surfaces, manifests, permissions, storage, scheduling, or other shared boundaries change.
 - One targeted live-service or Playwright happy path when the behavior crosses that boundary.
 
-The full backend, Vitest, and Playwright suites are **not** a default local completion requirement. They are broad integration-gate checks unless the user explicitly requests them or the change is so cross-cutting that no honest bounded selection exists. Until every broad suite is wired into that gate, targeted coverage for changed behavior remains mandatory; never assume an unrun suite is covered elsewhere. In the handoff, list the exact commands run and any broader suites not run. Never imply unrun suites are green.
+The full backend, Vitest, and Playwright suites are **not** the default iteration loop. Targeted coverage remains mandatory because the broad gate cannot prove the changed behavior was exercised intentionally. In the handoff, list the exact targeted commands run and never imply an unrun suite is green.
 
 Verify the authoring rules above are satisfied for any new code.
 
-### 4. UX review (conditional, conversation-driven)
+### 4. Before opening or queueing a PR: clean-commit gate
+
+Targeted verification is necessary but not sufficient for a PR. Commit the exact candidate, make sure the worktree contains current `origin/main`, then run:
+
+```bash
+./test.sh pre-pr
+```
+
+This is mandatory for every code PR and must be rerun after any commit, amend, rebase, or merge. It refuses a dirty or stale worktree and reports the exact passing SHA. It covers every locally reproducible required PR and merge-queue boundary: repository freshness checks, production client and API builds, API/client lint and type checks, complete backend unit and E2E suites, complete Vitest, and zero-retry critical browser smoke.
+
+GitHub remains authoritative only for boundaries a workstation cannot reproduce: the synthetic merge-queue ref, registry push, signing, attestation, repository permissions, and third-party service availability. If CI fails in a locally reproducible gate after `pre-pr` passed for the same SHA, treat that as a defect in `pre-pr` or the harness and add the exposing condition to the local gate before retrying the PR.
+
+### 5. UX review (conditional, conversation-driven)
 
 **Trigger:** The user is in "I just built a new UI feature, let's write the first Playwright spec and make sure the UX is solid" mode. Signal comes from conversation, not from `git diff`. If unsure, ask once.
 
@@ -91,7 +104,7 @@ Verify the authoring rules above are satisfied for any new code.
 
 **Skip when:** bugfixes, backend changes, routine pre-merge sanity checks. Most runs do not need a UX review.
 
-### 5. Known failures outside the scoped run
+### 6. Known failures outside the scoped run
 
 A scoped change may be complete without running every suite. If a broader local run or CI later finds another failure, however, the failure becomes owned work and must be classified from evidence:
 
@@ -112,7 +125,7 @@ Diagnostics:
 - JUnit: `/tmp/bifrost/test-results.xml`.
 - To isolate a test, run it alone: `./test.sh tests/e2e/path/test_foo.py::TestClass::test_method -v`.
 
-### 6. Prefer simple tests
+### 7. Prefer simple tests
 
 Test complexity is a liability, not evidence of rigor. Prefer one observable contract, minimal fixtures, deterministic state, explicit cleanup, and the lowest test layer that can catch the regression. An end-to-end test should prove the primary integration or user journey, not reproduce every validation rule and edge case already covered below it.
 
@@ -127,6 +140,7 @@ Before declaring work complete, every box must be checked:
 - [ ] Backend logic has a unit test; endpoint/workflow changes have an e2e test
 - [ ] No new `skip`, `xfail`, `.only`, or commented-out tests introduced
 - [ ] Targeted suite green
+- [ ] `./test.sh pre-pr` green for the exact clean `HEAD` before any PR is opened or queued
 - [ ] Exact test commands and unrun broader suites reported honestly
 - [ ] Every known out-of-scope failure has a durable fix or a dedicated blocking repair change
 - [ ] UX review done if new UI was built

--- a/.codex/skills/bifrost-issues/SKILL.md
+++ b/.codex/skills/bifrost-issues/SKILL.md
@@ -118,8 +118,8 @@ Debug stacks are per-worktree — `./debug.sh` derives its Compose project name 
 
 - Make the change in the worktree, not in main.
 - Use `./test.sh stack up` once per worktree, then `./test.sh` many times.
-- Run `./test.sh`, `pyright`, `ruff`, `npm run tsc`, `npm run lint`, `./test.sh client unit` before claiming done (CLAUDE.md's verification checklist).
-- `pyright`/`ruff` require a repo-root `.venv`: `python -m venv .venv && ./.venv/bin/pip install -r requirements.txt pyright ruff` (matches `.github/workflows/ci.yml`).
+- Use targeted tests and quality checks while iterating (CLAUDE.md's verification checklist).
+- Use `./test.sh quality api` for Dockerized pyright and ruff parity; do not depend on a host `.venv`.
 
 ### 5.5. CI bottleneck reducers before PR
 
@@ -139,6 +139,16 @@ python api/scripts/skill-truth/generate.py
 ```
 
 If host Python is missing API dependencies, run the generator in the API test image with writable `.claude/skills` and read-only source mounts. Do not hand-edit generated appendices.
+
+### 5.6. Required local gate before PR
+
+After targeted verification, commit the exact candidate and run:
+
+```bash
+./test.sh pre-pr
+```
+
+Do not open a PR or queue it for merge unless this passes for the current `HEAD`. The command rejects dirty worktrees and branches that do not contain current `origin/main`; rerun it after every commit, amend, rebase, or merge. It exercises every locally reproducible PR and merge-queue gate. GitHub-only boundaries such as the synthetic merge ref, registry publication, signing, and attestation remain remote checks.
 
 ### 6. PR linkage
 
@@ -210,6 +220,8 @@ gh pr view <N> --repo gobifrost/bifrost \
   --jq '.statusCheckRollup[] | select((.conclusion // "") == "FAILURE") | {name,workflowName,detailsUrl}'
 gh api repos/gobifrost/bifrost/actions/jobs/<job_id>/logs
 ```
+
+If the failure is locally reproducible and `./test.sh pre-pr` passed for the same SHA, the local gate is incomplete or non-equivalent. Fix that harness/guidance defect and preserve the exposing condition in `pre-pr` before rerunning or requeueing; do not accept CI as the routine first broad test run.
 
 Fix CI failures in the same worktree and branch. Prefer a normal follow-up commit once reviewers or other agents may have seen the PR; amending with `--force-with-lease` is acceptable for a fresh, unreviewed PR where you are the only actor. After any force-push, re-check whether auto-merge/queue state survived.
 

--- a/.codex/skills/bifrost-testing/SKILL.md
+++ b/.codex/skills/bifrost-testing/SKILL.md
@@ -63,10 +63,11 @@ If `DOWN` → `./test.sh stack up`. Each worktree runs its own isolated stack (C
 - React component behavior → `./test.sh client unit` (vitest on host, no stack needed)
 - Full user flow through UI → `./test.sh client e2e`
 - All available suites (manual broad run) → `./test.sh all` (backend) + `./test.sh client unit` + `./test.sh client e2e`
+- Exact clean commit before opening or queueing a PR → `./test.sh pre-pr`
 
 State is auto-reset before every test subcommand. If migrations changed, run `./test.sh stack reset` once — that rebuilds the template DB.
 
-### 3. Before declaring done: scoped verification
+### 3. Before declaring implementation done: scoped verification
 
 Run the smallest test set that gives direct evidence for the change:
 
@@ -75,11 +76,23 @@ Run the smallest test set that gives direct evidence for the change:
 - The relevant contract tripwires when DTOs, CLI/MCP surfaces, manifests, permissions, storage, scheduling, or other shared boundaries change.
 - One targeted live-service or Playwright happy path when the behavior crosses that boundary.
 
-The full backend, Vitest, and Playwright suites are **not** a default local completion requirement. They are broad integration-gate checks unless the user explicitly requests them or the change is so cross-cutting that no honest bounded selection exists. Until every broad suite is wired into that gate, targeted coverage for changed behavior remains mandatory; never assume an unrun suite is covered elsewhere. In the handoff, list the exact commands run and any broader suites not run. Never imply unrun suites are green.
+The full backend, Vitest, and Playwright suites are **not** the default iteration loop. Targeted coverage remains mandatory because the broad gate cannot prove the changed behavior was exercised intentionally. In the handoff, list the exact targeted commands run and never imply an unrun suite is green.
 
 Verify the authoring rules above are satisfied for any new code.
 
-### 4. UX review (conditional, conversation-driven)
+### 4. Before opening or queueing a PR: clean-commit gate
+
+Targeted verification is necessary but not sufficient for a PR. Commit the exact candidate, make sure the worktree contains current `origin/main`, then run:
+
+```bash
+./test.sh pre-pr
+```
+
+This is mandatory for every code PR and must be rerun after any commit, amend, rebase, or merge. It refuses a dirty or stale worktree and reports the exact passing SHA. It covers every locally reproducible required PR and merge-queue boundary: repository freshness checks, production client and API builds, API/client lint and type checks, complete backend unit and E2E suites, complete Vitest, and zero-retry critical browser smoke.
+
+GitHub remains authoritative only for boundaries a workstation cannot reproduce: the synthetic merge-queue ref, registry push, signing, attestation, repository permissions, and third-party service availability. If CI fails in a locally reproducible gate after `pre-pr` passed for the same SHA, treat that as a defect in `pre-pr` or the harness and add the exposing condition to the local gate before retrying the PR.
+
+### 5. UX review (conditional, conversation-driven)
 
 **Trigger:** The user is in "I just built a new UI feature, let's write the first Playwright spec and make sure the UX is solid" mode. Signal comes from conversation, not from `git diff`. If unsure, ask once.
 
@@ -91,7 +104,7 @@ Verify the authoring rules above are satisfied for any new code.
 
 **Skip when:** bugfixes, backend changes, routine pre-merge sanity checks. Most runs do not need a UX review.
 
-### 5. Known failures outside the scoped run
+### 6. Known failures outside the scoped run
 
 A scoped change may be complete without running every suite. If a broader local run or CI later finds another failure, however, the failure becomes owned work and must be classified from evidence:
 
@@ -112,7 +125,7 @@ Diagnostics:
 - JUnit: `/tmp/bifrost/test-results.xml`.
 - To isolate a test, run it alone: `./test.sh tests/e2e/path/test_foo.py::TestClass::test_method -v`.
 
-### 6. Prefer simple tests
+### 7. Prefer simple tests
 
 Test complexity is a liability, not evidence of rigor. Prefer one observable contract, minimal fixtures, deterministic state, explicit cleanup, and the lowest test layer that can catch the regression. An end-to-end test should prove the primary integration or user journey, not reproduce every validation rule and edge case already covered below it.
 
@@ -127,6 +140,7 @@ Before declaring work complete, every box must be checked:
 - [ ] Backend logic has a unit test; endpoint/workflow changes have an e2e test
 - [ ] No new `skip`, `xfail`, `.only`, or commented-out tests introduced
 - [ ] Targeted suite green
+- [ ] `./test.sh pre-pr` green for the exact clean `HEAD` before any PR is opened or queued
 - [ ] Exact test commands and unrun broader suites reported honestly
 - [ ] Every known out-of-scope failure has a durable fix or a dedicated blocking repair change
 - [ ] UX review done if new UI was built

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -286,7 +286,7 @@ export async function getDataProviders() {
 
 -   **Tests**: All work requires tests. Backend logic → unit tests in `api/tests/unit/`. Endpoint/workflow/integration changes → e2e tests in `api/tests/e2e/`. React components → sibling `*.test.tsx` (vitest). User-facing features → happy-path spec in `client/e2e/` (Playwright).
     -   **Functional frontend modules require vitest coverage.** New or modified `.ts` files under `client/src/lib/**` and `client/src/services/**` that export functions (auth helpers, storage adapters, API wrappers, formatters, etc.) need a sibling `*.test.ts` covering the public API. Pure type/constant re-export files and files that only import and re-configure third-party SDKs are exempt. If the module has a cross-tab, cross-window, or storage-boundary concern (like `auth-token.ts`), the test MUST exercise that boundary — a regression that only reproduces with two tabs open is one a future refactor will silently re-introduce otherwise.
-    -   **Scoped verification is the local default.** Run the tests that directly exercise the changed behavior, its known consumers, and any affected contract boundaries. Full backend, Vitest, and Playwright suites are broad integration-gate checks, not a routine local completion requirement. Until every suite is wired into that gate, targeted coverage for changed behavior remains mandatory; never assume an unrun suite is covered elsewhere. Report exactly what ran and which broader suites did not run.
+    -   **Scoped verification is the development-loop default.** Run the tests that directly exercise the changed behavior, its known consumers, and any affected contract boundaries while iterating. Before opening or queueing a PR, commit the exact candidate and run `./test.sh pre-pr`; this broad local gate is mandatory even when the change itself is narrowly scoped. Rerun it after any commit, rebase, or merge. Report exact targeted commands and the pre-PR candidate SHA.
     -   **A known failure must receive a durable disposition.** If a broader local or CI run finds a failure outside the scoped set, determine whether it is a regression, product race, leaked state, harness defect, overcomplicated test, or obsolete coverage. Fix the cause, simplify the test, or delete genuinely redundant coverage with a documented replacement. "Unrelated" or "flaky" alone is not a disposition.
     -   **Never rerun until green or mask instability.** Do not add retries, longer timeouts, `skip`, or `xfail`. Reproduce the exposing condition, fix the hypothesized cause, then use repetition only to validate the fix. See `.claude/skills/bifrost-testing/SKILL.md` for the full protocol.
     -   **Prefer simple, durable tests.** Keep one observable contract per test, minimal fixtures, deterministic state, explicit cleanup, and only one useful end-to-end happy path. Move edge cases down to unit/component tests; complexity is not evidence of rigor.
@@ -316,7 +316,7 @@ export async function getDataProviders() {
 ./test.sh                                          # Unit tests only (fast default)
 ./test.sh unit                                     # Same
 ./test.sh e2e                                      # Backend e2e
-./test.sh all                                      # Unit + e2e (mirrors CI)
+./test.sh all                                      # All backend tests, including slow tests
 ./test.sh tests/unit/test_foo.py::test_bar -v      # Passthrough to pytest
 
 # Client tests
@@ -326,6 +326,7 @@ export async function getDataProviders() {
 ./test.sh client e2e e2e/auth.unauth.spec.ts       # Passthrough to Playwright
 
 # CI (one-shot: boot → all tests → tear down)
+./test.sh pre-pr                         # Required clean-commit gate before opening/queueing a PR
 ./test.sh ci
 
 # Type Generation (requires dev stack running via ./debug.sh)
@@ -396,6 +397,8 @@ Before marking work complete, select verification from the actual change surface
 (cd client && npm run generate:types)
 ```
 
-The selected tests must cover the changed behavior, known consumers, and contract tripwires. Do not run `./test.sh all`, the full Vitest suite, or the full Playwright suite by default; use them when explicitly requested, when reproducing a broad CI failure, or when no honest bounded selection exists for a cross-cutting change.
+The selected tests must cover the changed behavior, known consumers, and contract tripwires. During iteration, do not run `./test.sh all`, the full Vitest suite, or the full Playwright suite by default; use targeted coverage to get fast, relevant feedback.
+
+Before opening or queueing a PR, the worktree must be clean and based on current `origin/main`, and `./test.sh pre-pr` must pass for the exact `HEAD`. This is separate from scoped completion verification: it runs every locally reproducible required PR/merge-queue check, including the full backend E2E and critical browser-smoke suites. GitHub still owns non-local boundaries such as the synthetic merge ref, registry publication, signing, and attestation.
 
 In the final handoff, list the exact checks and tests run, state which broader suites were not run, and disclose any known failure. A known out-of-scope failure must be permanently fixed in the current change or split into a dedicated blocking repair change; it cannot be waived as flaky or left as an unowned follow-up.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -288,7 +288,7 @@ export async function getDataProviders() {
 
 -   **Tests**: All work requires tests. Backend logic → unit tests in `api/tests/unit/`. Endpoint/workflow/integration changes → e2e tests in `api/tests/e2e/`. React components → sibling `*.test.tsx` (vitest). User-facing features → happy-path spec in `client/e2e/` (Playwright).
     -   **Functional frontend modules require vitest coverage.** New or modified `.ts` files under `client/src/lib/**` and `client/src/services/**` that export functions (auth helpers, storage adapters, API wrappers, formatters, etc.) need a sibling `*.test.ts` covering the public API. Pure type/constant re-export files and files that only import and re-configure third-party SDKs are exempt. If the module has a cross-tab, cross-window, or storage-boundary concern (like `auth-token.ts`), the test MUST exercise that boundary — a regression that only reproduces with two tabs open is one a future refactor will silently re-introduce otherwise.
-    -   **Scoped verification is the local default.** Run the tests that directly exercise the changed behavior, its known consumers, and any affected contract boundaries. Full backend, Vitest, and Playwright suites are broad integration-gate checks, not a routine local completion requirement. Until every suite is wired into that gate, targeted coverage for changed behavior remains mandatory; never assume an unrun suite is covered elsewhere. Report exactly what ran and which broader suites did not run.
+    -   **Scoped verification is the development-loop default.** Run the tests that directly exercise the changed behavior, its known consumers, and any affected contract boundaries while iterating. Before opening or queueing a PR, commit the exact candidate and run `./test.sh pre-pr`; this broad local gate is mandatory even when the change itself is narrowly scoped. Rerun it after any commit, rebase, or merge. Report exact targeted commands and the pre-PR candidate SHA.
     -   **A known failure must receive a durable disposition.** If a broader local or CI run finds a failure outside the scoped set, determine whether it is a regression, product race, leaked state, harness defect, overcomplicated test, or obsolete coverage. Fix the cause, simplify the test, or delete genuinely redundant coverage with a documented replacement. "Unrelated" or "flaky" alone is not a disposition.
     -   **Never rerun until green or mask instability.** Do not add retries, longer timeouts, `skip`, or `xfail`. Reproduce the exposing condition, fix the hypothesized cause, then use repetition only to validate the fix. See `.claude/skills/bifrost-testing/SKILL.md` for the full protocol.
     -   **Prefer simple, durable tests.** Keep one observable contract per test, minimal fixtures, deterministic state, explicit cleanup, and only one useful end-to-end happy path. Move edge cases down to unit/component tests; complexity is not evidence of rigor.
@@ -318,7 +318,7 @@ export async function getDataProviders() {
 ./test.sh                                          # Unit tests only (fast default)
 ./test.sh unit                                     # Same
 ./test.sh e2e                                      # Backend e2e
-./test.sh all                                      # Unit + e2e (mirrors CI)
+./test.sh all                                      # All backend tests, including slow tests
 ./test.sh tests/unit/test_foo.py::test_bar -v      # Passthrough to pytest
 
 # Client tests
@@ -328,6 +328,7 @@ export async function getDataProviders() {
 ./test.sh client e2e e2e/auth.unauth.spec.ts       # Passthrough to Playwright
 
 # CI (one-shot: boot → all tests → tear down)
+./test.sh pre-pr                         # Required clean-commit gate before opening/queueing a PR
 ./test.sh ci
 
 # Type Generation (requires dev stack running via ./debug.sh)
@@ -398,6 +399,8 @@ Before marking work complete, select verification from the actual change surface
 (cd client && npm run generate:types)
 ```
 
-The selected tests must cover the changed behavior, known consumers, and contract tripwires. Do not run `./test.sh all`, the full Vitest suite, or the full Playwright suite by default; use them when explicitly requested, when reproducing a broad CI failure, or when no honest bounded selection exists for a cross-cutting change.
+The selected tests must cover the changed behavior, known consumers, and contract tripwires. During iteration, do not run `./test.sh all`, the full Vitest suite, or the full Playwright suite by default; use targeted coverage to get fast, relevant feedback.
+
+Before opening or queueing a PR, the worktree must be clean and based on current `origin/main`, and `./test.sh pre-pr` must pass for the exact `HEAD`. This is separate from scoped completion verification: it runs every locally reproducible required PR/merge-queue check, including the full backend E2E and critical browser-smoke suites. GitHub still owns non-local boundaries such as the synthetic merge ref, registry publication, signing, and attestation.
 
 In the final handoff, list the exact checks and tests run, state which broader suites were not run, and disclose any known failure. A known out-of-scope failure must be permanently fixed in the current change or split into a dedicated blocking repair change; it cannot be waived as flaky or left as an unowned follow-up.

--- a/README.md
+++ b/README.md
@@ -179,15 +179,16 @@ The test stack runs in Docker and is separate from your dev stack. Boot it once 
 # Backend tests (stack must be up)
 ./test.sh                                          # Unit tests (fast default)
 ./test.sh e2e                                      # Backend e2e
-./test.sh all                                      # Unit + e2e (mirrors CI)
+./test.sh all                                      # All backend tests, including slow tests
 ./test.sh tests/unit/test_foo.py::test_bar -v      # Passthrough to pytest
 
 # Client tests
 ./test.sh client unit                              # Vitest (no stack needed)
 ./test.sh client e2e                               # Playwright in containers
 
-# CI-equivalent (one-shot: boot → run → tear down)
-./test.sh ci
+# Required pre-PR gate and broader one-shot run
+./test.sh pre-pr                                 # Required clean-commit gate before a PR
+./test.sh ci                                     # All backend + full browser suites
 ```
 
 Parallel worktrees each get their own isolated stack, so you can run tests in several worktrees simultaneously without conflict.

--- a/api/tests/unit/test_compose_test_harness.py
+++ b/api/tests/unit/test_compose_test_harness.py
@@ -140,6 +140,57 @@ def test_test_sh_advertises_dockerized_api_quality_lane():
     assert "sh /app/scripts/quality_api.sh" in script
 
 
+def test_pre_pr_gate_covers_every_locally_reproducible_merge_gate():
+    """A PR must not be the first place broad, reproducible checks run."""
+    script = _find_repo_file("test.sh").read_text()
+    pre_pr = script.split("cmd_pre_pr() {", 1)[1].split("\n}", 1)[0]
+
+    for required_call in (
+        "repository_ci_checks",
+        "client_ci_checks",
+        "quality_api",
+        "cmd_unit",
+        "cmd_e2e",
+        "client_smoke",
+        "build_local_api_candidate",
+    ):
+        assert required_call in pre_pr
+
+    assert "git status --porcelain --untracked-files=all" in pre_pr
+    assert "git fetch --quiet origin main" in pre_pr
+    assert "git merge-base --is-ancestor origin/main HEAD" in pre_pr
+    assert 'git rev-parse HEAD' in pre_pr
+
+    repository_checks = script.split("repository_ci_checks() {", 1)[1].split(
+        "\n}", 1
+    )[0]
+    assert "check_github_action_pins.py --verify-versions" in repository_checks
+    assert "scripts/sync-codex-skills.sh" in repository_checks
+    assert "git diff --quiet -- plugins/bifrost/skills .codex/skills" in repository_checks
+
+    api_candidate = script.split("build_local_api_candidate() {", 1)[1].split(
+        "\n}", 1
+    )[0]
+    assert "--file api/Dockerfile" in api_candidate
+    assert "from src.main import app" in api_candidate
+
+
+def test_pre_pr_client_checks_use_the_ci_node_and_production_build():
+    compose = yaml.safe_load(_COMPOSE.read_text())
+    runner = compose["services"]["client-check-runner"]
+
+    assert runner["build"]["dockerfile"] == "Dockerfile"
+    assert runner["build"]["target"] == "builder"
+    assert runner["command"] == [
+        "sh",
+        "-c",
+        "npm run tsc && npm run lint && npm test",
+    ]
+
+    dockerfile = _find_repo_file("client/Dockerfile").read_text()
+    assert "FROM --platform=$BUILDPLATFORM node:26-slim@" in dockerfile
+
+
 def test_api_quality_script_runs_pyright_without_ci_venv_config():
     script = _find_repo_file("api/scripts/quality_api.sh").read_text()
     assert 'config.pop("venvPath", None)' in script

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -429,6 +429,21 @@ services:
     profiles:
       - test  # Only start when running tests
 
+  # Node 26 matches actions/setup-node in CI. The builder target compiles the
+  # production client before this runner executes TypeScript, ESLint, and the
+  # complete Vitest suite against the same source snapshot.
+  client-check-runner:
+    image: bifrost-test-client-check:latest
+    build:
+      context: ./client
+      dockerfile: Dockerfile
+      target: builder
+      args:
+        VITE_BIFROST_VERSION: test
+    command: ["sh", "-c", "npm run tsc && npm run lint && npm test"]
+    profiles:
+      - client-check
+
   # =============================================================================
   # Client E2E Testing Services (started with --profile client)
   # =============================================================================

--- a/test.sh
+++ b/test.sh
@@ -11,7 +11,7 @@
 #   ./test.sh                           Unit tests only (fast default).
 #   ./test.sh unit                      Same as above.
 #   ./test.sh e2e                       Backend e2e tests.
-#   ./test.sh all                       Unit + e2e (mirrors CI).
+#   ./test.sh all                       All backend tests, including slow tests.
 #   ./test.sh tests/path/... [args]     Pass through to pytest.
 #
 # Quality checks:
@@ -26,6 +26,7 @@
 #   ./test.sh client e2e e2e/auth.unauth.spec.ts   Pass through to playwright.
 #
 # CI escape hatch:
+#   ./test.sh pre-pr                    Required local PR/merge gate for a clean commit.
 #   ./test.sh ci                        Full isolated run: up, all tests, down.
 #
 # Global flags (apply to most subcommands):
@@ -337,6 +338,45 @@ client_unit() {
     (cd client && npm test "$@")
 }
 
+client_ci_checks() {
+    echo "Building the production client and running Node 26 CI checks..."
+    docker compose -f "$COMPOSE_FILE" --profile client-check build client-check-runner
+    docker compose -f "$COMPOSE_FILE" --profile client-check run --rm --no-deps \
+        client-check-runner
+}
+
+repository_ci_checks() {
+    echo "Checking GitHub Action pins..."
+    python3 api/scripts/check_github_action_pins.py --verify-versions
+
+    echo "Checking generated Codex skill mirrors..."
+    scripts/sync-codex-skills.sh
+    if ! git diff --quiet -- plugins/bifrost/skills .codex/skills; then
+        echo "ERROR: Codex skill mirrors were stale and have been regenerated." >&2
+        echo "Commit the generated changes, then rerun ./test.sh pre-pr." >&2
+        return 1
+    fi
+}
+
+build_local_api_candidate() {
+    local head_sha version image_tag
+    head_sha="$(git rev-parse --short=12 HEAD)"
+    version="$(scripts/compute-dev-version.sh)"
+    image_tag="bifrost-local-api-candidate:${head_sha}"
+
+    echo "Building and exercising the production API candidate..."
+    docker build \
+        --file api/Dockerfile \
+        --build-arg "BIFROST_VERSION=$version" \
+        --tag "$image_tag" \
+        .
+    docker run --rm \
+        --env "EXPECTED_VERSION=$version" \
+        --entrypoint python \
+        "$image_tag" \
+        -c "import os; from shared.version import get_version; from src.main import app; assert app is not None; assert get_version() == os.environ['EXPECTED_VERSION']"
+}
+
 start_test_client() {
     # Playwright runs against the production client image. Keep frontend
     # startup out of stack_up so backend-only lanes never build or boot a
@@ -448,6 +488,57 @@ cmd_ci() {
     client_e2e
 }
 
+cmd_pre_pr() {
+    local head_sha stack_was_up
+
+    if [ -n "$(git status --porcelain --untracked-files=all)" ]; then
+        echo "ERROR: ./test.sh pre-pr requires a clean worktree." >&2
+        echo "Commit the exact candidate first so the result maps to one SHA." >&2
+        git status --short >&2
+        return 1
+    fi
+
+    echo "Refreshing origin/main before the local PR gate..."
+    git fetch --quiet origin main
+    if ! git merge-base --is-ancestor origin/main HEAD; then
+        echo "ERROR: HEAD does not contain the latest origin/main." >&2
+        echo "Rebase or merge origin/main, then rerun ./test.sh pre-pr." >&2
+        return 1
+    fi
+
+    head_sha="$(git rev-parse HEAD)"
+    stack_was_up=0
+    if stack_is_up "$COMPOSE_PROJECT_NAME" "$COMPOSE_FILE"; then
+        stack_was_up=1
+    else
+        # Install the trap before boot so a partial startup is cleaned up too.
+        trap 'export_logs "$COMPOSE_PROJECT_NAME" "$COMPOSE_FILE"; stack_down' EXIT
+    fi
+
+    print_project
+    echo "Pre-PR candidate: $head_sha"
+    repository_ci_checks
+    client_ci_checks
+    stack_up
+    quality_api
+    cmd_unit
+    cmd_e2e
+    client_smoke
+    build_local_api_candidate
+
+    if [ "$(git rev-parse HEAD)" != "$head_sha" ] || \
+       [ -n "$(git status --porcelain --untracked-files=all)" ]; then
+        echo "ERROR: the candidate changed while ./test.sh pre-pr was running." >&2
+        echo "Commit the final state and rerun the gate." >&2
+        return 1
+    fi
+
+    echo "Local PR gate passed for $head_sha"
+    if [ "$stack_was_up" = "1" ]; then
+        echo "The pre-existing test stack remains running."
+    fi
+}
+
 # =============================================================================
 # Dispatch
 # =============================================================================
@@ -464,6 +555,7 @@ case "$1" in
     all) shift; cmd_all "$@" ;;
     quality) shift; cmd_quality "$@" ;;
     client) shift; cmd_client "$@" ;;
+    pre-pr) shift; cmd_pre_pr "$@" ;;
     ci) cmd_ci ;;
     -h|--help|help)
         sed -n '2,35p' "$0"


### PR DESCRIPTION
## Summary

- add a clean-commit `./test.sh pre-pr` gate covering every locally reproducible PR and merge-queue check
- run the production client build, TypeScript, ESLint, and full Vitest suite in the pinned Node 26 image used by CI
- run API quality, the complete PR unit suite, backend E2E, zero-retry browser smoke, and a production API image import/version check
- require the gate in contributor and Bifrost workflow guidance, with contract tests preventing future CI drift

## Root cause

Our guidance explicitly treated targeted tests as sufficient before opening a PR, while `./test.sh ci` did not match the actual PR gate. It omitted lint/type and production candidate checks, used the host Node version for frontend tests, and included a different backend selection. That made locally reproducible failures routine GitHub discoveries.

## Verification

- `./test.sh pre-pr` on `3ff80b2f5daddbd0e153971e1738132b6e35e750`
  - client production build, TypeScript, ESLint, 1,770 Vitest tests
  - API pyright and ruff
  - 5,659 backend unit/contract tests passed; 3 skipped; 20 slow tests intentionally excluded to match PR CI
  - 1,784 backend E2E tests passed; 1 environment-specific skip
  - 4 zero-retry Playwright smoke tests passed
  - production API image built, imported, and reported the expected version
- `./test.sh tests/unit/test_compose_test_harness.py -v` — 15 passed
- `./test.sh tests/unit/test_codex_mirror_sync.py tests/unit/test_skill_appendix_fresh.py tests/unit/test_ci_workflow_contract.py -v` — 9 passed, 2 intentional host-only skips

GitHub-only boundaries remain on GitHub: the synthetic merge ref, registry push, signing/attestation, permissions, and third-party infrastructure.
