### PR TITLE
Make docs and delivery gates reliable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -526,6 +526,8 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     name: Promote Dev Images
+    outputs:
+      version: ${{ steps.version.outputs.version }}
     permissions:
       contents: read
       packages: write
@@ -691,7 +693,7 @@ jobs:
           kubectl auth can-i patch deployment -n bifrost
           echo "::endgroup::"
 
-          echo "::group::Deployments the real job would restart"
+          echo "::group::Deployments the real job would monitor"
           kubectl -n bifrost get deployment \
             -l app.kubernetes.io/part-of=bifrost,app.kubernetes.io/component!=message-broker \
             -o wide
@@ -705,7 +707,7 @@ jobs:
             echo ""
             echo "If the step above passed, the real \`deploy-dev\` job will work when this PR merges."
             echo ""
-            echo "### Deployments that would be restarted"
+            echo "### Deployments that would be monitored"
             echo ""
             echo '```'
             kubectl -n bifrost get deployment \
@@ -716,8 +718,9 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
   # =============================================================================
-  # Deploy Dev - Push-to-main only. Rolls the DigitalOcean deployment once
-  # the :dev images are published. Targets anything labeled
+  # Deploy Dev - Push-to-main only. Waits for Keel to move the DigitalOcean
+  # deployments to the immutable version tags published alongside :dev.
+  # Targets anything labeled
   # `app.kubernetes.io/part-of=bifrost` in the `bifrost` namespace so new
   # services are picked up automatically. Failures page the maintainer via
   # GitHub's built-in workflow-failure email (no extra wiring).
@@ -743,15 +746,49 @@ jobs:
       - name: Save kubeconfig
         run: doctl kubernetes cluster kubeconfig save "${{ secrets.DO_CLUSTER_NAME }}"
 
-      - name: Roll deployments
+      - name: Wait for image automation
+        env:
+          EXPECTED_VERSION: ${{ needs.build-dev.outputs.version }}
         run: |
-          kubectl -n bifrost rollout restart deployment \
-            -l app.kubernetes.io/part-of=bifrost,app.kubernetes.io/component!=message-broker
+          set -euo pipefail
+          expected_api="ghcr.io/${{ env.API_IMAGE }}:${EXPECTED_VERSION}"
+          expected_client="ghcr.io/${{ env.CLIENT_IMAGE }}:${EXPECTED_VERSION}"
+          deadline=$((SECONDS + 600))
+
+          while true; do
+            pending=0
+            DEPLOYMENTS=$(kubectl -n bifrost get deployment \
+              -l app.kubernetes.io/part-of=bifrost,app.kubernetes.io/component!=message-broker \
+              -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}')
+            for d in $DEPLOYMENTS; do
+              component=$(kubectl -n bifrost get "deployment/$d" \
+                -o jsonpath='{.metadata.labels.app\.kubernetes\.io/component}')
+              case "$component" in
+                client) expected="$expected_client" ;;
+                api|scheduler|worker) expected="$expected_api" ;;
+                *) echo "Unsupported Bifrost deployment component: $d ($component)" >&2; exit 1 ;;
+              esac
+              images=$(kubectl -n bifrost get "deployment/$d" \
+                -o jsonpath='{range .spec.template.spec.initContainers[*]}{.image}{"\n"}{end}{range .spec.template.spec.containers[*]}{.image}{"\n"}{end}')
+              if [ -z "$images" ] || [ "$(printf '%s\n' "$images" | sort -u)" != "$expected" ]; then
+                echo "Waiting for $d to use $expected (currently: $(printf '%s' "$images" | tr '\n' ' '))"
+                pending=1
+              fi
+            done
+            if [ "$pending" -eq 0 ]; then
+              break
+            fi
+            if [ "$SECONDS" -ge "$deadline" ]; then
+              echo "Timed out waiting for image automation to deploy ${EXPECTED_VERSION}" >&2
+              exit 1
+            fi
+            sleep 10
+          done
 
       - name: Wait for rollouts
         run: |
           set -e
