### PR TITLE
fix(events): enforce subscription payload filters

### DIFF
--- a/api/shared/event_filters.py
+++ b/api/shared/event_filters.py
@@ -1,0 +1,57 @@
+"""Safe evaluation for event subscription payload filters."""
+
+from dataclasses import dataclass
+from typing import Any
+
+import jmespath
+from jmespath.exceptions import JMESPathError
+
+
+@dataclass(frozen=True)
+class EventFilterDecision:
+    """The result of evaluating one subscription filter."""
+
+    matches: bool
+    error: str | None = None
+
+
+def _normalize_expression(expression: str) -> str:
+    """Accept the documented JSONPath-style root prefix in JMESPath expressions."""
+    normalized = expression.strip()
+    if normalized == "$":
+        return "@"
+    if normalized.startswith("$."):
+        return normalized[2:]
+    if normalized.startswith("$["):
+        return normalized[1:]
+    return normalized
+
+
+def _is_truthy(value: Any) -> bool:
+    """Apply JMESPath truthiness, where numeric zero remains truthy."""
+    if value is None or value is False:
+        return False
+    if isinstance(value, (str, list, dict)) and not value:
+        return False
+    return True
+
+
+def evaluate_event_filter(
+    expression: str | None,
+    payload: dict[str, Any],
+) -> EventFilterDecision:
+    """Evaluate a JSONPath-style subscription filter against an event payload.
+
+    Expressions use JMESPath operators and accept an optional JSONPath ``$`` root
+    prefix for compatibility with the public event subscription contract. Invalid
+    or unevaluable expressions fail closed.
+    """
+    if expression is None or not expression.strip():
+        return EventFilterDecision(matches=True)
+
+    try:
+        result = jmespath.search(_normalize_expression(expression), payload)
+    except JMESPathError as exc:
+        return EventFilterDecision(matches=False, error=str(exc))
+
+    return EventFilterDecision(matches=_is_truthy(result))

