### PR TITLE
Improve solution deploy progress and failure diagnostics

### DIFF
--- a/api/bifrost/commands/solution.py
+++ b/api/bifrost/commands/solution.py
@@ -1891,8 +1891,9 @@ async def _poll_deploy_job(
     interval: float = 3.0,
     action: str = "Deploy",
     timeout_seconds: float = DEPLOY_JOB_TIMEOUT_SECONDS,
+    interactive: bool | None = None,
 ) -> int:
-    """Poll a deploy/install job until terminal, printing a heartbeat each tick.
+    """Poll a deploy/install job until terminal with TTY-aware progress.
 
     The deploy and install endpoints run the (often >30s) work as a background job
     and return immediately, so the CLI polls for the result instead of holding one
@@ -1901,10 +1902,44 @@ async def _poll_deploy_job(
 
     ``action`` is the verb used in the messages ("Deploy" / "Install"); the
     grammar assumes ``<action>ing`` reads naturally ("Deploying" / "Installing").
+    Interactive terminals get an in-place spinner between the three-second HTTP
+    polls. Redirected/CI output only receives durable phase and terminal lines.
     """
     gerund = f"{action[:-1]}ing" if action.endswith("e") else f"{action}ing"
+    if interactive is None:
+        interactive = bool(click.get_text_stream("stdout").isatty())
     start = time.monotonic()
     last_phase: str | None = None
+
+    async def _wait_for_next_poll() -> None:
+        if interval <= 0:
+            return
+        if not interactive:
+            await asyncio.sleep(interval)
+            return
+
+        frames = "|/-\\"
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + interval
+        width = 0
+        frame_index = 0
+        try:
+            while True:
+                remaining = deadline - loop.time()
+                if remaining <= 0:
+                    return
+                elapsed = int(time.monotonic() - start)
+                message = f"{frames[frame_index % len(frames)]} {gerund}... {elapsed}s"
+                width = max(width, len(message))
+                click.echo(f"\r{message}", nl=False)
+                frame_index += 1
+                await asyncio.sleep(min(0.08, remaining))
+        finally:
+            click.echo(f"\r{' ' * width}\r", nl=False)
+
+    def _job_details_url() -> str:
+        return f"{client.api_url.rstrip('/')}/api/platform-jobs/{job_id}"
+
     while True:
         resp = await client.get(f"/api/solutions/deploy-jobs/{job_id}")
         if resp.status_code != 200:
@@ -1913,6 +1948,7 @@ async def _poll_deploy_job(
                 f"({resp.status_code}): {resp.text[:200]}",
                 err=True,
             )
+            click.echo(f"Job details: {_job_details_url()}", err=True)
             return 1
         body = resp.json()
         status = body.get("status")
@@ -1928,6 +1964,13 @@ async def _poll_deploy_job(
             return 0
         if status == "failed":
             error = body.get("error") or "unknown error"
+            error_code: str | None = None
+            platform_response = await client.get(f"/api/platform-jobs/{job_id}")
+            if platform_response.status_code == 200:
+                platform_error = platform_response.json().get("error") or {}
+                if isinstance(platform_error, dict):
+                    error = platform_error.get("message") or error
+                    error_code = platform_error.get("code")
             # The build gates now surface as a failed job — re-attach the
             # deliberate-override hints so the operator knows how to proceed.
             if "older than installed" in error:
@@ -1943,7 +1986,9 @@ async def _poll_deploy_job(
                     f"{error}\nRe-run with --replace-secrets to overwrite "
                     "conflicting config values, or --replace-data for table data."
                 )
-            click.echo(f"{action} failed: {error}", err=True)
+            code_note = f" [{error_code}]" if error_code else ""
+            click.echo(f"{action} failed{code_note}: {error}", err=True)
+            click.echo(f"Job details: {_job_details_url()}", err=True)
             return 1
         phase = (body.get("result") or {}).get("phase")
         if isinstance(phase, str) and phase and phase != last_phase:
@@ -1956,10 +2001,9 @@ async def _poll_deploy_job(
                 f"(job {job_id}). Check the job status before retrying.",
                 err=True,
             )
+            click.echo(f"Job details: {_job_details_url()}", err=True)
             return 1
-        elapsed = int(elapsed_seconds)
-        click.echo(f"Still {gerund.lower()}... {elapsed}s")
-        await asyncio.sleep(interval)
+        await _wait_for_next_poll()
 
 
 # Vendoring modules/ + shared/ into a Solution can balloon the bundle; warn the
@@ -2210,7 +2254,10 @@ def deploy_cmd(
             extra_text_files=extra_text_files,
         )
 
-        click.echo("Uploading workspace zip...")
+        if prebuilt:
+            click.echo("Uploading workspace artifact (source + locally built app dist)...")
+        else:
+            click.echo("Uploading workspace artifact...")
         # Deploy is async server-side; the POST returns a job id quickly. We give
         # the upload itself a generous timeout (large bundles) but never block on
         # the deploy work — that is observed via the poll loop below.

--- a/api/bifrost/commands/solution.py
+++ b/api/bifrost/commands/solution.py
@@ -1965,12 +1965,15 @@ async def _poll_deploy_job(
         if status == "failed":
             error = body.get("error") or "unknown error"
             error_code: str | None = None
-            platform_response = await client.get(f"/api/platform-jobs/{job_id}")
-            if platform_response.status_code == 200:
-                platform_error = platform_response.json().get("error") or {}
-                if isinstance(platform_error, dict):
-                    error = platform_error.get("message") or error
-                    error_code = platform_error.get("code")
+            try:
+                platform_response = await client.get(f"/api/platform-jobs/{job_id}")
+                if platform_response.status_code == 200:
+                    platform_error = platform_response.json().get("error") or {}
+                    if isinstance(platform_error, dict):
+                        error = platform_error.get("message") or error
+                        error_code = platform_error.get("code")
+            except Exception:  # noqa: BLE001 - diagnostics must not mask deploy error
+                pass
             # The build gates now surface as a failed job — re-attach the
             # deliberate-override hints so the operator knows how to proceed.
             if "older than installed" in error:

--- a/api/src/routers/solutions.py
+++ b/api/src/routers/solutions.py
@@ -1468,7 +1468,7 @@ async def _run_deploy_job(
                 solution = await db.get(SolutionORM, solution_id)
                 if solution is None:
                     raise SolutionDeployConflict("Solution not found")
-                await _set_phase("parsing workspace zip and building app dist")
+                await _set_phase("validating bundle and applying resources")
                 result = await deploy_zip_to_solution_path(
                     db, solution, zip_path, force=force
                 )

--- a/api/tests/unit/test_cli_solution_deploy_phases.py
+++ b/api/tests/unit/test_cli_solution_deploy_phases.py
@@ -7,7 +7,7 @@ that gap stays instrumented:
   Scanning solution files...  ->  found N ... file(s)
   Vendoring shared dependencies...  ->  (vendored M | no shared dependencies)
   Bundle: ...
-  Uploading workspace zip...  ->  Deploying install ...
+  Uploading workspace artifact...  ->  Deploying install ...
 
 BifrostClient is mocked so no network/DB is touched. Deploying with a local
 binding and the default (vendoring-on) descriptor drives the no-shared-deps
@@ -111,7 +111,7 @@ def test_deploy_prints_each_phase(tmp_path) -> None:
     assert "found" in out and "python file(s)" in out
     assert "Vendoring shared dependencies..." in out
     assert "Bundle:" in out
-    assert "Uploading workspace zip..." in out
+    assert "Uploading workspace artifact..." in out
     assert "Deploying install" in out
 
 
@@ -237,6 +237,10 @@ def test_deploy_embeds_local_prebuild_without_mutating_workspace(tmp_path) -> No
         )
 
     assert result.exit_code == 0, result.output
+    assert (
+        "Uploading workspace artifact (source + locally built app dist)..."
+        in result.output
+    )
     deploy_call = next(
         kwargs for path, kwargs in captured["posts"] if path.endswith("/deploy")
     )

--- a/api/tests/unit/test_deploy_cli_poll.py
+++ b/api/tests/unit/test_deploy_cli_poll.py
@@ -94,6 +94,26 @@ def test_poll_surfaces_failure(capsys):
     assert "https://bifrost.example/api/platform-jobs/job-2" in combined
 
 
+def test_poll_preserves_failure_when_job_details_lookup_fails(capsys):
+    class DetailsFailureClient(_FakeClient):
+        async def get(self, path: str, **kwargs):  # noqa: ANN003
+            if path.startswith("/api/platform-jobs/"):
+                raise RuntimeError("job details unavailable")
+            return await super().get(path, **kwargs)
+
+    client = DetailsFailureClient(
+        {"status": "failed", "error": "bundle downgrade blocked"}
+    )
+
+    rc = _run(_poll_deploy_job(client, "job-details-fail", interval=0.0))
+
+    captured = capsys.readouterr()
+    combined = captured.out + captured.err
+    assert rc == 1
+    assert "bundle downgrade blocked" in combined
+    assert "https://bifrost.example/api/platform-jobs/job-details-fail" in combined
+
+
 def test_poll_install_action_reports_solution_id(capsys):
     """The install command reuses the poll loop with ``action="Install"``; on
     success it echoes the solution id the job's ``result`` carries."""

--- a/api/tests/unit/test_deploy_cli_poll.py
+++ b/api/tests/unit/test_deploy_cli_poll.py
@@ -1,9 +1,9 @@
-"""Unit: the CLI deploy poll loop prints a heartbeat + terminal status.
+"""Unit: the CLI deploy poll loop renders progress + terminal status.
 
 The deploy endpoint is async (Task 7) — the CLI POSTs, gets a job id, then
-polls ``GET /api/solutions/deploy-jobs/{id}`` until a terminal status. While the
-job is still running it prints ``Still deploying... Ns``; on success it prints
-``Deploy complete``; on failure it surfaces the server-captured error.
+polls ``GET /api/solutions/deploy-jobs/{id}`` until a terminal status. Interactive
+terminals animate one spinner line; redirected output stays stable. Failures
+surface the shared platform-job error and durable details URL.
 """
 from __future__ import annotations
 
@@ -25,13 +25,22 @@ class _FakeResponse:
 class _FakeClient:
     """Returns ``running`` for the first N status polls, then a terminal state."""
 
-    def __init__(self, terminal: dict, running_count: int = 2) -> None:
+    def __init__(
+        self,
+        terminal: dict,
+        running_count: int = 2,
+        platform_error: dict | None = None,
+    ) -> None:
         self._terminal = terminal
         self._running_left = running_count
+        self._platform_error = platform_error
         self.calls = 0
+        self.api_url = "https://bifrost.example"
 
     async def get(self, path: str, **kwargs):  # noqa: ANN003
         self.calls += 1
+        if path.startswith("/api/platform-jobs/"):
+            return _FakeResponse({"error": self._platform_error})
         if self._running_left > 0:
             self._running_left -= 1
             return _FakeResponse({"status": "running", "error": None})
@@ -42,25 +51,47 @@ def _run(coro):
     return asyncio.run(coro)
 
 
-def test_poll_prints_heartbeat_and_result(capsys):
+def test_poll_non_interactive_prints_only_result(capsys):
     client = _FakeClient(
         {"status": "succeeded", "error": None, "install_id": "abc"}
     )
-    rc = _run(_poll_deploy_job(client, "job-1", interval=0.0))
+    rc = _run(_poll_deploy_job(client, "job-1", interval=0.0, interactive=False))
     out = capsys.readouterr().out
     assert rc == 0
-    assert "Still deploying..." in out
+    assert "deploying..." not in out.lower()
+    assert "Deploy complete" in out
+
+
+def test_poll_interactive_animates_one_spinner_line(capsys):
+    client = _FakeClient(
+        {"status": "succeeded", "error": None}, running_count=1
+    )
+
+    rc = _run(_poll_deploy_job(client, "job-spin", interval=0.001, interactive=True))
+
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "\r| Deploying..." in out
+    assert "Still deploying" not in out
     assert "Deploy complete" in out
 
 
 def test_poll_surfaces_failure(capsys):
     client = _FakeClient(
-        {"status": "failed", "error": "manifest entry `diverged` mismatch"}
+        {"status": "failed", "error": "manifest entry `diverged` mismatch"},
+        platform_error={
+            "code": "solution_deploy_failed",
+            "message": "manifest entry `diverged` mismatch",
+            "retryable": False,
+        },
     )
     rc = _run(_poll_deploy_job(client, "job-2", interval=0.0))
     captured = capsys.readouterr()
     assert rc == 1
-    assert "diverged" in (captured.out + captured.err)
+    combined = captured.out + captured.err
+    assert "diverged" in combined
+    assert "solution_deploy_failed" in combined
+    assert "https://bifrost.example/api/platform-jobs/job-2" in combined
 
 
 def test_poll_install_action_reports_solution_id(capsys):
@@ -77,7 +108,7 @@ def test_poll_install_action_reports_solution_id(capsys):
     rc = _run(_poll_deploy_job(client, "job-i", interval=0.0, action="Install"))
     out = capsys.readouterr().out
     assert rc == 0
-    assert "Still installing..." in out
+    assert "Still installing..." not in out
     assert "Install complete: solution sol-123 (slug=acme)." in out
 
 


### PR DESCRIPTION
## Summary

- replace repeated three-second deploy/install heartbeat lines with a TTY-aware in-place spinner
- keep redirected and CI output stable, emitting only phases and terminal results
- surface structured platform-job errors and a durable job-details URL on failures and timeouts
- clarify that app dist is built locally and rename the misleading server phase

## Verification

- `./test.sh tests/unit/test_deploy_cli_poll.py tests/unit/test_cli_solution_deploy_phases.py tests/unit/routers/test_solution_deploy_jobs.py tests/unit/jobs/test_solution_deploy_platform_job.py -v` (18 passed)
- `./test.sh tests/unit/test_cli_solution_deploy_phases.py::test_deploy_embeds_local_prebuild_without_mutating_workspace -v` (1 passed after strengthening the output assertion)
- `./test.sh tests/unit/test_cli_surface_smoke.py tests/unit/test_skill_appendix_fresh.py -v` (117 passed)
- `./test.sh quality api` (Pyright and Ruff passed)

Broader backend unit/e2e, client Vitest, and Playwright suites were not run.

Fixes #637
