### PR TITLE
Audit file and table policy denials in Event Log

### DIFF
--- a/api/src/repositories/audit_logs.py
+++ b/api/src/repositories/audit_logs.py
@@ -11,10 +11,12 @@ from datetime import datetime
 from typing import Any
 from uuid import UUID
 
-from sqlalchemy import and_, or_, select
+from sqlalchemy import Text, and_, cast, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.models.orm.audit import AuditLog
+from src.models.orm.organizations import Organization
+from src.models.orm.users import User
 
 logger = logging.getLogger(__name__)
 
@@ -85,6 +87,9 @@ class AuditLogRepository:
 
         action_prefix: matches `action` by prefix (e.g. "user." matches
         "user.create", "user.update", etc.)
+        search: matches actor identity, organization, action, resource type,
+        IP address, or serialized event details so Event Log context such as
+        file paths and table names/IDs is searchable across every page.
         """
         limit = max(1, min(limit, 500))
 
@@ -104,10 +109,19 @@ class AuditLogRepository:
             query = query.where(AuditLog.created_at <= end_date)
         if search:
             like = f"%{search}%"
+            query = query.outerjoin(User, User.id == AuditLog.user_id).outerjoin(
+                Organization,
+                Organization.id == AuditLog.organization_id,
+            )
             query = query.where(
                 or_(
+                    User.email.ilike(like),
+                    User.name.ilike(like),
+                    Organization.name.ilike(like),
                     AuditLog.action.ilike(like),
                     AuditLog.resource_type.ilike(like),
+                    AuditLog.ip_address.ilike(like),
+                    cast(AuditLog.details, Text).ilike(like),
                 )
             )
 

--- a/api/src/routers/audit.py
+++ b/api/src/routers/audit.py
@@ -38,7 +38,10 @@ async def list_audit_logs(
     user_id: UUID | None = Query(None, description="Filter by acting user ID"),
     start_date: datetime | None = Query(None, description="Start of time range (inclusive)"),
     end_date: datetime | None = Query(None, description="End of time range (inclusive)"),
-    search: str | None = Query(None, description="Free-text search on action/resource_type"),
+    search: str | None = Query(
+        None,
+        description="Free-text search on actor, organization, action, resource type, IP address, and event details",
+    ),
     limit: int = Query(50, ge=1, le=500),
     continuation_token: str | None = Query(None, description="Pagination cursor"),
 ) -> AuditLogListResponse:

--- a/api/src/routers/files.py
+++ b/api/src/routers/files.py
@@ -50,7 +50,7 @@ from src.models import (
     SearchResponse,
     WorkflowIdConflict,
 )
-from src.services.audit import emit_audit
+from src.services.audit import emit_file_policy_deny
 from src.services.editor.search import search_files_db
 from src.services.file_backend import get_backend
 from src.services.file_storage import FileStorageService
@@ -461,16 +461,13 @@ async def _deny_file_policy(
     HTTPException propagate rolls back the request-scoped session and loses
     the audit row.
     """
