### PR TITLE
fix(execution): preserve optional import misses

### DIFF
--- a/api/src/services/execution/virtual_import.py
+++ b/api/src/services/execution/virtual_import.py
@@ -352,15 +352,15 @@ class VirtualModuleFinder(MetaPathFinder):
         try:
             resolution = resolve_module_sync(fullname)
         except ModuleResolutionError:
-            # Installed dependencies commonly probe optional companions inside
-            # ``try: import ... except ImportError`` blocks. If the workspace
-            # resolver is temporarily unavailable, preserve that normal Python
-            # contract for an import originating outside workspace/platform
-            # code. Workspace imports still fail closed so a cache/API outage
-            # cannot silently masquerade as a missing workspace module.
-            if _import_origin_is_external():
-                return None
-            raise
+            # A finder that cannot provide a module must let Python continue
+            # through the normal import chain. Keep the resolver failure visible
+            # to operators without exposing platform-specific import semantics
+            # to workspace or dependency code.
+            logger.exception(
+                "Virtual module resolution failed for %s; continuing normal import",
+                fullname,
+            )
+            return None
         if resolution.kind in {"module", "package"} and resolution.content is not None:
             is_package = resolution.kind == "package"
             loader = VirtualModuleLoader(
@@ -409,28 +409,6 @@ def _is_bifrost_source_spec(spec: ModuleSpec) -> bool:
         resolved = Path(location).resolve()
         if any(resolved.is_relative_to(root) for root in _BIFROST_SOURCE_ROOTS):
             return True
-    return False
-
-
-def _import_origin_is_external() -> bool:
-    """Return whether the import statement came from installed/stdlib code."""
-    frame = sys._getframe(1)
-    while frame is not None:
-        filename = frame.f_code.co_filename
-        if filename == __file__ or filename.startswith("<frozen importlib"):
-            frame = frame.f_back
-            continue
-
-        if isinstance(frame.f_globals.get("__loader__"), VirtualModuleLoader):
-            return False
-        if filename.startswith("<"):
-            return False
-
-        resolved = Path(filename).resolve()
-        return not any(
-            resolved.is_relative_to(root) for root in _BIFROST_SOURCE_ROOTS
-        )
-
     return False
 
 # Global finder instance (for invalidation access)

--- a/api/src/services/execution/virtual_import.py
+++ b/api/src/services/execution/virtual_import.py
@@ -31,6 +31,7 @@ from types import ModuleType
 from typing import Any
 
 from src.core.module_cache_sync import (
+    ModuleResolutionError,
     resolve_module_sync,
 )
 
@@ -348,7 +349,18 @@ class VirtualModuleFinder(MetaPathFinder):
         if local_spec is not None and not _is_bifrost_source_spec(local_spec):
             return None
 
-        resolution = resolve_module_sync(fullname)
+        try:
+            resolution = resolve_module_sync(fullname)
+        except ModuleResolutionError:
+            # Installed dependencies commonly probe optional companions inside
+            # ``try: import ... except ImportError`` blocks. If the workspace
+            # resolver is temporarily unavailable, preserve that normal Python
+            # contract for an import originating outside workspace/platform
+            # code. Workspace imports still fail closed so a cache/API outage
+            # cannot silently masquerade as a missing workspace module.
+            if _import_origin_is_external():
+                return None
+            raise
         if resolution.kind in {"module", "package"} and resolution.content is not None:
             is_package = resolution.kind == "package"
             loader = VirtualModuleLoader(
@@ -397,6 +409,28 @@ def _is_bifrost_source_spec(spec: ModuleSpec) -> bool:
         resolved = Path(location).resolve()
         if any(resolved.is_relative_to(root) for root in _BIFROST_SOURCE_ROOTS):
             return True
+    return False
+
+
+def _import_origin_is_external() -> bool:
+    """Return whether the import statement came from installed/stdlib code."""
+    frame = sys._getframe(1)
+    while frame is not None:
+        filename = frame.f_code.co_filename
+        if filename == __file__ or filename.startswith("<frozen importlib"):
+            frame = frame.f_back
+            continue
+
+        if isinstance(frame.f_globals.get("__loader__"), VirtualModuleLoader):
+            return False
+        if filename.startswith("<"):
+            return False
+
+        resolved = Path(filename).resolve()
+        return not any(
+            resolved.is_relative_to(root) for root in _BIFROST_SOURCE_ROOTS
+        )
+
     return False
 
 # Global finder instance (for invalidation access)

--- a/api/tests/unit/services/test_virtual_import.py
+++ b/api/tests/unit/services/test_virtual_import.py
@@ -665,8 +665,8 @@ class TestIntegration:
         finally:
             sys.modules.pop(optional_name, None)
 
-    def test_workspace_import_still_fails_when_resolver_is_unavailable(self):
-        """Workspace imports remain fail-closed during a resolver outage."""
+    def test_workspace_optional_import_preserves_importerror(self, caplog):
+        """Workspace code gets the same optional-import behavior as dependencies."""
         module_name = "virtual_resolver_outage_workflow"
         missing_name = "virtual_resolver_outage_helper"
         install_virtual_import_hook()
@@ -676,7 +676,10 @@ class TestIntegration:
                 return ModuleResolution(
                     kind="module",
                     path=f"{module_name}.py",
-                    content=f"import {missing_name}\n",
+                    content=(
+                        f"try:\n    import {missing_name}\nexcept ImportError:\n"
+                        "    OPTIONAL_AVAILABLE = False\n"
+                    ),
                     hash="abc",
                 )
             raise ModuleResolutionError("resolver unavailable")
@@ -691,9 +694,24 @@ class TestIntegration:
                     "src.services.execution.virtual_import.resolve_module_sync",
                     side_effect=resolve,
                 ),
-                pytest.raises(ModuleResolutionError, match="resolver unavailable"),
             ):
