### PR TITLE
Standardize AI request retry and recovery policy

### DIFF
--- a/api/src/jobs/consumers/agent_run.py
+++ b/api/src/jobs/consumers/agent_run.py
@@ -228,12 +228,26 @@ class AgentRunConsumer(BaseConsumer):
 
             # Update run record and flush buffered steps (brief DB session)
             duration_ms = int((time.time() - start_time) * 1000)
+            consumer_applied_result = False
             async with self._session_factory() as db:
-                # Re-fetch the AgentRun in this session to update it
-                run_obj = await db.get(AgentRun, UUID(run_id))
-                if run_obj:
+                # Re-fetch the AgentRun in this session to update it, but only
+                # if it is still live. A scheduler may have already terminalized
+                # the row; in that case we must not overwrite the final status.
+                run_obj = await db.get(
+                    AgentRun,
+                    UUID(run_id),
+                    with_for_update={"of": AgentRun},
+                )
+                if run_obj is None:
+                    logger.info(f"Agent run {run_id}: final update skipped because row disappeared")
+                    return
+                if run_obj.status == "running":
                     run_obj.status = run_result.get("status", "completed")
-                    run_obj.output = run_result.get("output") if isinstance(run_result.get("output"), dict) else {"text": run_result.get("output")}
+                    run_obj.output = (
+                        run_result.get("output")
+                        if isinstance(run_result.get("output"), dict)
+                        else {"text": run_result.get("output")}
+                    )
                     run_obj.iterations_used = run_result.get("iterations_used", 0)
                     run_obj.tokens_used = run_result.get("tokens_used", 0)
                     run_obj.llm_model = run_result.get("llm_model")
@@ -241,8 +255,17 @@ class AgentRunConsumer(BaseConsumer):
                     run_obj.completed_at = datetime.now(timezone.utc)
                     if run_result.get("error"):
                         run_obj.error = run_result["error"]
+                    consumer_applied_result = True
+                else:
+                    logger.info(
+                        "Agent run %s: final update skipped because current status is %s",
+                        run_id,
+                        run_obj.status,
+                    )
 
-                # Flush executor's buffered steps and AI usage
+                # Flush metering and steps even when the scheduler won the
+                # terminal-state race; completed provider work still incurred
+                # cost and remains useful diagnostic evidence.
                 if executor:
                     await executor.flush_to_db(db)
 
@@ -267,7 +290,7 @@ class AgentRunConsumer(BaseConsumer):
             # exposes a regenerate button to retry from any state.
             # Errors here MUST NOT crash the run — summary_status stays
             # 'pending' and the UI offers a regenerate path.
-            if run_result.get("status") == "completed":
+            if consumer_applied_result and agent_run.status == "completed":
                 try:
                     from src.services.execution.run_summarizer import enqueue_summarize
                     await enqueue_summarize(UUID(run_id))
@@ -292,12 +315,12 @@ class AgentRunConsumer(BaseConsumer):
                 await _publish_sync_result(
                     run_id,
                     {
-                        "output": run_result.get("output"),
-                        "status": run_result.get("status", "completed"),
-                        "error": run_result.get("error"),
-                        "iterations_used": run_result.get("iterations_used", 0),
-                        "tokens_used": run_result.get("tokens_used", 0),
-                        "llm_model": run_result.get("llm_model"),
+                        "output": agent_run.output,
+                        "status": agent_run.status,
+                        "error": agent_run.error,
+                        "iterations_used": agent_run.iterations_used,
+                        "tokens_used": agent_run.tokens_used,
+                        "llm_model": agent_run.llm_model,
                     },
                 )
 
@@ -306,18 +329,32 @@ class AgentRunConsumer(BaseConsumer):
             if agent_run is not None:
                 try:
                     async with self._session_factory() as db:
-                        run_obj = await db.get(AgentRun, UUID(run_id))
+                        run_obj = await db.get(
+                            AgentRun,
+                            UUID(run_id),
+                            with_for_update={"of": AgentRun},
+                        )
                         if run_obj:
-                            run_obj.status = "failed"
-                            run_obj.error = str(e)
-                            run_obj.duration_ms = int((time.time() - start_time) * 1000)
-                            run_obj.completed_at = datetime.now(timezone.utc)
+                            if run_obj.status == "running":
+                                run_obj.status = "failed"
+                                run_obj.error = str(e)
+                                run_obj.duration_ms = int(
+                                    (time.time() - start_time) * 1000
+                                )
+                                run_obj.completed_at = datetime.now(timezone.utc)
+                            else:
+                                logger.info(
+                                    "Agent run %s: failure update skipped because current status is %s",
+                                    run_id,
+                                    run_obj.status,
+                                )
 
                             # Still flush any buffered steps on failure
                             if executor:
                                 await executor.flush_to_db(db)
 
                             await db.commit()
+                            agent_run = run_obj
                 except Exception:
                     logger.exception(f"Failed to update agent_run {run_id} after error")
 
@@ -341,9 +378,9 @@ class AgentRunConsumer(BaseConsumer):
                 await _publish_sync_result(
                     run_id,
                     {
-                        "output": None,
-                        "status": "failed",
-                        "error": str(e),
+                        "output": agent_run.output if agent_run else None,
+                        "status": agent_run.status if agent_run else "failed",
+                        "error": agent_run.error if agent_run else str(e),
                     },
                 )
 

--- a/api/src/jobs/schedulers/execution_cleanup.py
+++ b/api/src/jobs/schedulers/execution_cleanup.py
@@ -1,8 +1,8 @@
 """
 Execution Cleanup Scheduler
 
-Cleans up stuck executions that remain in PENDING, RUNNING, or CANCELLING
-status for too long.
+Cleans up stuck workflow executions and stale autonomous agent runs that
+remain in in-progress states for too long.
 
 Runs every 5 minutes to find and timeout stuck executions.
 """
@@ -11,10 +11,16 @@ import logging
 from datetime import datetime, timedelta, timezone
 from typing import Any
 
-from sqlalchemy import select, and_
+from sqlalchemy import and_, select
 
 from src.core.database import get_session_factory
-from src.core.pubsub import publish_execution_update, publish_history_update
+from src.core.pubsub import (
+    publish_agent_run_update,
+    publish_execution_update,
+    publish_history_update,
+)
+from src.models.orm.agent_runs import AgentRun
+from src.models.orm.agents import Agent
 from src.models import Execution as ExecutionModel, ExecutionLog
 from src.models.orm.workflows import Workflow
 
@@ -24,6 +30,8 @@ logger = logging.getLogger(__name__)
 PENDING_TIMEOUT_MINUTES = 10  # If PENDING for 10+ minutes, it's stuck in queue
 RUNNING_TIMEOUT_MINUTES = 30  # If RUNNING for 30+ minutes, worker likely crashed
 CANCELLING_TIMEOUT_MINUTES = 3  # If CANCELLING for 3+ minutes, worker failed to cancel
+DEFAULT_AGENT_RUN_TIMEOUT_SECONDS = 30 * 60
+AGENT_RUN_TIMEOUT_GRACE_SECONDS = 5 * 60
 
 
 async def cleanup_stuck_executions() -> dict[str, Any]:
@@ -46,6 +54,10 @@ async def cleanup_stuck_executions() -> dict[str, Any]:
         "cancelling_timeouts": 0,
         "total_cleaned": 0,
         "errors": [],
+        "agent_run_queued_timeouts": 0,
+        "agent_run_running_timeouts": 0,
+        "agent_run_total_cleaned": 0,
+        "agent_run_errors": [],
     }
 
     now = datetime.now(timezone.utc)
@@ -237,5 +249,150 @@ async def cleanup_stuck_executions() -> dict[str, Any]:
     except Exception as e:
         logger.error("Error in execution cleanup", extra={"error": str(e)}, exc_info=True)
         results["errors"].append({"error": str(e)})
+    finally:
+        try:
+            agent_run_results = await _cleanup_stale_agent_runs(now)
+            results.update(agent_run_results)
+        except Exception as e:
+            logger.error("Error in agent run cleanup", extra={"error": str(e)}, exc_info=True)
+            results["agent_run_errors"].append({"error": str(e)})
+        else:
+            logger.info(
+                "Agent run cleanup completed",
+                extra={
+                    "agent_run_queued_timeouts": results["agent_run_queued_timeouts"],
+                    "agent_run_running_timeouts": results["agent_run_running_timeouts"],
+                    "agent_run_total_cleaned": results["agent_run_total_cleaned"],
+                },
+            )
 
     return results