-    await emit_audit(
+    await emit_file_policy_deny(
         ctx.db,
-        "policy.deny",
-        resource_type="file",
-        outcome="failure",
-        details={
-            "policy_action": action,
-            "location": location,
-            "path": path,
-        },
+        policy_action=action,
+        location=location,
+        path=path,
+        scope=scope,
+        solution_id=solution_id,
     )
     await ctx.db.commit()
     # A policy denial must identify its scope inputs (no user/token data —

--- a/api/src/routers/tables.py
+++ b/api/src/routers/tables.py
@@ -64,7 +64,7 @@ from src.services.solution_scope import (
 from src.services.table_policy_loader import load_resolved_table_policies
 from src.repositories.tables import TableRepository
 from src.core.pubsub import publish_document_change, publish_policy_changed
-from src.services.audit import emit_audit
+from src.services.audit import emit_table_policy_deny
 
 logger = logging.getLogger(__name__)
 
@@ -168,17 +168,12 @@ async def _check_action_or_403(
         except (ValueError, TypeError):
             resource_id = None
 
-    await emit_audit(
+    await emit_table_policy_deny(
         db,
-        "policy.deny",
-        resource_type="table_document",
+        policy_action=action,
+        table_id=table.id,
+        table_name=table.name,
         resource_id=resource_id,
-        outcome="failure",
-        details={
-            "policy_action": action,
-            "table_id": str(table.id),
-            "table_name": table.name,
-        },
     )
     # Commit the audit row now — if we let the HTTPException propagate
     # without committing, the request-scoped session rolls back and the

--- a/api/src/routers/websocket.py
+++ b/api/src/routers/websocket.py
@@ -33,7 +33,7 @@ from src.models.contracts.policies import FileAction
 from src.models.orm import Agent
 from src.models.orm.applications import Application
 from src.models.orm.tables import Table as TableOrm
-from src.services.audit import emit_file_policy_deny
+from src.services.audit import emit_file_policy_deny, emit_table_policy_deny
 from src.services.audit_context import ActorContext
 
 logger = logging.getLogger(__name__)
@@ -425,6 +425,11 @@ async def _authorize_table_subscribe(
 
     await _populate_user_roles(user)
     if not is_subscribe_authorized(policies, user):
+        await _emit_table_subscribe_denial(
+            websocket=websocket,
+            user=user,
+            table_id=UUID(canonical_id),
+        )
         await websocket.send_json({
             "type": "error",
             "channel": spec.name,
@@ -616,20 +621,7 @@ async def _emit_file_subscribe_denial(
     scope: str | None,
 ) -> None:
     """Persist a WebSocket denial through the same Event Log path as REST."""
-    forwarded = websocket.headers.get("x-forwarded-for")
-    ip_address = (
-        forwarded.split(",", 1)[0].strip()
-        if forwarded
-        else websocket.client.host if websocket.client else "unknown"
-    )
-    actor = ActorContext(
-        user_id=user.user_id,
-        organization_id=user.organization_id,
-        email=user.email,
-        name=user.name,
-        ip_address=ip_address,
-        user_agent=websocket.headers.get("user-agent"),
-    )
+    actor = _websocket_actor(websocket, user)
     async with get_db_context() as db:
         await emit_file_policy_deny(
             db,
@@ -639,6 +631,46 @@ async def _emit_file_subscribe_denial(
             scope=scope,
             solution_id=None,
             actor_override=actor,
+        )
+
+
+def _websocket_actor(websocket: WebSocket, user: UserPrincipal) -> ActorContext:
+    """Build the HTTP-equivalent audit actor for an upgraded connection."""
+    forwarded = websocket.headers.get("x-forwarded-for")
+    ip_address = (
+        forwarded.split(",", 1)[0].strip()
+        if forwarded
+        else websocket.client.host if websocket.client else "unknown"
+    )
+    return ActorContext(
+        user_id=user.user_id,
+        organization_id=user.organization_id,
+        email=user.email,
+        name=user.name,
+        ip_address=ip_address,
+        user_agent=websocket.headers.get("user-agent"),
+    )
+
+
+async def _emit_table_subscribe_denial(
+    *,
+    websocket: WebSocket,
+    user: UserPrincipal,
+    table_id: UUID,
+) -> None:
+    """Persist a table subscribe denial through the canonical Event Log path."""
+    async with get_db_context() as db:
+        table_name = await db.scalar(
+            select(TableOrm.name).where(TableOrm.id == table_id)
+        )
+        if table_name is None:
+            return
+        await emit_table_policy_deny(
+            db,
+            policy_action="subscribe",
+            table_id=table_id,
+            table_name=table_name,
+            actor_override=_websocket_actor(websocket, user),
         )
 
 

--- a/api/src/routers/websocket.py
+++ b/api/src/routers/websocket.py
@@ -33,6 +33,8 @@ from src.models.contracts.policies import FileAction
 from src.models.orm import Agent
 from src.models.orm.applications import Application
 from src.models.orm.tables import Table as TableOrm
+from src.services.audit import emit_file_policy_deny
+from src.services.audit_context import ActorContext
 
 logger = logging.getLogger(__name__)
 
@@ -552,6 +554,13 @@ async def _authorize_file_subscribe(
         requested_scope=spec.scope,
     )
     if scope_result is None:
+        await _emit_file_subscribe_denial(
+            websocket=websocket,
+            user=user,
+            location=location,
+            path=prefix,
+            scope=spec.scope,
+        )
         await websocket.send_json({
             "type": "error",
             "channel": spec.name,
@@ -566,6 +575,13 @@ async def _authorize_file_subscribe(
         location=location,
         path=prefix,
     ):
+        await _emit_file_subscribe_denial(
+            websocket=websocket,
+            user=user,
+            location=location,
+            path=prefix,
+            scope=scope,
+        )
         await websocket.send_json({
             "type": "error",
             "channel": spec.name,
@@ -589,6 +605,41 @@ async def _authorize_file_subscribe(
     if not hasattr(websocket, "_file_dispatcher"):
         websocket._file_dispatcher = _make_file_dispatcher(websocket, user)  # type: ignore[attr-defined]
     return canonical_channel
+
+
+async def _emit_file_subscribe_denial(
+    *,
+    websocket: WebSocket,
+    user: UserPrincipal,
+    location: str,
+    path: str,
+    scope: str | None,
+) -> None:
+    """Persist a WebSocket denial through the same Event Log path as REST."""
+    forwarded = websocket.headers.get("x-forwarded-for")
+    ip_address = (
+        forwarded.split(",", 1)[0].strip()
+        if forwarded
+        else websocket.client.host if websocket.client else "unknown"
+    )
+    actor = ActorContext(
+        user_id=user.user_id,
+        organization_id=user.organization_id,
+        email=user.email,
+        name=user.name,
+        ip_address=ip_address,
+        user_agent=websocket.headers.get("user-agent"),
+    )
+    async with get_db_context() as db:
+        await emit_file_policy_deny(
+            db,
+            policy_action="subscribe",
+            location=location,
+            path=path,
+            scope=scope,
+            solution_id=None,
+            actor_override=actor,
+        )
 
 
 async def _handle_file_message(

--- a/api/src/services/audit.py
+++ b/api/src/services/audit.py
@@ -137,3 +137,28 @@ async def emit_file_policy_deny(
         },
         actor_override=actor_override,
     )
+
+
+async def emit_table_policy_deny(
+    db: AsyncSession,
+    *,
+    policy_action: str,
+    table_id: UUID,
+    table_name: str,
+    resource_id: UUID | None = None,
+    actor_override: ActorContext | None = None,
+) -> None:
+    """Emit the canonical Event Log payload for a denied table operation."""
+    await emit_audit(
+        db,
+        "policy.deny",
+        resource_type="table_document",
+        resource_id=resource_id,
+        outcome="failure",
+        details={
+            "policy_action": policy_action,
+            "table_id": str(table_id),
+            "table_name": table_name,
+        },
+        actor_override=actor_override,
+    )

--- a/api/src/services/audit.py
+++ b/api/src/services/audit.py
@@ -110,3 +110,30 @@ async def emit_audit(
             exc,
             exc_info=True,
         )
+
+
+async def emit_file_policy_deny(
+    db: AsyncSession,
+    *,
+    policy_action: str,
+    location: str,
+    path: str,
+    scope: str | None,
+    solution_id: UUID | None,
+    actor_override: ActorContext | None = None,
+) -> None:
+    """Emit the canonical Event Log payload for a denied file operation."""
+    await emit_audit(
+        db,
+        "policy.deny",
+        resource_type="file",
+        outcome="failure",
+        details={
+            "policy_action": policy_action,
+            "location": location,
+            "path": path,
+            "scope": scope,
+            "solution_id": str(solution_id) if solution_id else None,
+        },
+        actor_override=actor_override,
+    )

--- a/api/tests/e2e/api/test_audit_log.py
+++ b/api/tests/e2e/api/test_audit_log.py
@@ -8,7 +8,11 @@ Covers:
 - Access control (non-platform-admin denied)
 """
 
+from uuid import uuid4
+
 import pytest
+
+from src.models.orm.audit import AuditLog
 
 
 @pytest.mark.e2e
@@ -106,6 +110,53 @@ class TestAuditLogEmission:
         assert resp.status_code == 200
         for entry in resp.json()["entries"]:
             assert entry["outcome"] == "success"
+
+    @pytest.mark.asyncio
+    async def test_search_matches_file_path_and_table_context(
+        self,
+        e2e_client,
+        platform_admin,
+        db_session,
+    ):
+        path = f"reports/deny-{uuid4().hex}.csv"
+        table_name = f"customers_{uuid4().hex[:8]}"
+        db_session.add_all([
+            AuditLog(
+                action="policy.deny",
+                user_id=platform_admin.user_id,
+                organization_id=None,
+                resource_type="file",
+                outcome="failure",
+                source="http",
+                details={"path": path, "location": "reports"},
+            ),
+            AuditLog(
+                action="policy.deny",
+                user_id=platform_admin.user_id,
+                organization_id=None,
+                resource_type="table_document",
+                outcome="failure",
+                source="http",
+                details={"table_name": table_name, "table_id": str(uuid4())},
+            ),
+        ])
+        await db_session.commit()
+
+        for needle, expected_context in (
+            (path, path),
+            (table_name, table_name),
+            (platform_admin.email, path),
+        ):
+            response = e2e_client.get(
+                "/api/audit",
+                headers=platform_admin.headers,
+                params={"search": needle},
+            )
+            assert response.status_code == 200, response.text
+            assert any(
+                entry["details"] and expected_context in str(entry["details"])
+                for entry in response.json()["entries"]
+            )
 
 
 @pytest.mark.e2e

--- a/api/tests/e2e/api/test_builtin_events.py
+++ b/api/tests/e2e/api/test_builtin_events.py
@@ -332,9 +332,17 @@ class TestBuiltInIntegrationEvents:
         await db_session.refresh(token)
 
         try:
+            import src.core.redis_client as redis_module
+            from src.jobs.rabbitmq import rabbitmq
             from src.routers.oauth_connections import _apply_callback_to_mapping
             from src.routers import integrations
             from src.services import oauth_provider
+
+            # Source/workflow setup above runs through TestClient, while the
+            # emitter below runs on pytest-asyncio's function-scoped loop.
+            # Rebuild loop-bound clients before crossing that boundary.
+            redis_module._redis_client = None
+            rabbitmq.reset_pools()
 
             await _apply_callback_to_mapping(
                 db_session,

--- a/api/tests/e2e/platform/test_file_policies_rest.py
+++ b/api/tests/e2e/platform/test_file_policies_rest.py
@@ -253,9 +253,13 @@ def test_denied_read_emits_policy_deny_audit_row(
     assert entry["action"] == "policy.deny"
     assert entry["resource_type"] == "file"
     assert entry["outcome"] == "failure"
-    assert entry["details"]["policy_action"] == "read"
-    assert entry["details"]["location"] == location
-    assert entry["details"]["path"] == path
+    assert entry["details"] == {
+        "policy_action": "read",
+        "location": location,
+        "path": path,
+        "scope": scope,
+        "solution_id": None,
+    }
 
 
 @pytest.mark.e2e
@@ -286,9 +290,13 @@ def test_denied_write_emits_exactly_one_policy_deny_audit_row(
     assert entry["action"] == "policy.deny"
     assert entry["resource_type"] == "file"
     assert entry["outcome"] == "failure"
-    assert entry["details"]["policy_action"] == "write"
-    assert entry["details"]["location"] == location
-    assert entry["details"]["path"] == path
+    assert entry["details"] == {
+        "policy_action": "write",
+        "location": location,
+        "path": path,
+        "scope": scope,
+        "solution_id": None,
+    }
 
 
 @pytest.mark.e2e

--- a/api/tests/e2e/platform/test_file_websocket_subscriptions.py
+++ b/api/tests/e2e/platform/test_file_websocket_subscriptions.py
@@ -53,19 +53,114 @@ async def _put_allow_policy(client: httpx.AsyncClient, headers: dict, *, locatio
     assert resp.status_code == 200, resp.text
 
 
+async def _policy_deny_rows(
+    client: httpx.AsyncClient,
+    headers: dict,
+    *,
+    user_id: str,
+) -> list[dict]:
+    response = await client.get(
+        "/api/audit",
+        headers=headers,
+        params={
+            "action": "policy.deny",
+            "resource_type": "file",
+            "user_id": user_id,
+            "limit": 50,
+        },
+    )
+    assert response.status_code == 200, response.text
+    return response.json()["entries"]
+
+
 @pytest.mark.e2e
 @pytest.mark.asyncio
-async def test_file_subscribe_without_policy_is_rejected(org1_user, org1):
+async def test_file_subscribe_without_policy_is_rejected_and_audited(
+    platform_admin,
+    org1_user,
+    org1,
+):
     location = f"wssub-{uuid.uuid4().hex[:8]}"
     channel = f"files:{location}:gallery"
 
-    ws, ack = await _ws_subscribe(org1_user.access_token, channel, scope=org1["id"])
-    try:
-        assert ack.get("type") == "error", ack
-        assert ack.get("channel") == channel
-        assert ack.get("message") == "Access denied"
-    finally:
-        await ws.close()
+    async with httpx.AsyncClient(base_url=TEST_API_URL) as client:
+        before = len(
+            await _policy_deny_rows(
+                client,
+                platform_admin.headers,
+                user_id=str(org1_user.user_id),
+            )
+        )
+        ws, ack = await _ws_subscribe(
+            org1_user.access_token,
+            channel,
+            scope=org1["id"],
+        )
+        try:
+            assert ack.get("type") == "error", ack
+            assert ack.get("channel") == channel
+            assert ack.get("message") == "Access denied"
+        finally:
+            await ws.close()
+
+        rows = await _policy_deny_rows(
+            client,
+            platform_admin.headers,
+            user_id=str(org1_user.user_id),
+        )
+        assert len(rows) == before + 1
+        assert rows[0]["details"] == {
+            "policy_action": "subscribe",
+            "location": location,
+            "path": "gallery",
+            "scope": org1["id"],
+            "solution_id": None,
+        }
+
+
+@pytest.mark.e2e
+@pytest.mark.asyncio
+async def test_file_subscribe_scope_denial_is_audited(
+    platform_admin,
+    org1_user,
+    org2,
+):
+    location = f"wssub-{uuid.uuid4().hex[:8]}"
+    channel = f"files:{location}:gallery"
+
+    async with httpx.AsyncClient(base_url=TEST_API_URL) as client:
+        before = len(
+            await _policy_deny_rows(
+                client,
+                platform_admin.headers,
+                user_id=str(org1_user.user_id),
+            )
+        )
+        ws, ack = await _ws_subscribe(
+            org1_user.access_token,
+            channel,
+            scope=org2["id"],
+        )
+        try:
+            assert ack.get("type") == "error", ack
+            assert ack.get("channel") == channel
+            assert ack.get("message") == "Access denied"
+        finally:
+            await ws.close()
+
+        rows = await _policy_deny_rows(
+            client,
+            platform_admin.headers,
+            user_id=str(org1_user.user_id),
+        )
+        assert len(rows) == before + 1
+        assert rows[0]["details"] == {
+            "policy_action": "subscribe",
+            "location": location,
+            "path": "gallery",
+            "scope": org2["id"],
+            "solution_id": None,
+        }
 
 
 @pytest.mark.e2e

--- a/api/tests/e2e/platform/test_solution_file_scope.py
+++ b/api/tests/e2e/platform/test_solution_file_scope.py
@@ -478,6 +478,61 @@ async def test_solution_app_files_resolve_to_install_scope(
 
 @pytest.mark.e2e
 @pytest.mark.asyncio
+async def test_solution_file_policy_denial_audits_install_scope(
+    e2e_client,
+    platform_admin,
+    org1,
+    db_session,
+):
+    solution = _create_solution(
+        e2e_client,
+        platform_admin.headers,
+        f"file-deny-audit-{uuid.uuid4().hex[:8]}",
+        org_id=org1["id"],
+    )
+    solution_id = solution["id"]
+    location = f"reports-{uuid.uuid4().hex[:8]}"
+    path = f"denied/{uuid.uuid4().hex}.txt"
+    await _declare_file_location(db_session, solution_id, location)
+
+    denied = e2e_client.post(
+        f"/api/files/write?solution={solution_id}",
+        headers=platform_admin.headers,
+        json={
+            "location": location,
+            "path": path,
+            "content": "blocked",
+            "mode": "cloud",
+        },
+    )
+    assert denied.status_code == 403, denied.text
+
+    audit = e2e_client.get(
+        "/api/audit",
+        headers=platform_admin.headers,
+        params={
+            "action": "policy.deny",
+            "resource_type": "file",
+            "user_id": str(platform_admin.user_id),
+            "limit": 50,
+        },
+    )
+    assert audit.status_code == 200, audit.text
+    entry = next(
+        row for row in audit.json()["entries"]
+        if row["details"].get("path") == path
+    )
+    assert entry["details"] == {
+        "policy_action": "write",
+        "location": location,
+        "path": path,
+        "scope": solution_id,
+        "solution_id": solution_id,
+    }
+
+
+@pytest.mark.e2e
+@pytest.mark.asyncio
 async def test_solution_app_read_requires_declared_file_location(
     e2e_client,
     platform_admin,

--- a/api/tests/e2e/platform/test_subscriptions.py
+++ b/api/tests/e2e/platform/test_subscriptions.py
@@ -42,6 +42,26 @@ async def _ws_subscribe(user_token: str, channels: list):
     return ws, ack
 
 
+async def _policy_deny_rows(
+    client: httpx.AsyncClient,
+    headers: dict,
+    *,
+    user_id: str,
+) -> list[dict]:
+    response = await client.get(
+        "/api/audit",
+        headers=headers,
+        params={
+            "action": "policy.deny",
+            "resource_type": "table_document",
+            "user_id": user_id,
+            "limit": 50,
+        },
+    )
+    assert response.status_code == 200, response.text
+    return response.json()["entries"]
+
+
 @pytest.mark.e2e
 @pytest.mark.asyncio
 async def test_subscribe_with_read_accepted(platform_admin, alice_user):
@@ -82,24 +102,49 @@ async def test_subscribe_with_read_accepted(platform_admin, alice_user):
 @pytest.mark.asyncio
 async def test_subscribe_without_read_rejected(platform_admin, alice_user):
     """Alice subscribes to a seeded-only table → rejected."""
+    table_name = f"sub_deny_{uuid.uuid4().hex[:8]}"
     async with httpx.AsyncClient(base_url=TEST_API_URL) as client:
         r = await client.post(
             "/api/tables",
             headers=platform_admin.headers,
             json={
-                "name": f"sub_deny_{uuid.uuid4().hex[:8]}",
+                "name": table_name,
                 "organization_id": None,
             },  # seeded admin_bypass only
         )
         assert r.status_code == 201, r.text
         table_id = r.json()["id"]
+        before = len(
+            await _policy_deny_rows(
+                client,
+                platform_admin.headers,
+                user_id=str(alice_user.user_id),
+            )
+        )
 
-    ws, ack = await _ws_subscribe(alice_user.access_token, [f"table:{table_id}"])
-    try:
-        assert ack.get("type") == "error", f"expected error ack, got {ack}"
-        assert ack.get("channel") == f"table:{table_id}"
-    finally:
-        await ws.close()
+        ws, ack = await _ws_subscribe(
+            alice_user.access_token,
+            [f"table:{table_id}"],
+        )
+        try:
+            assert ack.get("type") == "error", f"expected error ack, got {ack}"
+            assert ack.get("channel") == f"table:{table_id}"
+        finally:
+            await ws.close()
+
+        rows = await _policy_deny_rows(
+            client,
+            platform_admin.headers,
+            user_id=str(alice_user.user_id),
+        )
+        assert len(rows) == before + 1
+        assert rows[0]["action"] == "policy.deny"
+        assert rows[0]["outcome"] == "failure"
+        assert rows[0]["details"] == {
+            "policy_action": "subscribe",
+            "table_id": table_id,
+            "table_name": table_name,
+        }
 
 
 @pytest.mark.e2e

--- a/api/tests/unit/services/test_audit.py
+++ b/api/tests/unit/services/test_audit.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from src.services.audit import emit_audit
+from src.services.audit import emit_audit, emit_file_policy_deny
 from src.services.audit_context import (
     ActorContext,
     clear_actor,
@@ -180,3 +180,37 @@ class TestEmitAudit:
         )
 
         assert captured["user_id"] == bob_id
+
+
+@pytest.mark.asyncio
+async def test_file_policy_deny_uses_canonical_scope_payload(monkeypatch):
+    emitted = AsyncMock()
+    monkeypatch.setattr("src.services.audit.emit_audit", emitted)
+    solution_id = uuid4()
+    actor = ActorContext(user_id=uuid4(), organization_id=uuid4())
+    db = MagicMock()
+
+    await emit_file_policy_deny(
+        db,
+        policy_action="write",
+        location="reports",
+        path="quarterly/result.csv",
+        scope=str(solution_id),
+        solution_id=solution_id,
+        actor_override=actor,
+    )
+
+    emitted.assert_awaited_once_with(
+        db,
+        "policy.deny",
+        resource_type="file",
+        outcome="failure",
+        details={
+            "policy_action": "write",
+            "location": "reports",
+            "path": "quarterly/result.csv",
+            "scope": str(solution_id),
+            "solution_id": str(solution_id),
+        },
+        actor_override=actor,
+    )

--- a/api/tests/unit/services/test_audit.py
+++ b/api/tests/unit/services/test_audit.py
@@ -7,7 +7,11 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from src.services.audit import emit_audit, emit_file_policy_deny
+from src.services.audit import (
+    emit_audit,
+    emit_file_policy_deny,
+    emit_table_policy_deny,
+)
 from src.services.audit_context import (
     ActorContext,
     clear_actor,
@@ -211,6 +215,37 @@ async def test_file_policy_deny_uses_canonical_scope_payload(monkeypatch):
             "path": "quarterly/result.csv",
             "scope": str(solution_id),
             "solution_id": str(solution_id),
+        },
+        actor_override=actor,
+    )
+
+
+@pytest.mark.asyncio
+async def test_table_policy_deny_uses_canonical_table_payload(monkeypatch):
+    emitted = AsyncMock()
+    monkeypatch.setattr("src.services.audit.emit_audit", emitted)
+    table_id = uuid4()
+    actor = ActorContext(user_id=uuid4(), organization_id=uuid4())
+    db = MagicMock()
+
+    await emit_table_policy_deny(
+        db,
+        policy_action="subscribe",
+        table_id=table_id,
+        table_name="customers",
+        actor_override=actor,
+    )
+
+    emitted.assert_awaited_once_with(
+        db,
+        "policy.deny",
+        resource_type="table_document",
+        resource_id=None,
+        outcome="failure",
+        details={
+            "policy_action": "subscribe",
+            "table_id": str(table_id),
+            "table_name": "customers",
         },
         actor_override=actor,
     )

--- a/api/tests/unit/services/test_file_policy_service.py
+++ b/api/tests/unit/services/test_file_policy_service.py
@@ -747,17 +747,18 @@ async def test_require_file_policy_denial_emits_audit(monkeypatch, db_session) -
     )
     emitted: dict = {}
 
-    async def fake_emit(db, action, **kwargs):
-        emitted["action"] = action
+    async def fake_emit(db, **kwargs):
         emitted.update(kwargs)
 
-    monkeypatch.setattr(files_module, "emit_audit", fake_emit)
+    monkeypatch.setattr(files_module, "emit_file_policy_deny", fake_emit)
+
+    solution_id = uuid4()
 
     ctx = SimpleNamespace(
         db=db_session,
         user=_user(org.id),
         org_id=org.id,
-        solution_id=None,
+        solution_id=solution_id,
     )
 
     with pytest.raises(HTTPException) as exc:
@@ -765,18 +766,18 @@ async def test_require_file_policy_denial_emits_audit(monkeypatch, db_session) -
             ctx,  # type: ignore[arg-type]
             action="read",
             location="attachments",
-            scope=str(org.id),
+            scope=str(solution_id),
             path="private/doc.txt",
+            solution_id=solution_id,
         )
 
     assert exc.value.status_code == 403
-    assert emitted["action"] == "policy.deny"
-    assert emitted["resource_type"] == "file"
-    assert emitted["outcome"] == "failure"
-    assert emitted["details"] == {
+    assert emitted == {
         "policy_action": "read",
         "location": "attachments",
         "path": "private/doc.txt",
+        "scope": str(solution_id),
+        "solution_id": solution_id,
     }
 
 

--- a/client/e2e/audit-log.admin.spec.ts
+++ b/client/e2e/audit-log.admin.spec.ts
@@ -1,0 +1,39 @@
+import { expect, test, type Page } from "@playwright/test";
+
+async function createDeniedFileRead(page: Page, path: string) {
+	return page.evaluate(async (deniedPath) => {
+		const token = localStorage.getItem("bifrost_access_token");
+		const response = await fetch("/api/files/read", {
+			method: "POST",
+			headers: {
+				Authorization: `Bearer ${token}`,
+				"Content-Type": "application/json",
+			},
+			body: JSON.stringify({
+				location: "audit-browser",
+				scope: "global",
+				path: deniedPath,
+				mode: "cloud",
+			}),
+		});
+		return response.status;
+	}, path);
+}
+
+test("filters policy denials by file path", async ({ page }) => {
+	const path = `browser-denial-${Date.now()}.txt`;
+	await page.goto("/audit");
+	await expect(page.getByRole("heading", { name: "Audit Log" })).toBeVisible();
+	expect(await createDeniedFileRead(page, path)).toBe(403);
+
+	await page.getByRole("combobox", { name: "Action filter" }).click();
+	await page.getByRole("option", { name: "Policy denials" }).click();
+	await page.getByRole("combobox", { name: "Outcome filter" }).click();
+	await page.getByRole("option", { name: "Failure" }).click();
+	await page
+		.getByRole("searchbox", { name: "Search audit events" })
+		.fill(path);
+
+	await expect(page.getByText(`audit-browser / ${path}`)).toBeVisible();
+	await expect(page.getByText("policy.deny", { exact: true })).toBeVisible();
+});

--- a/client/src/pages/audit/AuditLogPage.test.tsx
+++ b/client/src/pages/audit/AuditLogPage.test.tsx
@@ -1,0 +1,114 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { renderWithProviders, screen, waitFor } from "@/test-utils";
+
+const mockUseAuditLog = vi.fn();
+
+vi.mock("@/hooks/useAuditLog", () => ({
+	useAuditLog: (params: unknown) => mockUseAuditLog(params),
+}));
+
+vi.mock("@/contexts/AuthContext", () => ({
+	useAuth: () => ({ isPlatformAdmin: true }),
+}));
+
+import { AuditLogPage } from "./AuditLogPage";
+
+const filePath = "denied/quarterly-result.csv";
+
+beforeEach(() => {
+	mockUseAuditLog.mockReturnValue({
+		data: {
+			entries: [
+				{
+					id: "11111111-1111-1111-1111-111111111111",
+					timestamp: "2026-08-25T12:00:00Z",
+					action: "policy.deny",
+					resource_type: "file",
+					resource_id: null,
+					outcome: "failure",
+					source: "http",
+					actor: {
+						user_id: "22222222-2222-2222-2222-222222222222",
+						user_email: "auditor@example.com",
+						user_name: "Auditor",
+						organization_id: null,
+						organization_name: null,
+					},
+					ip_address: "192.0.2.10",
+					user_agent: "vitest",
+					details: {
+						policy_action: "subscribe",
+						location: "reports",
+						path: filePath,
+						scope: "org-1",
+						solution_id: null,
+					},
+				},
+				{
+					id: "33333333-3333-3333-3333-333333333333",
+					timestamp: "2026-08-25T12:01:00Z",
+					action: "policy.deny",
+					resource_type: "table_document",
+					resource_id: null,
+					outcome: "failure",
+					source: "websocket",
+					actor: {
+						user_id: "55555555-5555-5555-5555-555555555555",
+						user_email: "subscriber@example.com",
+						user_name: "Subscriber",
+						organization_id: null,
+						organization_name: null,
+					},
+					ip_address: null,
+					user_agent: null,
+					details: {
+						policy_action: "subscribe",
+						table_name: "restricted_customers",
+						table_id: "44444444-4444-4444-4444-444444444444",
+					},
+				},
+			],
+			continuation_token: null,
+		},
+		isLoading: false,
+		error: null,
+		refetch: vi.fn(),
+	});
+});
+
+describe("AuditLogPage policy filters", () => {
+	it("shows denial context and searches it across the API result set", async () => {
+		const { user } = renderWithProviders(<AuditLogPage />);
+
+		expect(screen.getByText(`reports / ${filePath}`)).toBeInTheDocument();
+		expect(
+			screen.getByText(
+				"restricted_customers / 44444444-4444-4444-4444-444444444444",
+			),
+		).toBeInTheDocument();
+
+		await user.click(screen.getByRole("combobox", { name: "Action filter" }));
+		await user.click(
+			await screen.findByRole("option", { name: "Policy denials" }),
+		);
+		await user.click(screen.getByRole("combobox", { name: "Outcome filter" }));
+		await user.click(await screen.findByRole("option", { name: "Failure" }));
+		await user.type(
+			screen.getByRole("searchbox", { name: "Search audit events" }),
+			filePath,
+		);
+
+		await waitFor(() => {
+			expect(mockUseAuditLog).toHaveBeenLastCalledWith(
+				expect.objectContaining({
+						action: "policy.deny",
+						outcome: "failure",
+						search: filePath,
+				}),
+			);
+		});
+		expect(
+			screen.getByRole("button", { name: "Clear filters" }),
+		).toBeVisible();
+	});
+});

--- a/client/src/pages/audit/AuditLogPage.tsx
+++ b/client/src/pages/audit/AuditLogPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from "react";
+import { useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { useAuth } from "@/contexts/AuthContext";
 import { useAuditLog } from "@/hooks/useAuditLog";
@@ -39,7 +39,25 @@ const ACTION_GROUPS = [
 	{ value: "user.", label: "Users" },
 	{ value: "role.", label: "Roles" },
 	{ value: "organization.", label: "Organizations" },
+	{ value: "policy.deny", label: "Policy denials" },
 ];
+
+function auditContext(entry: AuditLogEntry): string {
+	const details = entry.details;
+	if (!details) return "-";
+
+	const path = typeof details.path === "string" ? details.path : null;
+	const location =
+		typeof details.location === "string" ? details.location : null;
+	if (path) return location ? `${location} / ${path}` : path;
+
+	const tableName =
+		typeof details.table_name === "string" ? details.table_name : null;
+	const tableId =
+		typeof details.table_id === "string" ? details.table_id : null;
+	if (tableName) return tableId ? `${tableName} / ${tableId}` : tableName;
+	return tableId ?? "-";
+}
 
 const OUTCOMES = [
 	{ value: "All", label: "All outcomes" },
@@ -59,33 +77,52 @@ export function AuditLogPage() {
 	const [continuationTokens, setContinuationTokens] = useState<string[]>([]);
 	const [currentPage, setCurrentPage] = useState(0);
 
+	const resetPagination = () => {
+		setContinuationTokens([]);
+		setCurrentPage(0);
+	};
+
+	const updateFilter = (setter: (value: string) => void, value: string) => {
+		setter(value);
+		resetPagination();
+	};
+
 	const queryParams = useMemo(() => {
 		const params: GetAuditLogParams = { limit: 50 };
 		if (actionGroup !== "All") params.action = actionGroup;
 		if (outcome !== "All") params.outcome = outcome;
+		if (searchText) params.search = searchText;
 		if (startDate) params.start_date = startDate;
 		if (endDate) params.end_date = endDate;
 		if (continuationTokens[currentPage])
 			params.continuation_token = continuationTokens[currentPage];
 		return params;
-	}, [actionGroup, outcome, startDate, endDate, currentPage, continuationTokens]);
+	}, [
+		actionGroup,
+		outcome,
+		searchText,
+		startDate,
+		endDate,
+		currentPage,
+		continuationTokens,
+	]);
 
 	const { data, isLoading, error, refetch } = useAuditLog(queryParams);
 
-	const filteredEntries = useMemo(() => {
-		if (!data?.entries) return [];
-		if (!searchText) return data.entries;
-		const q = searchText.toLowerCase();
-		return data.entries.filter((entry: AuditLogEntry) => {
-			return (
-				entry.action.toLowerCase().includes(q) ||
-				(entry.actor.user_email?.toLowerCase().includes(q) ?? false) ||
-				(entry.actor.user_name?.toLowerCase().includes(q) ?? false) ||
-				(entry.resource_type?.toLowerCase().includes(q) ?? false) ||
-				(entry.ip_address?.toLowerCase().includes(q) ?? false)
-			);
-		});
-	}, [data, searchText]);
+	const entries = data?.entries ?? [];
+	const hasActiveFilters =
+		actionGroup !== "All" ||
+		outcome !== "All" ||
+		Boolean(searchText || startDate || endDate);
+
+	const clearFilters = () => {
+		setActionGroup("All");
+		setOutcome("All");
+		setSearchText("");
+		setStartDate("");
+		setEndDate("");
+		resetPagination();
+	};
 
 	const handleNextPage = () => {
 		if (data?.continuation_token) {
@@ -123,14 +160,18 @@ export function AuditLogPage() {
 			<div>
 				<h1 className="text-4xl font-extrabold tracking-tight">Audit Log</h1>
 				<p className="mt-2 text-muted-foreground">
-					Review authentication, user, role, and organization events
+					Trace security decisions and administrative activity across the
+					platform
 				</p>
 			</div>
 
 			{/* Filters */}
 			<div className="flex items-center gap-4 flex-wrap">
-				<Select value={actionGroup} onValueChange={setActionGroup}>
-					<SelectTrigger className="w-[200px]">
+				<Select
+					value={actionGroup}
+					onValueChange={(value) => updateFilter(setActionGroup, value)}
+				>
+					<SelectTrigger className="w-[200px]" aria-label="Action filter">
 						<SelectValue placeholder="Action" />
 					</SelectTrigger>
 					<SelectContent>
@@ -142,8 +183,11 @@ export function AuditLogPage() {
 					</SelectContent>
 				</Select>
 
-				<Select value={outcome} onValueChange={setOutcome}>
-					<SelectTrigger className="w-[160px]">
+				<Select
+					value={outcome}
+					onValueChange={(value) => updateFilter(setOutcome, value)}
+				>
+					<SelectTrigger className="w-[160px]" aria-label="Outcome filter">
 						<SelectValue placeholder="Outcome" />
 					</SelectTrigger>
 					<SelectContent>
@@ -156,22 +200,26 @@ export function AuditLogPage() {
 				</Select>
 
 				<Input
-					placeholder="Search action, actor, IP…"
+					type="search"
+					aria-label="Search audit events"
+					placeholder="Search path, table, action, or IP…"
 					value={searchText}
-					onChange={(e) => setSearchText(e.target.value)}
-					className="flex-1 max-w-md"
+					onChange={(e) => updateFilter(setSearchText, e.target.value)}
+					className="w-full min-w-0 max-w-md sm:min-w-[320px] sm:flex-1"
 				/>
 
 				<Input
 					type="date"
+					aria-label="Start date"
 					value={startDate}
-					onChange={(e) => setStartDate(e.target.value)}
+					onChange={(e) => updateFilter(setStartDate, e.target.value)}
 					className="w-[160px]"
 				/>
 				<Input
 					type="date"
+					aria-label="End date"
 					value={endDate}
-					onChange={(e) => setEndDate(e.target.value)}
+					onChange={(e) => updateFilter(setEndDate, e.target.value)}
 					className="w-[160px]"
 				/>
 
@@ -180,12 +228,18 @@ export function AuditLogPage() {
 					size="icon"
 					onClick={() => refetch()}
 					disabled={isLoading}
-					title="Refresh"
+					aria-label="Refresh audit log"
 				>
 					<RefreshCw
 						className={`h-4 w-4 ${isLoading ? "animate-spin" : ""}`}
 					/>
 				</Button>
+
+				{hasActiveFilters && (
+					<Button variant="ghost" onClick={clearFilters}>
+						Clear filters
+					</Button>
+				)}
 			</div>
 
 			{/* Content */}
@@ -200,11 +254,11 @@ export function AuditLogPage() {
 					</Alert>
 				)}
 
-				{isLoading && !filteredEntries.length ? (
+				{isLoading && !entries.length ? (
 					<div className="flex items-center justify-center py-12">
 						<Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
 					</div>
-				) : filteredEntries.length > 0 ? (
+				) : entries.length > 0 ? (
 					<DataTable>
 						<DataTableHeader>
 							<DataTableRow>
@@ -213,11 +267,12 @@ export function AuditLogPage() {
 								<DataTableHead>Outcome</DataTableHead>
 								<DataTableHead>Actor</DataTableHead>
 								<DataTableHead>Resource</DataTableHead>
+								<DataTableHead>Context</DataTableHead>
 								<DataTableHead>IP</DataTableHead>
 							</DataTableRow>
 						</DataTableHeader>
 						<DataTableBody>
-							{filteredEntries.map((entry: AuditLogEntry) => (
+							{entries.map((entry: AuditLogEntry) => (
 								<DataTableRow key={entry.id}>
 									<DataTableCell className="font-mono text-xs whitespace-nowrap">
 										{new Date(entry.timestamp).toLocaleString()}
@@ -249,6 +304,12 @@ export function AuditLogPage() {
 											? `${entry.resource_type}${entry.resource_id ? ` / ${entry.resource_id.slice(0, 8)}` : ""}`
 											: "-"}
 									</DataTableCell>
+									<DataTableCell
+										className="max-w-80 truncate text-sm text-muted-foreground"
+										title={auditContext(entry)}
+									>
+										{auditContext(entry)}
+									</DataTableCell>
 									<DataTableCell className="text-xs font-mono text-muted-foreground">
 										{entry.ip_address || "-"}
 									</DataTableCell>
@@ -257,9 +318,9 @@ export function AuditLogPage() {
 						</DataTableBody>
 						<DataTableFooter>
 							<DataTableRow>
-								<DataTableCell colSpan={3} className="text-sm text-muted-foreground">
-									{filteredEntries.length} event
-									{filteredEntries.length !== 1 ? "s" : ""} on this page
+								<DataTableCell colSpan={4} className="text-sm text-muted-foreground">
+									{entries.length} event
+									{entries.length !== 1 ? "s" : ""} on this page
 								</DataTableCell>
 								<DataTableCell colSpan={3} className="text-right">
 									<div className="flex gap-2 justify-end">

--- a/client/src/pages/audit/AuditLogPage.tsx
+++ b/client/src/pages/audit/AuditLogPage.tsx
@@ -143,8 +143,8 @@ export function AuditLogPage() {
 				<Alert variant="destructive">
 					<AlertCircle className="h-4 w-4" />
 					<AlertDescription>
-						You do not have permission to view the audit log. Platform
-						administrator access is required.
+						You do not have permission to view the audit log.
+						Platform administrator access is required.
 					</AlertDescription>
 				</Alert>
 				<Button onClick={() => navigate("/")} className="mt-4">
@@ -157,89 +157,123 @@ export function AuditLogPage() {
 	return (
 		<div className="h-[calc(100vh-8rem)] flex flex-col space-y-6">
 			{/* Header */}
-			<div>
-				<h1 className="text-4xl font-extrabold tracking-tight">Audit Log</h1>
-				<p className="mt-2 text-muted-foreground">
-					Trace security decisions and administrative activity across the
-					platform
-				</p>
-			</div>
-
-			{/* Filters */}
-			<div className="flex items-center gap-4 flex-wrap">
-				<Select
-					value={actionGroup}
-					onValueChange={(value) => updateFilter(setActionGroup, value)}
-				>
-					<SelectTrigger className="w-[200px]" aria-label="Action filter">
-						<SelectValue placeholder="Action" />
-					</SelectTrigger>
-					<SelectContent>
-						{ACTION_GROUPS.map((g) => (
-							<SelectItem key={g.value} value={g.value}>
-								{g.label}
-							</SelectItem>
-						))}
-					</SelectContent>
-				</Select>
-
-				<Select
-					value={outcome}
-					onValueChange={(value) => updateFilter(setOutcome, value)}
-				>
-					<SelectTrigger className="w-[160px]" aria-label="Outcome filter">
-						<SelectValue placeholder="Outcome" />
-					</SelectTrigger>
-					<SelectContent>
-						{OUTCOMES.map((o) => (
-							<SelectItem key={o.value} value={o.value}>
-								{o.label}
-							</SelectItem>
-						))}
-					</SelectContent>
-				</Select>
-
-				<Input
-					type="search"
-					aria-label="Search audit events"
-					placeholder="Search path, table, action, or IP…"
-					value={searchText}
-					onChange={(e) => updateFilter(setSearchText, e.target.value)}
-					className="w-full min-w-0 max-w-md sm:min-w-[320px] sm:flex-1"
-				/>
-
-				<Input
-					type="date"
-					aria-label="Start date"
-					value={startDate}
-					onChange={(e) => updateFilter(setStartDate, e.target.value)}
-					className="w-[160px]"
-				/>
-				<Input
-					type="date"
-					aria-label="End date"
-					value={endDate}
-					onChange={(e) => updateFilter(setEndDate, e.target.value)}
-					className="w-[160px]"
-				/>
-
+			<div className="flex items-start justify-between gap-4">
+				<div>
+					<h1 className="text-4xl font-extrabold tracking-tight">
+						Audit Log
+					</h1>
+					<p className="mt-2 text-muted-foreground">
+						Trace security decisions and administrative activity
+						across the platform
+					</p>
+				</div>
 				<Button
 					variant="outline"
 					size="icon"
 					onClick={() => refetch()}
 					disabled={isLoading}
 					aria-label="Refresh audit log"
+					className="shrink-0"
 				>
 					<RefreshCw
 						className={`h-4 w-4 ${isLoading ? "animate-spin" : ""}`}
 					/>
 				</Button>
+			</div>
 
-				{hasActiveFilters && (
-					<Button variant="ghost" onClick={clearFilters}>
-						Clear filters
-					</Button>
-				)}
+			{/* Filters */}
+			<div className="space-y-3">
+				<Input
+					type="search"
+					aria-label="Search audit events"
+					placeholder="Search path, table, action, or IP…"
+					value={searchText}
+					onChange={(e) =>
+						updateFilter(setSearchText, e.target.value)
+					}
+					className="w-full"
+				/>
+
+				<div className="grid gap-3 sm:grid-cols-2 lg:flex lg:items-center">
+					<Select
+						value={actionGroup}
+						onValueChange={(value) =>
+							updateFilter(setActionGroup, value)
+						}
+					>
+						<SelectTrigger
+							className="w-full lg:w-[200px]"
+							aria-label="Action filter"
+						>
+							<SelectValue placeholder="Action" />
+						</SelectTrigger>
+						<SelectContent>
+							{ACTION_GROUPS.map((g) => (
+								<SelectItem key={g.value} value={g.value}>
+									{g.label}
+								</SelectItem>
+							))}
+						</SelectContent>
+					</Select>
+
+					<Select
+						value={outcome}
+						onValueChange={(value) =>
+							updateFilter(setOutcome, value)
+						}
+					>
+						<SelectTrigger
+							className="w-full lg:w-[160px]"
+							aria-label="Outcome filter"
+						>
+							<SelectValue placeholder="Outcome" />
+						</SelectTrigger>
+						<SelectContent>
+							{OUTCOMES.map((o) => (
+								<SelectItem key={o.value} value={o.value}>
+									{o.label}
+								</SelectItem>
+							))}
+						</SelectContent>
+					</Select>
+
+					<div className="grid grid-cols-[auto_minmax(0,1fr)] items-center gap-x-2 gap-y-2 sm:col-span-2 lg:ml-auto lg:flex">
+						<span className="text-sm text-muted-foreground">
+							From
+						</span>
+						<Input
+							type="date"
+							aria-label="Start date"
+							value={startDate}
+							onChange={(e) =>
+								updateFilter(setStartDate, e.target.value)
+							}
+							className="min-w-0 lg:w-[150px]"
+						/>
+						<span className="text-sm text-muted-foreground">
+							To
+						</span>
+						<Input
+							type="date"
+							aria-label="End date"
+							value={endDate}
+							onChange={(e) =>
+								updateFilter(setEndDate, e.target.value)
+							}
+							className="min-w-0 lg:w-[150px]"
+						/>
+					</div>
+
+					{hasActiveFilters && (
+						<Button
+							variant="ghost"
+							onClick={clearFilters}
+							className="justify-self-start lg:shrink-0"
+						>
+							Clear filters
+						</Button>
+					)}
+				</div>
 			</div>
 
 			{/* Content */}
@@ -275,10 +309,14 @@ export function AuditLogPage() {
 							{entries.map((entry: AuditLogEntry) => (
 								<DataTableRow key={entry.id}>
 									<DataTableCell className="font-mono text-xs whitespace-nowrap">
-										{new Date(entry.timestamp).toLocaleString()}
+										{new Date(
+											entry.timestamp,
+										).toLocaleString()}
 									</DataTableCell>
 									<DataTableCell>
-										<Badge variant="secondary">{entry.action}</Badge>
+										<Badge variant="secondary">
+											{entry.action}
+										</Badge>
 									</DataTableCell>
 									<DataTableCell>
 										<Badge
@@ -318,11 +356,18 @@ export function AuditLogPage() {
 						</DataTableBody>
 						<DataTableFooter>
 							<DataTableRow>
-								<DataTableCell colSpan={4} className="text-sm text-muted-foreground">
+								<DataTableCell
+									colSpan={4}
+									className="text-sm text-muted-foreground"
+								>
 									{entries.length} event
-									{entries.length !== 1 ? "s" : ""} on this page
+									{entries.length !== 1 ? "s" : ""} on this
+									page
 								</DataTableCell>
-								<DataTableCell colSpan={3} className="text-right">
+								<DataTableCell
+									colSpan={3}
+									className="text-right"
+								>
 									<div className="flex gap-2 justify-end">
 										<Button
 											variant="outline"
@@ -350,7 +395,9 @@ export function AuditLogPage() {
 				) : (
 					<Card>
 						<CardContent className="flex flex-col items-center justify-center py-12 text-center">
-							<h3 className="text-lg font-semibold">No events found</h3>
+							<h3 className="text-lg font-semibold">
+								No events found
+							</h3>
 							<p className="mt-2 text-sm text-muted-foreground">
 								Try adjusting your filters or date range
 							</p>


### PR DESCRIPTION
## Summary

- route REST and WebSocket file-policy denials through one canonical `policy.deny` Event Log payload
- persist `scope` and `solution_id` in file-policy denial details
- emit canonical `policy.deny` events for denied WebSocket table subscriptions, matching REST table denials
- attribute WebSocket denial events to the authenticated actor before returning the denial frame
- make Event Log search server-side across actor, action, resource, IP, and structured details so file paths and table names/IDs filter across all pages
- add first-class `Policy denials` and `Failure` filters plus readable file/table context in the Event Log UI
- give search a deliberate full-width row, keep categorical/date filters compact beneath it, and move refresh into the page header so desktop controls never wrap accidentally

## Verification against origin/main

Both issues remained reproducible on `origin/main` at `7256d1db2`: `_deny_file_policy` persisted only `policy_action`, `location`, and `path`, while `_authorize_file_subscribe` returned `Access denied` without calling the audit system for either scope-resolution failure or missing applicable policy. Table WebSocket denials also returned an authorization error without persisting the REST-equivalent audit event, and Event Log search could not match structured path/table detail fields.

## Verification

Exact pre-PR candidate: `4769d5ddb0b79aa74a75fff77d75b728f0dd854d`

- `./test.sh pre-pr` — passed on the exact candidate; includes production client build, TypeScript/ESLint, full Vitest, API Pyright/Ruff, 5,761 backend unit/contract passes, 1,778 backend E2E passes with 1 environment skip, critical browser smoke, and production candidate image validation
- `./test.sh tests/unit/services/test_audit.py tests/e2e/api/test_audit_log.py::TestAuditLogEmission::test_search_matches_file_path_and_table_context tests/e2e/platform/test_subscriptions.py::test_subscribe_without_read_rejected tests/e2e/platform/test_file_websocket_subscriptions.py::test_file_subscribe_without_policy_is_rejected_and_audited tests/e2e/platform/test_file_websocket_subscriptions.py::test_file_subscribe_scope_denial_is_audited -v` — 14 passed
- `./test.sh client unit src/pages/audit/AuditLogPage.test.tsx` — 1 passed
- `./test.sh client e2e --screenshots e2e/audit-log.admin.spec.ts` — 2 passed, including global setup
- Impeccable layout review against Configuration and Platform Jobs patterns; layout detector returned no findings
- `./test.sh tests/e2e/api/test_builtin_events.py::TestBuiltInIntegrationEvents::test_integration_events_run_subscribers -v` — 1 passed after repairing the cross-event-loop test client lifecycle exposed by the first broad gate
- `./test.sh quality api` — Pyright and Ruff passed
- `(cd client && npm run tsc && npm run lint)` — passed with two existing warnings and zero errors
- `git diff --check`

No locally reproducible broader suite was omitted: `pre-pr` ran the repository's complete local PR gate. GitHub-only synthetic merge-ref, registry publication, signing, and attestation boundaries remain owned by CI. No known failures.

Fixes #437
Fixes #438