-          # Query the same label selector we restarted, so new services are
+          # Query the same label selector watched above, so new services are
           # picked up without editing this workflow.
           DEPLOYMENTS=$(kubectl -n bifrost get deployment \
             -l app.kubernetes.io/part-of=bifrost,app.kubernetes.io/component!=message-broker \

--- a/api/src/routers/files.py
+++ b/api/src/routers/files.py
@@ -1276,6 +1276,10 @@ async def write_file(
                 solution_id=solution_id,
                 org_id=await _install_org_id(ctx, solution_id),
             )
+            # The yielded DB dependency commits after the response body is sent.
+            # Commit here so a successful write response and its notification
+            # never race ahead of durable metadata.
+            await db.commit()
             await publish_file_change(
                 location=request.location,
                 scope=effective_scope,
@@ -1361,19 +1365,21 @@ async def delete_file(
             from src.core.pubsub import publish_file_change
             from src.services.file_policy_service import FilePolicyService
 
-            await publish_file_change(
-                location=request.location,
-                scope=effective_scope,
-                path=request.path,
-                action="delete",
-            )
             await FilePolicyService(db).delete_metadata(
                 organization_id=await _install_org_id(ctx, solution_id),
                 location=request.location,
                 path=request.path,
                 solution_id=solution_id,
             )
-            await db.flush()
+            # Do not acknowledge or publish the deletion while its metadata is
+            # still visible to another transaction.
+            await db.commit()
+            await publish_file_change(
+                location=request.location,
+                scope=effective_scope,
+                path=request.path,
+                action="delete",
+            )
 
         logger.info(f"Deleted file: {log_safe(request.path)} (mode={log_safe(request.mode)}, location={log_safe(request.location)})")
 

--- a/api/tests/unit/routers/test_files_mutation_commit.py
+++ b/api/tests/unit/routers/test_files_mutation_commit.py
@@ -1,0 +1,93 @@
+"""Transaction-order contracts for direct file mutations."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+from uuid import UUID
+
+import pytest
+
+from src.routers import files
+from src.services import file_policy_service
+
+
+SOLUTION_ID = UUID("11111111-1111-1111-1111-111111111111")
+ORG_ID = UUID("22222222-2222-2222-2222-222222222222")
+
+
+@pytest.fixture
+def mutation_context(monkeypatch):
+    """Bypass authorization plumbing while preserving mutation ordering."""
+    ctx = MagicMock()
+    ctx.user.email = "admin@example.com"
+    ctx.user.user_id = UUID("33333333-3333-3333-3333-333333333333")
+
+    monkeypatch.setattr(files, "_resolve_effective_scope", lambda *_args: str(SOLUTION_ID))
+    monkeypatch.setattr(files, "_ctx_solution_id", lambda *_args: SOLUTION_ID)
+    monkeypatch.setattr(
+        files,
+        "_require_declared_solution_file_location",
+        AsyncMock(return_value=None),
+    )
+    monkeypatch.setattr(files, "_require_file_policy", AsyncMock(return_value=None))
+    monkeypatch.setattr(files, "_lock_file_mutation", AsyncMock(return_value=None))
+    monkeypatch.setattr(files, "_install_org_id", AsyncMock(return_value=ORG_ID))
+    return ctx
+
+
+@pytest.mark.asyncio
+async def test_cloud_write_commits_metadata_before_publishing(monkeypatch, mutation_context):
+    events: list[str] = []
+    backend = MagicMock()
+    backend.write = AsyncMock(side_effect=lambda *_args, **_kwargs: events.append("write"))
+    storage = MagicMock()
+    storage.record_file_write_metadata = AsyncMock(
+        side_effect=lambda **_kwargs: events.append("metadata")
+    )
+    db = AsyncMock()
+    db.commit = AsyncMock(side_effect=lambda: events.append("commit"))
+    publish = AsyncMock(side_effect=lambda **_kwargs: events.append("publish"))
+
+    monkeypatch.setattr(files, "get_backend", lambda *_args: backend)
+    monkeypatch.setattr(files, "FileStorageService", lambda _db: storage)
+    monkeypatch.setattr("src.core.pubsub.publish_file_change", publish)
+
+    await files.write_file(
+        files.FileWriteRequest(
+            path="report.txt",
+            content="ready",
+            location="solutions",
+        ),
+        mutation_context,
+        MagicMock(),
+        db,
+    )
+
+    assert events == ["write", "metadata", "commit", "publish"]
+
+
+@pytest.mark.asyncio
+async def test_cloud_delete_commits_metadata_before_publishing(monkeypatch, mutation_context):
+    events: list[str] = []
+    backend = MagicMock()
+    backend.delete = AsyncMock(side_effect=lambda *_args, **_kwargs: events.append("delete"))
+    policy_service = MagicMock()
+    policy_service.delete_metadata = AsyncMock(
+        side_effect=lambda **_kwargs: events.append("metadata")
+    )
+    db = AsyncMock()
+    db.commit = AsyncMock(side_effect=lambda: events.append("commit"))
+    publish = AsyncMock(side_effect=lambda **_kwargs: events.append("publish"))
+
+    monkeypatch.setattr(files, "get_backend", lambda *_args: backend)
+    monkeypatch.setattr(file_policy_service, "FilePolicyService", lambda _db: policy_service)
+    monkeypatch.setattr("src.core.pubsub.publish_file_change", publish)
+
+    await files.delete_file(
+        files.FileDeleteRequest(path="report.txt", location="solutions"),
+        mutation_context,
+        MagicMock(),
+        db,
+    )
+
+    assert events == ["delete", "metadata", "commit", "publish"]

--- a/api/tests/unit/test_ci_workflow_contract.py
+++ b/api/tests/unit/test_ci_workflow_contract.py
@@ -199,10 +199,20 @@ def test_dev_artifact_is_built_on_merge_candidate_and_promoted_without_rebuild()
     assert "docker buildx imagetools create" in promotion_source
     assert "Digest mismatch" in promotion_source
     assert "fallback" not in promotion_source.lower()
+    assert promotion["outputs"]["version"] == "${{ steps.version.outputs.version }}"
 
     deploy = jobs["deploy-dev"]
     assert deploy["needs"] == ["build-dev"]
     deploy_source = "\n".join(step.get("run", "") for step in deploy["steps"])
+    assert "rollout restart" not in deploy_source
+    assert "Wait for image automation" in {
+        step.get("name") for step in deploy["steps"]
+    }
+    assert "needs.build-dev.outputs.version" in str(deploy["steps"])
+    assert 'expected_api="ghcr.io/${{ env.API_IMAGE }}:${EXPECTED_VERSION}"' in deploy_source
+    assert 'expected_client="ghcr.io/${{ env.CLIENT_IMAGE }}:${EXPECTED_VERSION}"' in deploy_source
+    assert "app.kubernetes.io/component!=message-broker" in deploy_source
+    assert "Timed out waiting for image automation" in deploy_source
     assert "port-forward service/api" in deploy_source
     assert "port-forward service/client" in deploy_source
     assert "http://127.0.0.1:18000/health/ready" in deploy_source

--- a/api/tests/unit/test_compose_test_harness.py
+++ b/api/tests/unit/test_compose_test_harness.py
@@ -223,6 +223,19 @@ def test_clean_boot_optimization_is_one_shot_and_shared_by_test_runners():
     assert "prepare_test_state" in browser_runner
 
 
+def test_pytest_runner_prevents_concurrent_or_orphaned_stack_mutation():
+    """A detached pytest container must block a second run on the same stack."""
+    script = _find_repo_file("test.sh").read_text()
+    pytest_runner = script.split("run_pytest() {", 1)[1].split("\n}", 1)[0]
+
+    assert 'flock -n "$runner_lock_fd"' in pytest_runner
+    assert 'runner_name="${COMPOSE_PROJECT_NAME}-pytest-runner"' in pytest_runner
+    assert 'docker container inspect "$runner_name"' in pytest_runner
+    assert '--name "$runner_name" test-runner' in pytest_runner
+    assert "trap cleanup_pytest_runner INT TERM" in pytest_runner
+    assert 'docker rm -f "$runner_name"' in pytest_runner
+
+
 def test_playwright_uses_the_production_client_image():
     """Browser gates must cover compiled assets and nginx, not Vite transforms."""
     compose = yaml.safe_load(_COMPOSE.read_text())

--- a/scripts/docs/package-lock.json
+++ b/scripts/docs/package-lock.json
@@ -8,7 +8,7 @@
       "name": "bifrost-docs-pipeline",
       "version": "0.0.1",
       "dependencies": {
-        "js-yaml": "^4.3.0",
+        "js-yaml": "^4.3.1",
         "pixelmatch": "^7.1.0",
         "pngjs": "^7.0.0",
         "sharp": "^0.35.0",
@@ -589,9 +589,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "funding": [
         {
           "type": "github",

--- a/scripts/docs/package.json
+++ b/scripts/docs/package.json
@@ -4,8 +4,11 @@
   "type": "module",
   "version": "0.0.1",
   "description": "Tooling for the gobifrost screenshot pipeline.",
+  "scripts": {
+    "test": "node --test post-process.test.mjs"
+  },
   "dependencies": {
-    "js-yaml": "^4.3.0",
+    "js-yaml": "^4.3.1",
     "pixelmatch": "^7.1.0",
     "pngjs": "^7.0.0",
     "sharp": "^0.35.0",

--- a/scripts/docs/post-process.mjs
+++ b/scripts/docs/post-process.mjs
@@ -9,9 +9,9 @@
  *   2. Applies `capture.crop` (if defined) to extract a sub-region.
  *   3. Overlays `capture.callouts` rectangles + labels.
  *   4. Compares the result to the committed PNG at `<docs>/<entry.image>`.
- *      If pixel diff exceeds threshold, replaces the committed PNG and
- *      marks the entry's `captured_at` with the current bifrost SHA.
- *      Otherwise discards the temp file silently.
+ *      If pixel diff exceeds threshold, replaces the committed PNG.
+ *      Every successful capture marks the entry's `captured_at` with the
+ *      current bifrost SHA, including visual no-ops below the threshold.
  *
  * Inputs:
  *   --docs-repo <path>     required
@@ -206,8 +206,13 @@ async function main() {
         const targetTmp = `${targetPath}.tmp-${process.pid}-${Date.now()}`;
         writeFileSync(targetTmp, finalBuf);
         renameSync(targetTmp, targetPath);
-        entry.captured_at = { bifrost_sha: sha, timestamp: new Date().toISOString() };
       }
+
+      // The watermark records what was successfully exercised, not whether
+      // the resulting pixels changed enough to replace the committed image.
+      // Leaving visual no-ops on their old SHA makes diff mode select them
+      // forever and prevents the manifest's minimum SHA from advancing.
+      entry.captured_at = { bifrost_sha: sha, timestamp: new Date().toISOString() };
 
       try {
         unlinkSync(hostTempPath);

--- a/scripts/docs/post-process.test.mjs
+++ b/scripts/docs/post-process.test.mjs
@@ -1,0 +1,71 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { test } from "node:test";
+
+import * as yaml from "js-yaml";
+import { PNG } from "pngjs";
+
+const scriptPath = join(import.meta.dirname, "post-process.mjs");
+
+function writePng(path) {
+  mkdirSync(dirname(path), { recursive: true });
+  const png = new PNG({ width: 1, height: 1 });
+  png.data.set([15, 25, 35, 255]);
+  writeFileSync(path, PNG.sync.write(png));
+}
+
+function initializeGitRepo(path) {
+  mkdirSync(path, { recursive: true });
+  execFileSync("git", ["init", "--quiet"], { cwd: path });
+  execFileSync("git", ["config", "user.email", "docs-test@gobifrost.com"], { cwd: path });
+  execFileSync("git", ["config", "user.name", "Docs Test"], { cwd: path });
+  writeFileSync(join(path, "marker"), "capture source\n");
+  execFileSync("git", ["add", "marker"], { cwd: path });
+  execFileSync("git", ["commit", "--quiet", "-m", "capture source"], { cwd: path });
+  return execFileSync("git", ["rev-parse", "HEAD"], { cwd: path, encoding: "utf8" }).trim();
+}
+
+test("an unchanged successful capture advances the manifest watermark", () => {
+  const root = mkdtempSync(join(tmpdir(), "bifrost-docs-post-process-"));
+  const docsRepo = join(root, "docs");
+  const bifrostRepo = join(root, "bifrost");
+  const expectedSha = initializeGitRepo(bifrostRepo);
+  const imagePath = join(docsRepo, "public", "images", "example.png");
+  const tempPath = join(docsRepo, ".tmp-captures", "example.png");
+
+  writePng(imagePath);
+  writePng(tempPath);
+  writeFileSync(
+    join(docsRepo, "screenshots.yaml"),
+    yaml.dump({
+      defaults: {},
+      entries: [
+        {
+          id: "example",
+          image: "public/images/example.png",
+          captured_at: { bifrost_sha: "old-sha", timestamp: "2026-01-01T00:00:00.000Z" },
+        },
+      ],
+    }),
+  );
+  writeFileSync(
+    join(docsRepo, ".tmp-captures", "results.json"),
+    JSON.stringify([{ id: "example", status: "captured", tempPath: "/docs/.tmp-captures/example.png" }]),
+  );
+
+  const output = execFileSync(
+    process.execPath,
+    [scriptPath, "--docs-repo", docsRepo, "--bifrost-repo", bifrostRepo],
+    { encoding: "utf8" },
+  );
+  const summary = JSON.parse(output);
+  const manifest = yaml.load(readFileSync(join(docsRepo, "screenshots.yaml"), "utf8"));
+
+  assert.deepEqual(summary.committed, []);
+  assert.equal(summary.unchanged[0].id, "example");
+  assert.equal(manifest.entries[0].captured_at.bifrost_sha, expectedSha);
+  assert.notEqual(manifest.entries[0].captured_at.timestamp, "2026-01-01T00:00:00.000Z");
+});

--- a/test.sh
+++ b/test.sh
@@ -262,6 +262,34 @@ stack_status() {
 # =============================================================================
 
 run_pytest() {
+    local runner_lock_fd runner_name runner_status
+
+    # One worktree owns one mutable Docker test stack.  A second pytest process
+    # against that stack can reset the database underneath the first process and
+    # produce order-impossible failures.  The flock covers the normal case; the
+    # stable container name is a second guard when the parent shell is killed and
+    # Docker leaves the already-running one-off container behind.
+    exec {runner_lock_fd}>"$LOG_DIR/test-runner.lock"
+    if ! flock -n "$runner_lock_fd"; then
+        echo "ERROR: another pytest run is already using this worktree's test stack." >&2
+        echo "Wait for it to finish before starting another test command." >&2
+        exec {runner_lock_fd}>&-
+        return 1
+    fi
+
+    runner_name="${COMPOSE_PROJECT_NAME}-pytest-runner"
+    if docker container inspect "$runner_name" > /dev/null 2>&1; then
+        echo "ERROR: pytest runner container '$runner_name' still exists." >&2
+        echo "Wait for it to finish; if its parent was interrupted, stop that container explicitly." >&2
+        exec {runner_lock_fd}>&-
+        return 1
+    fi
+
+    cleanup_pytest_runner() {
+        docker rm -f "$runner_name" > /dev/null 2>&1 || true
+    }
+    trap cleanup_pytest_runner INT TERM
+
     # Note: we deliberately do NOT re-run stack_template_init.sh here.
     # `stack reset` / `stack up` is where migration changes flow into the
     # template. `run_pytest` clones the current template, so if the user
@@ -275,9 +303,16 @@ run_pytest() {
     # the whole session is reported as ERROR even though every test ran. Make the
     # mount dir world-writable so the uid-1000 container can write results into it.
     chmod 777 "$LOG_DIR" 2>/dev/null || true
-    docker compose -f "$COMPOSE_FILE" --profile test run --rm test-runner \
-        pytest "$@" --junitxml="/tmp/bifrost/test-results.xml" 2>&1 | tee "$LOG_DIR/test-runner.log"
-    return "${PIPESTATUS[0]}"
+    runner_status=0
+    docker compose -f "$COMPOSE_FILE" --profile test run --rm \
+        --name "$runner_name" test-runner \
+        pytest "$@" --junitxml="/tmp/bifrost/test-results.xml" 2>&1 \
+        | tee "$LOG_DIR/test-runner.log" || runner_status="${PIPESTATUS[0]}"
+
+    cleanup_pytest_runner
+    trap - INT TERM
+    exec {runner_lock_fd}>&-
+    return "$runner_status"
 }
 
 # `unit` is the fast every-PR lane: it deselects `@pytest.mark.slow` tests


### PR DESCRIPTION
## Summary

- advance docs screenshot watermarks for every successful capture, including visual no-ops, and patch the docs runner dependency vulnerability
- make the dev deploy gate wait for the exact immutable images published for the commit instead of restarting old workloads and racing Keel
- serialize local pytest use of each worktree stack and give the runner a stable container name so interrupted clients cannot leave a second suite resetting shared state
- commit direct file metadata mutations before successful responses and notifications, closing the stale-read race exposed by the repaired full suite

## Root causes resolved

- no-op screenshots were skipped by post-processing and left the docs watermark permanently stale
- the deploy workflow restarted the prior image, then Keel changed it during the same rollout, exhausting the fixed timeout
- detached Compose one-off pytest containers could survive a killed parent and contaminate a later run against the same database
- file write/delete responses could be sent before the yielded database dependency committed metadata

## Verification

- `./test.sh pre-pr` on clean commit `76a6fcc2aab7f7b17d5942af95e2cc2dac9c08de`
  - production client build, TypeScript, and lint passed
  - Vitest: 1,770 passed
  - API quality: Pyright 0 errors; Ruff passed
  - backend unit: 5,662 passed, 3 skipped, 20 deselected
  - backend E2E: 1,784 passed, 1 skipped
  - production-client Playwright smoke: 4 passed
  - production API image build/import passed
- docs post-process test: 1 passed; `npm audit`: 0 vulnerabilities
- workflow contract tests: 8 passed
- test-harness contract tests: 16 passed
- solution file transaction order + complete E2E file: 13 passed
- isolated git-sync E2E file: 89 passed

The full Playwright suite was not run; the required pre-PR gate runs the four production-client smoke journeys.