### PR TITLE
Unify agent workflow-tool dispatch

### DIFF
--- a/api/src/services/agent_executor.py
+++ b/api/src/services/agent_executor.py
@@ -73,6 +73,10 @@ from src.services.execution.agent_helpers import (
     parse_mcp_tool_name,
     resolve_agent_tools,
 )
+from src.services.execution.agent_workflow_tools import (
+    AgentWorkflowCaller,
+    execute_agent_workflow_tool,
+)
 from src.services.execution.autonomous_agent_executor import (
     AutonomousAgentExecutor,
     ToolError,
@@ -1359,22 +1363,20 @@ class AgentExecutor:
             # Get user info from conversation
             user = conversation.user if conversation else None
 
-            # Execute the workflow via execution service
-            from src.services.execution.service import execute_tool
-
             # Get org_id from agent (workflows are not org-scoped)
             org_id = str(agent.organization_id) if agent and agent.organization_id else None
 
-            execution_response = await execute_tool(
+            execution_response = await execute_agent_workflow_tool(
                 workflow_id=resolved_workflow_id,
                 workflow_name=resolved_workflow_name,
                 parameters=tool_call.arguments or {},
-                user_id=str(user.id) if user else "system",
-                user_email=user.email if user else "system@internal.gobifrost.com",
-                user_name=user.name if user else "System",
-                org_id=org_id,
-                is_platform_admin=user.is_superuser if user else False,
-                is_agent=True,
+                caller=AgentWorkflowCaller(
+                    user_id=str(user.id) if user else "system",
+                    email=user.email if user else "system@internal.gobifrost.com",
+                    name=user.name if user else "System",
+                    is_platform_admin=user.is_superuser if user else False,
+                ),
+                organization_id=org_id,
                 execution_id=execution_id,
                 artifact_workspace_id=str(conversation.id) if conversation else None,
             )

--- a/api/src/services/execution/agent_workflow_tools.py
+++ b/api/src/services/execution/agent_workflow_tools.py
@@ -1,0 +1,47 @@
+"""Shared execution boundary for workflow-backed agent tools."""
+
+from dataclasses import dataclass
+from typing import Any
+from uuid import UUID
+
+from src.models.contracts.executions import WorkflowExecutionResponse
+
+
+@dataclass(frozen=True)
+class AgentWorkflowCaller:
+    """Caller identity propagated into an agent-originated workflow run."""
+
+    user_id: str
+    email: str
+    name: str
+    is_platform_admin: bool = False
+
+
+async def execute_agent_workflow_tool(
+    *,
+    workflow_id: UUID | str,
+    workflow_name: str,
+    parameters: dict[str, Any],
+    caller: AgentWorkflowCaller,
+    organization_id: UUID | str | None,
+    execution_id: str | None = None,
+    artifact_workspace_id: str | None = None,
+    sync: bool = True,
+) -> WorkflowExecutionResponse:
+    """Execute a workflow tool with one canonical agent execution context."""
+    from src.services.execution.service import execute_tool
+
+    return await execute_tool(
+        workflow_id=str(workflow_id),
+        workflow_name=workflow_name,
+        parameters=parameters,
+        user_id=caller.user_id,
+        user_email=caller.email,
+        user_name=caller.name,
+        org_id=str(organization_id) if organization_id else None,
+        is_platform_admin=caller.is_platform_admin,
+        is_agent=True,
+        execution_id=execution_id,
+        artifact_workspace_id=artifact_workspace_id,
+        sync=sync,
+    )

--- a/api/src/services/execution/autonomous_agent_executor.py
+++ b/api/src/services/execution/autonomous_agent_executor.py
@@ -38,6 +38,10 @@ from src.services.execution.agent_helpers import (
     parse_mcp_tool_name,
     resolve_agent_tools,
 )
+from src.services.execution.agent_workflow_tools import (
+    AgentWorkflowCaller,
+    execute_agent_workflow_tool,
+)
 from src.services.agent_runtime import (
     AgentRunBudget,
     AgentRunCancelled,
@@ -537,38 +541,37 @@ class AutonomousAgentExecutor:
         if not workflow_id:
             raise ToolError(f"Unknown tool: {tool_call.name}")
 
-        from src.services.execution.service import execute_tool
-
-        response = await execute_tool(
-            workflow_id=str(workflow_id),
+        response = await execute_agent_workflow_tool(
+            workflow_id=workflow_id,
             workflow_name=tool_call.name,
             parameters=tool_call.arguments or {},
-            user_id=(
-                str(self._caller_user_id)
-                if self._caller_user_id
-                else SYSTEM_USER_ID
+            caller=AgentWorkflowCaller(
+                user_id=(
+                    str(self._caller_user_id)
+                    if self._caller_user_id
+                    else SYSTEM_USER_ID
+                ),
+                email=(
+                    str(self._caller.get("email"))
+                    if self._caller_user_id
+                    and self._caller
+                    and self._caller.get("email")
+                    else SYSTEM_USER_EMAIL
+                ),
+                name=(
+                    str(self._caller.get("name"))
+                    if self._caller_user_id
+                    and self._caller
+                    and self._caller.get("name")
+                    else agent.name
+                ),
+                is_platform_admin=(
+                    bool(self._caller.get("is_platform_admin", False))
+                    if self._caller_user_id and self._caller
+                    else False
+                ),
             ),
-            user_email=(
-                str(self._caller.get("email"))
-                if self._caller_user_id
-                and self._caller
-                and self._caller.get("email")
-                else SYSTEM_USER_EMAIL
-            ),
-            user_name=(
-                str(self._caller.get("name"))
-                if self._caller_user_id
-                and self._caller
-                and self._caller.get("name")
-                else agent.name
-            ),
-            org_id=str(agent.organization_id) if agent.organization_id else None,
-            is_platform_admin=(
-                bool(self._caller.get("is_platform_admin", False))
-                if self._caller_user_id and self._caller
-                else False
-            ),
-            is_agent=True,
+            organization_id=agent.organization_id,
             artifact_workspace_id=(
                 self._ancestor_run_ids[0]
                 if self._ancestor_run_ids

--- a/api/src/services/mcp_server/gateway.py
+++ b/api/src/services/mcp_server/gateway.py
@@ -28,6 +28,10 @@ from src.services.execution.agent_helpers import (
     parse_mcp_tool_name,
     resolve_agent_tools,
 )
+from src.services.execution.agent_workflow_tools import (
+    AgentWorkflowCaller,
+    execute_agent_workflow_tool,
+)
 from src.services.llm import ToolDefinition
 from src.services.mcp_client import dispatch as mcp_dispatch
 from src.services.mcp_client.errors import (
@@ -1225,23 +1229,22 @@ class MCPAgentGatewayService:
         *,
         async_execution: bool = False,
     ) -> Any:
-        from src.services.execution.service import execute_tool
-
         if tool.source_id is None:
             raise GatewayError(
                 "TOOL_EXECUTION_FAILED",
                 "Workflow identity is missing.",
             )
-        response = await execute_tool(
-            workflow_id=str(tool.source_id),
+        response = await execute_agent_workflow_tool(
+            workflow_id=tool.source_id,
             workflow_name=tool.definition.name,
             parameters=arguments,
-            user_id=str(self.context.user_id),
-            user_email=self.context.user_email,
-            user_name=self.context.user_name or "MCP User",
-            org_id=str(self.context.org_id) if self.context.org_id else None,
-            is_platform_admin=self.context.is_platform_admin,
-            is_agent=True,
+            caller=AgentWorkflowCaller(
+                user_id=str(self.context.user_id),
+                email=self.context.user_email,
+                name=self.context.user_name or "MCP User",
+                is_platform_admin=self.context.is_platform_admin,
+            ),
+            organization_id=self.context.org_id,
             sync=not async_execution,
         )
         data = {

--- a/api/tests/e2e/api/test_agent_workflow_tool_execution.py
+++ b/api/tests/e2e/api/test_agent_workflow_tool_execution.py
@@ -1,0 +1,187 @@
+"""Live chat boundary coverage for workflow-backed agent tools."""
+
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import UUID, uuid4
+
+import pytest
+from pydantic_ai.messages import (
+    ModelMessage,
+    ModelRequest,
+    ModelResponse,
+    TextPart,
+    ToolCallPart,
+    ToolReturnPart,
+)
+from pydantic_ai.models import ModelRequestParameters
+from pydantic_ai.models.test import TestModel
+from pydantic_ai.settings import ModelSettings
+from sqlalchemy import select
+from sqlalchemy.orm import selectinload
+
+from src.core.principal import UserPrincipal
+from src.models.orm.agents import Agent, Conversation
+from src.services.agent_executor import AgentExecutor
+from src.services.llm.base import LLMConfig
+from src.services.llm.pydantic_client import PydanticAIClient
+from src.services.model_capabilities import manual_capabilities
+
+
+pytestmark = pytest.mark.asyncio
+
+
+class WorkflowToolTestModel(TestModel):
+    """Call one workflow tool, then acknowledge its completed result."""
+
+    def __init__(self, tool_name: str) -> None:
+        super().__init__(model_name="test-chat-workflow-tool")
+        self._tool_name = tool_name
+
+    def _request(
+        self,
+        messages: list[ModelMessage],
+        model_settings: ModelSettings | None,
+        model_request_parameters: ModelRequestParameters,
+    ) -> ModelResponse:
+        del model_settings, model_request_parameters
+        tool_completed = any(
+            isinstance(message, ModelRequest)
+            and any(isinstance(part, ToolReturnPart) for part in message.parts)
+            for message in messages
+        )
+        if not tool_completed:
+            return ModelResponse(
+                parts=[
+                    ToolCallPart(
+                        self._tool_name,
+                        {"query": "session boundary"},
+                        tool_call_id="workflow-tool-call",
+                    )
+                ],
+                model_name=self.model_name,
+            )
+        return ModelResponse(
+            parts=[TextPart("Workflow tool completed.")],
+            model_name=self.model_name,
+        )
+
+
+def _session_factory_for(session):
+    @asynccontextmanager
+    async def session_factory():
+        yield session
+
+    return session_factory
+
+
+async def test_chat_executes_workflow_tool_through_live_worker(
+    e2e_client,
+    platform_admin,
+    db_session,
+    test_agent_with_tools,
+):
+    agent_data = test_agent_with_tools["agent"]
+    workflow = test_agent_with_tools["workflow"]
+    conversation_response = e2e_client.post(
+        "/api/chat/conversations",
+        json={
+            "agent_id": agent_data["id"],
+            "channel": "chat",
+            "title": "Workflow tool session boundary",
+        },
+        headers=platform_admin.headers,
+    )
+    assert conversation_response.status_code == 201, conversation_response.text
+    conversation_id = UUID(conversation_response.json()["id"])
+
+    llm_client = PydanticAIClient(
+        LLMConfig(provider="openai", model="test-chat", api_key="test-key")
+    )
+    profile = MagicMock(id=uuid4(), name="Test chat workflow tool")
+    capabilities = manual_capabilities(
+        provider="openai",
+        model="test-chat",
+        endpoint=None,
+        image_input=False,
+        pdf_input=False,
+        tool_calling=True,
+    )
+
+    try:
+        with (
+            patch(
+                "src.services.agent_executor.get_llm_client",
+                new_callable=AsyncMock,
+                return_value=llm_client,
+            ),
+            patch(
+                "src.services.agent_executor.AIModelService.resolve_chat_profile",
+                new=AsyncMock(
+                    return_value=(
+                        profile,
+                        LLMConfig(
+                            provider="openai",
+                            model="test-chat",
+                            api_key="test-key",
+                        ),
+                        capabilities,
+                    )
+                ),
+            ),
+            patch(
+                "src.services.agent_executor.create_agent_model",
+                return_value=WorkflowToolTestModel(f"wf_{workflow['name']}"),
+            ),
+        ):
+            result = await db_session.execute(
+                select(Conversation)
+                .options(
+                    selectinload(Conversation.agent).selectinload(Agent.tools),
+                    selectinload(Conversation.agent).selectinload(
+                        Agent.delegated_agents
+                    ),
+                    selectinload(Conversation.user),
+                )
+                .where(Conversation.id == conversation_id)
+            )
+            conversation = result.scalar_one()
+            assert platform_admin.user_id is not None
+            principal = UserPrincipal(
+                user_id=platform_admin.user_id,
+                email=platform_admin.email,
+                name=platform_admin.name,
+                organization_id=platform_admin.organization_id,
+                is_superuser=platform_admin.is_superuser,
+            )
+            executor = AgentExecutor(_session_factory_for(db_session))
+            final_content = ""
+            async for chunk in executor.chat(
+                agent=conversation.agent,
+                conversation=conversation,
+                user_message="Run the workflow tool.",
+                stream=False,
+                enable_routing=False,
+                user=principal,
+            ):
+                if chunk.type == "done":
+                    final_content = chunk.content or ""
+
+        assert final_content == "Workflow tool completed."
+        messages_response = e2e_client.get(
+            f"/api/chat/conversations/{conversation_id}/messages",
+            headers=platform_admin.headers,
+        )
+        assert messages_response.status_code == 200, messages_response.text
+        tool_calls = [
+            message
+            for message in messages_response.json()
+            if message["role"] == "tool_call"
+        ]
+        assert len(tool_calls) == 1
+        assert tool_calls[0]["tool_state"] == "completed"
+        assert tool_calls[0]["tool_result"] == "result: session boundary"
+    finally:
+        e2e_client.delete(
+            f"/api/chat/conversations/{conversation_id}",
+            headers=platform_admin.headers,
+        )

--- a/api/tests/e2e/fixtures/entity_setup.py
+++ b/api/tests/e2e/fixtures/entity_setup.py
@@ -233,7 +233,7 @@ from bifrost import workflow
     description="E2E portable ref test tool",
     is_tool=True
 )
-def {workflow_name}(query: str) -> str:
+async def {workflow_name}(query: str) -> str:
     """Search for information."""
     return f"result: {{query}}"
 '''

--- a/api/tests/unit/services/execution/test_agent_workflow_tools.py
+++ b/api/tests/unit/services/execution/test_agent_workflow_tools.py
@@ -1,0 +1,56 @@
+"""Tests for the shared agent workflow-tool execution boundary."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from src.services.execution.agent_workflow_tools import (
+    AgentWorkflowCaller,
+    execute_agent_workflow_tool,
+)
+
+
+@pytest.mark.asyncio
+async def test_execute_agent_workflow_tool_builds_canonical_agent_context():
+    workflow_id = uuid4()
+    organization_id = uuid4()
+    response = MagicMock()
+    caller = AgentWorkflowCaller(
+        user_id=str(uuid4()),
+        email="person@example.com",
+        name="Person",
+        is_platform_admin=True,
+    )
+
+    with patch(
+        "src.services.execution.service.execute_tool",
+        new_callable=AsyncMock,
+        return_value=response,
+    ) as execute_tool:
+        result = await execute_agent_workflow_tool(
+            workflow_id=workflow_id,
+            workflow_name="ticket_lookup",
+            parameters={"ticket_id": 42},
+            caller=caller,
+            organization_id=organization_id,
+            execution_id="execution-1",
+            artifact_workspace_id="workspace-1",
+            sync=False,
+        )
+
+    assert result is response
+    execute_tool.assert_awaited_once_with(
+        workflow_id=str(workflow_id),
+        workflow_name="ticket_lookup",
+        parameters={"ticket_id": 42},
+        user_id=caller.user_id,
+        user_email=caller.email,
+        user_name=caller.name,
+        org_id=str(organization_id),
+        is_platform_admin=True,
+        is_agent=True,
+        execution_id="execution-1",
+        artifact_workspace_id="workspace-1",
+        sync=False,
+    )

--- a/api/tests/unit/services/test_autonomous_agent_executor.py
+++ b/api/tests/unit/services/test_autonomous_agent_executor.py
@@ -333,7 +333,9 @@ class TestAutonomousAgentExecutor:
             org_id=str(mock_agent.organization_id),
             is_platform_admin=True,
             is_agent=True,
+            execution_id=None,
             artifact_workspace_id=None,
+            sync=True,
         )
 
     @pytest.mark.asyncio
@@ -375,7 +377,9 @@ class TestAutonomousAgentExecutor:
             org_id=str(mock_agent.organization_id),
             is_platform_admin=False,
             is_agent=True,
+            execution_id=None,
             artifact_workspace_id=None,
+            sync=True,
         )
 
     @pytest.mark.asyncio


### PR DESCRIPTION
Closes #630

## Summary
- add one canonical adapter for workflow-backed agent tool execution
- migrate chat, autonomous agent, and MCP gateway workflow dispatch while preserving each surface's identity, artifact, sync, and result behavior
- add direct adapter coverage and a live chat-to-worker workflow regression test
- correct the reusable E2E agent-tool fixture to use an async workflow

## Verification
- `./test.sh quality api`
- `./test.sh tests/unit/services/execution/test_agent_workflow_tools.py tests/unit/services/test_agent_executor_tools.py tests/unit/services/test_autonomous_agent_executor.py tests/unit/services/mcp_server/test_gateway.py -v` (108 passed)
- `./test.sh tests/e2e/api/test_agent_workflow_tool_execution.py -v` (1 passed)

Broader backend and E2E suites were not run locally.