--- a/api/src/models/contracts/events.py
+++ b/api/src/models/contracts/events.py
@@ -194,7 +194,7 @@ class EventSubscriptionCreate(BaseModel):
     )
     filter_expression: str | None = Field(
         default=None,
-        description="Optional JSONPath filter expression (future use)",
+        description="Optional JSONPath-style event payload filter (JMESPath syntax; '$' root prefix supported)",
     )
     input_mapping: dict[str, Any] | None = Field(
         default=None,

--- a/api/src/repositories/events.py
+++ b/api/src/repositories/events.py
@@ -526,7 +526,7 @@ class EventDeliveryRepository(BaseRepository[EventDelivery]):
         Update event status based on delivery statuses.
 
         Sets event to:
-        - COMPLETED if all deliveries succeeded
+        - COMPLETED if all deliveries reached a non-failed terminal status
         - FAILED if any delivery failed
         - PROCESSING if any delivery is pending
         """
@@ -546,12 +546,13 @@ class EventDeliveryRepository(BaseRepository[EventDelivery]):
         queued = status_counts.get(EventDeliveryStatus.QUEUED, 0)
         failed = status_counts.get(EventDeliveryStatus.FAILED, 0)
         success = status_counts.get(EventDeliveryStatus.SUCCESS, 0)
+        skipped = status_counts.get(EventDeliveryStatus.SKIPPED, 0)
 
         if pending > 0 or queued > 0:
             event.status = EventStatus.PROCESSING
         elif failed > 0:
             event.status = EventStatus.FAILED
-        elif success > 0:
+        elif success > 0 or skipped > 0:
             event.status = EventStatus.COMPLETED
         # else: keep current status
 

--- a/api/src/services/events/processor.py
+++ b/api/src/services/events/processor.py
@@ -20,6 +20,7 @@ from typing import Any
 from uuid import UUID
 
 import sqlalchemy as sa
+from shared.event_filters import EventFilterDecision, evaluate_event_filter
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import joinedload
 
@@ -214,6 +215,70 @@ class EventProcessor:
         self._event_repo = EventRepository(session)
         self._delivery_repo = EventDeliveryRepository(session)
 
+    @staticmethod
+    def _evaluate_subscription_filter(
+        subscription: EventSubscription,
+        payload: dict[str, Any],
+        event_id: uuid.UUID,
+    ) -> EventFilterDecision:
+        """Evaluate and log the dispatch decision for one subscription."""
+        decision = evaluate_event_filter(subscription.filter_expression, payload)
+        if decision.matches:
+            return decision
+
+        log_context = {
+            "event_id": str(event_id),
+            "subscription_id": str(subscription.id),
+        }
+        if decision.error:
+            logger.warning(
+                "Event subscription filter evaluation failed; delivery skipped",
+                extra={**log_context, "filter_error": log_safe(decision.error)},
+            )
+        else:
+            logger.info(
+                "Event subscription filter did not match; delivery skipped",
+                extra=log_context,
+            )
+        return decision
+
+    def _build_subscription_delivery(
+        self,
+        event: Event,
+        subscription: EventSubscription,
+    ) -> tuple[EventDelivery, bool]:
+        """Build a pending or observably skipped delivery for a subscription."""
+        filter_decision = self._evaluate_subscription_filter(
+            subscription,
+            event.data,
+            event.id,
+        )
+        if filter_decision.matches:
+            status = EventDeliveryStatus.PENDING
+            error_message = None
+            completed_at = None
+        else:
+            status = EventDeliveryStatus.SKIPPED
+            error_message = (
+                "Subscription filter did not match the event payload"
+                if filter_decision.error is None
+                else "Subscription filter could not be evaluated"
+            )
+            completed_at = datetime.now(timezone.utc)
+
+        return (
+            EventDelivery(
+                id=uuid.uuid4(),
+                event_id=event.id,
+                event_subscription_id=subscription.id,
+                workflow_id=subscription.workflow_id,
+                status=status,
+                error_message=error_message,
+                completed_at=completed_at,
+            ),
+            filter_decision.matches,
+        )
+
     async def process_webhook(
         self,
         event_source: EventSource,
@@ -346,9 +411,8 @@ class EventProcessor:
             logger.info(f"No subscriptions for topic '{log_safe(topic)}': {event.id}")
             return event.id, 0
 
-        event.status = EventStatus.PROCESSING
-        await self.session.flush()
-
+        deliveries_created = 0
+        matching_subscriptions = 0
         for subscription in subscriptions:
             target_type = getattr(subscription, "target_type", "workflow") or "workflow"
             if target_type == "agent":
@@ -364,24 +428,32 @@ class EventProcessor:
                     )
                     continue
 
-            delivery = EventDelivery(
-                id=uuid.uuid4(),
-                event_id=event.id,
-                event_subscription_id=subscription.id,
-                workflow_id=subscription.workflow_id,
-                status=EventDeliveryStatus.PENDING,
+            delivery, filter_matches = self._build_subscription_delivery(
+                event,
+                subscription,
             )
             self.session.add(delivery)
+            deliveries_created += 1
+            if filter_matches:
+                matching_subscriptions += 1
 
+        event.status = (
+            EventStatus.PROCESSING
+            if matching_subscriptions
+            else EventStatus.COMPLETED
+        )
         await self.session.flush()
         logger.info(
             f"Created deliveries for topic '{log_safe(topic)}': {event.id}",
             extra={
                 "event_id": str(event.id),
-                "subscription_count": len(subscriptions),
+                "delivery_count": deliveries_created,
+                "matching_subscription_count": matching_subscriptions,
+                "skipped_subscription_count": deliveries_created
+                - matching_subscriptions,
             },
         )
-        return event.id, len(subscriptions)
+        return event.id, matching_subscriptions
 
     async def _process_delivery(
         self,
@@ -442,11 +514,8 @@ class EventProcessor:
                 event_type=deliver.event_type,
             )
 
-        # Create deliveries and queue executions
-        event.status = EventStatus.PROCESSING
-        await self.session.flush()
-
         deliveries_created = 0
+        matching_subscriptions = 0
         for subscription in subscriptions:
             target_type = getattr(subscription, "target_type", "workflow") or "workflow"
 
@@ -463,17 +532,20 @@ class EventProcessor:
                     )
                     continue
 
-            # Create delivery record
-            delivery = EventDelivery(
-                id=uuid.uuid4(),
-                event_id=event.id,
-                event_subscription_id=subscription.id,
-                workflow_id=subscription.workflow_id,  # None for agent targets
-                status=EventDeliveryStatus.PENDING,
+            delivery, filter_matches = self._build_subscription_delivery(
+                event,
+                subscription,
             )
             self.session.add(delivery)
             deliveries_created += 1
+            if filter_matches:
+                matching_subscriptions += 1
 
+        event.status = (
+            EventStatus.PROCESSING
+            if matching_subscriptions
+            else EventStatus.COMPLETED
+        )
         await self.session.flush()
 
         logger.info(
@@ -481,6 +553,9 @@ class EventProcessor:
             extra={
                 "event_id": str(event.id),
                 "delivery_count": deliveries_created,
+                "matching_subscription_count": matching_subscriptions,
+                "skipped_subscription_count": deliveries_created
+                - matching_subscriptions,
             },
         )
 
@@ -499,6 +574,7 @@ class EventProcessor:
         failed_count: int = 0,
         queued_count: int = 0,
         pending_count: int = 0,
+        skipped_count: int = 0,
     ) -> None:
         """
         Broadcast event update to WebSocket subscribers.
@@ -511,6 +587,7 @@ class EventProcessor:
             failed_count: Number of failed deliveries
             queued_count: Number of queued deliveries
             pending_count: Number of pending deliveries
+            skipped_count: Number of deliveries skipped by subscription filters
         """
         from src.core.pubsub import manager
 
@@ -530,7 +607,12 @@ class EventProcessor:
                 "failed_count": failed_count,
                 "queued_count": queued_count,
                 "pending_count": pending_count,
-                "delivery_count": success_count + failed_count + queued_count + pending_count,
+                "skipped_count": skipped_count,
+                "delivery_count": success_count
+                + failed_count
+                + queued_count
+                + pending_count
+                + skipped_count,
             },
         }
 
@@ -568,8 +650,23 @@ class EventProcessor:
             if delivery.status != EventDeliveryStatus.PENDING:
                 continue
 
+            subscription = delivery.subscription
+            filter_decision = self._evaluate_subscription_filter(
+                subscription,
+                event_obj.data,
+                event_obj.id,
+            )
+            if not filter_decision.matches:
+                delivery.status = EventDeliveryStatus.SKIPPED
+                delivery.error_message = (
+                    "Subscription filter did not match the event payload"
+                    if filter_decision.error is None
+                    else "Subscription filter could not be evaluated"
+                )
+                delivery.completed_at = datetime.now(timezone.utc)
+                continue
+
             try:
-                subscription = delivery.subscription
                 if subscription and subscription.target_type == "agent":
                     await self._queue_agent_run(delivery, event_obj)
                 else:
@@ -585,6 +682,7 @@ class EventProcessor:
                 delivery.error_message = str(e)
 
         await self.session.flush()
+        await self._delivery_repo.update_event_status(event_id)
 
         # Broadcast update after queueing (use already-loaded deliveries)
         success_count = sum(
@@ -599,6 +697,9 @@ class EventProcessor:
         pending_count = sum(
             1 for d in deliveries if d.status == EventDeliveryStatus.PENDING
         )
+        skipped_count = sum(
+            1 for d in deliveries if d.status == EventDeliveryStatus.SKIPPED
+        )
 
         await self._broadcast_event_update(
             event_source_id=event_obj.event_source_id,
@@ -608,6 +709,7 @@ class EventProcessor:
             failed_count=failed_count,
             queued_count=queued_count,
             pending_count=pending_count,
+            skipped_count=skipped_count,
         )
 
         return queued

--- a/api/tests/e2e/platform/test_event_subscription_filters.py
+++ b/api/tests/e2e/platform/test_event_subscription_filters.py
@@ -1,0 +1,69 @@
+import uuid
+
+import pytest
+from sqlalchemy import select
+
+from src.models.enums import EventDeliveryStatus, EventSourceType, EventStatus
+from src.models.orm.events import Event, EventDelivery, EventSource, EventSubscription
+from src.models.orm.workflows import Workflow
+from src.services.events.processor import EventProcessor
+
+
+pytestmark = pytest.mark.e2e
+
+
+@pytest.mark.asyncio
+async def test_topic_filter_non_match_persists_skipped_delivery(db_session) -> None:
+    topic = f"ticket.filter_{uuid.uuid4().hex[:8]}"
+    workflow = Workflow(
+        id=uuid.uuid4(),
+        name=f"Event Filter Test {uuid.uuid4().hex[:8]}",
+        function_name="event_filter_test",
+        path=f"workflows/event_filter_{uuid.uuid4().hex[:8]}.py",
+        type="workflow",
+        access_level="authenticated",
+        is_active=True,
+    )
+    source = EventSource(
+        id=uuid.uuid4(),
+        name=f"Event Filter Source {uuid.uuid4().hex[:8]}",
+        source_type=EventSourceType.TOPIC,
+        event_type=topic,
+        organization_id=None,
+        is_active=True,
+        created_by="event-filter-test@gobifrost.com",
+    )
+    subscription = EventSubscription(
+        id=uuid.uuid4(),
+        event_source_id=source.id,
+        target_type="workflow",
+        workflow_id=workflow.id,
+        event_type=topic,
+        filter_expression="$.priority == 'high'",
+        is_active=True,
+        created_by="event-filter-test@gobifrost.com",
+    )
+    db_session.add_all([workflow, source, subscription])
+    await db_session.flush()
+
+    processor = EventProcessor(db_session)
+    event_id, matching_subscribers = await processor.emit_topic(
+        topic=topic,
+        data={"priority": "low"},
+    )
+    queued = await processor.queue_event_deliveries(event_id)
+
+    event = await db_session.get(Event, event_id)
+    delivery = (
+        await db_session.execute(
+            select(EventDelivery).where(EventDelivery.event_id == event_id)
+        )
+    ).scalar_one()
+
+    assert matching_subscribers == 0
+    assert queued == 0
+    assert event is not None
+    assert event.status == EventStatus.COMPLETED
+    assert delivery.status == EventDeliveryStatus.SKIPPED
+    assert delivery.execution_id is None
+    assert delivery.error_message == "Subscription filter did not match the event payload"

--- a/api/tests/unit/repositories/test_event_delivery_repository.py
+++ b/api/tests/unit/repositories/test_event_delivery_repository.py
@@ -1,0 +1,24 @@
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+
+from src.models.enums import EventDeliveryStatus, EventStatus
+from src.repositories.events import EventDeliveryRepository
+
+
+@pytest.mark.asyncio
+async def test_update_event_status_completes_when_all_deliveries_are_skipped() -> None:
+    session = AsyncMock()
+    event = MagicMock()
+    event.status = EventStatus.PROCESSING
+    session.get.return_value = event
+
+    count_result = MagicMock()
+    count_result.all.return_value = [(EventDeliveryStatus.SKIPPED, 1)]
+    session.execute.return_value = count_result
+
+    await EventDeliveryRepository(session).update_event_status(uuid4())
+
+    assert event.status == EventStatus.COMPLETED
+    session.flush.assert_awaited_once()

--- a/api/tests/unit/services/events/test_emit_topic.py
+++ b/api/tests/unit/services/events/test_emit_topic.py
@@ -17,6 +17,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from src.models.enums import EventDeliveryStatus
+from src.services.webhooks.protocol import Deliver, WebhookRequest
 
 
 def _make_source(topic: str, org_id=None):
@@ -66,6 +67,7 @@ def _make_workflow_subscription(workflow_id=None, org_id=None):
     sub.workflow_id = workflow_id or uuid.uuid4()
     sub.agent_id = None
     sub.input_mapping = None
+    sub.filter_expression = None
 
     workflow = MagicMock()
     workflow.id = sub.workflow_id
@@ -175,6 +177,103 @@ async def test_emit_topic_with_subscriber_creates_delivery():
     assert deliveries[0].event_subscription_id == sub.id
     assert deliveries[0].status == EventDeliveryStatus.PENDING
     assert count == 1
+
+
+@pytest.mark.asyncio
+async def test_emit_topic_marks_non_matching_filter_delivery_skipped():
+    """A non-matching payload is observable but never eligible for dispatch."""
+    source = _make_source("ticket.created")
+    sub = _make_workflow_subscription()
+    sub.filter_expression = "$.priority == 'high'"
+    processor, session = _make_processor(source=source, subscriptions=[sub])
+
+    added_objects = []
+    session.add = lambda obj: added_objects.append(obj)
+    session.flush = AsyncMock()
+
+    event_id, count = await processor.emit_topic(
+        topic="ticket.created",
+        data={"priority": "low"},
+    )
+
+    from src.models.enums import EventStatus
+    from src.models.orm.events import Event, EventDelivery
+
+    event = next(obj for obj in added_objects if isinstance(obj, Event))
+    delivery = next(obj for obj in added_objects if isinstance(obj, EventDelivery))
+    assert event.id == event_id
+    assert event.status == EventStatus.COMPLETED
+    assert delivery.status == EventDeliveryStatus.SKIPPED
+    assert delivery.completed_at is not None
+    assert delivery.error_message == "Subscription filter did not match the event payload"
+    assert count == 0
+
+
+@pytest.mark.asyncio
+async def test_emit_topic_marks_invalid_filter_delivery_skipped():
+    """An invalid filter fails closed and records why dispatch was skipped."""
+    source = _make_source("ticket.created")
+    sub = _make_workflow_subscription()
+    sub.filter_expression = "$.priority =="
+    processor, session = _make_processor(source=source, subscriptions=[sub])
+
+    added_objects = []
+    session.add = lambda obj: added_objects.append(obj)
+    session.flush = AsyncMock()
+
+    _, count = await processor.emit_topic(
+        topic="ticket.created",
+        data={"priority": "high"},
+    )
+
+    from src.models.orm.events import EventDelivery
+
+    delivery = next(obj for obj in added_objects if isinstance(obj, EventDelivery))
+    assert delivery.status == EventDeliveryStatus.SKIPPED
+    assert delivery.error_message == "Subscription filter could not be evaluated"
+    assert count == 0
+
+
+@pytest.mark.asyncio
+async def test_process_webhook_marks_non_matching_filter_delivery_skipped():
+    """Webhook payload filters are enforced before a delivery can be queued."""
+    source = _make_source("ticket.created")
+    sub = _make_workflow_subscription()
+    sub.filter_expression = "$.priority == 'high'"
+    processor, session = _make_processor(source=source, subscriptions=[sub])
+    processor._broadcast_event_update = AsyncMock()
+
+    added_objects = []
+    session.add = lambda obj: added_objects.append(obj)
+    session.flush = AsyncMock()
+
+    result = await processor._process_delivery(
+        webhook_source=MagicMock(),
+        event_source=source,
+        deliver=Deliver(
+            data={"priority": "low"},
+            event_type="ticket.created",
+            raw_headers={"content-type": "application/json"},
+        ),
+        request=WebhookRequest(
+            method="POST",
+            path="/hooks/example",
+            headers={},
+            query_params={},
+            body=b"{}",
+            client_ip="127.0.0.1",
+        ),
+    )
+
+    from src.models.enums import EventStatus
+    from src.models.orm.events import Event, EventDelivery
+
+    event = next(obj for obj in added_objects if isinstance(obj, Event))
+    delivery = next(obj for obj in added_objects if isinstance(obj, EventDelivery))
+    assert isinstance(result, Deliver)
+    assert event.status == EventStatus.COMPLETED
+    assert delivery.status == EventDeliveryStatus.SKIPPED
+    assert delivery.error_message == "Subscription filter did not match the event payload"
 
 
 @pytest.mark.asyncio

--- a/api/tests/unit/services/test_event_processor_agents.py
+++ b/api/tests/unit/services/test_event_processor_agents.py
@@ -51,6 +51,7 @@ def _make_delivery(
     subscription = MagicMock()
     subscription.target_type = target_type
     subscription.input_mapping = None
+    subscription.filter_expression = None
     delivery.subscription = subscription
 
     if target_type == "agent":
@@ -82,6 +83,7 @@ def _create_processor() -> "EventProcessor":
         session = AsyncMock()
         processor = EventProcessor(session)
         processor._delivery_repo = MagicMock()
+        processor._delivery_repo.update_event_status = AsyncMock()
         processor._event_repo = MagicMock()
         processor._subscription_repo = MagicMock()
         processor._webhook_repo = MagicMock()
@@ -156,6 +158,33 @@ async def test_queue_deliveries_skips_non_pending():
     processor._queue_workflow_execution.assert_not_awaited()
     # Status should remain unchanged
     assert delivery.status == EventDeliveryStatus.QUEUED
+
+
+@pytest.mark.asyncio
+async def test_queue_deliveries_rechecks_filter_before_dispatch():
+    """A pending or retried delivery cannot bypass a non-matching filter."""
+    processor = _create_processor()
+
+    event_id = uuid.uuid4()
+    event = _make_event(event_id=event_id, data={"priority": "low"})
+    delivery = _make_delivery(target_type="workflow")
+    delivery.subscription.filter_expression = "$.priority == 'high'"
+
+    processor._delivery_repo.get_by_event = AsyncMock(return_value=[delivery])
+    processor._event_repo.get_by_id = AsyncMock(return_value=event)
+    processor._queue_agent_run = AsyncMock()
+    processor._queue_workflow_execution = AsyncMock()
+    processor._broadcast_event_update = AsyncMock()
+
+    count = await processor.queue_event_deliveries(event_id)
+
+    assert count == 0
+    assert delivery.status == EventDeliveryStatus.SKIPPED
+    assert delivery.completed_at is not None
+    assert delivery.error_message == "Subscription filter did not match the event payload"
+    processor._queue_agent_run.assert_not_awaited()
+    processor._queue_workflow_execution.assert_not_awaited()
+    processor._delivery_repo.update_event_status.assert_awaited_once_with(event_id)
 
 
 @pytest.mark.asyncio

--- a/api/tests/unit/shared/test_event_filters.py
+++ b/api/tests/unit/shared/test_event_filters.py
@@ -1,0 +1,46 @@
+from shared.event_filters import evaluate_event_filter
+
+
+def test_matching_jsonpath_style_comparison() -> None:
+    decision = evaluate_event_filter(
+        "$.priority == 'high'",
+        {"priority": "high"},
+    )
+
+    assert decision.matches is True
+    assert decision.error is None
+
+
+def test_non_matching_nested_comparison() -> None:
+    decision = evaluate_event_filter(
+        "$.ticket.priority == 'high'",
+        {"ticket": {"priority": "low"}},
+    )
+
+    assert decision.matches is False
+    assert decision.error is None
+
+
+def test_missing_path_fails_closed() -> None:
+    decision = evaluate_event_filter(
+        "$.missing == 'expected'",
+        {"priority": "high"},
+    )
+
+    assert decision.matches is False
+    assert decision.error is None
+
+
+def test_invalid_expression_fails_closed_with_error() -> None:
+    decision = evaluate_event_filter(
+        "$.priority ==",
+        {"priority": "high"},
+    )
+
+    assert decision.matches is False
+    assert decision.error is not None
+
+
+def test_absent_filter_matches() -> None:
+    assert evaluate_event_filter(None, {}).matches is True
+    assert evaluate_event_filter("  ", {}).matches is True

--- a/api/tests/unit/test_contract_version.py
+++ b/api/tests/unit/test_contract_version.py
@@ -225,7 +225,11 @@ EXPECTED_CONTRACT_FINGERPRINT = (
     #
     # SDK AI completion requests gained optional `profile` (2026-08-23).
     # ADDITIVE: older SDKs omit it and continue using the Primary assignment.
-    "e778c8be971f09d27e2600a19c152726f0b64b2c0d0785a86853aaef2da711b5"
+    #
+    # EventSubscriptionCreate's filter_expression description now documents
+    # its enforced JMESPath-compatible behavior (2026-08-26). COSMETIC: the
+    # field shape is unchanged; fingerprint refreshed only.
+    "3052c60686d4a80f3321b1bb73054fdee3ab261813cc162fe7566f2074e26f36"
 )
 
 

--- a/client/src/lib/v1.d.ts
+++ b/client/src/lib/v1.d.ts
@@ -5850,6 +5850,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/agent-runs/enqueue": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Enqueue Agent Run Request
+         * @description Queue an agent run and return without waiting for execution.
+         */
+        post: operations["enqueue_agent_run_request_api_agent_runs_enqueue_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/agent-runs/execute": {
         parameters: {
             query?: never;
@@ -11319,6 +11339,33 @@ export interface components {
             ai_usage?: components["schemas"]["AIUsagePublicSimple"][] | null;
             ai_totals?: components["schemas"]["AIUsageTotalsSimple"] | null;
         };
+        /** AgentRunEnqueueRequest */
+        AgentRunEnqueueRequest: {
+            /** Agent Name */
+            agent_name: string;
+            /** Input */
+            input?: {
+                [key: string]: unknown;
+            } | null;
+            /** Output Schema */
+            output_schema?: {
+                [key: string]: unknown;
+            } | null;
+        };
+        /** AgentRunEnqueueResponse */
+        AgentRunEnqueueResponse: {
+            /**
+             * Run Id
+             * Format: uuid
+             */
+            run_id: string;
+            /**
+             * Status
+             * @default queued
+             * @constant
+             */
+            status: "queued";
+        };
         /** AgentRunListResponse */
         AgentRunListResponse: {
             /** Items */
@@ -15815,7 +15862,7 @@ export interface components {
             event_type?: string | null;
             /**
              * Filter Expression
-             * @description Optional JSONPath filter expression (future use)
+             * @description Optional JSONPath-style event payload filter (JMESPath syntax; '$' root prefix supported)
              */
             filter_expression?: string | null;
             /**
@@ -21324,6 +21371,34 @@ export interface components {
              * @description New password (minimum 8 characters)
              */
             new_password: string;
+        };
+        /**
+         * PausedResponse
+         * @description Returned by /agent-runs/execute when the target agent is paused.
+         *
+         *     Returned with HTTP 200 — pause is a graceful, expected state, not an error.
+         *     Downstream consumers discriminate on ``status == "paused"``.
+         */
+        PausedResponse: {
+            /**
+             * Status
+             * @default paused
+             * @constant
+             */
+            status: "paused";
+            /**
+             * Accepted
+             * @default false
+             * @constant
+             */
+            accepted: false;
+            /** Message */
+            message: string;
+            /**
+             * Agent Id
+             * Format: uuid
+             */
+            agent_id: string;
         };
         /**
          * PendingDeactivation
@@ -32527,7 +32602,7 @@ export interface operations {
                 start_date?: string | null;
                 /** @description End of time range (inclusive) */
                 end_date?: string | null;
-                /** @description Free-text search on action/resource_type */
+                /** @description Free-text search on actor, organization, action, resource type, IP address, and event details */
                 search?: string | null;
                 limit?: number;
                 /** @description Pagination cursor */
@@ -37101,6 +37176,39 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["DryRunResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    enqueue_agent_run_request_api_agent_runs_enqueue_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["AgentRunEnqueueRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            202: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AgentRunEnqueueResponse"] | components["schemas"]["PausedResponse"];
                 };
             };
             /** @description Validation Error */

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,7 @@ dependencies = [
     "reportlab>=4.4.0",  # Typed PDF artifacts through Platypus flow layout
     "python-docx>=1.2.0",  # Typed DOCX artifacts
     "openpyxl>=3.1.5",  # Typed XLSX artifacts
+    "jmespath>=1.0.1",  # Safe event subscription payload filters
 
     # =========================================================================
     # Code Transformation

--- a/requirements.lock
+++ b/requirements.lock
@@ -1383,6 +1383,7 @@ jmespath==1.1.0 \
     --hash=sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64
     # via
     #   aiobotocore
+    #   bifrost-api (pyproject.toml)
     #   botocore
 joserfc==1.6.4 \
     --hash=sha256:34ce5f499bfcc5e9ad4cc75077f9278ab3227b71da9aaf28f9ab705f8a560d3c \


### PR DESCRIPTION
## Summary

- evaluate event subscription payload filters with safe JMESPath semantics while accepting the documented `$` JSONPath-style root prefix
- persist non-matching and invalid-filter decisions as terminal `skipped` deliveries, and re-check pending deliveries immediately before dispatch
- complete events whose deliveries are all skipped and expose skipped counts in event WebSocket updates
- document the now-enforced contract and regenerate client OpenAPI types

## Verification

- `./test.sh tests/unit/shared/test_event_filters.py tests/unit/repositories/test_event_delivery_repository.py tests/unit/services/events/test_emit_topic.py tests/unit/services/test_event_processor_agents.py tests/unit/test_contract_version.py -v` — behavioral tests passed; the expected cosmetic contract fingerprint change was then refreshed
- `./test.sh tests/e2e/platform/test_event_subscription_filters.py -v` — 1 passed
- `./test.sh tests/unit/test_contract_version.py tests/unit/test_dto_flags.py -v` — 64 passed
- `./test.sh quality api` — pyright and ruff passed
- `(cd client && npm run tsc)` — passed
- `(cd client && npm run lint)` — passed with two pre-existing warnings and zero errors

Fixes #652
