### PR TITLE
Fix chat agent workflow tool session lifetime

### DIFF
--- a/api/src/services/agent_executor.py
+++ b/api/src/services/agent_executor.py
@@ -1325,6 +1325,7 @@ class AgentExecutor:
         try:
             # Get the workflow for this tool — prefer ID lookup (handles normalized names)
             workflow_id = self._tool_workflow_id_map.get(tool_call.name)
+            resolved_workflow: tuple[str, str] | None = None
             async with self._db() as session:
                 if workflow_id:
                     result = await session.execute(
@@ -1339,8 +1340,13 @@ class AgentExecutor:
                         .where(Workflow.is_active.is_(True))
                     )
                 workflow = result.scalar_one_or_none()
+                if workflow is not None:
+                    # Keep ORM access inside the owning async session. Session exit
+                    # may expire attributes, and later implicit IO would fail with
+                    # MissingGreenlet outside SQLAlchemy's async bridge.
+                    resolved_workflow = (str(workflow.id), workflow.name)
 
-            if not workflow:
+            if resolved_workflow is None:
                 return ToolResult(
                     tool_call_id=tool_call.id,
                     tool_name=tool_call.name,
@@ -1348,6 +1354,7 @@ class AgentExecutor:
                     error=f"Tool '{tool_call.name}' not found",
                     duration_ms=int((time.time() - start_time) * 1000),
                 )
+            resolved_workflow_id, resolved_workflow_name = resolved_workflow
 
             # Get user info from conversation
             user = conversation.user if conversation else None
@@ -1359,14 +1366,15 @@ class AgentExecutor:
             org_id = str(agent.organization_id) if agent and agent.organization_id else None
 
             execution_response = await execute_tool(
-                workflow_id=str(workflow.id),
-                workflow_name=workflow.name,
+                workflow_id=resolved_workflow_id,
+                workflow_name=resolved_workflow_name,
                 parameters=tool_call.arguments or {},
                 user_id=str(user.id) if user else "system",
                 user_email=user.email if user else "system@internal.gobifrost.com",
                 user_name=user.name if user else "System",
                 org_id=org_id,
                 is_platform_admin=user.is_superuser if user else False,
+                is_agent=True,
                 execution_id=execution_id,
                 artifact_workspace_id=str(conversation.id) if conversation else None,
             )

--- a/api/tests/unit/services/test_agent_executor_tools.py
+++ b/api/tests/unit/services/test_agent_executor_tools.py
@@ -13,6 +13,7 @@ from uuid import uuid4
 
 import pytest
 from pydantic import BaseModel
+from sqlalchemy.exc import MissingGreenlet
 
 from src.models.contracts.agents import ToolResult
 from src.repositories.knowledge import KnowledgeDocument
@@ -414,16 +415,33 @@ class TestWorkflowToolIdResolution:
 
     @pytest.mark.asyncio
     async def test_execute_tool_uses_id_lookup_for_normalized_names(self, executor, mock_session):
-        """_execute_tool looks up workflows by ID when name is in _tool_workflow_id_map."""
+        """Workflow identity is captured before session exit and executed as an agent."""
         from src.services.llm.base import ToolCallRequest
 
         workflow_id = uuid4()
         executor._tool_workflow_id_map["wf_execute_halopsa_sql"] = workflow_id
 
-        # Mock the DB query to return a workflow
-        mock_workflow = MagicMock()
-        mock_workflow.id = workflow_id
-        mock_workflow.name = "Execute HaloPSA SQL"
+        class ExpiringWorkflow:
+            expired = False
+
+            @property
+            def id(self):
+                if self.expired:
+                    raise MissingGreenlet("workflow.id accessed after session exit")
+                return workflow_id
+
+            @property
+            def name(self):
+                if self.expired:
+                    raise MissingGreenlet("workflow.name accessed after session exit")
+                return "Execute HaloPSA SQL"
+
+        mock_workflow = ExpiringWorkflow()
+
+        async def expire_workflow_on_commit():
+            mock_workflow.expired = True
+
+        mock_session.commit.side_effect = expire_workflow_on_commit
 
         mock_result = MagicMock()
         mock_result.scalar_one_or_none.return_value = mock_workflow
@@ -453,6 +471,12 @@ class TestWorkflowToolIdResolution:
             await executor._execute_tool(
                 tool_call, agent=mock_agent, conversation=mock_conversation
             )
+
+        execution_kwargs = mock_exec.await_args.kwargs
+        assert mock_workflow.expired is True
+        assert execution_kwargs["workflow_id"] == str(workflow_id)
+        assert execution_kwargs["workflow_name"] == "Execute HaloPSA SQL"
+        assert execution_kwargs["is_agent"] is True
 
         # Verify the DB query used Workflow.id, not Workflow.name
         call_args = mock_session.execute.call_args


### PR DESCRIPTION
## Summary
- capture workflow identity while its async DB session is still active
- execute chat workflow tools with agent context
- add a regression that raises `MissingGreenlet` on post-session ORM access

## Verification
- `./test.sh tests/unit/services/test_agent_executor_tools.py -v` (36 passed)
- `./test.sh quality api`

## Follow-up
After this patch is merged and verified, unify chat, autonomous-agent, and MCP-agent workflow tool dispatch behind one shared adapter.