+
+
+def _agent_run_timeout_seconds(agent: Agent | None) -> int:
+    """Return the configured timeout for an agent, falling back to the shared default."""
+    configured = getattr(agent, "max_run_timeout", None)
+    if configured is not None and configured > 0:
+        return configured
+    return DEFAULT_AGENT_RUN_TIMEOUT_SECONDS
+
+
+async def _cleanup_stale_agent_runs(now: datetime) -> dict[str, Any]:
+    """Terminalize stale queued/running AgentRun rows without replaying them."""
+    session_factory = get_session_factory()
+    updates: list[dict[str, Any]] = []
+    results: dict[str, Any] = {
+        "agent_run_queued_timeouts": 0,
+        "agent_run_running_timeouts": 0,
+        "agent_run_total_cleaned": 0,
+        "agent_run_errors": [],
+    }
+
+    try:
+        async with session_factory() as db:
+            query = (
+                select(AgentRun, Agent)
+                .join(Agent, AgentRun.agent_id == Agent.id)
+                .where(AgentRun.status.in_(("queued", "running")))
+                .order_by(AgentRun.created_at.asc())
+            )
+            runs = (await db.execute(query)).all()
+
+            for candidate, agent in runs:
+                timeout_seconds = _agent_run_timeout_seconds(agent)
+                timeout_with_grace = timeout_seconds + AGENT_RUN_TIMEOUT_GRACE_SECONDS
+                reference_time = (
+                    candidate.created_at
+                    if candidate.status == "queued"
+                    else (candidate.started_at or candidate.created_at)
+                )
+                if reference_time is None:
+                    continue
+
+                elapsed = (now - reference_time).total_seconds()
+                if elapsed <= timeout_with_grace:
+                    continue
+
+                # Lock only the row already identified as stale. The status
+                # predicate is a compare-and-set guard against a worker that
+                # completed between the candidate read and this lock.
+                run = (
+                    await db.execute(
+                        select(AgentRun)
+                        .where(
+                            AgentRun.id == candidate.id,
+                            AgentRun.status == candidate.status,
+                        )
+                        .with_for_update(skip_locked=True, of=AgentRun)
+                    )
+                ).scalar_one_or_none()
+                if run is None:
+                    continue
+
+                reference_time = (
+                    run.created_at
+                    if run.status == "queued"
+                    else (run.started_at or run.created_at)
+                )
+                if reference_time is None:
+                    continue
+                elapsed = (now - reference_time).total_seconds()
+                if elapsed <= timeout_with_grace:
+                    continue
+
+                agent_name = agent.name
+                if run.status == "queued":
+                    final_status = "failed"
+                    timeout_reason = (
+                        f"Agent run timed out waiting in queue after "
+                        f"{timeout_with_grace} seconds."
+                    )
+                    results["agent_run_queued_timeouts"] += 1
+                else:
+                    final_status = "timeout"
+                    timeout_reason = (
+                        f"Agent run timed out after {timeout_with_grace} seconds."
+                    )
+                    results["agent_run_running_timeouts"] += 1
+
+                logger.warning(
+                    "agent_run_swept",
+                    extra={
+                        "agent_run_id": str(run.id),
+                        "agent_id": str(run.agent_id),
+                        "agent_name": agent_name,
+                        "stuck_status": run.status,
+                        "stuck_for_seconds": int(elapsed),
+                        "timeout_seconds": timeout_seconds,
+                        "timeout_with_grace": timeout_with_grace,
+                    },
+                )
+
+                run.status = final_status
+                run.error = timeout_reason
+                run.completed_at = now
+                updates.append(
+                    {
+                        "run": run,
+                        "agent_name": agent_name,
+                    }
+                )
+                results["agent_run_total_cleaned"] += 1
+
+            await db.commit()
+
+        for update in updates:
+            try:
+                await publish_agent_run_update(update["run"], update["agent_name"])
+            except Exception:
+                logger.warning(
+                    "Failed to publish agent run update",
+                    extra={"agent_run_id": str(update["run"].id)},
+                    exc_info=True,
+                )
+
+        return results
+    except Exception as e:
+        logger.error("Error in agent run cleanup", extra={"error": str(e)}, exc_info=True)
+        results["agent_run_errors"].append({"error": str(e)})
+        return results

--- a/api/src/main.py
+++ b/api/src/main.py
@@ -169,6 +169,11 @@ async def app_lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     # Shutdown
     logger.info("Shutting down Bifrost API...")
 
+    from src.services.agent_runtime.retry_transport import (
+        close_ai_retry_http_client,
+    )
+
+    await close_ai_retry_http_client()
     await pubsub_manager.close()
     await close_health_check_clients()
     await close_db()

--- a/api/src/services/agent_executor.py
+++ b/api/src/services/agent_executor.py
@@ -612,6 +612,7 @@ class AgentExecutor:
             observed_model = ObservedModel(
                 create_agent_model(llm_client.config, model=model_name),
                 record_model_event,
+                retry_surface="chat_agent",
             )
             toolset = BifrostToolset(
                 tool_definitions,

--- a/api/src/services/agent_runtime/model_factory.py
+++ b/api/src/services/agent_runtime/model_factory.py
@@ -9,6 +9,7 @@ from decimal import Decimal, InvalidOperation
 from pydantic_ai.models import Model
 from pydantic_ai.usage import RequestUsage
 
+from src.services.agent_runtime.retry_transport import get_ai_retry_http_client
 from src.services.llm.base import LLMConfig, request_max_tokens
 from src.services.model_pricing import is_openrouter_endpoint
 
@@ -84,6 +85,7 @@ def create_agent_model(config: LLMConfig, *, model: str | None = None) -> Model:
 
     if config.provider == "openai":
         if is_openrouter_endpoint(config.endpoint):
+            from openai import AsyncOpenAI
             from pydantic_ai.models.openrouter import (
                 OpenRouterModel,
                 OpenRouterStreamedResponse,
@@ -126,29 +128,43 @@ def create_agent_model(config: LLMConfig, *, model: str | None = None) -> Model:
                         "openrouter_cache_messages": True,
                     }
                 )
+            client = AsyncOpenAI(
+                api_key=config.api_key,
+                base_url=config.endpoint or "https://openrouter.ai/api/v1",
+                http_client=get_ai_retry_http_client(),
+                max_retries=0,
+            )
             return BifrostOpenRouterModel(
                 model_name,
-                provider=OpenRouterProvider(api_key=config.api_key),
+                provider=OpenRouterProvider(openai_client=client),
                 settings=settings,
             )
 
+        from openai import AsyncOpenAI
         from pydantic_ai.models.openai import OpenAIChatModel
         from pydantic_ai.providers.openai import OpenAIProvider
 
