### PR TITLE
fix(apps): preserve V1 runtime across route changes

### DIFF
--- a/client/e2e/apps-preview.admin.spec.ts
+++ b/client/e2e/apps-preview.admin.spec.ts
@@ -25,11 +25,26 @@ const UNIQUE = `${Date.now()}-${Math.floor(Math.random() * 10000)}`;
 const APP_SLUG = `e2e-preview-${UNIQUE}`;
 const APP_NAME = `E2E Preview ${UNIQUE}`;
 
-const LAYOUT_TSX = `import { Outlet } from "react-router-dom";
+const LAYOUT_TSX = `import { useRef } from "react";
+import { Outlet } from "react-router-dom";
 export default function Layout() {
-	return <Outlet />;
+	const instanceId = useRef(crypto.randomUUID());
+	return (
+		<div
+			className="route-style-sentinel"
+			data-testid="app-layout"
+			data-instance-id={instanceId.current}
+		>
+			<Outlet />
+		</div>
+	);
 }
 `;
+
+const STYLES_CSS = `.route-style-sentinel {
+	padding: 37px;
+	background-color: rgb(12 34 56);
+}`;
 
 const indexTsx = (heading: string) => `import { Link } from "bifrost";
 import { useLocation } from "react-router-dom";
@@ -110,6 +125,7 @@ test.describe("Apps Preview", () => {
 			[`apps/${APP_SLUG}/_layout.tsx`, LAYOUT_TSX],
 			[`apps/${APP_SLUG}/pages/index.tsx`, indexTsx("HELLO V1")],
 			[`apps/${APP_SLUG}/pages/other.tsx`, OTHER_TSX],
+			[`apps/${APP_SLUG}/styles.css`, STYLES_CSS],
 		] as const) {
 			const writeResp = await api.post("/api/files/write", {
 				data: writeBody(relPath, source),
@@ -140,6 +156,10 @@ test.describe("Apps Preview", () => {
 				},
 			);
 			await expect(page.getByTestId("location-path")).toHaveText("/");
+			await expect(page.getByTestId("app-layout")).toHaveCSS(
+				"padding-top",
+				"37px",
+			);
 
 			// --- Step 2: push V2, preview updates WITHOUT reload ---
 			const writeResp = await api.post("/api/files/write", {
@@ -158,7 +178,27 @@ test.describe("Apps Preview", () => {
 			);
 			await expect(page.getByTestId("location-path")).toHaveText("/");
 
-			// --- Step 3: navigate to /other via in-app Link, then back ---
+			// --- Step 3: navigate without remounting the app or detaching its CSS ---
+			const layoutInstanceId = await page
+				.getByTestId("app-layout")
+				.getAttribute("data-instance-id");
+			await page.evaluate(() => {
+				const stylesheet = document.querySelector<HTMLLinkElement>(
+					'link[data-bifrost-bundle="true"]',
+				);
+				if (!stylesheet)
+					throw new Error("V1 bundle stylesheet was not mounted");
+				const continuity = { stylesheet, removed: false };
+				new MutationObserver(() => {
+					if (!stylesheet.isConnected) continuity.removed = true;
+				}).observe(document.head, { childList: true });
+				(
+					window as typeof window & {
+						__v1CssContinuity?: typeof continuity;
+					}
+				).__v1CssContinuity = continuity;
+			});
+
 			await page.getByTestId("to-other").click();
 			await expect(page).toHaveURL(
 				new RegExp(`/apps/${APP_SLUG}/preview/other/?$`),
@@ -169,6 +209,33 @@ test.describe("Apps Preview", () => {
 			await expect(page.getByTestId("location-path")).toHaveText(
 				"/other",
 			);
+			await expect(page.getByTestId("app-layout")).toHaveAttribute(
+				"data-instance-id",
+				layoutInstanceId!,
+			);
+			await expect(page.getByTestId("app-layout")).toHaveCSS(
+				"padding-top",
+				"37px",
+			);
+			expect(
+				await page.evaluate(() => {
+					const continuity = (
+						window as typeof window & {
+							__v1CssContinuity?: {
+								stylesheet: HTMLLinkElement;
+								removed: boolean;
+							};
+						}
+					).__v1CssContinuity;
+					return {
+						removed: continuity?.removed,
+						sameStylesheet:
+							document.querySelector(
+								'link[data-bifrost-bundle="true"]',
+							) === continuity?.stylesheet,
+					};
+				}),
+			).toEqual({ removed: false, sameStylesheet: true });
 
 			await page.getByTestId("to-home").click();
 			await expect(page).toHaveURL(

--- a/client/e2e/fixtures/v2-lazy-app/src/main.tsx
+++ b/client/e2e/fixtures/v2-lazy-app/src/main.tsx
@@ -1,5 +1,6 @@
 import { lazy, Suspense } from "react";
 import { createRoot } from "react-dom/client";
+import { BrowserRouter, Link, Route, Routes } from "react-router-dom";
 
 import "./style.css";
 
@@ -42,13 +43,33 @@ const LazyPage = lazy(() => import("./LazyPage"));
 
 function FixtureApp({ bootstrap }: { bootstrap: Bootstrap }) {
 	return (
-		<main>
-			<p data-testid="fixture-build">{buildLabel}</p>
-			<p data-testid="fixture-basename">{bootstrap.basename}</p>
-			<Suspense fallback={<p>Loading lazy chunk…</p>}>
-				<LazyPage />
-			</Suspense>
-		</main>
+		<BrowserRouter basename={bootstrap.basename}>
+			<Routes>
+				<Route
+					path="/"
+					element={
+						<main>
+							<p data-testid="fixture-build">{buildLabel}</p>
+							<p data-testid="fixture-basename">
+								{bootstrap.basename}
+							</p>
+							<Link to="/details" data-testid="v2-internal-route">
+								Open details
+							</Link>
+							<Suspense fallback={<p>Loading lazy chunk…</p>}>
+								<LazyPage />
+							</Suspense>
+						</main>
+					}
+				/>
+				<Route
+					path="/details"
+					element={
+						<main data-testid="v2-details">Details rendered</main>
+					}
+				/>
+			</Routes>
+		</BrowserRouter>
 	);
 }
 

--- a/client/e2e/solution-v2-code-splitting.admin.spec.ts
+++ b/client/e2e/solution-v2-code-splitting.admin.spec.ts
@@ -215,8 +215,7 @@ test.describe("Apps v2 code splitting", () => {
 							`/api/solutions/deploy-jobs/${jobId}`,
 						);
 						const body = await response.json();
-						if (body.status === "failed")
-							throw new Error(body.error);
+						if (body.status === "failed") throw new Error(body.error);
 						return body.status;
 					},
 					{ timeout: 60_000 },
@@ -237,6 +236,32 @@ test.describe("Apps v2 code splitting", () => {
 			});
 			expect(entryRequests).toHaveLength(1);
 			expect(entryRequests[0]).not.toContain("?");
+
+			// An internal app URL change must not tear down and remount the v2 root.
+			// The host route still matches /apps/:slug/*, so the app owns this
+			// navigation and its runtime must remain continuous.
+			await page.getByTestId("v2-internal-route").click();
+			await expect(page).toHaveURL(
+				new RegExp(`/apps/${APP_SLUG}/details$`),
+			);
+			await expect(page.getByTestId("v2-details")).toHaveText(
+				"Details rendered",
+			);
+			expect(await page.evaluate(() => window.__v2LazyFixture)).toEqual({
+				entryExecutions: 1,
+				mounts: 1,
+				unmounts: 0,
+			});
+			await page.goBack();
+			await expect(page).toHaveURL(new RegExp(`/apps/${APP_SLUG}/?$`));
+			await expect(page.getByTestId("lazy-page")).toHaveText(
+				"Lazy chunk rendered",
+			);
+			expect(await page.evaluate(() => window.__v2LazyFixture)).toEqual({
+				entryExecutions: 1,
+				mounts: 1,
+				unmounts: 0,
+			});
 
 			// Leave and re-enter through the host SPA: the module stays evaluated once,
 			// while mount() and its returned teardown run for each visit.
@@ -317,7 +342,8 @@ test.describe("Apps v2 code splitting", () => {
 							`/api/solutions/deploy-jobs/${jobId}`,
 						);
 						const body = await job.json();
-						if (body.status === "failed") throw new Error(body.error);
+						if (body.status === "failed")
+							throw new Error(body.error);
 						return body.status;
 					},
 					{ timeout: 60_000 },

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -265,6 +265,11 @@ function AppFrame() {
 			null ||
 			matchPath("/apps/:applicationId/*", location.pathname) !== null) &&
 		matchPath("/apps/:applicationId/edit/*", location.pathname) === null;
+	// App routes own their nested navigation. Keep their runtime mounted while
+	// the wildcard portion changes so inline_v1 does not detach its stylesheet
+	// and standalone_v2 does not tear down its React root. Other platform routes
+	// retain the keyed reveal animation on every completed navigation.
+	const routeRevealKey = isAppRunnerRoute ? "app-runner" : location.key;
 	useEffect(() => {
 		if (isAppRunnerRoute) return;
 		document.title = applicationName;
@@ -293,7 +298,7 @@ function AppFrame() {
 			<UnifiedDock />
 
 			<Suspense fallback={<PageLoader />}>
-				<RouteReadyReveal key={location.key}>
+				<RouteReadyReveal key={routeRevealKey}>
 					<Outlet />
 				</RouteReadyReveal>
 			</Suspense>

--- a/client/src/lib/app-code-platform/useWorkflowMutation.test.tsx
+++ b/client/src/lib/app-code-platform/useWorkflowMutation.test.tsx
@@ -1,0 +1,81 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi, type Mock } from "vitest";
+
+vi.mock("@/lib/api-client", () => ({
+	apiClient: { POST: vi.fn() },
+}));
+vi.mock("@/hooks/useExecutions", () => ({ getExecution: vi.fn() }));
+vi.mock("@/lib/app-sdk/execution-stream", () => ({
+	subscribeToExecution: vi.fn(),
+}));
+
+import { apiClient } from "@/lib/api-client";
+import { getExecution } from "@/hooks/useExecutions";
+import {
+	subscribeToExecution,
+	type ExecutionStreamEvent,
+} from "@/lib/app-sdk/execution-stream";
+import { useWorkflowMutation } from "./useWorkflowMutation";
+
+describe("useWorkflowMutation", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("uses the reconnecting SDK stream and reconciles a result after reconnect", async () => {
+		(apiClient.POST as Mock).mockResolvedValue({
+			data: { execution_id: "exec-1", status: "Running" },
+			error: undefined,
+		});
+		(getExecution as Mock).mockResolvedValue({ status: "Running" });
+
+		let onEvent: ((event: ExecutionStreamEvent) => void) | undefined;
+		let onSocketDown: (() => void) | undefined;
+		const unsubscribe = vi.fn();
+		(subscribeToExecution as Mock).mockImplementation(
+			(
+				_executionId: string,
+				eventCallback: (event: ExecutionStreamEvent) => void,
+				socketDownCallback: () => void,
+			) => {
+				onEvent = eventCallback;
+				onSocketDown = socketDownCallback;
+				return unsubscribe;
+			},
+		);
+
+		const { result } = renderHook(() =>
+			useWorkflowMutation<{ value: number }>("workflow-1"),
+		);
+		let executionPromise!: Promise<{ value: number }>;
+		act(() => {
+			executionPromise = result.current.execute({ input: true });
+		});
+
+		await waitFor(() => {
+			expect(subscribeToExecution).toHaveBeenCalledWith(
+				"exec-1",
+				expect.any(Function),
+				expect.any(Function),
+			);
+			expect(getExecution).toHaveBeenCalledTimes(1);
+		});
+
+		// The shared stream reconnects automatically. While it is down the V1 hook
+		// polls; its next `ready` event is the post-reconnect subscribe ack.
+		act(() => onSocketDown?.());
+		(getExecution as Mock).mockResolvedValue({
+			status: "Success",
+			result: { value: 42 },
+			error_message: null,
+		});
+		act(() => onEvent?.({ type: "ready" }));
+
+		await expect(executionPromise).resolves.toEqual({ value: 42 });
+		await waitFor(() => {
+			expect(result.current.data).toEqual({ value: 42 });
+			expect(result.current.isLoading).toBe(false);
+			expect(unsubscribe).toHaveBeenCalledOnce();
+		});
+	});
+});

--- a/client/src/lib/app-code-platform/useWorkflowMutation.ts
+++ b/client/src/lib/app-code-platform/useWorkflowMutation.ts
@@ -10,9 +10,9 @@
 import { useState, useCallback, useRef, useEffect } from "react";
 import { apiClient } from "@/lib/api-client";
 import {
-	webSocketService,
-	type ExecutionLog,
-} from "@/services/websocket";
+	subscribeToExecution,
+	type ExecutionStreamEvent,
+} from "@/lib/app-sdk/execution-stream";
 import {
 	useExecutionStreamStore,
 	type ExecutionStatus,
@@ -68,11 +68,11 @@ export interface UseWorkflowMutationResult<T> {
 }
 
 interface Subscription {
-	unsubUpdate: () => void;
-	unsubLog: () => void;
-	channel: string;
+	unsubscribe: () => void;
 	timeout: ReturnType<typeof setTimeout>;
 }
+
+const POLL_INTERVAL_MS = 2_000;
 
 export function useWorkflowMutation<T = unknown>(
 	workflowId: string,
@@ -90,10 +90,8 @@ export function useWorkflowMutation<T = unknown>(
 	const cleanupExecution = useCallback((execId: string) => {
 		const sub = subscriptionsRef.current.get(execId);
 		if (sub) {
-			sub.unsubUpdate();
-			sub.unsubLog();
+			sub.unsubscribe();
 			clearTimeout(sub.timeout);
-			webSocketService.unsubscribe(sub.channel);
 			subscriptionsRef.current.delete(execId);
 		}
 		deferredMapRef.current.delete(execId);
@@ -112,10 +110,8 @@ export function useWorkflowMutation<T = unknown>(
 				deferred.reject(new Error("Component unmounted"));
 				const sub = subscriptions.get(execId);
 				if (sub) {
-					sub.unsubUpdate();
-					sub.unsubLog();
+					sub.unsubscribe();
 					clearTimeout(sub.timeout);
-					webSocketService.unsubscribe(sub.channel);
 				}
 				useExecutionStreamStore.getState().clearStream(execId);
 			}
@@ -149,9 +145,7 @@ export function useWorkflowMutation<T = unknown>(
 					typeof responseError === "object" &&
 					responseError !== null &&
 					"detail" in responseError
-						? String(
-								(responseError as { detail: unknown }).detail,
-							)
+						? String((responseError as { detail: unknown }).detail)
 						: "Workflow execution failed";
 				if (mountedRef.current) {
 					setError(errorMessage);
@@ -186,8 +180,7 @@ export function useWorkflowMutation<T = unknown>(
 					return result;
 				} else {
 					const errMsg =
-						responseData.error ??
-						`Workflow ${responseData.status}`;
+						responseData.error ?? `Workflow ${responseData.status}`;
 					if (mountedRef.current) {
 						setError(errMsg);
 						setIsLoading(false);
@@ -209,23 +202,6 @@ export function useWorkflowMutation<T = unknown>(
 			const store = useExecutionStreamStore.getState();
 			store.startStreaming(execId);
 
-			// Connect WebSocket and subscribe
-			const channel = `execution:${execId}`;
-			try {
-				await webSocketService.connect([channel]);
-			} catch (err) {
-				cleanupExecution(execId);
-				const errorMessage =
-					err instanceof Error
-						? err.message
-						: "WebSocket connection failed";
-				if (mountedRef.current) {
-					setError(errorMessage);
-					setIsLoading(false);
-				}
-				throw new Error(errorMessage, { cause: err });
-			}
-
 			// Set up timeout
 			const timeout = setTimeout(() => {
 				const pending = deferredMapRef.current.get(execId);
@@ -241,52 +217,47 @@ export function useWorkflowMutation<T = unknown>(
 				}
 			}, EXECUTION_TIMEOUT_MS);
 
-			// Subscribe to execution updates
-			const unsubUpdate = webSocketService.onExecutionUpdate(
-				execId,
-				async (update) => {
-					const currentStore = useExecutionStreamStore.getState();
-
-					if (update.status) {
+			let pollTimer: ReturnType<typeof setInterval> | null = null;
+			const stopPolling = () => {
+				if (pollTimer) clearInterval(pollTimer);
+				pollTimer = null;
+			};
+			const reconcileExecution = async () => {
+				if (!deferredMapRef.current.has(execId)) return;
+				try {
+					const execution = await getExecution(execId);
+					if (
+						TERMINAL_STATUSES.includes(
+							execution.status as ExecutionStatus,
+						)
+					) {
+						const currentStore = useExecutionStreamStore.getState();
 						currentStore.updateStatus(
 							execId,
-							update.status as ExecutionStatus,
+							execution.status as ExecutionStatus,
 						);
-					}
-
-					if (update.isComplete) {
 						currentStore.completeExecution(
 							execId,
 							undefined,
-							update.status as ExecutionStatus,
+							execution.status as ExecutionStatus,
 						);
 
 						const pending = deferredMapRef.current.get(execId);
 						if (pending) {
-							try {
-								const execution = await getExecution(execId);
-								if (execution.status === "Success") {
-									const result = execution.result as T;
-									if (mountedRef.current) {
-										setData(result);
-										setIsLoading(false);
-									}
-									pending.resolve(result);
-								} else {
-									const errMsg =
-										execution.error_message ||
-										`Workflow ${update.status}`;
-									if (mountedRef.current) {
-										setError(errMsg);
-										setIsLoading(false);
-									}
-									pending.reject(new Error(errMsg));
+							if (
+								execution.status === "Success" ||
+								execution.status === "CompletedWithErrors"
+							) {
+								const result = execution.result as T;
+								if (mountedRef.current) {
+									setData(result);
+									setIsLoading(false);
 								}
-							} catch (fetchErr) {
+								pending.resolve(result);
+							} else {
 								const errMsg =
-									fetchErr instanceof Error
-										? fetchErr.message
-										: "Failed to fetch result";
+									execution.error_message ||
+									`Workflow ${execution.status}`;
 								if (mountedRef.current) {
 									setError(errMsg);
 									setIsLoading(false);
@@ -296,84 +267,56 @@ export function useWorkflowMutation<T = unknown>(
 							cleanupExecution(execId);
 						}
 					}
-				},
-			);
+				} catch {
+					// A transient read failure must not strand the execution. The stream,
+					// reconnect acknowledgement, or polling fallback will check again.
+				}
+			};
+			const startPolling = () => {
+				if (!pollTimer) {
+					pollTimer = setInterval(() => {
+						void reconcileExecution();
+					}, POLL_INTERVAL_MS);
+				}
+			};
 
-			// Subscribe to execution logs
-			const unsubLog = webSocketService.onExecutionLog(
+			const unsubscribeStream = subscribeToExecution(
 				execId,
-				(log: ExecutionLog) => {
+				(event: ExecutionStreamEvent) => {
 					const currentStore = useExecutionStreamStore.getState();
-					const streamingLog: StreamingLog = {
-						level: log.level,
-						message: log.message,
-						timestamp: log.timestamp,
-					};
-					if (log.sequence !== undefined) {
-						streamingLog.sequence = log.sequence;
+					if (event.type === "ready") {
+						void reconcileExecution();
+					} else if (event.type === "status") {
+						if (event.status) {
+							currentStore.updateStatus(
+								execId,
+								event.status as ExecutionStatus,
+							);
+						}
+						if (event.isTerminal) {
+							startPolling();
+							void reconcileExecution();
+						}
+					} else if (event.type === "log" && event.log) {
+						const streamingLog: StreamingLog = { ...event.log };
+						currentStore.appendLogs(execId, [streamingLog]);
 					}
-					currentStore.appendLogs(execId, [streamingLog]);
 				},
+				startPolling,
 			);
 
-			// Store subscription references
+			// Keep the exact reconnecting stream used by the v2 SDK. If the socket
+			// drops, poll until settlement and reconcile after every subscribe ack.
 			subscriptionsRef.current.set(execId, {
-				unsubUpdate,
-				unsubLog,
-				channel,
+				unsubscribe: () => {
+					stopPolling();
+					unsubscribeStream();
+				},
 				timeout,
 			});
 
-			// Fast workflows can complete before the WebSocket callback is attached.
-			// Check once immediately after subscribing so the hook does not stay
-			// unresolved when the terminal event was missed.
-			try {
-				const execution = await getExecution(execId);
-				if (
-					TERMINAL_STATUSES.includes(
-						execution.status as ExecutionStatus,
-					)
-				) {
-					const currentStore = useExecutionStreamStore.getState();
-					currentStore.updateStatus(
-						execId,
-						execution.status as ExecutionStatus,
-					);
-					currentStore.completeExecution(
-						execId,
-						undefined,
-						execution.status as ExecutionStatus,
-					);
-
-					const pending = deferredMapRef.current.get(execId);
-					if (pending) {
-						if (
-							execution.status === "Success" ||
-							execution.status === "CompletedWithErrors"
-						) {
-							const result = execution.result as T;
-							if (mountedRef.current) {
-								setData(result);
-								setIsLoading(false);
-							}
-							pending.resolve(result);
-						} else {
-							const errMsg =
-								execution.error_message ||
-								`Workflow ${execution.status}`;
-							if (mountedRef.current) {
-								setError(errMsg);
-								setIsLoading(false);
-							}
-							pending.reject(new Error(errMsg));
-						}
-						cleanupExecution(execId);
-					}
-				}
-			} catch {
-				// Ignore immediate status fetch failures; the normal WebSocket path
-				// still handles ordinary execution flow.
-			}
+			// Fast workflows can finish before the first subscription acknowledgement.
+			void reconcileExecution();
 
 			return deferred.promise;
 		},


### PR DESCRIPTION
## Summary
- keep the app runner reveal boundary mounted during nested app navigation so V1 bundle stylesheets are never detached
- exercise V1 and V2 internal routes to protect both runtime lifecycles and retain the existing V2 stale-asset recovery behavior
- move the V1 workflow mutation hook onto the same reconnecting execution stream as V2, with missed-result reconciliation and polling after an outage

## Root cause
The route-ready reveal was keyed by every host-router location key. A V1 internal navigation therefore unmounted the complete app shell, whose stylesheet cleanup removed the bundle link until the new shell mounted it again. This was separate from the V2 stale-bundle recovery fix.

## Verification
- ./test.sh client unit src/lib/app-code-platform/useWorkflowMutation.test.tsx src/lib/app-sdk/execution-stream.test.ts src/lib/app-sdk/ws-client.test.ts (18 passed)
- ./test.sh client e2e e2e/apps-preview.admin.spec.ts e2e/solution-v2-code-splitting.admin.spec.ts (4 passed)
- cd client && npm run tsc
- cd client && npm run lint (0 errors; one existing React Compiler warning in FormRenderer.tsx)

Closes #622