-                importlib.import_module(module_name)
+                module = importlib.import_module(module_name)
+
+            assert module.OPTIONAL_AVAILABLE is False
+            assert (
+                "Virtual module resolution failed for "
+                f"{missing_name}; continuing normal import"
+            ) in caplog.text
+            failure_record = next(
+                record
+                for record in caplog.records
+                if record.getMessage().startswith(
+                    f"Virtual module resolution failed for {missing_name}"
+                )
+            )
+            assert failure_record.exc_info is not None
+            assert isinstance(failure_record.exc_info[1], ModuleResolutionError)
+            assert str(failure_record.exc_info[1]) == "resolver unavailable"
         finally:
             sys.modules.pop(module_name, None)
             sys.modules.pop(missing_name, None)

--- a/api/tests/unit/services/test_virtual_import.py
+++ b/api/tests/unit/services/test_virtual_import.py
@@ -11,12 +11,15 @@ The implementation uses a targeted resolver to identify workspace-owned imports:
 
 import importlib
 import sys
+import sysconfig
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
 from types import ModuleType
 from unittest.mock import MagicMock, patch
 
 import pytest
 
-from src.core.module_cache_sync import ModuleResolution
+from src.core.module_cache_sync import ModuleResolution, ModuleResolutionError
 from src.services.execution.virtual_import import (
     _is_bifrost_source_spec,
     NamespacePackageLoader,
@@ -600,6 +603,100 @@ class TestIntegration:
                 f"{module_name}.submodule",
             ]:
                 sys.modules.pop(loaded, None)