-        provider = OpenAIProvider(
+        client = AsyncOpenAI(
             api_key=config.api_key,
             base_url=config.endpoint,
+            http_client=get_ai_retry_http_client(),
+            max_retries=0,
         )
+        provider = OpenAIProvider(openai_client=client)
         return OpenAIChatModel(model_name, provider=provider)
 
     if config.provider == "anthropic":
+        from anthropic import AsyncAnthropic
         from pydantic_ai.models.anthropic import AnthropicModel
         from pydantic_ai.providers.anthropic import AnthropicProvider
 
-        provider = AnthropicProvider(
+        client = AsyncAnthropic(
             api_key=config.api_key,
             base_url=config.endpoint,
+            http_client=get_ai_retry_http_client(),
+            max_retries=0,
         )
+        provider = AnthropicProvider(anthropic_client=client)
         return AnthropicModel(model_name, provider=provider)
 
     if config.provider == "google":
@@ -158,6 +174,7 @@ def create_agent_model(config: LLMConfig, *, model: str | None = None) -> Model:
         provider = GoogleProvider(
             api_key=config.api_key,
             base_url=config.endpoint,
+            http_client=get_ai_retry_http_client(),
         )
         return GoogleModel(model_name, provider=provider)
 

--- a/api/src/services/agent_runtime/observed_model.py
+++ b/api/src/services/agent_runtime/observed_model.py
@@ -24,6 +24,8 @@ from pydantic_ai.models.wrapper import WrapperModel
 from pydantic_ai.settings import ModelSettings
 from pydantic_ai.usage import RequestUsage
 
+from src.services.agent_runtime.retry_transport import ai_retry_context
+
 
 @dataclass(frozen=True)
 class ModelCallEvent:
@@ -44,9 +46,16 @@ ModelCallObserver = Callable[[ModelCallEvent], Awaitable[None]]
 class ObservedModel(WrapperModel):
     """Report every provider request while leaving Pydantic AI in control of the loop."""
 
-    def __init__(self, wrapped: Model, observer: ModelCallObserver):
+    def __init__(
+        self,
+        wrapped: Model,
+        observer: ModelCallObserver,
+        *,
+        retry_surface: str = "agent",
+    ):
         super().__init__(wrapped)
         self._observer = observer
+        self._retry_surface = retry_surface
 
     @staticmethod
     def _estimated_input_tokens(
@@ -187,11 +196,16 @@ class ObservedModel(WrapperModel):
         )
         started = time.monotonic()
         try:
-            response = await self.wrapped.request(
-                messages,
-                model_settings,
-                model_request_parameters,
-            )
+            with ai_retry_context(
+                provider=self.wrapped.system,
+                model=self.wrapped.model_name,
+                surface=self._retry_surface,
+            ):
+                response = await self.wrapped.request(
+                    messages,
+                    model_settings,
+                    model_request_parameters,
+                )
         except Exception as exc:
             await self._observer(
                 ModelCallEvent(
@@ -239,19 +253,24 @@ class ObservedModel(WrapperModel):
         )
         started = time.monotonic()
         try:
-            async with self.wrapped.request_stream(
-                messages,
-                model_settings,
-                model_request_parameters,
-                run_context,
-            ) as response_stream:
-                yield response_stream
-                # Agent graphs can stop consuming after a final-result event,
-                # before OpenAI-compatible providers send their trailing
-                # usage-only chunk. Resume the same iterator so actual usage
-                # and cost are captured before persistence.
-                async for _ in response_stream:
-                    pass
+            with ai_retry_context(
+                provider=self.wrapped.system,
+                model=self.wrapped.model_name,
+                surface=self._retry_surface,
+            ):
+                async with self.wrapped.request_stream(
+                    messages,
+                    model_settings,
+                    model_request_parameters,
+                    run_context,
+                ) as response_stream:
+                    yield response_stream
+                    # Agent graphs can stop consuming after a final-result event,
+                    # before OpenAI-compatible providers send their trailing
+                    # usage-only chunk. Resume the same iterator so actual usage
+                    # and cost are captured before persistence.
+                    async for _ in response_stream:
+                        pass
             response = response_stream.get()
         except Exception as exc:
             await self._observer(

--- a/api/src/services/agent_runtime/retry_transport.py
+++ b/api/src/services/agent_runtime/retry_transport.py
@@ -1,0 +1,162 @@
+"""Process-scoped Pydantic AI HTTP retry transport.
+
+Transport retries are deliberately the only retry layer for model requests.
+Agent ``retries`` remain reserved for malformed tool/output correction.
+"""
+
+from __future__ import annotations
+
+import logging
+from contextlib import contextmanager
+from contextvars import ContextVar
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from email.utils import parsedate_to_datetime
+from typing import Iterator
+
+import httpx2
+from pydantic_ai.models import get_user_agent
+from pydantic_ai.retries import (
+    AsyncHTTPX2TenacityTransport,
+    RetryConfig,
+    wait_retry_after,
+)
+from tenacity import (
+    RetryCallState,
+    retry_if_exception,
+    stop_after_attempt,
+    wait_random_exponential,
+)
+
+logger = logging.getLogger(__name__)
+
+MAX_ATTEMPTS = 3
+MAX_RETRY_AFTER_SECONDS = 60.0
+RETRYABLE_STATUS_CODES = frozenset({408, 429, 500, 502, 503, 504})
+
+
+@dataclass(frozen=True)
+class AIRetryContext:
+    provider: str
+    model: str
+    surface: str
+
+
+_retry_context: ContextVar[AIRetryContext | None] = ContextVar(
+    "bifrost_ai_retry_context",
+    default=None,
+)
+_retry_http_client: httpx2.AsyncClient | None = None
+
+
+@contextmanager
+def ai_retry_context(*, provider: str, model: str, surface: str) -> Iterator[None]:
+    """Attach privacy-safe request identity to transport retry log records."""
+
+    token = _retry_context.set(AIRetryContext(provider, model, surface))
+    try:
+        yield
+    finally:
+        _retry_context.reset(token)
+
+
+def _retry_after_seconds(response: httpx2.Response) -> float | None:
+    raw = response.headers.get("Retry-After")
+    if not raw:
+        return None
+    try:
+        return max(0.0, float(raw))
+    except ValueError:
+        try:
+            retry_at = parsedate_to_datetime(raw)
+            if retry_at.tzinfo is None:
+                retry_at = retry_at.replace(tzinfo=timezone.utc)
+            return max(0.0, (retry_at - datetime.now(timezone.utc)).total_seconds())
+        except (TypeError, ValueError, OverflowError):
+            return None
+
+
+def _validate_response(response: httpx2.Response) -> None:
+    if response.status_code in RETRYABLE_STATUS_CODES:
+        response.raise_for_status()
+
+
+def _should_retry(exc: BaseException) -> bool:
+    if isinstance(exc, httpx2.HTTPStatusError):
+        response = exc.response
+        if response.status_code not in RETRYABLE_STATUS_CODES:
+            return False
+        retry_after = _retry_after_seconds(response)
+        if retry_after is not None and retry_after > MAX_RETRY_AFTER_SECONDS:
+            return False
+        return True
+    return isinstance(exc, httpx2.TransportError)
+
+
+def _log_before_sleep(state: RetryCallState) -> None:
+    exc = state.outcome.exception() if state.outcome is not None else None
+    response = getattr(exc, "response", None)
+    context = _retry_context.get()
+    logger.warning(
+        "ai_provider_request_retry",
+        extra={
+            "provider": context.provider if context else None,
+            "model": context.model if context else None,
+            "surface": context.surface if context else None,
+            "attempt": state.attempt_number,
+            "max_attempts": MAX_ATTEMPTS,
+            "status_code": getattr(response, "status_code", None),
+            "retry_after_seconds": (
+                _retry_after_seconds(response) if response is not None else None
+            ),
+            "sleep_seconds": (
+                state.next_action.sleep if state.next_action is not None else None
+            ),
+            "error_type": type(exc).__name__ if exc is not None else None,
+        },
+    )
+
+
+def _create_retry_transport(
+    wrapped: httpx2.AsyncBaseTransport | None = None,
+) -> AsyncHTTPX2TenacityTransport:
+    return AsyncHTTPX2TenacityTransport(
+        config=RetryConfig(
+            retry=retry_if_exception(_should_retry),
+            wait=wait_retry_after(
+                fallback_strategy=wait_random_exponential(multiplier=1, max=4),
+                max_wait=MAX_RETRY_AFTER_SECONDS,
+            ),
+            stop=stop_after_attempt(MAX_ATTEMPTS),
+            before_sleep=_log_before_sleep,
+            reraise=True,
+        ),
+        wrapped=wrapped,
+        validate_response=_validate_response,
+    )
+
+
+def _create_retry_http_client() -> httpx2.AsyncClient:
+    return httpx2.AsyncClient(
+        transport=_create_retry_transport(),
+        timeout=httpx2.Timeout(timeout=600, connect=5),
+        headers={"User-Agent": get_user_agent()},
+    )
+
+
+def get_ai_retry_http_client() -> httpx2.AsyncClient:
+    """Return the single retrying provider client owned by this process."""
+
+    global _retry_http_client
+    if _retry_http_client is None or _retry_http_client.is_closed:
+        _retry_http_client = _create_retry_http_client()
+    return _retry_http_client
+
+
+async def close_ai_retry_http_client() -> None:
+    """Close the process-scoped retry client during service shutdown."""
+
+    global _retry_http_client
+    client, _retry_http_client = _retry_http_client, None
+    if client is not None and not client.is_closed:
+        await client.aclose()

--- a/api/src/services/embeddings/openai_client.py
+++ b/api/src/services/embeddings/openai_client.py
@@ -9,6 +9,10 @@ import logging
 
 from openai import AsyncOpenAI
 
+from src.services.agent_runtime.retry_transport import (
+    ai_retry_context,
+    get_ai_retry_http_client,
+)
 from src.services.embeddings.base import BaseEmbeddingClient, EmbeddingConfig
 
 logger = logging.getLogger(__name__)
@@ -48,7 +52,12 @@ class OpenAIEmbeddingClient(BaseEmbeddingClient):
 
     def __init__(self, config: EmbeddingConfig):
         super().__init__(config)
-        self._client = AsyncOpenAI(api_key=config.api_key, base_url=config.endpoint or None)
+        self._client = AsyncOpenAI(
+            api_key=config.api_key,
+            base_url=config.endpoint or None,
+            http_client=get_ai_retry_http_client(),
+            max_retries=0,
+        )
 
     async def embed(self, texts: list[str]) -> list[list[float]]:
         """
@@ -83,11 +92,16 @@ class OpenAIEmbeddingClient(BaseEmbeddingClient):
             # to it) explicitly rejects base64 with a 200-shaped error body
             # the SDK then silently turns into "No embedding data received".
             # Plain floats work everywhere.
-            response = await self._client.embeddings.create(
-                input=texts,
+            with ai_retry_context(
+                provider="openai",
                 model=self.config.model,
-                encoding_format="float",
-            )
+                surface="embeddings",
+            ):
+                response = await self._client.embeddings.create(
+                    input=texts,
+                    model=self.config.model,
+                    encoding_format="float",
+                )
         except Exception as e:
             logger.error(f"Failed to generate embeddings: {e}")
             raise

--- a/api/src/services/execution/autonomous_agent_executor.py
+++ b/api/src/services/execution/autonomous_agent_executor.py
@@ -369,7 +369,11 @@ class AutonomousAgentExecutor:
             )
 
         base_model = create_agent_model(llm_config, model=model_name)
-        observed_model = ObservedModel(base_model, record_model_event)
+        observed_model = ObservedModel(
+            base_model,
+            record_model_event,
+            retry_surface="autonomous_agent",
+        )
         toolset = BifrostToolset(
             tool_definitions,
             execute_tool,

--- a/api/src/services/execution/run_summarizer.py
+++ b/api/src/services/execution/run_summarizer.py
@@ -14,10 +14,8 @@ swallowed. The handler in :mod:`src.jobs.summarize_worker` does the same
 belt-and-suspenders so the message is never re-queued. The UI exposes a
 regenerate button for recovery.
 """
-import asyncio
 import json
 import logging
-import random
 from datetime import datetime, timezone
 from typing import Any
 from uuid import UUID
@@ -32,7 +30,7 @@ from src.models.orm.agent_runs import AgentRun
 from src.models.orm.agents import Agent
 from src.services.ai_usage_service import record_ai_usage
 from src.services.execution.model_selection import get_summarization_client
-from src.services.llm import BaseLLMClient, LLMMessage, LLMResponse
+from src.services.llm import LLMMessage
 
 logger = logging.getLogger(__name__)
 
@@ -45,35 +43,6 @@ SUMMARIZE_BACKFILL_QUEUE = "agent-summarization-backfill"
 # endpoint's ``prompt_version_below`` filter to re-summarize runs stamped
 # with an older version.
 SUMMARIZE_PROMPT_VERSION = "v4"
-
-def _transient_llm_errors() -> tuple[type[BaseException], ...]:
-    """Transient LLM provider errors worth retrying in-handler.
-
-    The consumer runs with prefetch_count=1, so retrying here naturally
-    backpressures the whole pod — another pod's handler is free to service
-    other messages meanwhile.
-
-    openai is imported lazily so the SDK stays out of the worker import
-    closure (tests/unit/test_import_hygiene.py); except clauses evaluate
-    this call only when an exception is being matched, i.e. after an LLM
-    call has already loaded the SDK.
-    """
-    import openai
-
-    return (
-        openai.RateLimitError,
-        openai.APITimeoutError,
-        openai.APIConnectionError,
-        openai.InternalServerError,
-    )
-
-# Max wall time we'll spend retrying a single summarization. OpenRouter's RPM
-# windows reset every 60s, so ~2 minutes covers the common 429 case plus one
-# provider burp. Beyond this, the run is marked failed and the admin can
-# regenerate from the UI.
-_MAX_RETRIES = 5
-_INITIAL_BACKOFF_S = 2.0
-_MAX_BACKOFF_S = 30.0
 
 SUMMARIZE_SYSTEM_PROMPT = """You summarize what an AI agent did on a single run.
 
@@ -223,67 +192,6 @@ def _truncate(value: Any, max_len: int) -> str | None:
     return s or None
 
 
-def _retry_delay_from_exception(exc: BaseException, attempt: int) -> float:
-    """Compute backoff for a transient LLM error.
-
-    Prefers the provider-supplied ``Retry-After`` header on 429s (OpenRouter
-    sets this, and honoring it is the polite thing to do). Falls back to
-    exponential backoff with jitter so that many workers retrying in parallel
-    don't rendezvous on the same moment.
-    """
-    retry_after = None
-    response = getattr(exc, "response", None)
-    if response is not None:
-        headers = getattr(response, "headers", None)
-        if headers is not None:
-            raw = headers.get("Retry-After") or headers.get("retry-after")
-            if raw:
-                try:
-                    retry_after = float(raw)
-                except (TypeError, ValueError):
-                    retry_after = None
-
-    if retry_after is not None and retry_after > 0:
-        return min(retry_after, _MAX_BACKOFF_S)
-
-    base = min(_INITIAL_BACKOFF_S * (2 ** attempt), _MAX_BACKOFF_S)
-    return base * (0.5 + random.random() * 0.5)
-
-
-async def _complete_with_retry(
-    llm_client: BaseLLMClient,
-    messages: list[LLMMessage],
-    model: str,
-    run_id: UUID,
-) -> LLMResponse:
-    """Call the LLM with bounded retry on transient errors.
-
-    Retries ``RateLimitError``, timeouts, connection errors, and 5xx up to
-    ``_MAX_RETRIES`` times, then re-raises the last exception to the caller
-    (which will persist ``summary_status='failed'`` with the error message).
-    """
-    last_exc: BaseException | None = None
-    for attempt in range(_MAX_RETRIES + 1):
-        try:
-            return await llm_client.complete(messages=messages, model=model)
-        except _transient_llm_errors() as exc:
-            last_exc = exc
-            if attempt >= _MAX_RETRIES:
-                break
-            delay = _retry_delay_from_exception(exc, attempt)
-            logger.warning(
-                "Transient LLM error for run %s (attempt %d/%d, sleeping %.1fs): %s",
-                run_id,
-                attempt + 1,
-                _MAX_RETRIES,
-                delay,
-                type(exc).__name__,
-            )
-            await asyncio.sleep(delay)
-    assert last_exc is not None  # loop exits only via break after an exception
-    raise last_exc
-
-
 async def summarize_run(
     run_id: UUID, session_factory: async_sessionmaker[AsyncSession]
 ) -> None:
@@ -355,11 +263,11 @@ async def summarize_run(
     # truncation for reasoning models that spend tokens on hidden thinking.
     response = None
     try:
-        response = await _complete_with_retry(
-            llm_client=llm_client,
+        # Pydantic AI's native transport owns the single bounded request retry
+        # budget. Do not add an outer loop here: stacked budgets amplify 429s.
+        response = await llm_client.complete(
             messages=messages,
             model=resolved_model,
-            run_id=run_id,
         )
         raw_content = response.content or ""
         # Empty content is its own class of failure — OpenAI / reasoning models
@@ -421,24 +329,6 @@ async def summarize_run(
             await db.commit()
             await _broadcast_run(run, db)
         return
-    except _transient_llm_errors() as exc:
-        logger.warning(
-            "Summarizer exhausted retries on transient error for run %s: %s",
-            run_id,
-            type(exc).__name__,
-        )
-        async with session_factory() as db:
-            run = (
-                await db.execute(select(AgentRun).where(AgentRun.id == run_id))
-            ).scalar_one()
-            run.summary_status = "failed"
-            run.summary_error = (
-                f"LLM provider unavailable after retries "
-                f"({type(exc).__name__}): {str(exc)[:160]}"
-            )
-            await db.commit()
-            await _broadcast_run(run, db)
-        return
     except Exception as exc:  # pragma: no cover - defensive
         logger.exception("Summarizer LLM call failed for run %s", run_id)
         async with session_factory() as db:
@@ -446,7 +336,10 @@ async def summarize_run(
                 await db.execute(select(AgentRun).where(AgentRun.id == run_id))
             ).scalar_one()
             run.summary_status = "failed"
-            run.summary_error = f"LLM call failed: {str(exc)[:200]}"
+            run.summary_error = (
+                f"LLM provider request failed ({type(exc).__name__}): "
+                f"{str(exc)[:160]}"
+            )
             await db.commit()
             await _broadcast_run(run, db)
         return

--- a/api/src/services/llm/pydantic_client.py
+++ b/api/src/services/llm/pydantic_client.py
@@ -33,6 +33,7 @@ from src.services.agent_runtime.model_factory import (
     create_agent_model,
     provider_name_for_config,
 )
+from src.services.agent_runtime.retry_transport import ai_retry_context
 from src.services.agent_runtime.usage import provider_reported_cost
 from src.services.llm.base import (
     BaseLLMClient,
@@ -67,17 +68,23 @@ class PydanticAIClient(BaseLLMClient):
         # response. Anthropic rejects high-output non-streaming requests that
         # could exceed ten minutes, so this preserves the legacy contract
         # without leaking provider-specific behavior into callers.
-        async with model_request_stream(
-            create_agent_model(self.config, model=model),
-            self.convert_messages(messages),
-            model_settings=self._model_settings(max_tokens),
-            model_request_parameters=self._request_parameters(
-                tools, require_tool_call=require_tool_call
-            ),
-        ) as stream:
-            async for _ in stream:
-                pass
-            response = stream.get()
+        resolved_model = model or self.config.model
+        with ai_retry_context(
+            provider=self.provider_name,
+            model=resolved_model,
+            surface="llm_client.complete",
+        ):
+            async with model_request_stream(
+                create_agent_model(self.config, model=resolved_model),
+                self.convert_messages(messages),
+                model_settings=self._model_settings(max_tokens),
+                model_request_parameters=self._request_parameters(
+                    tools, require_tool_call=require_tool_call
+                ),
+            ) as stream:
+                async for _ in stream:
+                    pass
+                response = stream.get()
         return self._convert_response(response)
 
     async def stream(
@@ -89,39 +96,45 @@ class PydanticAIClient(BaseLLMClient):
         model: str | None = None,
     ) -> AsyncGenerator[LLMStreamChunk, None]:
         try:
-            async with model_request_stream(
-                create_agent_model(self.config, model=model),
-                self.convert_messages(messages),
-                model_settings=self._model_settings(max_tokens),
-                model_request_parameters=self._request_parameters(tools),
-            ) as stream:
-                async for event in stream:
-                    if isinstance(event, PartStartEvent) and isinstance(event.part, TextPart):
-                        if event.part.content:
-                            yield LLMStreamChunk(type="delta", content=event.part.content)
-                    elif isinstance(event, PartDeltaEvent) and isinstance(event.delta, TextPartDelta):
-                        if event.delta.content_delta:
-                            yield LLMStreamChunk(type="delta", content=event.delta.content_delta)
+            resolved_model = model or self.config.model
+            with ai_retry_context(
+                provider=self.provider_name,
+                model=resolved_model,
+                surface="llm_client.stream",
+            ):
+                async with model_request_stream(
+                    create_agent_model(self.config, model=resolved_model),
+                    self.convert_messages(messages),
+                    model_settings=self._model_settings(max_tokens),
+                    model_request_parameters=self._request_parameters(tools),
+                ) as stream:
+                    async for event in stream:
+                        if isinstance(event, PartStartEvent) and isinstance(event.part, TextPart):
+                            if event.part.content:
+                                yield LLMStreamChunk(type="delta", content=event.part.content)
+                        elif isinstance(event, PartDeltaEvent) and isinstance(event.delta, TextPartDelta):
+                            if event.delta.content_delta:
+                                yield LLMStreamChunk(type="delta", content=event.delta.content_delta)
 
-                response = stream.get()
-                for tool_call in response.tool_calls:
+                    response = stream.get()
+                    for tool_call in response.tool_calls:
+                        yield LLMStreamChunk(
+                            type="tool_call",
+                            tool_call=ToolCallRequest(
+                                id=tool_call.tool_call_id,
+                                name=tool_call.tool_name,
+                                arguments=tool_call.args_as_dict(),
+                            ),
+                        )
                     yield LLMStreamChunk(
-                        type="tool_call",
-                        tool_call=ToolCallRequest(
-                            id=tool_call.tool_call_id,
-                            name=tool_call.tool_name,
-                            arguments=tool_call.args_as_dict(),
-                        ),
+                        type="done",
+                        finish_reason=response.finish_reason,
+                        input_tokens=response.usage.input_tokens,
+                        output_tokens=response.usage.output_tokens,
+                        cache_read_tokens=response.usage.cache_read_tokens,
+                        cache_write_tokens=response.usage.cache_write_tokens,
+                        provider_cost=provider_reported_cost(response),
                     )
-                yield LLMStreamChunk(
-                    type="done",
-                    finish_reason=response.finish_reason,
-                    input_tokens=response.usage.input_tokens,
-                    output_tokens=response.usage.output_tokens,
-                    cache_read_tokens=response.usage.cache_read_tokens,
-                    cache_write_tokens=response.usage.cache_write_tokens,
-                    provider_cost=provider_reported_cost(response),
-                )
         except Exception as exc:
             logger.error("Pydantic AI streaming error: %s", exc)
             yield LLMStreamChunk(type="error", error=str(exc))

--- a/api/src/services/provider_catalog_service.py
+++ b/api/src/services/provider_catalog_service.py
@@ -8,6 +8,12 @@ from urllib.parse import urlparse
 
 import httpx
 
+from src.services.agent_runtime.retry_transport import (
+    MAX_ATTEMPTS,
+    RETRYABLE_STATUS_CODES,
+    ai_retry_context,
+    get_ai_retry_http_client,
+)
 from src.services.model_capabilities import OPENROUTER_MODELS_URL
 
 logger = logging.getLogger(__name__)
@@ -113,10 +119,20 @@ class ProviderCatalogService:
         try:
             from openai import AsyncOpenAI
 
-            client = AsyncOpenAI(api_key=api_key, base_url=endpoint or None)
+            client = AsyncOpenAI(
+                api_key=api_key,
+                base_url=endpoint or None,
+                http_client=get_ai_retry_http_client(),
+                max_retries=0,
+            )
             endpoint_label = endpoint or "https://api.openai.com/v1"
             try:
-                response = await client.models.list()
+                with ai_retry_context(
+                    provider="openrouter" if _is_openrouter_endpoint(endpoint) else "openai",
+                    model="catalog",
+                    surface="provider_catalog",
+                ):
+                    response = await client.models.list()
                 models = [
                     ProviderModelInfo(m.id, m.id, _model_output_modalities(m))
                     for m in sorted(response.data, key=lambda item: item.id)
@@ -139,10 +155,20 @@ class ProviderCatalogService:
         try:
             from anthropic import AsyncAnthropic
 
-            client = AsyncAnthropic(api_key=api_key, base_url=endpoint or None)
+            client = AsyncAnthropic(
+                api_key=api_key,
+                base_url=endpoint or None,
+                http_client=get_ai_retry_http_client(),
+                max_retries=0,
+            )
             endpoint_label = endpoint or "https://api.anthropic.com"
             try:
-                response = await client.models.list()
+                with ai_retry_context(
+                    provider="anthropic",
+                    model="catalog",
+                    surface="provider_catalog",
+                ):
+                    response = await client.models.list()
                 seen: set[str] = set()
                 models: list[ProviderModelInfo] = []
                 for item in sorted(response.data, key=lambda model: model.id, reverse=True):
@@ -167,10 +193,25 @@ class ProviderCatalogService:
 
             client = genai.Client(
                 api_key=api_key,
-                http_options=types.HttpOptions(base_url=endpoint) if endpoint else None,
+                http_options=types.HttpOptions(
+                    base_url=endpoint,
+                    retry_options=types.HttpRetryOptions(
+                        attempts=MAX_ATTEMPTS,
+                        initial_delay=1.0,
+                        max_delay=4.0,
+                        exp_base=2.0,
+                        jitter=1.0,
+                        http_status_codes=sorted(RETRYABLE_STATUS_CODES),
+                    ),
+                ),
             )
             try:
-                pager = await client.aio.models.list(config={"page_size": 100})
+                with ai_retry_context(
+                    provider="google",
+                    model="catalog",
+                    surface="provider_catalog",
+                ):
+                    pager = await client.aio.models.list(config={"page_size": 100})
                 models = [
                     ProviderModelInfo(
                         (item.name or "").removeprefix("models/"),

--- a/api/src/worker/app.py
+++ b/api/src/worker/app.py
@@ -197,6 +197,12 @@ class Worker:
         await rabbitmq.close()
         logger.info("RabbitMQ connections closed")
 
+        from src.services.agent_runtime.retry_transport import (
+            close_ai_retry_http_client,
+        )
+
+        await close_ai_retry_http_client()
+
         # Close database connections.
         await close_db()
         logger.info("Database connections closed")

--- a/api/tests/unit/jobs/schedulers/test_execution_cleanup.py
+++ b/api/tests/unit/jobs/schedulers/test_execution_cleanup.py
@@ -1,0 +1,150 @@
+"""Regression coverage for the scheduler execution cleanup job.
+
+The job now cleans up both workflow executions and stale AgentRun rows.
+These tests pin the agent-run side so the cleanup remains generic and
+does not interfere with active runs.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import select
+
+from src.jobs.schedulers import execution_cleanup as cleanup
+from src.models.orm.agent_runs import AgentRun
+
+pytestmark = pytest.mark.asyncio
+
+
+def _stale_time(minutes: int) -> datetime:
+    return datetime.now(timezone.utc) - timedelta(minutes=minutes)
+
+
+def _fresh_time(minutes: int) -> datetime:
+    return datetime.now(timezone.utc) - timedelta(minutes=minutes)
+
+
+async def _seed_agent_runs(db_session, agent, *, stale_minutes: int = 10) -> tuple[AgentRun, AgentRun, AgentRun]:
+    agent.max_run_timeout = 60
+    agent.updated_at = datetime.now(timezone.utc)
+
+    queued = AgentRun(
+        id=uuid4(),
+        agent_id=agent.id,
+        trigger_type="api",
+        status="queued",
+        iterations_used=0,
+        tokens_used=0,
+        created_at=_stale_time(stale_minutes),
+    )
+    running = AgentRun(
+        id=uuid4(),
+        agent_id=agent.id,
+        trigger_type="api",
+        status="running",
+        iterations_used=1,
+        tokens_used=25,
+        created_at=_stale_time(stale_minutes),
+        started_at=_stale_time(stale_minutes),
+    )
+    fresh_running = AgentRun(
+        id=uuid4(),
+        agent_id=agent.id,
+        trigger_type="api",
+        status="running",
+        iterations_used=1,
+        tokens_used=25,
+        created_at=_fresh_time(2),
+        started_at=_fresh_time(2),
+    )
+
+    db_session.add_all([agent, queued, running, fresh_running])
+    await db_session.commit()
+    return queued, running, fresh_running
+
+
+def _patch_cleanup_dependencies(monkeypatch, async_session_factory):
+    monkeypatch.setattr(cleanup, "get_session_factory", lambda: async_session_factory)
+    monkeypatch.setattr(cleanup, "publish_execution_update", AsyncMock())
+    monkeypatch.setattr(cleanup, "publish_history_update", AsyncMock())
+    monkeypatch.setattr(cleanup, "publish_agent_run_update", AsyncMock())
+
+
+async def _load_run(async_session_factory, run_id):
+    async with async_session_factory() as db_session:
+        result = await db_session.execute(select(AgentRun).where(AgentRun.id == run_id))
+        return result.scalar_one()
+
+
+def _agent_run_updates(mock_publish):
+    return [(call.args[0].id, call.args[0].status) for call in mock_publish.await_args_list]
+
+
+class TestExecutionCleanupAgentRuns:
+    async def test_cleanup_stale_agent_runs_terminalizes_and_broadcasts(
+        self,
+        db_session,
+        async_session_factory,
+        seed_agent,
+        monkeypatch,
+    ) -> None:
+        _patch_cleanup_dependencies(monkeypatch, async_session_factory)
+        queued, running, fresh_running = await _seed_agent_runs(db_session, seed_agent)
+
+        results = await cleanup.cleanup_stuck_executions()
+
+        assert results["agent_run_queued_timeouts"] == 1
+        assert results["agent_run_running_timeouts"] == 1
+        assert results["agent_run_total_cleaned"] == 2
+
+        queued_reloaded = await _load_run(async_session_factory, queued.id)
+        running_reloaded = await _load_run(async_session_factory, running.id)
+        fresh_reloaded = await _load_run(async_session_factory, fresh_running.id)
+
+        assert queued_reloaded.status == "failed"
+        assert queued_reloaded.completed_at is not None
+        assert "waiting in queue" in queued_reloaded.error
+
+        assert running_reloaded.status == "timeout"
+        assert running_reloaded.completed_at is not None
+        assert "timed out after 360 seconds" in running_reloaded.error
+
+        assert fresh_reloaded.status == "running"
+        assert fresh_reloaded.completed_at is None
+
+        assert cleanup.publish_agent_run_update.await_count == 2
+        assert set(_agent_run_updates(cleanup.publish_agent_run_update)) == {
+            (queued.id, "failed"),
+            (running.id, "timeout"),
+        }
+
+    async def test_cleanup_is_idempotent_and_skips_active_runs(
+        self,
+        db_session,
+        async_session_factory,
+        seed_agent,
+        monkeypatch,
+    ) -> None:
+        _patch_cleanup_dependencies(monkeypatch, async_session_factory)
+        queued, running, fresh_running = await _seed_agent_runs(db_session, seed_agent)
+
+        first = await cleanup.cleanup_stuck_executions()
+        queued_first = await _load_run(async_session_factory, queued.id)
+        running_first = await _load_run(async_session_factory, running.id)
+        fresh_first = await _load_run(async_session_factory, fresh_running.id)
+
+        second = await cleanup.cleanup_stuck_executions()
+        queued_second = await _load_run(async_session_factory, queued.id)
+        running_second = await _load_run(async_session_factory, running.id)
+        fresh_second = await _load_run(async_session_factory, fresh_running.id)
+
+        assert first["agent_run_total_cleaned"] == 2
+        assert second["agent_run_total_cleaned"] == 0
+        assert queued_first.status == queued_second.status == "failed"
+        assert running_first.status == running_second.status == "timeout"
+        assert fresh_first.status == fresh_second.status == "running"
+        assert fresh_second.completed_at is None

--- a/api/tests/unit/services/test_agent_run_consumer.py
+++ b/api/tests/unit/services/test_agent_run_consumer.py
@@ -1,9 +1,11 @@
 """Unit tests for AgentRunConsumer error handling paths."""
 
 import json
+from datetime import datetime, timezone
 import pytest
+from sqlalchemy import select
 from unittest.mock import AsyncMock, MagicMock, patch
-from uuid import uuid4
+from uuid import UUID, uuid4
 
 from src.jobs.consumers.agent_run import AgentRunConsumer
 from src.models.orm.agent_runs import AgentRun
@@ -20,6 +22,39 @@ class FakeRedisCtx:
 
     async def __aexit__(self, *args):
         pass
+
+
+class FakeLateExecutor:
+    """Executor stub that simulates a late terminalizer racing the consumer."""
+
+    def __init__(self, session_factory, redis_client):
+        self._session_factory = session_factory
+        self._redis = redis_client
+
+    async def run(self, *, run_id, **kwargs):
+        async with self._session_factory() as db:
+            run_obj = await db.get(AgentRun, UUID(run_id))
+            run_obj.status = "timeout"
+            run_obj.error = "scheduler terminalized the run"
+            run_obj.completed_at = datetime.now(timezone.utc)
+            await db.commit()
+
+        return {
+            "output": {"text": "late consumer result"},
+            "iterations_used": 9,
+            "tokens_used": 27,
+            "status": "completed",
+            "llm_model": "test-model",
+        }
+
+    async def flush_to_db(self, db):
+        return None
+
+
+async def _load_run(async_session_factory, run_id):
+    async with async_session_factory() as db:
+        result = await db.execute(select(AgentRun).where(AgentRun.id == run_id))
+        return result.scalar_one()
 
 
 @pytest.fixture
@@ -143,3 +178,68 @@ async def test_pre_cancel_updates_existing_queued_run(consumer):
     mock_session.add.assert_not_called()
     _, get_kwargs = mock_session.get.call_args
     assert get_kwargs["with_for_update"] == {"of": AgentRun}
+
+
+@pytest.mark.asyncio
+async def test_late_terminalized_run_is_not_overwritten(
+    consumer,
+    db_session,
+    async_session_factory,
+    seed_agent,
+):
+    run_id = uuid4()
+    run = AgentRun(
+        id=run_id,
+        agent_id=seed_agent.id,
+        trigger_type="manual",
+        status="queued",
+        iterations_used=0,
+        tokens_used=0,
+        created_at=datetime.now(timezone.utc),
+    )
+    db_session.add(run)
+    await db_session.commit()
+
+    consumer._session_factory = async_session_factory
+
+    redis_mock = AsyncMock()
+    context_key = f"bifrost:agent_run:{run_id}:context"
+    cancel_key = f"bifrost:agent_run:{run_id}:cancel"
+
+    async def _redis_get(key):
+        if key == context_key:
+            return json.dumps({"org_id": str(uuid4()), "input": "hello"})
+        if key == cancel_key:
+            return None
+        return None
+
+    redis_mock.get.side_effect = _redis_get
+
+    with (
+        patch("src.jobs.consumers.agent_run.get_redis", return_value=FakeRedisCtx(redis_mock)),
+        patch(
+            "src.services.execution.autonomous_agent_executor.AutonomousAgentExecutor",
+            FakeLateExecutor,
+        ),
+        patch("src.jobs.consumers.agent_run.publish_agent_run_update", AsyncMock()) as publish_mock,
+        patch("src.jobs.consumers.agent_run._publish_sync_result", AsyncMock()) as sync_mock,
+    ):
+        await consumer.process_message(
+            {
+                "run_id": str(run_id),
+                "agent_id": str(seed_agent.id),
+                "trigger_type": "manual",
+                "sync": True,
+            }
+        )
+
+    refreshed = await _load_run(async_session_factory, run_id)
+    assert refreshed.status == "timeout"
+    assert refreshed.error == "scheduler terminalized the run"
+    assert refreshed.completed_at is not None
+    assert publish_mock.await_count == 2
+    assert publish_mock.await_args_list[0].args[0].status == "running"
+    assert publish_mock.await_args_list[1].args[0].status == "timeout"
+    sync_payload = sync_mock.await_args.args[1]
+    assert sync_payload["status"] == "timeout"
+    assert sync_payload["error"] == "scheduler terminalized the run"

--- a/api/tests/unit/services/test_agent_runtime.py
+++ b/api/tests/unit/services/test_agent_runtime.py
@@ -165,6 +165,11 @@ def test_create_agent_model_supports_every_configured_provider(
 
     assert model.model_name == "test-model"
     assert model.system == expected_system
+    provider_client = model.provider.client
+    if provider == "google":
+        assert provider_client._api_client._async_httpx_client is not None
+    else:
+        assert provider_client.max_retries == 0
 
 
 def test_create_agent_model_uses_native_openrouter_adapter() -> None:
@@ -182,6 +187,7 @@ def test_create_agent_model_uses_native_openrouter_adapter() -> None:
     assert isinstance(model, OpenRouterModel)
     assert model.model_name == "~deepseek/deepseek-v4-flash-latest"
     assert model.system == "openrouter"
+    assert model.provider.client.max_retries == 0
     settings = cast(OpenRouterModelSettings, model.settings)
     assert settings.get("openrouter_usage") == {"include": True}
 

--- a/api/tests/unit/services/test_ai_retry_transport.py
+++ b/api/tests/unit/services/test_ai_retry_transport.py
@@ -1,0 +1,132 @@
+"""Focused contracts for Bifrost's native Pydantic AI retry transport."""
+
+from __future__ import annotations
+
+import logging
+
+import httpx2
+import pytest
+
+from src.services.agent_runtime.retry_transport import (
+    MAX_ATTEMPTS,
+    _create_retry_transport,
+    ai_retry_context,
+)
+
+
+def _client(handler) -> httpx2.AsyncClient:
+    return httpx2.AsyncClient(
+        transport=_create_retry_transport(httpx2.MockTransport(handler))
+    )
+
+
+@pytest.mark.asyncio
+async def test_retries_429_with_retry_after_and_logs_context(caplog) -> None:
+    attempts = 0
+
+    async def handler(request: httpx2.Request) -> httpx2.Response:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            return httpx2.Response(429, headers={"Retry-After": "0"})
+        return httpx2.Response(200, json={"ok": True})
+
+    async with _client(handler) as client:
+        with (
+            caplog.at_level(logging.WARNING),
+            ai_retry_context(
+                provider="openrouter",
+                model="test-model",
+                surface="test",
+            ),
+        ):
+            response = await client.get("https://openrouter.ai/test")
+
+    assert response.status_code == 200
+    assert attempts == 2
+    record = next(r for r in caplog.records if r.message == "ai_provider_request_retry")
+    assert record.provider == "openrouter"
+    assert record.model == "test-model"
+    assert record.surface == "test"
+    assert record.status_code == 429
+    assert record.retry_after_seconds == 0
+
+
+@pytest.mark.asyncio
+async def test_exhaustion_is_bounded_to_three_total_attempts() -> None:
+    attempts = 0
+
+    async def handler(request: httpx2.Request) -> httpx2.Response:
+        nonlocal attempts
+        attempts += 1
+        return httpx2.Response(503, headers={"Retry-After": "0"})
+
+    async with _client(handler) as client:
+        with pytest.raises(httpx2.HTTPStatusError):
+            await client.get("https://api.example.test/model")
+
+    assert attempts == MAX_ATTEMPTS
+
+
+@pytest.mark.asyncio
+async def test_non_retryable_400_is_returned_once() -> None:
+    attempts = 0
+
+    async def handler(request: httpx2.Request) -> httpx2.Response:
+        nonlocal attempts
+        attempts += 1
+        return httpx2.Response(400)
+
+    async with _client(handler) as client:
+        response = await client.get("https://api.example.test/model")
+
+    assert response.status_code == 400
+    assert attempts == 1
+
+
+@pytest.mark.asyncio
+async def test_retry_after_over_limit_is_terminal() -> None:
+    attempts = 0
+
+    async def handler(request: httpx2.Request) -> httpx2.Response:
+        nonlocal attempts
+        attempts += 1
+        return httpx2.Response(429, headers={"Retry-After": "61"})
+
+    async with _client(handler) as client:
+        with pytest.raises(httpx2.HTTPStatusError):
+            await client.get("https://api.example.test/model")
+
+    assert attempts == 1
+
+
+@pytest.mark.asyncio
+async def test_transport_errors_use_the_same_bounded_budget() -> None:
+    attempts = 0
+
+    async def handler(request: httpx2.Request) -> httpx2.Response:
+        nonlocal attempts
+        attempts += 1
+        raise httpx2.ConnectError("provider unavailable", request=request)
+
+    async with _client(handler) as client:
+        with pytest.raises(httpx2.ConnectError):
+            await client.get("https://api.example.test/model")
+
+    assert attempts == MAX_ATTEMPTS
+
+
+@pytest.mark.asyncio
+async def test_invalid_retry_after_falls_back_to_bounded_retry() -> None:
+    attempts = 0
+
+    async def handler(request: httpx2.Request) -> httpx2.Response:
+        nonlocal attempts
+        attempts += 1
+        return httpx2.Response(429, headers={"Retry-After": "not-a-delay"})
+
+    async with _client(handler) as client:
+        with pytest.raises(httpx2.HTTPStatusError):
+            await client.get("https://api.example.test/model")
+
+    assert attempts == MAX_ATTEMPTS

--- a/api/tests/unit/test_run_summarizer.py
+++ b/api/tests/unit/test_run_summarizer.py
@@ -8,8 +8,6 @@ extraction, and persists the parsed result onto the run record + an
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
-import httpx
-import openai
 import pytest
 import pytest_asyncio
 from sqlalchemy import delete, select
@@ -20,30 +18,8 @@ from src.services.llm import LLMResponse
 from src.services.execution.run_summarizer import (
     _clamp_confidence,
     _extract_json_object,
-    _retry_delay_from_exception,
     summarize_run,
 )
-
-
-def _build_rate_limit_error(retry_after: str | None = None) -> openai.RateLimitError:
-    """Build a realistic-looking openai.RateLimitError for retry tests.
-
-    The SDK's exception requires an httpx.Response so ``exc.response.headers``
-    works; retry-after honoring depends on that attribute chain.
-    """
-    headers = {}
-    if retry_after is not None:
-        headers["Retry-After"] = retry_after
-    response = httpx.Response(
-        status_code=429,
-        headers=headers,
-        request=httpx.Request("POST", "https://openrouter.ai/api/v1/chat/completions"),
-    )
-    return openai.RateLimitError(
-        "429 rate limit exceeded (test)",
-        response=response,
-        body=None,
-    )
 
 
 @pytest_asyncio.fixture
@@ -346,98 +322,25 @@ def test_clamp_confidence():
     assert _clamp_confidence("0.7") == 0.7  # numeric string parsed
 
 
-def test_retry_delay_honors_retry_after_header():
-    """429 with Retry-After should override the exponential backoff."""
-    exc = _build_rate_limit_error(retry_after="3")
-    # Attempt index shouldn't matter when the header is present.
-    assert _retry_delay_from_exception(exc, attempt=0) == 3.0
-    assert _retry_delay_from_exception(exc, attempt=4) == 3.0
-
-
-def test_retry_delay_falls_back_to_exponential_with_jitter():
-    """Without Retry-After, delay grows with attempt and has jitter."""
-    exc = _build_rate_limit_error(retry_after=None)
-    # Jitter is in [0.5, 1.0) of base — we just bound it.
-    d0 = _retry_delay_from_exception(exc, attempt=0)
-    d2 = _retry_delay_from_exception(exc, attempt=2)
-    assert 1.0 <= d0 <= 2.0  # base=2, jitter half-to-full
-    assert 4.0 <= d2 <= 8.0  # base=8
-    # Cap enforced.
-    huge = _retry_delay_from_exception(exc, attempt=10)
-    assert huge <= 30.0
-
-
 @pytest.mark.asyncio
-async def test_summarize_run_retries_429_then_succeeds(
+async def test_summarize_run_does_not_stack_transport_retries(
     async_session_factory, seed_completed_run
 ):
-    """Transient 429 on the first attempt should be retried, not persisted as
-    a terminal failure. Regression: prior to the fix, OpenRouter 429s during
-    a backfill permanently failed ~525 runs because the summarizer's generic
-    `except Exception` treated rate limits the same as invalid JSON."""
-    from src.services.execution import run_summarizer as mod
-
-    ok_resp = _build_mock_llm_response(
-        '{"asked": "reset", "did": "routed", "confidence": 0.8, '
-        '"confidence_reason": "clear", "metadata": {}}'
-    )
-    mock_client = MagicMock()
-    # First call: 429. Second call: success.
-    mock_client.complete = AsyncMock(
-        side_effect=[_build_rate_limit_error(retry_after="0"), ok_resp]
-    )
-    mock_client.provider_name = "openai"
-
-    # Patch asyncio.sleep so the test doesn't actually wait.
-    with (
-        patch.object(
-            mod,
-            "get_summarization_client",
-            new=AsyncMock(return_value=(mock_client, "gemini-3-flash")),
-        ),
-        patch.object(mod.asyncio, "sleep", new=AsyncMock()),
-    ):
-        await summarize_run(seed_completed_run.id, async_session_factory)
-
-    assert mock_client.complete.await_count == 2
-    async with async_session_factory() as db:
-        run = (
-            await db.execute(
-                select(AgentRun).where(AgentRun.id == seed_completed_run.id)
-            )
-        ).scalar_one()
-        assert run.summary_status == "completed"
-        assert run.asked == "reset"
-
-
-@pytest.mark.asyncio
-async def test_summarize_run_429_exhausts_retries_marks_failed(
-    async_session_factory, seed_completed_run
-):
-    """After the retry budget is exhausted, the run is marked failed with a
-    message that identifies the transient error type — admins should not have
-    to grep worker logs to tell 'provider was rate-limiting us' from 'model
-    returned bad JSON'."""
+    """A provider-exhausted request is attempted once at the summary layer."""
     from src.services.execution import run_summarizer as mod
 
     mock_client = MagicMock()
-    mock_client.complete = AsyncMock(
-        side_effect=_build_rate_limit_error(retry_after="0")
-    )
+    mock_client.complete = AsyncMock(side_effect=RuntimeError("429 rate limited"))
     mock_client.provider_name = "openai"
 
-    with (
-        patch.object(
-            mod,
-            "get_summarization_client",
-            new=AsyncMock(return_value=(mock_client, "gemini-3-flash")),
-        ),
-        patch.object(mod.asyncio, "sleep", new=AsyncMock()),
+    with patch.object(
+        mod,
+        "get_summarization_client",
+        new=AsyncMock(return_value=(mock_client, "gemini-3-flash")),
     ):
         await summarize_run(seed_completed_run.id, async_session_factory)
 
-    # _MAX_RETRIES=5 retries after the initial attempt → 6 total calls.
-    assert mock_client.complete.await_count == mod._MAX_RETRIES + 1
+    assert mock_client.complete.await_count == 1
     async with async_session_factory() as db:
         run = (
             await db.execute(
@@ -446,8 +349,8 @@ async def test_summarize_run_429_exhausts_retries_marks_failed(
         ).scalar_one()
         assert run.summary_status == "failed"
         assert run.summary_error is not None
-        assert "RateLimitError" in run.summary_error
-        assert "after retries" in run.summary_error
+        assert "RuntimeError" in run.summary_error
+        assert "429 rate limited" in run.summary_error
 
 
 class TestExtractJsonObject:

--- a/docs/architecture/pydantic-ai-runtime-recovery.md
+++ b/docs/architecture/pydantic-ai-runtime-recovery.md
@@ -1,0 +1,174 @@
+# Pydantic AI runtime and recovery policy
+
+Issue: [#647](https://github.com/gobifrost/bifrost/issues/647)
+
+This note covers the shared AI runtime after the Pydantic AI migration, the
+boundaries between native provider transport and Bifrost-owned recovery, and
+the terminal recovery paths we keep exposed to operators.
+
+## Policy
+
+Bifrost uses Pydantic AI for provider transport and message/tool execution, but
+Bifrost still owns:
+
+- authorization and persistence;
+- recovery semantics above the transport layer;
+- terminal run state;
+- operator-visible summaries and backfills;
+- no-fallback policy decisions.
+
+Approved retry policy:
+
+- Pydantic AI native transport is the sole model-request retry layer.
+- Model requests retry at most 3 attempts total.
+- Retryable statuses are 408, 429, 500, 502, 503, and 504; transport
+  timeouts and connection failures are also retryable.
+- When a 429 includes `Retry-After`, honor it if the value is `<= 60`
+  seconds.
+- When `Retry-After` is missing or invalid, use exponential jitter. A valid
+  value greater than 60 seconds is terminal at the transport layer rather
+  than occupying a worker or retrying before the provider permits it.
+- Streaming calls do not get a separate replay path; if a stream fails, the
+  failure is surfaced rather than retried as a stream.
+- Raw media POSTs are not model requests. Image/video upload and generation
+  calls use their own request handling and do not participate in the model
+  retry loop.
+
+The runtime must not invent a second provider selection path or silently switch
+to a different provider when the selected provider fails.
+
+## Runtime split
+
+The transport boundary is the Pydantic AI client layer:
+
+- `api/src/services/llm/pydantic_client.py` adapts Bifrost's public LLM
+  contract onto Pydantic AI.
+- `api/src/services/agent_runtime/model_factory.py` chooses the provider-native
+  adapter and preserves OpenRouter identity when the endpoint is OpenRouter.
+- `api/src/services/agent_runtime/observed_model.py` records privacy-safe
+  request shape and provider-visible usage without storing prompt contents.
+
+Bifrost-owned recovery lives above that layer:
+
+- `api/src/services/execution/agent_executor.py` and
+  `api/src/services/execution/autonomous_agent_executor.py` own run budgets,
+  one bounded correction for malformed tool output, and terminal run states.
+- `api/src/services/execution/run_summarizer.py` owns summary terminalization
+  and recovery bookkeeping, not a second outer retry loop.
+- `api/src/services/execution/backfill_tracker.py` and the existing
+  backfill/status surfaces own durable recovery for summarization work.
+
+## Raw AI surfaces
+
+These are the places where we intentionally talk to providers or provider-like
+catalogs directly, so they should be treated as raw AI surfaces rather than
+generic agent retries:
+
+| Surface | What can fail | Intended behavior |
+| --- | --- | --- |
+| Embeddings | empty 200s, transient HTTP errors, bad endpoint config | Use the same bounded transport with SDK retries disabled; split empty batches; do not fall back to a different provider |
+| Model discovery / catalogs | provider auth errors, 429s, unsupported model-listing endpoints | Return a clear test result; do not replace the selected provider |
+| Pricing discovery | catalog fetch failures, malformed pricing payloads | Best-effort update only; stale pricing is better than broken writes |
+| Raw media POSTs | provider-specific HTTP / transport failures on image/video upload or generation posts | Surface the provider failure to the caller; do not auto-switch providers or replay the binary request |
+| Agent summarization | transient provider 429 / timeout / connection errors | Let the native transport handle retries; summarize_run records the terminal outcome and recovery path |
+
+The media row is intentionally separate: raw image/video POSTs are not model
+requests, so they are outside the native transport retry contract even though
+they still talk to the same provider family.
+
+## Idempotency rules
+
+Recovery is idempotent only when the data model says it is:
+
+- `summarize_run` is idempotent once `summary_status == "completed"`.
+- Backfill messages are deduplicated through the existing summarization queue
+  and the completed-summary guard.
+- Agent runs are terminal when they are `completed`, `failed`, `cancelled`, or
+  `budget_exceeded`; recovery means a new run or a resumable handoff, not a
+  hidden restart of the same terminal row.
+- Bifrost permits one bounded retry for malformed tool sequencing in the agent
+  runtime, but not an unbounded provider retry loop.
+- Current AgentRun cleanup only terminalizes stale runs; it does not replay or
+  resurrect the prior execution.
+
+## No provider fallback
+
+Do not turn a provider failure into a different provider selection decision.
+That includes:
+
+- falling back from OpenRouter to stock OpenAI when the selected OpenRouter
+  route is rate-limited;
+- falling back from a custom endpoint to stock OpenAI for embeddings;
+- silently swapping catalog sources after a pricing or model-listing failure.
+
+The selected provider or endpoint is part of the contract. If it fails, the
+caller sees the failure and the operator decides whether to retry, repair the
+configuration, or use a separate recovery path.
+
+## Observability
+
+We want failures to be visible without exposing prompt text or keys:
+
+- `ObservedModel` records request shape, not raw content.
+- `AgentRunStep` and `AgentRun.summary_error` make terminal failure states
+  inspectable.
+- `AIUsage` records the token/cost ledger for completed model calls.
+- Summarization recovery publishes updates through the existing run-update
+  surfaces so admins can see progress without polling a custom endpoint.
+
+The main diagnostic distinction is this:
+
+- transport failure means the provider or endpoint failed;
+- terminal failure means Bifrost has exhausted its bounded recovery and the row
+  is now awaiting operator action;
+- resumable recovery means the user can rerun the same logical task through the
+  dedicated recovery surface.
+
+## Ticket 432431
+
+Ticket `432431` was recovered by ticket-specific Halo lease/watchdog logic for
+an idle assigned ticket. It is not a summarization retry incident, and it does
+not generalize to the broader AI runtime.
+
+The follow-on AgentRun cleanup only terminalizes stale runs without replaying
+them. That is intentionally narrower than the 432431 ticket path and should not
+be treated as a generalized recover-and-rerun mechanism.
+
+## Operator runbook
+
+1. If summarization fails transiently, rerun the existing recovery surface
+   rather than adding a second retry loop or reprocessing the whole
+   conversation manually.
+2. If an embedding or catalog call fails, fix the saved provider/endpoint
+   configuration and retry the original action.
+3. If a run is terminal, use the terminal recovery path for that surface
+   instead of reopening the same row.
+4. If the same failure repeats, capture the exact provider, endpoint, model,
+   and error shape before changing policy.
+
+## Remaining limitations
+
+- The runtime still depends on provider-specific behavior for rate limiting and
+  retry headers.
+- Direct OpenRouter media-catalog and pricing GETs remain best-effort raw HTTP
+  calls and do not yet share the model-request transport.
+- Raw media POSTs do not yet retry even an explicit 429. They remain terminal
+  until those legacy HTTPX calls have provider-supported idempotency keys or a
+  dedicated Pydantic AI transport that cannot replay an accepted submission.
+- Some raw AI surfaces still return generic provider errors rather than
+  structured error codes.
+- Catalog and pricing discovery are best-effort by design, so stale data is
+  acceptable when the provider is unavailable.
+- This policy does not define a new global provider failover system.
+
+## Related code
+
+- `api/src/services/llm/pydantic_client.py`
+- `api/src/services/agent_runtime/model_factory.py`
+- `api/src/services/agent_runtime/observed_model.py`
+- `api/src/services/execution/agent_executor.py`
+- `api/src/services/execution/autonomous_agent_executor.py`
+- `api/src/services/execution/run_summarizer.py`
+- `api/src/services/embeddings/openai_client.py`
+- `api/src/services/provider_catalog_service.py`
+- `api/src/services/model_pricing.py`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,7 +130,7 @@ dependencies = [
     # =========================================================================
     # Exact pins are intentional: the Harness API is still pre-1.0 and is the
     # execution boundary for every Bifrost agent surface.
-    "pydantic-ai-slim[openai,anthropic,google]==2.33.0",
+    "pydantic-ai-slim[openai,anthropic,google,retries]==2.33.0",
     "pydantic-ai-harness==0.24.0",
 
     # =========================================================================

--- a/requirements.lock
+++ b/requirements.lock
@@ -1212,6 +1212,7 @@ httpx==0.28.1 \
     #   google-genai
     #   mcp
     #   pydantic-ai-harness
+    #   pydantic-ai-slim
 httpx-sse==0.4.3 \
     --hash=sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc \
     --hash=sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d
@@ -2309,7 +2310,7 @@ pydantic-ai-harness==0.24.0 \
     --hash=sha256:6caa05a553b0cef6acc8a63fd1440ce80aaba2709ef02987daaf8ef415c85234 \
     --hash=sha256:f1b738b788b48a30570d47ea094b0e6cbcb4ff1b3ec5a889d0d37691733178a1
     # via bifrost-api (pyproject.toml)
-pydantic-ai-slim[anthropic,google,openai]==2.33.0 \
+pydantic-ai-slim[anthropic,google,openai,retries]==2.33.0 \
     --hash=sha256:5ab28c9f6d7c0a6dd8e5c4f75ba4bcfa84a7f6aa0faa7b64209fbcaa981f922b \
     --hash=sha256:7809e3000df0265ee93e7c55ff1d852621a23b22ccb5ad790d9228e457cfb10a
     # via
@@ -3025,7 +3026,9 @@ starlette==1.0.0 \
 tenacity==9.1.4 \
     --hash=sha256:6095a360c919085f28c6527de529e76a06ad89b23659fa881ae0649b867a9d55 \
     --hash=sha256:adb31d4c263f2bd041081ab33b498309a57c77f9acf2db65aadf0898179cf93a
-    # via google-genai
+    # via
+    #   google-genai
+    #   pydantic-ai-slim
 textual==8.2.4 \
     --hash=sha256:a83bd3f0cc7125ca203845af753f9d6b6be030025ecd1b05cc75ebe645b9c4ba \
     --hash=sha256:d4e2b2ddd7157191d00b228592b7c739ea080b7d792fd410f23ca75f05ea76c4


### PR DESCRIPTION
## Summary
- make Pydantic AI native transport the sole model-request retry layer with a three-attempt, Retry-After-aware policy
- disable provider SDK retry stacking across agents, chat, summarization, embeddings, and supported catalog clients
- terminalize stale non-ticket AgentRuns safely without replay and prevent late workers from overwriting watchdog outcomes
- document the audited execution surfaces, ticket 432431 generalization boundary, and remaining raw HTTP limitations

## Verification
- `./test.sh pre-pr`
  - production client build, TypeScript, and lint passed
  - 290 Vitest files / 1,861 tests passed
  - API quality passed
  - backend unit/contract: 5,767 passed, 3 skipped, 20 deselected
  - backend E2E: 1,778 passed, 1 skipped
  - Playwright smoke: 4 passed
  - production API candidate build/smoke passed
- focused retry/recovery suite: 62 passed, then retry transport expansion: 6 passed

Fixes #647