+
+    def test_installed_dependency_optional_import_preserves_importerror(
+        self, tmp_path, monkeypatch
+    ):
+        """A resolver outage must not break a dependency's optional import probe."""
+        package_name = "virtual_optional_dependency"
+        optional_name = "virtual_optional_dependency_companion"
+        installed_dir = tmp_path / "site-packages"
+        package_dir = installed_dir / package_name
+        package_dir.mkdir(parents=True)
+        (package_dir / "__init__.py").write_text(
+            f"try:\n    import {optional_name}\nexcept ImportError:\n"
+            "    OPTIONAL_AVAILABLE = False\n"
+        )
+        monkeypatch.syspath_prepend(str(installed_dir))
+        install_virtual_import_hook()
+
+        try:
+            with patch(
+                "src.services.execution.virtual_import.resolve_module_sync",
+                side_effect=ModuleResolutionError("resolver unavailable"),
+            ) as resolver:
+                module = importlib.import_module(package_name)
+
+            assert module.OPTIONAL_AVAILABLE is False
+            resolver.assert_called_once_with(optional_name)
+        finally:
+            sys.modules.pop(package_name, None)
+            sys.modules.pop(optional_name, None)
+
+    def test_stdlib_optional_import_preserves_importerror(self):
+        """A resolver outage must not break a stdlib optional import probe."""
+        optional_name = "virtual_stdlib_optional_companion"
+        module_name = "virtual_stdlib_optional_probe"
+        filename = str(Path(sysconfig.get_path("stdlib")) / f"{module_name}.py")
+        namespace = {
+            "__name__": module_name,
+            "__file__": filename,
+            "__loader__": SourceFileLoader(module_name, filename),
+        }
+        install_virtual_import_hook()
+
+        try:
+            with patch(
+                "src.services.execution.virtual_import.resolve_module_sync",
+                side_effect=ModuleResolutionError("resolver unavailable"),
+            ) as resolver:
+                exec(
+                    compile(
+                        f"try:\n    import {optional_name}\nexcept ImportError:\n"
+                        "    OPTIONAL_AVAILABLE = False\n",
+                        filename,
+                        "exec",
+                    ),
+                    namespace,
+                )
+
+            assert namespace["OPTIONAL_AVAILABLE"] is False
+            resolver.assert_called_once_with(optional_name)
+        finally:
+            sys.modules.pop(optional_name, None)
+
+    def test_workspace_import_still_fails_when_resolver_is_unavailable(self):
+        """Workspace imports remain fail-closed during a resolver outage."""
+        module_name = "virtual_resolver_outage_workflow"
+        missing_name = "virtual_resolver_outage_helper"
+        install_virtual_import_hook()
+
+        def resolve(name: str) -> ModuleResolution:
+            if name == module_name:
+                return ModuleResolution(
+                    kind="module",
+                    path=f"{module_name}.py",
+                    content=f"import {missing_name}\n",
+                    hash="abc",
+                )
+            raise ModuleResolutionError("resolver unavailable")
+
+        try:
+            with (
+                patch(
+                    "src.services.execution.virtual_import.PathFinder.find_spec",
+                    return_value=None,
+                ),
+                patch(
+                    "src.services.execution.virtual_import.resolve_module_sync",
+                    side_effect=resolve,
+                ),
+                pytest.raises(ModuleResolutionError, match="resolver unavailable"),
+            ):
+                importlib.import_module(module_name)
+        finally:
+            sys.modules.pop(module_name, None)
+            sys.modules.pop(missing_name, None)
 
     def test_virtual_package_takes_precedence_over_platform_source_module(self, tmp_path):
         """Workspace packages should not be shadowed by Bifrost source modules."""


### PR DESCRIPTION
## Summary

- preserve normal Python import behavior for every caller when the workspace resolver is unavailable
- log the requested module and original resolver exception for operators before continuing the import chain
- cover installed-package, standard-library, and virtual-workspace optional imports

## Root cause

The targeted virtual-import finder introduced in #621 consults the workspace resolver after Python's path finder misses a module. Code commonly probes optional companions inside `try`/`except ImportError`; when the resolver is unavailable, `ModuleResolutionError` currently escapes instead of allowing Python to continue through its importer chain. A `grpcio` import probing the absent `grpc_tools` package exposed the regression.

The finder now logs the resolver exception and returns `None` uniformly. Another finder may still provide the module. If none does, Python raises the normal `ModuleNotFoundError`, regardless of whether the import originated in an installed dependency, standard-library module, or virtual workspace module.

## Verification

- `python -m pytest -q tests/unit/services/test_virtual_import.py` — 38 passed
- `ruff check api/src/services/execution/virtual_import.py api/tests/unit/services/test_virtual_import.py`
- `python -m py_compile api/src/services/execution/virtual_import.py api/tests/unit/services/test_virtual_import.py`

## Review note

This touches the execution engine. The tests exercise the resolver-outage boundary for installed, standard-library, and workspace callers, and verify that the operator log retains the original exception.

Fixes #645
