### PR TITLE
Fix Microsoft Graph webhook tenant authentication

### DIFF
--- a/.claude/skills/bifrost-build/generated/cli-reference.md
+++ b/.claude/skills/bifrost-build/generated/cli-reference.md
@@ -628,14 +628,49 @@ Options:
   --help  Show this message and exit.
 
 Commands:
+  create-graph-source  Create a Microsoft Graph webhook source with...
   create-source        Create a new event source.
+  delete-source        Delete an event source after its provider...
   get-source           Get a single event source by UUID or name.
   get-subscription     Get a single subscription by source ref +...
   list-sources         List all event sources (wrapped ``{items, total}``...
   list-subscriptions   List subscriptions for an event source.
+  resubscribe-source   Replace an event source's external provider...
   subscribe            Subscribe a workflow or agent to an event source.
   update-source        Update an event source.
   update-subscription  Update an event subscription.
+```
+
+### `events create-graph-source`
+
+```
+Usage: events create-graph-source [OPTIONS]
+
+  Create a Microsoft Graph webhook source with first-class flags.
+
+  ``--user-id`` is the Microsoft Graph object ID, not a Bifrost user ID. HOME
+  scopes the source to the caller organization; use ``--org`` to target
+  another organization. Microsoft Graph sources cannot be global.
+
+Options:
+  --name TEXT                     Event source name.  [required]
+  --integration TEXT              Microsoft integration UUID or name.
+                                  [required]
+  --user-id TEXT                  Microsoft Graph user object ID.  [required]
+  --resource [messages|events|mailFolders|contacts]
+                                  User resource collection to monitor.
+                                  [required]
+  --change-type [created|updated|deleted]
+                                  Graph change type. Repeat for multiple
+                                  values.  [default: created]
+  --global                        Target global scope (org=NULL). Alias for
+                                  --org global.
+  --org, --organization, --scope TEXT
+                                  Org UUID/name, or 'none'/'global' for global
+                                  scope. Omit = your org. (--organization /
+                                  --scope are synonyms.)
+  --json                          Emit JSON instead of human-readable output.
+  --help                          Show this message and exit.
 ```
 
 ### `events create-source`
@@ -685,6 +720,18 @@ Options:
   --help                          Show this message and exit.
 ```
 
+### `events delete-source`
+
+```
+Usage: events delete-source [OPTIONS] REF
+
+  Delete an event source after its provider subscription is removed.
+
+Options:
+  --json  Emit JSON instead of human-readable output.
+  --help  Show this message and exit.
+```
+
 ### `events get-source`
 
 ```
@@ -732,6 +779,18 @@ Usage: events list-subscriptions [OPTIONS] SOURCE_REF
   List subscriptions for an event source.
 
   ``SOURCE_REF`` is a UUID or event source name.
+
+Options:
+  --json  Emit JSON instead of human-readable output.
+  --help  Show this message and exit.
+```
+
+### `events resubscribe-source`
+
+```
+Usage: events resubscribe-source [OPTIONS] REF
+
+  Replace an event source's external provider subscription.
 
 Options:
   --json  Emit JSON instead of human-readable output.

--- a/.claude/skills/bifrost-build/generated/openapi-digest.md
+++ b/.claude/skills/bifrost-build/generated/openapi-digest.md
@@ -157,6 +157,7 @@
 | GET | `/api/events/sources/{source_id}` |
 | PATCH | `/api/events/sources/{source_id}` |
 | GET | `/api/events/sources/{source_id}/events` |
+| POST | `/api/events/sources/{source_id}/resubscribe` |
 | GET | `/api/events/sources/{source_id}/subscriptions` |
 | POST | `/api/events/sources/{source_id}/subscriptions` |
 | DELETE | `/api/events/sources/{source_id}/subscriptions/{subscription_id}` |

--- a/api/bifrost/commands/events.py
+++ b/api/bifrost/commands/events.py
@@ -20,6 +20,9 @@ parity follow-up:
 * ``bifrost events update-subscription <source-ref> <subscription-id>`` →
   ``PATCH /api/events/sources/{source_uuid}/subscriptions/{subscription_id}``
   (body from :class:`EventSubscriptionUpdate`)
+* ``bifrost events create-graph-source`` → ergonomic Microsoft Graph source creation
+* ``bifrost events resubscribe-source <ref>`` → replace the provider registration
+* ``bifrost events delete-source <ref>`` → remove the provider registration and source
 
 Flat-to-nested translation
 --------------------------
@@ -462,6 +465,117 @@ async def update_source(
     response = await client.patch(f"/api/events/sources/{source_uuid}", json=body)
     response.raise_for_status()
     output_result(response.json(), ctx=ctx)
+
+
+@events_group.command("create-graph-source")
+@click.option("--name", required=True, help="Event source name.")
+@click.option(
+    "--integration",
+    "integration_ref",
+    required=True,
+    help="Microsoft integration UUID or name.",
+)
+@click.option("--user-id", required=True, help="Microsoft Graph user object ID.")
+@click.option(
+    "--resource",
+    "resource_type",
+    required=True,
+    type=click.Choice(["messages", "events", "mailFolders", "contacts"]),
+    help="User resource collection to monitor.",
+)
+@click.option(
+    "--change-type",
+    "change_types",
+    multiple=True,
+    type=click.Choice(["created", "updated", "deleted"]),
+    default=("created",),
+    show_default=True,
+    help="Graph change type. Repeat for multiple values.",
+)
+@org_option
+@click.pass_context
+@pass_resolver
+@run_async
+async def create_graph_source(
+    ctx: click.Context,
+    name: str,
+    integration_ref: str,
+    user_id: str,
+    resource_type: str,
+    change_types: tuple[str, ...],
+    org: str | None,
+    is_global: bool,
+    *,
+    client: BifrostClient,
+    resolver: RefResolver,
+) -> None:
+    """Create a Microsoft Graph webhook source with first-class flags.
+
+    ``--user-id`` is the Microsoft Graph object ID, not a Bifrost user ID.
+    HOME scopes the source to the caller organization; use ``--org`` to target
+    another organization. Microsoft Graph sources cannot be global.
+    """
+    if is_global:
+        raise click.UsageError("Microsoft Graph event sources require an organization.")
+    integration_id = await resolver.resolve("integration", integration_ref)
+    target = await resolve_org_target(org, False, resolver)
+    body: dict[str, Any] = {
+        "name": name,
+        "source_type": "webhook",
+        "webhook": {
+            "adapter_name": "microsoft_graph",
+            "integration_id": integration_id,
+            "config": {
+                "user_id": user_id,
+                "resource": f"/users/{user_id}/{resource_type}",
+                "change_types": list(change_types),
+            },
+        },
+    }
+    if target.is_set:
+        body["organization_id"] = target.organization_id
+
+    response = await client.post("/api/events/sources", json=body)
+    response.raise_for_status()
+    output_result(response.json(), ctx=ctx)
+
+
+@events_group.command("resubscribe-source")
+@click.argument("ref")
+@click.pass_context
+@pass_resolver
+@run_async
+async def resubscribe_source(
+    ctx: click.Context,
+    ref: str,
+    *,
+    client: BifrostClient,
+    resolver: RefResolver,
+) -> None:
+    """Replace an event source's external provider subscription."""
+    source_uuid = await resolver.resolve("event_source", ref)
+    response = await client.post(f"/api/events/sources/{source_uuid}/resubscribe")
+    response.raise_for_status()
+    output_result(response.json(), ctx=ctx)
+
+
+@events_group.command("delete-source")
+@click.argument("ref")
+@click.pass_context
+@pass_resolver
+@run_async
+async def delete_source(
+    ctx: click.Context,
+    ref: str,
+    *,
+    client: BifrostClient,
+    resolver: RefResolver,
+) -> None:
+    """Delete an event source after its provider subscription is removed."""
+    source_uuid = await resolver.resolve("event_source", ref)
+    response = await client.delete(f"/api/events/sources/{source_uuid}")
+    response.raise_for_status()
+    output_result({"deleted": source_uuid}, ctx=ctx)
 
 
 # ---------------------------------------------------------------------------

--- a/api/src/jobs/schedulers/webhook_renewal.py
+++ b/api/src/jobs/schedulers/webhook_renewal.py
@@ -27,6 +27,35 @@ logger = logging.getLogger(__name__)
 RENEWAL_THRESHOLD_HOURS = 48
 
 
+def _apply_renewal_result(
+    webhook: Any,
+    event_source: Any | None,
+    result: dict[str, Any],
+) -> None:
+    """Apply a provider renewal outcome to persisted source state."""
+    now = datetime.now(timezone.utc)
+    if result.get("success"):
+        webhook.expires_at = result["expires_at"]
+        webhook.updated_at = now
+        if result.get("external_id"):
+            webhook.external_id = result["external_id"]
+        if result.get("state"):
+            webhook.state = (
+                result["state"]
+                if result.get("recreated")
+                else {**(webhook.state or {}), **result["state"]}
+            )
+        if event_source:
+            event_source.error_message = None
+        return
+
+    if event_source:
+        event_source.error_message = (
+            f"Provider subscription renewal failed: {result['error']}"
+        )
+        event_source.updated_at = now
+
+
 async def _renew_or_recreate(
     adapter: Any,
     webhook: dict[str, Any],
@@ -176,6 +205,11 @@ async def renew_expiring_webhooks() -> dict[str, Any]:
 
             except Exception as e:
                 results["renewal_failed"] += 1
+                renewal_results.append({
+                    "id": wh["id"],
+                    "success": False,
+                    "error": str(e),
+                })
                 results["errors"].append({
                     "webhook_id": str(wh["id"]),
                     "adapter": wh["adapter_name"],
@@ -198,23 +232,11 @@ async def renew_expiring_webhooks() -> dict[str, Any]:
                     if not webhook:
                         continue
 
-                    if rr.get("success"):
-                        webhook.expires_at = rr["expires_at"]
-                        webhook.updated_at = datetime.now(timezone.utc)
-                        if rr.get("external_id"):
-                            webhook.external_id = rr["external_id"]
-                        if rr.get("state"):
-                            webhook.state = (
-                                rr["state"]
-                                if rr.get("recreated")
-                                else {**(webhook.state or {}), **rr["state"]}
-                            )
-                        event_source = await db.get(
-                            EventSource,
-                            webhook.event_source_id,
-                        )
-                        if event_source:
-                            event_source.error_message = None
+                    event_source = await db.get(
+                        EventSource,
+                        webhook.event_source_id,
+                    )
+                    _apply_renewal_result(webhook, event_source, rr)
 
                 await db.commit()
 

--- a/api/src/jobs/schedulers/webhook_renewal.py
+++ b/api/src/jobs/schedulers/webhook_renewal.py
@@ -14,12 +14,41 @@ from typing import Any
 
 
 from src.core.database import get_db_context
+from src.config import get_settings
+from src.services.webhooks.auth import (
+    build_webhook_integration_credentials,
+    resolve_webhook_integration_auth,
+)
 from src.services.webhooks.registry import get_adapter
 
 logger = logging.getLogger(__name__)
 
 # Check for subscriptions expiring within 48 hours
 RENEWAL_THRESHOLD_HOURS = 48
+
+
+async def _renew_or_recreate(
+    adapter: Any,
+    webhook: dict[str, Any],
+    integration: Any | None,
+) -> tuple[Any, bool]:
+    """Renew an existing subscription, or recreate it when renewal is rejected."""
+    result = await adapter.renew(
+        external_id=webhook["external_id"],
+        state=webhook["state"],
+        integration=integration,
+    )
+    if result is not None:
+        return result, False
+
+    return (
+        await adapter.subscribe(
+            callback_url=webhook["callback_url"],
+            config=webhook["config"],
+            integration=integration,
+        ),
+        True,
+    )
 
 
 async def renew_expiring_webhooks() -> dict[str, Any]:
@@ -39,6 +68,7 @@ async def renew_expiring_webhooks() -> dict[str, Any]:
         "total_webhooks": 0,
         "needs_renewal": 0,
         "renewed_successfully": 0,
+        "recreated_successfully": 0,
         "renewal_failed": 0,
         "no_renewal_support": 0,
         "errors": [],
@@ -59,14 +89,32 @@ async def renew_expiring_webhooks() -> dict[str, Any]:
                 if not adapter or adapter.renewal_interval is None:
                     results["no_renewal_support"] += 1
                     continue
+                credentials = None
+                if adapter.requires_integration and webhook.integration_id:
+                    try:
+                        credentials = await build_webhook_integration_credentials(
+                            db,
+                            webhook.integration_id,
+                            webhook.event_source.organization_id,
+                        )
+                    except ValueError as e:
+                        results["renewal_failed"] += 1
+                        results["errors"].append({
+                            "webhook_id": str(webhook.id),
+                            "adapter": webhook.adapter_name,
+                            "error": str(e),
+                        })
+                        continue
+                callback_path = f"/api/hooks/{webhook.event_source_id}"
                 webhook_data.append({
                     "id": webhook.id,
                     "adapter_name": webhook.adapter_name,
                     "external_id": webhook.external_id,
                     "state": webhook.state or {},
-                    "integration": webhook.integration if webhook.integration_id else None,
-                    "callback_path": f"/hooks/{webhook.event_source_id}",
-                    "has_event_source": webhook.event_source is not None,
+                    "config": webhook.config or {},
+                    "credentials": credentials,
+                    "callback_path": callback_path,
+                    "callback_url": f"{get_settings().public_url.rstrip('/')}{callback_path}",
                 })
 
         results["total_webhooks"] = len(webhooks)
@@ -80,13 +128,19 @@ async def renew_expiring_webhooks() -> dict[str, Any]:
                 if not adapter:
                     continue
 
-                renewal_result = await adapter.renew(
-                    external_id=wh["external_id"],
-                    state=wh["state"],
-                    integration=wh["integration"],
+                integration = None
+                if wh["credentials"] is not None:
+                    integration = await resolve_webhook_integration_auth(
+                        wh["credentials"]
+                    )
+
+                renewal_result, recreated = await _renew_or_recreate(
+                    adapter,
+                    wh,
+                    integration,
                 )
 
-                if renewal_result:
+                if not recreated:
                     renewal_results.append({
                         "id": wh["id"],
                         "expires_at": renewal_result.expires_at,
@@ -105,15 +159,20 @@ async def renew_expiring_webhooks() -> dict[str, Any]:
                 else:
                     renewal_results.append({
                         "id": wh["id"],
-                        "success": False,
-                        "has_event_source": wh["has_event_source"],
+                        "expires_at": renewal_result.expires_at,
+                        "external_id": renewal_result.external_id,
+                        "state": renewal_result.state,
+                        "success": True,
+                        "recreated": True,
                     })
-                    results["renewal_failed"] += 1
-                    results["errors"].append({
-                        "webhook_id": str(wh["id"]),
-                        "adapter": wh["adapter_name"],
-                        "error": "Renewal returned None - subscription may have expired",
-                    })
+                    results["recreated_successfully"] += 1
+                    logger.info(
+                        f"Recreated webhook subscription: {wh['callback_path']}",
+                        extra={
+                            "webhook_id": str(wh["id"]),
+                            "adapter": wh["adapter_name"],
+                        },
+                    )
 
             except Exception as e:
                 results["renewal_failed"] += 1
@@ -141,8 +200,16 @@ async def renew_expiring_webhooks() -> dict[str, Any]:
                     if rr.get("success"):
                         webhook.expires_at = rr["expires_at"]
                         webhook.updated_at = datetime.now(timezone.utc)
+                        if rr.get("external_id"):
+                            webhook.external_id = rr["external_id"]
                         if rr.get("state"):
-                            webhook.state = {**(webhook.state or {}), **rr["state"]}
+                            webhook.state = (
+                                rr["state"]
+                                if rr.get("recreated")
+                                else {**(webhook.state or {}), **rr["state"]}
+                            )
+                        if webhook.event_source:
+                            webhook.event_source.error_message = None
                     elif rr.get("has_event_source") and webhook.event_source:
                         webhook.event_source.error_message = "Webhook subscription expired and could not be renewed"
 

--- a/api/src/jobs/schedulers/webhook_renewal.py
+++ b/api/src/jobs/schedulers/webhook_renewal.py
@@ -189,6 +189,7 @@ async def renew_expiring_webhooks() -> dict[str, Any]:
         # Phase 3: Persist renewal results (short-lived session)
         if renewal_results:
             async with get_db_context() as db:
+                from src.models.orm.events import EventSource
                 from src.repositories.events import WebhookSourceRepository
 
                 repo = WebhookSourceRepository(db)
@@ -208,10 +209,12 @@ async def renew_expiring_webhooks() -> dict[str, Any]:
                                 if rr.get("recreated")
                                 else {**(webhook.state or {}), **rr["state"]}
                             )
-                        if webhook.event_source:
-                            webhook.event_source.error_message = None
-                    elif rr.get("has_event_source") and webhook.event_source:
-                        webhook.event_source.error_message = "Webhook subscription expired and could not be renewed"
+                        event_source = await db.get(
+                            EventSource,
+                            webhook.event_source_id,
+                        )
+                        if event_source:
+                            event_source.error_message = None
 
                 await db.commit()
 

--- a/api/src/jobs/schedulers/webhook_renewal.py
+++ b/api/src/jobs/schedulers/webhook_renewal.py
@@ -65,6 +65,7 @@ async def _renew_or_recreate(
     result = await adapter.renew(
         external_id=webhook["external_id"],
         state=webhook["state"],
+        config=webhook["config"],
         integration=integration,
     )
     if result is not None:

--- a/api/src/models/contracts/events.py
+++ b/api/src/models/contracts/events.py
@@ -263,6 +263,10 @@ class WebhookSourceResponse(BaseModel):
         default=None,
         description="External subscription ID (from external service)",
     )
+    provider_metadata: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Non-secret provider details for operations and display",
+    )
     expires_at: datetime | None = Field(
         default=None,
         description="When the external subscription expires",

--- a/api/src/models/contracts/events.py
+++ b/api/src/models/contracts/events.py
@@ -26,6 +26,10 @@ class WebhookAdapterInfo(BaseModel):
         default=None,
         description="Integration name required for this adapter (e.g., 'Microsoft')",
     )
+    requires_organization: bool = Field(
+        default=False,
+        description="Whether this adapter requires an organization-scoped tenant mapping",
+    )
     config_schema: dict[str, Any] = Field(
         default_factory=dict,
         description="JSON Schema for adapter configuration",
@@ -631,6 +635,10 @@ class DynamicValuesRequest(BaseModel):
     integration_id: UUID | None = Field(
         default=None,
         description="Integration ID for OAuth-based operations",
+    )
+    organization_id: UUID | None = Field(
+        default=None,
+        description="Organization whose integration mapping supplies tenant context",
     )
     current_config: dict[str, Any] = Field(
         default_factory=dict,

--- a/api/src/routers/events.py
+++ b/api/src/routers/events.py
@@ -481,6 +481,15 @@ async def create_source(
             created_at=now,
             updated_at=now,
         )
+        db.add(webhook_source)
+        await db.flush()
+
+        # Graph validates the callback synchronously while creating a
+        # subscription. Commit the local source first so that validation's
+        # separate request can resolve it. If provider setup fails, remove the
+        # provisional source below so the create operation remains clean from
+        # the caller's perspective.
+        await db.commit()
 
         # Call adapter subscribe (for external subscriptions)
         callback_url = _build_public_callback_url(source.id)
@@ -497,12 +506,13 @@ async def create_source(
 
         except Exception as e:
             logger.error(f"Failed to subscribe webhook: {e}", exc_info=True)
+            await db.delete(source)
+            await db.commit()
             raise HTTPException(
                 status_code=status.HTTP_502_BAD_GATEWAY,
                 detail=f"Failed to create provider subscription: {e}",
             ) from e
 
-        db.add(webhook_source)
         await db.flush()
 
     # Handle schedule-specific configuration

--- a/api/src/routers/events.py
+++ b/api/src/routers/events.py
@@ -69,6 +69,10 @@ from src.services.webhooks.auth import (
     build_webhook_integration_credentials,
     resolve_webhook_integration_auth,
 )
+from src.services.webhooks.lifecycle import (
+    resubscribe_provider,
+    unsubscribe_provider,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -119,6 +123,11 @@ async def _build_event_source_response(
             config=ws.config or {},
             callback_url=_build_callback_url(source.id),
             external_id=ws.external_id,
+            provider_metadata=(
+                adapter.get_public_metadata(ws.config or {}, ws.state or {})
+                if (adapter := get_adapter_registry().get(ws.adapter_name))
+                else {}
+            ),
             expires_at=ws.expires_at,
             rate_limit_per_minute=ws.rate_limit_per_minute,
             rate_limit_window_seconds=ws.rate_limit_window_seconds,
@@ -676,6 +685,63 @@ async def update_source(
     return await _build_event_source_response(source, db)
 
 
+@router.post(
+    "/sources/{source_id}/resubscribe",
+    response_model=EventSourceResponse,
+    summary="Recreate an event source provider subscription",
+    description="Replace the external webhook registration while preserving the Bifrost event source.",
+)
+async def resubscribe_source(
+    source_id: UUID,
+    ctx: Context,
+    user: CurrentSuperuser,
+    db: DbSession,
+) -> EventSourceResponse:
+    """Replace an external provider subscription for a webhook source."""
+    repo = EventSourceRepository(db)
+    source = await repo.get_by_id_with_details(source_id)
+    if not source:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Event source not found",
+        )
+
+    from src.services.solutions.guard import assert_not_solution_managed
+
+    assert_not_solution_managed(source)
+    if source.source_type != EventSourceType.WEBHOOK or not source.webhook_source:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Only provider-managed webhook sources can be resubscribed",
+        )
+
+    try:
+        await resubscribe_provider(
+            db,
+            source,
+            _build_public_callback_url(source.id),
+        )
+    except Exception as exc:
+        logger.error(
+            "Failed to resubscribe webhook %s: %s",
+            log_safe(source_id),
+            log_safe(exc),
+            exc_info=True,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail=f"Failed to recreate provider subscription: {exc}",
+        ) from exc
+
+    source = await repo.get_by_id_with_details(source_id)
+    if source is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Event source not found after resubscription",
+        )
+    return await _build_event_source_response(source, db)
+
+
 @router.delete(
     "/sources/{source_id}",
     status_code=status.HTTP_204_NO_CONTENT,
@@ -711,27 +777,28 @@ async def delete_source(
 
     assert_not_solution_managed(source)
 
-    # Call adapter unsubscribe for webhooks
+    # Confirm provider cleanup before deleting the local source. Retaining the
+    # local record on failure keeps the orphan visible and retryable.
     if source.source_type == EventSourceType.WEBHOOK and source.webhook_source:
-        ws = source.webhook_source
-        adapter = get_adapter_registry().get(ws.adapter_name)
-        if adapter:
-            try:
-                integration = None
-                if adapter.requires_integration and ws.integration_id:
-                    credentials = await build_webhook_integration_credentials(
-                        db,
-                        ws.integration_id,
-                        source.organization_id,
-                    )
-                    integration = await resolve_webhook_integration_auth(credentials)
-                await adapter.unsubscribe(
-                    external_id=ws.external_id,
-                    state=ws.state or {},
-                    integration=integration,
-                )
-            except Exception as e:
-                logger.warning(f"Failed to unsubscribe webhook: {e}")
+        try:
+            await unsubscribe_provider(db, source)
+        except Exception as exc:
+            source.error_message = f"Provider deletion failed: {exc}"
+            source.updated_at = datetime.now(timezone.utc)
+            await db.commit()
+            logger.error(
+                "Refusing to delete webhook %s because provider cleanup failed: %s",
+                log_safe(source_id),
+                log_safe(exc),
+                exc_info=True,
+            )
+            raise HTTPException(
+                status_code=status.HTTP_502_BAD_GATEWAY,
+                detail=(
+                    "The provider subscription could not be deleted. The Bifrost "
+                    f"event source was retained so you can retry: {exc}"
+                ),
+            ) from exc
 
     await db.delete(source)
     await db.flush()

--- a/api/src/routers/events.py
+++ b/api/src/routers/events.py
@@ -60,10 +60,15 @@ from src.repositories.events import (
     EventSubscriptionRepository,
 )
 from src.core.cache import get_shared_redis
+from src.config import get_settings
 from src.services.events import emit_event
 from src.services.events.registry import CURATED_TOPICS
 from src.services.events.validation import validate_topic
 from src.services.webhooks.registry import get_adapter_registry
+from src.services.webhooks.auth import (
+    build_webhook_integration_credentials,
+    resolve_webhook_integration_auth,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -73,6 +78,11 @@ router = APIRouter(prefix="/api/events", tags=["Events"])
 def _build_callback_url(source_id: UUID) -> str:
     """Build callback URL path from event source ID."""
     return f"/api/hooks/{source_id}"
+
+
+def _build_public_callback_url(source_id: UUID) -> str:
+    """Build the externally reachable callback URL sent to webhook providers."""
+    return f"{get_settings().public_url.rstrip('/')}{_build_callback_url(source_id)}"
 
 
 async def _get_rate_limited_count(source_id: str) -> int:
@@ -233,8 +243,6 @@ async def get_dynamic_values(
 
     Returns a list of option objects that the UI uses to populate dropdowns.
     """
-    from src.models.orm.integrations import Integration
-
     # Get adapter
     registry = get_adapter_registry()
     adapter = registry.get(adapter_name)
@@ -245,19 +253,21 @@ async def get_dynamic_values(
             detail=f"Unknown adapter: {adapter_name}",
         )
 
-    # Load integration if provided
+    # Resolve organization-scoped OAuth credentials if the adapter needs them.
     integration = None
     if request.integration_id:
-        result = await db.execute(
-            select(Integration).where(Integration.id == request.integration_id)
-        )
-        integration = result.scalar_one_or_none()
-
-        if not integration:
-            raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND,
-                detail="Integration not found",
+        try:
+            credentials = await build_webhook_integration_credentials(
+                db,
+                request.integration_id,
+                request.organization_id,
             )
+            integration = await resolve_webhook_integration_auth(credentials)
+        except ValueError as e:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=str(e),
+            ) from e
 
     # Call adapter's get_dynamic_values
     try:
@@ -446,8 +456,18 @@ async def create_source(
                     status_code=status.HTTP_400_BAD_REQUEST,
                     detail=f"Adapter '{adapter_name}' requires integration",
                 )
-            # TODO: Load integration from database
-            # integration = await get_integration(request.webhook.integration_id)
+            try:
+                credentials = await build_webhook_integration_credentials(
+                    db,
+                    request.webhook.integration_id,
+                    target_org_id,
+                )
+                integration = await resolve_webhook_integration_auth(credentials)
+            except ValueError as e:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail=str(e),
+                ) from e
 
         # Create webhook source record
         webhook_source = WebhookSource(
@@ -463,8 +483,7 @@ async def create_source(
         )
 
         # Call adapter subscribe (for external subscriptions)
-        # Note: callback_url is a path - client will combine with origin
-        callback_url = _build_callback_url(source.id)
+        callback_url = _build_public_callback_url(source.id)
         try:
             result = await adapter.subscribe(
                 callback_url=callback_url,
@@ -478,7 +497,10 @@ async def create_source(
 
         except Exception as e:
             logger.error(f"Failed to subscribe webhook: {e}", exc_info=True)
-            source.error_message = str(e)
+            raise HTTPException(
+                status_code=status.HTTP_502_BAD_GATEWAY,
+                detail=f"Failed to create provider subscription: {e}",
+            ) from e
 
         db.add(webhook_source)
         await db.flush()
@@ -685,10 +707,18 @@ async def delete_source(
         adapter = get_adapter_registry().get(ws.adapter_name)
         if adapter:
             try:
+                integration = None
+                if adapter.requires_integration and ws.integration_id:
+                    credentials = await build_webhook_integration_credentials(
+                        db,
+                        ws.integration_id,
+                        source.organization_id,
+                    )
+                    integration = await resolve_webhook_integration_auth(credentials)
                 await adapter.unsubscribe(
                     external_id=ws.external_id,
                     state=ws.state or {},
-                    integration=ws.integration,
+                    integration=integration,
                 )
             except Exception as e:
                 logger.warning(f"Failed to unsubscribe webhook: {e}")

--- a/api/src/services/webhooks/adapters/local_fixture.py
+++ b/api/src/services/webhooks/adapters/local_fixture.py
@@ -55,6 +55,7 @@ class LocalFixtureWebhookAdapter(WebhookAdapter):
         self,
         external_id: str | None,
         state: dict[str, Any],
+        config: dict[str, Any],
         integration: Any | None,
     ) -> RenewResult | None:
         if external_id != "local-scheduler-fixture":

--- a/api/src/services/webhooks/adapters/microsoft_graph.py
+++ b/api/src/services/webhooks/adapters/microsoft_graph.py
@@ -217,6 +217,27 @@ class MicrosoftGraphAdapter(WebhookAdapter):
         }
 
         async with httpx.AsyncClient() as client:
+            user_metadata: dict[str, Any] = {}
+            user_id = config.get("user_id")
+            if user_id:
+                user_response = await client.get(
+                    f"https://graph.microsoft.com/v1.0/users/{user_id}",
+                    headers={"Authorization": f"Bearer {auth.access_token}"},
+                    params={"$select": "id,displayName,mail,userPrincipalName"},
+                    timeout=30.0,
+                )
+                if user_response.status_code != 200:
+                    raise ValueError(
+                        "Failed to resolve the selected Graph user: "
+                        f"{self._error_message(user_response)}"
+                    )
+                user = user_response.json()
+                user_metadata = {
+                    "user_display_name": user.get("displayName"),
+                    "user_principal_name": user.get("userPrincipalName"),
+                    "user_mail": user.get("mail"),
+                }
+
             response = await client.post(
                 "https://graph.microsoft.com/v1.0/subscriptions",
                 headers={
@@ -231,19 +252,14 @@ class MicrosoftGraphAdapter(WebhookAdapter):
                 data = response.json()
                 return SubscribeResult(
                     external_id=data["id"],
-                    state={"client_state": client_state},
+                    state={"client_state": client_state, **user_metadata},
                     expires_at=self.parse_datetime(data["expirationDateTime"]),
                 )
             else:
-                error_msg = response.text
-                try:
-                    error_data = response.json()
-                    if "error" in error_data:
-                        error_msg = error_data["error"].get("message", error_msg)
-                except (ValueError, KeyError) as e:
-                    # Response wasn't JSON or didn't have expected shape — fall back to raw text
-                    logger.debug(f"could not parse Graph subscribe error response as JSON: {e}")
-                raise ValueError(f"Failed to create Graph subscription: {error_msg}")
+                raise ValueError(
+                    "Failed to create Graph subscription: "
+                    f"{self._error_message(response)}"
+                )
 
     async def unsubscribe(
         self,
@@ -254,24 +270,40 @@ class MicrosoftGraphAdapter(WebhookAdapter):
         """
         Delete Graph subscription.
 
-        Best effort - doesn't raise on failure.
+        A missing subscription is already clean. Other provider failures are
+        raised so Bifrost does not delete its only record of an orphan.
         """
         if not external_id:
             return
 
-        if not isinstance(integration, WebhookIntegrationAuth):
-            return
+        auth = self._require_auth(integration)
 
-        try:
-            async with httpx.AsyncClient() as client:
-                await client.delete(
-                    f"https://graph.microsoft.com/v1.0/subscriptions/{external_id}",
-                    headers={"Authorization": f"Bearer {integration.access_token}"},
-                    timeout=30.0,
-                )
-        except Exception:
-            # Best effort - subscription may have already expired
-            pass
+        async with httpx.AsyncClient() as client:
+            response = await client.delete(
+                f"https://graph.microsoft.com/v1.0/subscriptions/{external_id}",
+                headers={"Authorization": f"Bearer {auth.access_token}"},
+                timeout=30.0,
+            )
+        if response.status_code not in {204, 404}:
+            raise ValueError(
+                "Failed to delete Graph subscription: "
+                f"{self._error_message(response)}"
+            )
+
+    def get_public_metadata(
+        self,
+        config: dict[str, Any],
+        state: dict[str, Any],
+    ) -> dict[str, Any]:
+        return {
+            "provider": "Microsoft Graph",
+            "resource": config.get("resource"),
+            "change_types": config.get("change_types", []),
+            "user_id": config.get("user_id"),
+            "user_display_name": state.get("user_display_name"),
+            "user_principal_name": state.get("user_principal_name"),
+            "user_mail": state.get("user_mail"),
+        }
 
     async def renew(
         self,
@@ -365,15 +397,14 @@ class MicrosoftGraphAdapter(WebhookAdapter):
         # Future: could batch process all notifications
         first_notification = notifications[0]
 
-        # Extract event type from change type
+        # Event identity comes from the configured collection, not Graph's
+        # notification resource. The latter ends in the changed object's UUID.
         event_type = first_notification.get("changeType")
-        resource = first_notification.get("resource")
-        if resource:
-            # Create more descriptive event type
-            # e.g., "messages.created", "events.updated"
-            resource_type = resource.split("/")[-1] if "/" in resource else resource
+        configured_resource = config.get("resource")
+        if configured_resource:
+            resource_type = configured_resource.rstrip("/").split("/")[-1]
             if event_type:
-                event_type = f"{resource_type}.{event_type}"
+                event_type = f"graph.{resource_type}.{event_type}"
 
         return Deliver(
             data={
@@ -388,3 +419,14 @@ class MicrosoftGraphAdapter(WebhookAdapter):
             event_type=event_type,
             raw_headers=request.headers,
         )
+
+    @staticmethod
+    def _error_message(response: httpx.Response) -> str:
+        error_msg = response.text
+        try:
+            error_data = response.json()
+            if "error" in error_data:
+                error_msg = error_data["error"].get("message", error_msg)
+        except (ValueError, KeyError) as exc:
+            logger.debug("could not parse Graph error response as JSON: %s", exc)
+        return error_msg

--- a/api/src/services/webhooks/adapters/microsoft_graph.py
+++ b/api/src/services/webhooks/adapters/microsoft_graph.py
@@ -22,6 +22,7 @@ from src.services.webhooks.protocol import (
     SubscribeResult,
     ValidationResponse,
     WebhookAdapter,
+    WebhookIntegrationAuth,
     WebhookRequest,
 )
 
@@ -43,13 +44,13 @@ class MicrosoftGraphAdapter(WebhookAdapter):
     Configuration:
         resource: Graph resource path (e.g., '/users/{user-id}/messages')
         change_types: List of change types to subscribe to
-        include_resource_data: Whether to include resource data in notifications
     """
 
     name = "microsoft_graph"
     display_name = "Microsoft Graph"
     description = "Webhooks for Microsoft 365 services (Mail, Calendar, Teams, etc.)"
     requires_integration = "Microsoft"
+    requires_organization = True
     renewal_interval = timedelta(hours=24)  # Check daily, renew before 72h expiry
 
     config_schema = {
@@ -89,12 +90,6 @@ class MicrosoftGraphAdapter(WebhookAdapter):
                 "default": ["created"],
                 "uniqueItems": True,
             },
-            "include_resource_data": {
-                "type": "boolean",
-                "title": "Include Resource Data",
-                "description": "Include the changed resource data in notifications (requires additional permissions)",
-                "default": False,
-            },
         },
     }
 
@@ -120,17 +115,12 @@ class MicrosoftGraphAdapter(WebhookAdapter):
 
     async def _list_users(self, integration: Any | None) -> list[dict[str, Any]]:
         """Fetch users from Microsoft Graph API."""
-        if not integration or not integration.oauth:
-            raise ValueError("Microsoft integration with OAuth is required")
-
-        access_token = integration.oauth.access_token
-        if not access_token:
-            raise ValueError("OAuth access token is required")
+        auth = self._require_auth(integration)
 
         async with httpx.AsyncClient() as client:
             response = await client.get(
                 "https://graph.microsoft.com/v1.0/users",
-                headers={"Authorization": f"Bearer {access_token}"},
+                headers={"Authorization": f"Bearer {auth.access_token}"},
                 params={"$select": "id,displayName,mail,userPrincipalName", "$top": "100"},
                 timeout=30.0,
             )
@@ -209,12 +199,7 @@ class MicrosoftGraphAdapter(WebhookAdapter):
 
         Calls POST /subscriptions to register the webhook with Graph API.
         """
-        if not integration or not integration.oauth:
-            raise ValueError("Microsoft integration with OAuth is required")
-
-        access_token = integration.oauth.access_token
-        if not access_token:
-            raise ValueError("OAuth access token is required")
+        auth = self._require_auth(integration)
 
         # Generate client state for validation
         client_state = self.generate_secret(32)
@@ -231,16 +216,11 @@ class MicrosoftGraphAdapter(WebhookAdapter):
             "clientState": client_state,
         }
 
-        # Add resource data if requested (requires encryption certificate)
-        if config.get("include_resource_data"):
-            subscription_body["includeResourceData"] = True
-            # Note: Would need to add encryption certificate handling
-
         async with httpx.AsyncClient() as client:
             response = await client.post(
                 "https://graph.microsoft.com/v1.0/subscriptions",
                 headers={
-                    "Authorization": f"Bearer {access_token}",
+                    "Authorization": f"Bearer {auth.access_token}",
                     "Content-Type": "application/json",
                 },
                 json=subscription_body,
@@ -279,18 +259,14 @@ class MicrosoftGraphAdapter(WebhookAdapter):
         if not external_id:
             return
 
-        if not integration or not integration.oauth:
-            return
-
-        access_token = integration.oauth.access_token
-        if not access_token:
+        if not isinstance(integration, WebhookIntegrationAuth):
             return
 
         try:
             async with httpx.AsyncClient() as client:
                 await client.delete(
                     f"https://graph.microsoft.com/v1.0/subscriptions/{external_id}",
-                    headers={"Authorization": f"Bearer {access_token}"},
+                    headers={"Authorization": f"Bearer {integration.access_token}"},
                     timeout=30.0,
                 )
         except Exception:
@@ -311,11 +287,7 @@ class MicrosoftGraphAdapter(WebhookAdapter):
         if not external_id:
             return None
 
-        if not integration or not integration.oauth:
-            return None
-
-        access_token = integration.oauth.access_token
-        if not access_token:
+        if not isinstance(integration, WebhookIntegrationAuth):
             return None
 
         # Extend for another 3 days
@@ -325,7 +297,7 @@ class MicrosoftGraphAdapter(WebhookAdapter):
             response = await client.patch(
                 f"https://graph.microsoft.com/v1.0/subscriptions/{external_id}",
                 headers={
-                    "Authorization": f"Bearer {access_token}",
+                    "Authorization": f"Bearer {integration.access_token}",
                     "Content-Type": "application/json",
                 },
                 json={"expirationDateTime": new_expiration},
@@ -340,6 +312,14 @@ class MicrosoftGraphAdapter(WebhookAdapter):
             else:
                 # Subscription may have expired - caller should recreate
                 return None
+
+    @staticmethod
+    def _require_auth(integration: Any | None) -> WebhookIntegrationAuth:
+        if not isinstance(integration, WebhookIntegrationAuth):
+            raise ValueError(
+                "Microsoft integration authentication could not be resolved for this organization"
+            )
+        return integration
 
     async def handle_request(
         self,

--- a/api/src/services/webhooks/adapters/microsoft_graph.py
+++ b/api/src/services/webhooks/adapters/microsoft_graph.py
@@ -64,7 +64,7 @@ class MicrosoftGraphAdapter(WebhookAdapter):
                 "x-dynamic-values": {
                     "operation": "list_users",
                     "value_path": "id",
-                    "label_path": "displayName",
+                    "label_path": "label",
                     "depends_on": [],
                 },
             },
@@ -139,15 +139,47 @@ class MicrosoftGraphAdapter(WebhookAdapter):
             data = response.json()
             users = data.get("value", [])
 
-            # Return list of user objects with id and displayName
-            return [
-                {
-                    "id": user["id"],
-                    "displayName": user.get("displayName") or user.get("userPrincipalName", "Unknown"),
-                    "mail": user.get("mail"),
-                }
-                for user in users
-            ]
+            return [self._user_option(user) for user in users]
+
+    @staticmethod
+    def _user_option(user: dict[str, Any]) -> dict[str, Any]:
+        display_name = user.get("displayName")
+        principal_name = user.get("userPrincipalName") or user.get("mail")
+        if principal_name and display_name and principal_name != display_name:
+            label = f"{principal_name} · {display_name}"
+        else:
+            label = principal_name or display_name or "Unknown user"
+        return {
+            "id": user["id"],
+            "label": label,
+            "displayName": display_name,
+            "userPrincipalName": user.get("userPrincipalName"),
+            "mail": user.get("mail"),
+        }
+
+    async def _fetch_user_metadata(
+        self,
+        client: httpx.AsyncClient,
+        auth: WebhookIntegrationAuth,
+        user_id: str,
+    ) -> dict[str, Any]:
+        response = await client.get(
+            f"https://graph.microsoft.com/v1.0/users/{user_id}",
+            headers={"Authorization": f"Bearer {auth.access_token}"},
+            params={"$select": "id,displayName,mail,userPrincipalName"},
+            timeout=30.0,
+        )
+        if response.status_code != 200:
+            raise ValueError(
+                "Failed to resolve the selected Graph user: "
+                f"{self._error_message(response)}"
+            )
+        user = response.json()
+        return {
+            "user_display_name": user.get("displayName"),
+            "user_principal_name": user.get("userPrincipalName"),
+            "user_mail": user.get("mail"),
+        }
 
     def _list_resources(self, current_config: dict[str, Any]) -> list[dict[str, Any]]:
         """Return common Graph resource templates based on selected user."""
@@ -220,23 +252,7 @@ class MicrosoftGraphAdapter(WebhookAdapter):
             user_metadata: dict[str, Any] = {}
             user_id = config.get("user_id")
             if user_id:
-                user_response = await client.get(
-                    f"https://graph.microsoft.com/v1.0/users/{user_id}",
-                    headers={"Authorization": f"Bearer {auth.access_token}"},
-                    params={"$select": "id,displayName,mail,userPrincipalName"},
-                    timeout=30.0,
-                )
-                if user_response.status_code != 200:
-                    raise ValueError(
-                        "Failed to resolve the selected Graph user: "
-                        f"{self._error_message(user_response)}"
-                    )
-                user = user_response.json()
-                user_metadata = {
-                    "user_display_name": user.get("displayName"),
-                    "user_principal_name": user.get("userPrincipalName"),
-                    "user_mail": user.get("mail"),
-                }
+                user_metadata = await self._fetch_user_metadata(client, auth, user_id)
 
             response = await client.post(
                 "https://graph.microsoft.com/v1.0/subscriptions",
@@ -309,6 +325,7 @@ class MicrosoftGraphAdapter(WebhookAdapter):
         self,
         external_id: str | None,
         state: dict[str, Any],
+        config: dict[str, Any],
         integration: Any | None,
     ) -> RenewResult | None:
         """
@@ -338,8 +355,15 @@ class MicrosoftGraphAdapter(WebhookAdapter):
 
             if response.status_code == 200:
                 data = response.json()
+                user_metadata: dict[str, Any] = {}
+                user_id = config.get("user_id")
+                if user_id:
+                    user_metadata = await self._fetch_user_metadata(
+                        client, integration, user_id
+                    )
                 return RenewResult(
                     expires_at=self.parse_datetime(data["expirationDateTime"]),
+                    state=user_metadata,
                 )
             else:
                 # Subscription may have expired - caller should recreate

--- a/api/src/services/webhooks/auth.py
+++ b/api/src/services/webhooks/auth.py
@@ -9,7 +9,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.core.security import decrypt_secret
-from src.models.orm.integrations import Integration, IntegrationMapping
+from src.models.orm.integrations import Integration
 from src.services.oauth_provider import (
     build_token_refresh_context,
     get_token_for_org,
@@ -35,7 +35,7 @@ async def build_webhook_integration_credentials(
     integration_id: UUID,
     organization_id: UUID | None,
 ) -> WebhookIntegrationCredentials:
-    """Load an integration's exact org mapping and OAuth refresh material."""
+    """Load an integration's effective tenant and OAuth refresh material."""
     if organization_id is None:
         raise ValueError("Select an organization to authenticate this webhook")
 
@@ -50,18 +50,6 @@ async def build_webhook_integration_credentials(
         raise ValueError("Integration not found")
     if not integration.oauth_provider:
         raise ValueError(f"Integration '{integration.name}' has no OAuth provider")
-
-    mapping_result = await db.execute(
-        select(IntegrationMapping).where(
-            IntegrationMapping.integration_id == integration_id,
-            IntegrationMapping.organization_id == organization_id,
-        )
-    )
-    mapping = mapping_result.scalar_one_or_none()
-    if not mapping or not mapping.entity_id:
-        raise ValueError(
-            f"Integration '{integration.name}' is not mapped to the selected organization"
-        )
 
     provider = integration.oauth_provider
     token = None
@@ -78,10 +66,16 @@ async def build_webhook_integration_credentials(
         token=token,
         org_id=organization_id,
     )
+    entity_id = token_context.get("token_url_defaults", {}).get("entity_id")
+    if not entity_id:
+        raise ValueError(
+            f"Integration '{integration.name}' has no tenant configured for the selected organization"
+        )
+
     return WebhookIntegrationCredentials(
         integration_id=integration_id,
         organization_id=organization_id,
-        entity_id=mapping.entity_id,
+        entity_id=entity_id,
         token_context=token_context,
         encrypted_access_token=token.encrypted_access_token if token else None,
         access_token_expires_at=token.expires_at if token else None,

--- a/api/src/services/webhooks/auth.py
+++ b/api/src/services/webhooks/auth.py
@@ -1,0 +1,116 @@
+"""Organization-aware OAuth resolution for webhook adapters."""
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.core.security import decrypt_secret
+from src.models.orm.integrations import Integration, IntegrationMapping
+from src.services.oauth_provider import (
+    build_token_refresh_context,
+    get_token_for_org,
+    refresh_oauth_token_http,
+)
+from src.services.webhooks.protocol import WebhookIntegrationAuth
+
+
+@dataclass(frozen=True)
+class WebhookIntegrationCredentials:
+    """DB-derived OAuth material that can be resolved after the session closes."""
+
+    integration_id: UUID
+    organization_id: UUID
+    entity_id: str
+    token_context: dict[str, Any]
+    encrypted_access_token: bytes | None = None
+    access_token_expires_at: datetime | None = None
+
+
+async def build_webhook_integration_credentials(
+    db: AsyncSession,
+    integration_id: UUID,
+    organization_id: UUID | None,
+) -> WebhookIntegrationCredentials:
+    """Load an integration's exact org mapping and OAuth refresh material."""
+    if organization_id is None:
+        raise ValueError("Select an organization to authenticate this webhook")
+
+    integration_result = await db.execute(
+        select(Integration).where(
+            Integration.id == integration_id,
+            Integration.is_deleted.is_(False),
+        )
+    )
+    integration = integration_result.scalar_one_or_none()
+    if not integration:
+        raise ValueError("Integration not found")
+    if not integration.oauth_provider:
+        raise ValueError(f"Integration '{integration.name}' has no OAuth provider")
+
+    mapping_result = await db.execute(
+        select(IntegrationMapping).where(
+            IntegrationMapping.integration_id == integration_id,
+            IntegrationMapping.organization_id == organization_id,
+        )
+    )
+    mapping = mapping_result.scalar_one_or_none()
+    if not mapping or not mapping.entity_id:
+        raise ValueError(
+            f"Integration '{integration.name}' is not mapped to the selected organization"
+        )
+
+    provider = integration.oauth_provider
+    token = None
+    if provider.oauth_flow_type != "client_credentials":
+        token = await get_token_for_org(db, integration_id, organization_id)
+        if not token:
+            raise ValueError(
+                f"Integration '{integration.name}' is not connected for the selected organization"
+            )
+
+    token_context = await build_token_refresh_context(
+        db,
+        provider,
+        token=token,
+        org_id=organization_id,
+    )
+    return WebhookIntegrationCredentials(
+        integration_id=integration_id,
+        organization_id=organization_id,
+        entity_id=mapping.entity_id,
+        token_context=token_context,
+        encrypted_access_token=token.encrypted_access_token if token else None,
+        access_token_expires_at=token.expires_at if token else None,
+    )
+
+
+async def resolve_webhook_integration_auth(
+    credentials: WebhookIntegrationCredentials,
+) -> WebhookIntegrationAuth:
+    """Resolve a fresh plaintext access token without retaining a DB session."""
+    use_stored_token = (
+        credentials.encrypted_access_token is not None
+        and credentials.access_token_expires_at is not None
+        and credentials.access_token_expires_at
+        > datetime.now(timezone.utc) + timedelta(minutes=5)
+    )
+
+    if use_stored_token:
+        raw = credentials.encrypted_access_token
+        access_token = decrypt_secret(raw.decode() if isinstance(raw, bytes) else raw)
+    else:
+        outcome = await refresh_oauth_token_http(credentials.token_context)
+        if not outcome.get("success") or not outcome.get("access_token"):
+            raise ValueError(outcome.get("error", "OAuth token request failed"))
+        access_token = outcome["access_token"]
+
+    return WebhookIntegrationAuth(
+        integration_id=credentials.integration_id,
+        organization_id=credentials.organization_id,
+        entity_id=credentials.entity_id,
+        access_token=access_token,
+    )

--- a/api/src/services/webhooks/lifecycle.py
+++ b/api/src/services/webhooks/lifecycle.py
@@ -1,0 +1,105 @@
+"""Provider-managed webhook lifecycle operations."""
+
+from datetime import datetime, timezone
+from typing import Any
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.models.orm.events import EventSource, WebhookSource
+from src.services.webhooks.auth import (
+    build_webhook_integration_credentials,
+    resolve_webhook_integration_auth,
+)
+from src.services.webhooks.registry import get_adapter_registry
+
+
+async def _resolve_integration(
+    db: AsyncSession,
+    source: EventSource,
+    webhook: WebhookSource,
+    adapter: Any,
+) -> Any | None:
+    if not adapter.requires_integration:
+        return None
+    if not webhook.integration_id:
+        raise ValueError(
+            f"Adapter '{webhook.adapter_name}' requires an integration"
+        )
+    credentials = await build_webhook_integration_credentials(
+        db,
+        webhook.integration_id,
+        source.organization_id,
+    )
+    return await resolve_webhook_integration_auth(credentials)
+
+
+async def unsubscribe_provider(
+    db: AsyncSession,
+    source: EventSource,
+) -> None:
+    """Confirm a provider subscription is gone before local deletion."""
+    webhook = source.webhook_source
+    if webhook is None or webhook.adapter_name is None:
+        return
+    adapter = get_adapter_registry().get(webhook.adapter_name)
+    if adapter is None:
+        raise ValueError(f"Unknown webhook adapter: {webhook.adapter_name}")
+    integration = await _resolve_integration(db, source, webhook, adapter)
+    await adapter.unsubscribe(
+        external_id=webhook.external_id,
+        state=webhook.state or {},
+        integration=integration,
+    )
+
+
+async def resubscribe_provider(
+    db: AsyncSession,
+    source: EventSource,
+    callback_url: str,
+) -> None:
+    """Replace a provider registration while preserving the local source."""
+    webhook = source.webhook_source
+    if webhook is None or webhook.adapter_name is None:
+        raise ValueError("This event source has no provider-managed webhook")
+    adapter = get_adapter_registry().get(webhook.adapter_name)
+    if adapter is None:
+        raise ValueError(f"Unknown webhook adapter: {webhook.adapter_name}")
+    integration = await _resolve_integration(db, source, webhook, adapter)
+
+    try:
+        await adapter.unsubscribe(
+            external_id=webhook.external_id,
+            state=webhook.state or {},
+            integration=integration,
+        )
+    except Exception as exc:
+        source.error_message = f"Could not remove the existing provider subscription: {exc}"
+        source.updated_at = datetime.now(timezone.utc)
+        await db.commit()
+        raise
+
+    webhook.external_id = None
+    webhook.state = {}
+    webhook.expires_at = None
+    webhook.updated_at = datetime.now(timezone.utc)
+    await db.commit()
+
+    try:
+        result = await adapter.subscribe(
+            callback_url=callback_url,
+            config=webhook.config or {},
+            integration=integration,
+        )
+    except Exception as exc:
+        source.error_message = f"Provider resubscription failed: {exc}"
+        source.updated_at = datetime.now(timezone.utc)
+        await db.commit()
+        raise
+
+    webhook.external_id = result.external_id
+    webhook.state = result.state
+    webhook.expires_at = result.expires_at
+    webhook.updated_at = datetime.now(timezone.utc)
+    source.error_message = None
+    source.updated_at = datetime.now(timezone.utc)
+    await db.commit()

--- a/api/src/services/webhooks/protocol.py
+++ b/api/src/services/webhooks/protocol.py
@@ -9,6 +9,7 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 from typing import Any
+from uuid import UUID
 
 from starlette.requests import Request
 
@@ -103,6 +104,16 @@ class RenewResult:
     """Updated state (merged with existing)."""
 
 
+@dataclass(frozen=True)
+class WebhookIntegrationAuth:
+    """Resolved, tenant-scoped credentials passed to a webhook adapter."""
+
+    integration_id: UUID
+    organization_id: UUID
+    entity_id: str
+    access_token: str = field(repr=False)
+
+
 @dataclass
 class ValidationResponse:
     """
@@ -184,6 +195,9 @@ class WebhookAdapter(ABC):
     requires_integration: str | None = None
     """Integration name required for this adapter (e.g., 'Microsoft')."""
 
+    requires_organization: bool = False
+    """Whether the adapter must authenticate in an organization/tenant context."""
+
     config_schema: dict[str, Any] = {}
     """JSON Schema for adapter configuration."""
 
@@ -205,7 +219,7 @@ class WebhookAdapter(ABC):
         Args:
             callback_url: Full URL for the webhook endpoint.
             config: Adapter-specific configuration from user.
-            integration: IntegrationData with OAuth credentials (if requires_integration).
+            integration: Resolved organization-scoped authentication, when required.
 
         Returns:
             SubscribeResult with external_id, state, and optional expires_at.
@@ -228,7 +242,7 @@ class WebhookAdapter(ABC):
         Args:
             external_id: ID from SubscribeResult.external_id.
             state: State dict from SubscribeResult.state.
-            integration: IntegrationData with OAuth credentials (if requires_integration).
+            integration: Resolved organization-scoped authentication, when required.
 
         Note:
             Should not raise exceptions - best effort cleanup.
@@ -274,7 +288,7 @@ class WebhookAdapter(ABC):
 
         Args:
             operation: The operation name from x-dynamic-values.operation
-            integration: IntegrationData with OAuth credentials (if requires_integration)
+            integration: Resolved organization-scoped authentication, when required.
             current_config: Config values selected so far (for dependent fields)
 
         Returns:
@@ -300,7 +314,7 @@ class WebhookAdapter(ABC):
         Args:
             external_id: ID from SubscribeResult.external_id.
             state: State dict from SubscribeResult.state.
-            integration: IntegrationData with OAuth credentials (if requires_integration).
+            integration: Resolved organization-scoped authentication, when required.
 
         Returns:
             RenewResult with new expires_at and optional state updates.

--- a/api/src/services/webhooks/protocol.py
+++ b/api/src/services/webhooks/protocol.py
@@ -244,10 +244,19 @@ class WebhookAdapter(ABC):
             state: State dict from SubscribeResult.state.
             integration: Resolved organization-scoped authentication, when required.
 
-        Note:
-            Should not raise exceptions - best effort cleanup.
+        Raises:
+            Exception: If the provider cannot confirm the subscription is gone.
+                Providers should treat an already-missing subscription as success.
         """
         pass
+
+    def get_public_metadata(
+        self,
+        config: dict[str, Any],
+        state: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Return non-secret provider details that are safe to show to operators."""
+        return {}
 
     @abstractmethod
     async def handle_request(

--- a/api/src/services/webhooks/protocol.py
+++ b/api/src/services/webhooks/protocol.py
@@ -313,6 +313,7 @@ class WebhookAdapter(ABC):
         self,
         external_id: str | None,
         state: dict[str, Any],
+        config: dict[str, Any],
         integration: Any | None,
     ) -> RenewResult | None:
         """
@@ -323,6 +324,7 @@ class WebhookAdapter(ABC):
         Args:
             external_id: ID from SubscribeResult.external_id.
             state: State dict from SubscribeResult.state.
+            config: Persisted adapter configuration for the subscription.
             integration: Resolved organization-scoped authentication, when required.
 
         Returns:

--- a/api/src/services/webhooks/registry.py
+++ b/api/src/services/webhooks/registry.py
@@ -127,6 +127,7 @@ class AdapterRegistry:
             "display_name": adapter.display_name,
             "description": adapter.description,
             "requires_integration": adapter.requires_integration,
+            "requires_organization": adapter.requires_organization,
             "config_schema": adapter.config_schema,
             "supports_renewal": adapter.renewal_interval is not None,
         }
@@ -145,6 +146,7 @@ class AdapterRegistry:
                 "display_name": adapter.display_name,
                 "description": adapter.description,
                 "requires_integration": adapter.requires_integration,
+                "requires_organization": adapter.requires_organization,
                 "config_schema": adapter.config_schema,
                 "supports_renewal": adapter.renewal_interval is not None,
             })

--- a/api/tests/e2e/platform/test_cli_events.py
+++ b/api/tests/e2e/platform/test_cli_events.py
@@ -156,11 +156,55 @@ class TestCliEvents:
         assert created["schedule"]["timezone"] == "UTC"
         assert created["schedule"]["enabled"] is True
 
-        # Cleanup: delete the source directly via REST (no CLI delete-source cmd).
+        # Cleanup this fixture through REST; delete-source has dedicated coverage below.
         e2e_client.delete(
             f"/api/events/sources/{source_id}",
             headers=platform_admin.headers,
         )
+
+    def test_provider_source_can_be_resubscribed_and_deleted(
+        self,
+        cli_client,
+        _invoke,
+        e2e_client,
+        platform_admin,
+    ) -> None:
+        name = f"cli-evt-provider-{uuid4().hex[:8]}"
+        create_result = _invoke([
+            "--json",
+            "create-source",
+            "--name", name,
+            "--source-type", "webhook",
+            "--adapter", "local_fixture",
+            "--webhook-config", "{}",
+        ])
+        assert create_result.exit_code == 0, create_result.output
+        source = json.loads(create_result.output)
+
+        resubscribe_result = _invoke([
+            "--json",
+            "resubscribe-source", source["id"],
+        ])
+        assert resubscribe_result.exit_code == 0, resubscribe_result.output
+        resubscribed = json.loads(resubscribe_result.output)
+        assert resubscribed["webhook"]["external_id"] == "local-scheduler-fixture"
+
+        delete_result = _invoke(["--json", "delete-source", source["id"]])
+        assert delete_result.exit_code == 0, delete_result.output
+        assert json.loads(delete_result.output) == {"deleted": source["id"]}
+        missing = e2e_client.get(
+            f"/api/events/sources/{source['id']}",
+            headers=platform_admin.headers,
+        )
+        assert missing.status_code == 404
+
+    def test_graph_create_help_exposes_first_class_provider_flags(self, _invoke) -> None:
+        result = _invoke(["create-graph-source", "--help"])
+        assert result.exit_code == 0, result.output
+        assert "--integration" in result.output
+        assert "--user-id" in result.output
+        assert "--resource" in result.output
+        assert "--change-type" in result.output
 
     def test_subscribe_workflow_and_update_event_type(
         self,

--- a/api/tests/unit/jobs/test_webhook_renewal.py
+++ b/api/tests/unit/jobs/test_webhook_renewal.py
@@ -1,11 +1,15 @@
 """Tests for provider webhook renewal fallback behavior."""
 
 from datetime import datetime, timezone
+from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import pytest
 
-from src.jobs.schedulers.webhook_renewal import _renew_or_recreate
+from src.jobs.schedulers.webhook_renewal import (
+    _apply_renewal_result,
+    _renew_or_recreate,
+)
 from src.services.webhooks.protocol import RenewResult, SubscribeResult
 
 
@@ -53,3 +57,19 @@ async def test_recreates_subscription_when_renewal_is_rejected():
         config=webhook["config"],
         integration="auth",
     )
+
+
+def test_failed_renewal_is_visible_on_event_source():
+    webhook = SimpleNamespace()
+    source = SimpleNamespace(error_message=None, updated_at=None)
+
+    _apply_renewal_result(
+        webhook,
+        source,
+        {"success": False, "error": "token refresh failed"},
+    )
+
+    assert source.error_message == (
+        "Provider subscription renewal failed: token refresh failed"
+    )
+    assert source.updated_at is not None

--- a/api/tests/unit/jobs/test_webhook_renewal.py
+++ b/api/tests/unit/jobs/test_webhook_renewal.py
@@ -1,0 +1,55 @@
+"""Tests for provider webhook renewal fallback behavior."""
+
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock
+
+import pytest
+
+from src.jobs.schedulers.webhook_renewal import _renew_or_recreate
+from src.services.webhooks.protocol import RenewResult, SubscribeResult
+
+
+@pytest.mark.asyncio
+async def test_keeps_subscription_when_renewal_succeeds():
+    renewed = RenewResult(expires_at=datetime.now(timezone.utc))
+    adapter = AsyncMock()
+    adapter.renew.return_value = renewed
+
+    result, recreated = await _renew_or_recreate(
+        adapter,
+        {
+            "external_id": "existing",
+            "state": {},
+            "callback_url": "https://example.com/api/hooks/source",
+            "config": {},
+        },
+        integration=None,
+    )
+
+    assert result is renewed
+    assert recreated is False
+    adapter.subscribe.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_recreates_subscription_when_renewal_is_rejected():
+    replacement = SubscribeResult(external_id="replacement")
+    adapter = AsyncMock()
+    adapter.renew.return_value = None
+    adapter.subscribe.return_value = replacement
+    webhook = {
+        "external_id": "expired",
+        "state": {"client_state": "old"},
+        "callback_url": "https://example.com/api/hooks/source",
+        "config": {"resource": "/users/1/messages"},
+    }
+
+    result, recreated = await _renew_or_recreate(adapter, webhook, integration="auth")
+
+    assert result is replacement
+    assert recreated is True
+    adapter.subscribe.assert_awaited_once_with(
+        callback_url=webhook["callback_url"],
+        config=webhook["config"],
+        integration="auth",
+    )

--- a/api/tests/unit/routers/test_events_webhook_creation.py
+++ b/api/tests/unit/routers/test_events_webhook_creation.py
@@ -1,0 +1,107 @@
+"""Transaction-order regressions for provider-managed webhook creation."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+from fastapi import HTTPException
+
+from src.models.contracts.events import EventSourceCreate
+from src.models.enums import EventSourceType
+from src.routers.events import create_source
+from src.services.webhooks.protocol import SubscribeResult
+
+
+def _session_that_assigns_ids() -> tuple[MagicMock, list[object]]:
+    db = MagicMock()
+    db.flush = AsyncMock()
+    db.commit = AsyncMock()
+    db.delete = AsyncMock()
+    db.execute = AsyncMock()
+    added: list[object] = []
+
+    def add(entity: object) -> None:
+        if getattr(entity, "id", None) is None:
+            entity.id = uuid4()
+        added.append(entity)
+
+    db.add.side_effect = add
+    return db, added
+
+
+def _request() -> EventSourceCreate:
+    return EventSourceCreate.model_validate(
+        {
+            "name": "Graph callback ordering",
+            "source_type": EventSourceType.WEBHOOK,
+            "webhook": {
+                "adapter_name": "test_provider",
+                "config": {},
+            },
+        }
+    )
+
+
+@pytest.mark.asyncio
+async def test_provider_subscription_starts_after_webhook_source_commit(monkeypatch):
+    db, added = _session_that_assigns_ids()
+    response = object()
+
+    async def subscribe(**_kwargs):
+        assert db.commit.await_count == 1
+        assert len(added) == 2
+        return SubscribeResult()
+
+    adapter = SimpleNamespace(
+        requires_integration=None,
+        subscribe=AsyncMock(side_effect=subscribe),
+    )
+    registry = MagicMock()
+    registry.get.return_value = adapter
+    monkeypatch.setattr("src.routers.events.get_adapter_registry", lambda: registry)
+    monkeypatch.setattr(
+        "src.routers.events._build_event_source_response",
+        AsyncMock(return_value=response),
+    )
+    async def execute(_statement):
+        source = added[0]
+        result = MagicMock()
+        result.unique.return_value.scalar_one.return_value = source
+        return result
+
+    db.execute.side_effect = execute
+
+    actual = await create_source(
+        _request(),
+        SimpleNamespace(org_id=uuid4(), user=SimpleNamespace(email="admin@example.com")),
+        SimpleNamespace(),
+        db,
+    )
+
+    assert actual is response
+    assert db.commit.await_count == 1
+    db.delete.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_failed_provider_subscription_removes_provisional_source(monkeypatch):
+    db, added = _session_that_assigns_ids()
+    adapter = SimpleNamespace(
+        requires_integration=None,
+        subscribe=AsyncMock(side_effect=ValueError("provider rejected callback")),
+    )
+    registry = MagicMock()
+    registry.get.return_value = adapter
+    monkeypatch.setattr("src.routers.events.get_adapter_registry", lambda: registry)
+
+    with pytest.raises(HTTPException, match="Failed to create provider subscription"):
+        await create_source(
+            _request(),
+            SimpleNamespace(org_id=uuid4(), user=SimpleNamespace(email="admin@example.com")),
+            SimpleNamespace(),
+            db,
+        )
+
+    db.delete.assert_awaited_once_with(added[0])
+    assert db.commit.await_count == 2

--- a/api/tests/unit/services/test_webhook_adapters.py
+++ b/api/tests/unit/services/test_webhook_adapters.py
@@ -110,7 +110,17 @@ async def test_graph_lists_users_with_resolved_tenant_token(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_graph_subscription_uses_public_callback_and_resolved_token(monkeypatch):
-    response = SimpleNamespace(
+    user_response = SimpleNamespace(
+        status_code=200,
+        json=lambda: {
+            "id": "user-1",
+            "displayName": "Ada Lovelace",
+            "mail": "ada@example.com",
+            "userPrincipalName": "ada@example.com",
+        },
+        text="",
+    )
+    subscription_response = SimpleNamespace(
         status_code=201,
         json=lambda: {
             "id": "subscription-1",
@@ -118,7 +128,8 @@ async def test_graph_subscription_uses_public_callback_and_resolved_token(monkey
         },
         text="",
     )
-    client = _GraphClient(response)
+    client = _GraphClient(subscription_response)
+    client.get.return_value = user_response
     monkeypatch.setattr(
         "src.services.webhooks.adapters.microsoft_graph.httpx.AsyncClient",
         lambda: client,
@@ -126,17 +137,81 @@ async def test_graph_subscription_uses_public_callback_and_resolved_token(monkey
 
     result = await MicrosoftGraphAdapter().subscribe(
         "https://dev.example.com/api/hooks/source-1",
-        {"resource": "/users/user-1/messages", "change_types": ["created"]},
+        {
+            "user_id": "user-1",
+            "resource": "/users/user-1/messages",
+            "change_types": ["created"],
+        },
         _graph_auth(),
     )
 
     assert result.external_id == "subscription-1"
+    assert result.state["user_display_name"] == "Ada Lovelace"
     request = client.post.await_args
     assert request.kwargs["headers"]["Authorization"] == "Bearer tenant-token"
     assert request.kwargs["json"]["notificationUrl"] == (
         "https://dev.example.com/api/hooks/source-1"
     )
     assert "includeResourceData" not in request.kwargs["json"]
+
+
+@pytest.mark.asyncio
+async def test_graph_event_type_uses_configured_collection_not_object_id():
+    request = WebhookRequest(
+        method="POST",
+        path="/api/hooks/source-1",
+        headers={},
+        query_params={},
+        body=(
+            b'{"value":[{"changeType":"created","resource":'
+            b'"Users/user-1/Messages/01LONGMESSAGEID"}]}'
+        ),
+    )
+
+    result = await MicrosoftGraphAdapter().handle_request(
+        request,
+        config={"resource": "/users/user-1/messages"},
+        state={},
+    )
+
+    assert isinstance(result, Deliver)
+    assert result.event_type == "graph.messages.created"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status_code", [204, 404])
+async def test_graph_unsubscribe_accepts_deleted_or_already_missing(
+    monkeypatch, status_code
+):
+    response = SimpleNamespace(status_code=status_code, text="", json=lambda: {})
+    client = _GraphClient(response)
+    monkeypatch.setattr(
+        "src.services.webhooks.adapters.microsoft_graph.httpx.AsyncClient",
+        lambda: client,
+    )
+
+    await MicrosoftGraphAdapter().unsubscribe("subscription-1", {}, _graph_auth())
+
+    client.delete.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_graph_unsubscribe_raises_when_provider_does_not_delete(monkeypatch):
+    response = SimpleNamespace(
+        status_code=503,
+        text="unavailable",
+        json=lambda: {"error": {"message": "Graph unavailable"}},
+    )
+    client = _GraphClient(response)
+    monkeypatch.setattr(
+        "src.services.webhooks.adapters.microsoft_graph.httpx.AsyncClient",
+        lambda: client,
+    )
+
+    with pytest.raises(ValueError, match="Graph unavailable"):
+        await MicrosoftGraphAdapter().unsubscribe(
+            "subscription-1", {}, _graph_auth()
+        )
 
 
 @pytest.mark.asyncio

--- a/api/tests/unit/services/test_webhook_adapters.py
+++ b/api/tests/unit/services/test_webhook_adapters.py
@@ -83,6 +83,7 @@ async def test_graph_lists_users_with_resolved_tenant_token(monkeypatch):
                     "id": "user-1",
                     "displayName": "Ada Lovelace",
                     "mail": "ada@example.com",
+                    "userPrincipalName": "ada@example.com",
                 }
             ]
         },
@@ -101,7 +102,13 @@ async def test_graph_lists_users_with_resolved_tenant_token(monkeypatch):
     )
 
     assert users == [
-        {"id": "user-1", "displayName": "Ada Lovelace", "mail": "ada@example.com"}
+        {
+            "id": "user-1",
+            "label": "ada@example.com · Ada Lovelace",
+            "displayName": "Ada Lovelace",
+            "userPrincipalName": "ada@example.com",
+            "mail": "ada@example.com",
+        }
     ]
     assert client.get.await_args.kwargs["headers"] == {
         "Authorization": "Bearer tenant-token"
@@ -153,6 +160,48 @@ async def test_graph_subscription_uses_public_callback_and_resolved_token(monkey
         "https://dev.example.com/api/hooks/source-1"
     )
     assert "includeResourceData" not in request.kwargs["json"]
+
+
+@pytest.mark.asyncio
+async def test_graph_renewal_refreshes_user_identity_metadata(monkeypatch):
+    renewal_response = SimpleNamespace(
+        status_code=200,
+        json=lambda: {"expirationDateTime": "2026-08-31T12:00:00Z"},
+        text="",
+    )
+    user_response = SimpleNamespace(
+        status_code=200,
+        json=lambda: {
+            "id": "user-1",
+            "displayName": "Ada Lovelace",
+            "mail": "ada@example.com",
+            "userPrincipalName": "ada@example.com",
+        },
+        text="",
+    )
+    client = _GraphClient(renewal_response)
+    client.get.return_value = user_response
+    monkeypatch.setattr(
+        "src.services.webhooks.adapters.microsoft_graph.httpx.AsyncClient",
+        lambda: client,
+    )
+
+    result = await MicrosoftGraphAdapter().renew(
+        external_id="subscription-1",
+        state={},
+        config={
+            "user_id": "user-1",
+            "resource": "/users/user-1/messages",
+        },
+        integration=_graph_auth(),
+    )
+
+    assert result is not None
+    assert result.state == {
+        "user_display_name": "Ada Lovelace",
+        "user_principal_name": "ada@example.com",
+        "user_mail": "ada@example.com",
+    }
 
 
 @pytest.mark.asyncio
@@ -221,6 +270,7 @@ async def test_local_fixture_adapter_renews_deterministically():
     result = await adapter.renew(
         external_id="local-scheduler-fixture",
         state={"renewal_count": 2},
+        config={},
         integration=None,
     )
 
@@ -237,6 +287,7 @@ async def test_local_fixture_adapter_rejects_unknown_subscription():
     result = await adapter.renew(
         external_id="not-the-fixture",
         state={},
+        config={},
         integration=None,
     )
 

--- a/api/tests/unit/services/test_webhook_adapters.py
+++ b/api/tests/unit/services/test_webhook_adapters.py
@@ -9,13 +9,22 @@ import hashlib
 import hmac
 from datetime import datetime, timezone
 from types import SimpleNamespace
+from unittest.mock import AsyncMock
+from uuid import uuid4
 
 import pytest
 
 from src.services.webhooks.adapters.generic import GenericWebhookAdapter
 from src.services.webhooks.adapters.local_fixture import LocalFixtureWebhookAdapter
+from src.services.webhooks.adapters.microsoft_graph import MicrosoftGraphAdapter
 from src.services.webhooks import registry as webhook_registry
-from src.services.webhooks.protocol import Deliver, Rejected, WebhookAdapter, WebhookRequest
+from src.services.webhooks.protocol import (
+    Deliver,
+    Rejected,
+    WebhookAdapter,
+    WebhookIntegrationAuth,
+    WebhookRequest,
+)
 
 
 def _sign(body: bytes, secret: str, prefix: str = "sha256=") -> str:
@@ -36,6 +45,98 @@ def _make_request(
         body=body,
         query_params={},
     )
+
+
+class _GraphClient:
+    """Small async client double that records Graph requests."""
+
+    def __init__(self, response):
+        self.response = response
+        self.get = AsyncMock(return_value=response)
+        self.post = AsyncMock(return_value=response)
+        self.patch = AsyncMock(return_value=response)
+        self.delete = AsyncMock(return_value=response)
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_args):
+        return None
+
+
+def _graph_auth() -> WebhookIntegrationAuth:
+    return WebhookIntegrationAuth(
+        integration_id=uuid4(),
+        organization_id=uuid4(),
+        entity_id="tenant-covi",
+        access_token="tenant-token",
+    )
+
+
+@pytest.mark.asyncio
+async def test_graph_lists_users_with_resolved_tenant_token(monkeypatch):
+    response = SimpleNamespace(
+        status_code=200,
+        json=lambda: {
+            "value": [
+                {
+                    "id": "user-1",
+                    "displayName": "Ada Lovelace",
+                    "mail": "ada@example.com",
+                }
+            ]
+        },
+        text="",
+    )
+    client = _GraphClient(response)
+    monkeypatch.setattr(
+        "src.services.webhooks.adapters.microsoft_graph.httpx.AsyncClient",
+        lambda: client,
+    )
+
+    users = await MicrosoftGraphAdapter().get_dynamic_values(
+        "list_users",
+        _graph_auth(),
+        {},
+    )
+
+    assert users == [
+        {"id": "user-1", "displayName": "Ada Lovelace", "mail": "ada@example.com"}
+    ]
+    assert client.get.await_args.kwargs["headers"] == {
+        "Authorization": "Bearer tenant-token"
+    }
+
+
+@pytest.mark.asyncio
+async def test_graph_subscription_uses_public_callback_and_resolved_token(monkeypatch):
+    response = SimpleNamespace(
+        status_code=201,
+        json=lambda: {
+            "id": "subscription-1",
+            "expirationDateTime": "2026-08-30T12:00:00Z",
+        },
+        text="",
+    )
+    client = _GraphClient(response)
+    monkeypatch.setattr(
+        "src.services.webhooks.adapters.microsoft_graph.httpx.AsyncClient",
+        lambda: client,
+    )
+
+    result = await MicrosoftGraphAdapter().subscribe(
+        "https://dev.example.com/api/hooks/source-1",
+        {"resource": "/users/user-1/messages", "change_types": ["created"]},
+        _graph_auth(),
+    )
+
+    assert result.external_id == "subscription-1"
+    request = client.post.await_args
+    assert request.kwargs["headers"]["Authorization"] == "Bearer tenant-token"
+    assert request.kwargs["json"]["notificationUrl"] == (
+        "https://dev.example.com/api/hooks/source-1"
+    )
+    assert "includeResourceData" not in request.kwargs["json"]
 
 
 @pytest.mark.asyncio

--- a/api/tests/unit/services/test_webhook_integration_auth.py
+++ b/api/tests/unit/services/test_webhook_integration_auth.py
@@ -1,0 +1,142 @@
+"""Tests for tenant-scoped webhook OAuth resolution."""
+
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+
+from src.services.webhooks.auth import (
+    WebhookIntegrationCredentials,
+    build_webhook_integration_credentials,
+    resolve_webhook_integration_auth,
+)
+
+
+@pytest.mark.asyncio
+async def test_credentials_require_and_use_exact_organization_mapping(monkeypatch):
+    integration_id = uuid4()
+    organization_id = uuid4()
+    provider = SimpleNamespace(oauth_flow_type="client_credentials")
+    integration = SimpleNamespace(
+        id=integration_id,
+        name="Microsoft",
+        oauth_provider=provider,
+    )
+    mapping = SimpleNamespace(entity_id="tenant-from-mapping")
+    integration_result = MagicMock()
+    integration_result.scalar_one_or_none.return_value = integration
+    mapping_result = MagicMock()
+    mapping_result.scalar_one_or_none.return_value = mapping
+    db = AsyncMock()
+    db.execute.side_effect = [integration_result, mapping_result]
+    token_context = {"token_url_defaults": {"entity_id": mapping.entity_id}}
+    build_context = AsyncMock(return_value=token_context)
+    monkeypatch.setattr(
+        "src.services.webhooks.auth.build_token_refresh_context",
+        build_context,
+    )
+
+    credentials = await build_webhook_integration_credentials(
+        db,
+        integration_id,
+        organization_id,
+    )
+
+    assert credentials.entity_id == "tenant-from-mapping"
+    assert credentials.organization_id == organization_id
+    assert credentials.token_context == token_context
+    build_context.assert_awaited_once_with(
+        db,
+        provider,
+        token=None,
+        org_id=organization_id,
+    )
+
+
+@pytest.mark.asyncio
+async def test_credentials_reject_missing_organization_mapping(monkeypatch):
+    integration_id = uuid4()
+    provider = SimpleNamespace(oauth_flow_type="client_credentials")
+    integration = SimpleNamespace(
+        id=integration_id,
+        name="Microsoft",
+        oauth_provider=provider,
+    )
+    integration_result = MagicMock()
+    integration_result.scalar_one_or_none.return_value = integration
+    mapping_result = MagicMock()
+    mapping_result.scalar_one_or_none.return_value = None
+    db = AsyncMock()
+    db.execute.side_effect = [integration_result, mapping_result]
+
+    with pytest.raises(ValueError, match="not mapped to the selected organization"):
+        await build_webhook_integration_credentials(db, integration_id, uuid4())
+
+
+@pytest.mark.asyncio
+async def test_client_credentials_token_uses_mapping_identity(monkeypatch):
+    credentials = WebhookIntegrationCredentials(
+        integration_id=uuid4(),
+        organization_id=uuid4(),
+        entity_id="tenant-from-mapping",
+        token_context={"provider_id": uuid4()},
+    )
+    refresh = AsyncMock(
+        return_value={"success": True, "access_token": "fresh-tenant-token"}
+    )
+    monkeypatch.setattr(
+        "src.services.webhooks.auth.refresh_oauth_token_http",
+        refresh,
+    )
+
+    auth = await resolve_webhook_integration_auth(credentials)
+
+    assert auth.entity_id == "tenant-from-mapping"
+    assert auth.organization_id == credentials.organization_id
+    assert auth.access_token == "fresh-tenant-token"
+    refresh.assert_awaited_once_with(credentials.token_context)
+
+
+@pytest.mark.asyncio
+async def test_valid_stored_token_does_not_refresh(monkeypatch):
+    monkeypatch.setattr(
+        "src.services.webhooks.auth.decrypt_secret",
+        lambda _value: "stored-token",
+    )
+    refresh = AsyncMock()
+    monkeypatch.setattr(
+        "src.services.webhooks.auth.refresh_oauth_token_http",
+        refresh,
+    )
+    credentials = WebhookIntegrationCredentials(
+        integration_id=uuid4(),
+        organization_id=uuid4(),
+        entity_id="tenant-from-mapping",
+        token_context={},
+        encrypted_access_token=b"encrypted",
+        access_token_expires_at=datetime.now(timezone.utc) + timedelta(hours=1),
+    )
+
+    auth = await resolve_webhook_integration_auth(credentials)
+
+    assert auth.access_token == "stored-token"
+    refresh.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_failed_token_request_surfaces_provider_error(monkeypatch):
+    credentials = WebhookIntegrationCredentials(
+        integration_id=uuid4(),
+        organization_id=uuid4(),
+        entity_id="tenant-from-mapping",
+        token_context={},
+    )
+    monkeypatch.setattr(
+        "src.services.webhooks.auth.refresh_oauth_token_http",
+        AsyncMock(return_value={"success": False, "error": "invalid client secret"}),
+    )
+
+    with pytest.raises(ValueError, match="invalid client secret"):
+        await resolve_webhook_integration_auth(credentials)

--- a/api/tests/unit/services/test_webhook_integration_auth.py
+++ b/api/tests/unit/services/test_webhook_integration_auth.py
@@ -56,7 +56,7 @@ async def test_credentials_require_and_use_exact_organization_mapping(monkeypatc
 
 
 @pytest.mark.asyncio
-async def test_credentials_reject_missing_organization_mapping(monkeypatch):
+async def test_credentials_use_integration_default_without_organization_mapping(monkeypatch):
     integration_id = uuid4()
     provider = SimpleNamespace(oauth_flow_type="client_credentials")
     integration = SimpleNamespace(
@@ -66,12 +66,48 @@ async def test_credentials_reject_missing_organization_mapping(monkeypatch):
     )
     integration_result = MagicMock()
     integration_result.scalar_one_or_none.return_value = integration
-    mapping_result = MagicMock()
-    mapping_result.scalar_one_or_none.return_value = None
     db = AsyncMock()
-    db.execute.side_effect = [integration_result, mapping_result]
+    db.execute.return_value = integration_result
+    token_context = {"token_url_defaults": {"entity_id": "default-tenant"}}
+    build_context = AsyncMock(return_value=token_context)
+    monkeypatch.setattr(
+        "src.services.webhooks.auth.build_token_refresh_context",
+        build_context,
+    )
 
-    with pytest.raises(ValueError, match="not mapped to the selected organization"):
+    organization_id = uuid4()
+    credentials = await build_webhook_integration_credentials(
+        db, integration_id, organization_id
+    )
+
+    assert credentials.entity_id == "default-tenant"
+    build_context.assert_awaited_once_with(
+        db,
+        provider,
+        token=None,
+        org_id=organization_id,
+    )
+
+
+@pytest.mark.asyncio
+async def test_credentials_reject_when_no_effective_tenant_is_configured(monkeypatch):
+    integration_id = uuid4()
+    provider = SimpleNamespace(oauth_flow_type="client_credentials")
+    integration = SimpleNamespace(
+        id=integration_id,
+        name="Microsoft",
+        oauth_provider=provider,
+    )
+    integration_result = MagicMock()
+    integration_result.scalar_one_or_none.return_value = integration
+    db = AsyncMock()
+    db.execute.return_value = integration_result
+    monkeypatch.setattr(
+        "src.services.webhooks.auth.build_token_refresh_context",
+        AsyncMock(return_value={"token_url_defaults": {}}),
+    )
+
+    with pytest.raises(ValueError, match="has no tenant configured"):
         await build_webhook_integration_credentials(db, integration_id, uuid4())
 
 

--- a/api/tests/unit/services/test_webhook_lifecycle.py
+++ b/api/tests/unit/services/test_webhook_lifecycle.py
@@ -1,0 +1,119 @@
+"""Tests for provider-managed webhook recovery and cleanup."""
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.services.webhooks.lifecycle import (
+    resubscribe_provider,
+    unsubscribe_provider,
+)
+from src.services.webhooks.protocol import SubscribeResult
+
+
+def _source() -> SimpleNamespace:
+    return SimpleNamespace(
+        organization_id=None,
+        error_message=None,
+        updated_at=None,
+        webhook_source=SimpleNamespace(
+            adapter_name="provider",
+            integration_id=None,
+            external_id="old-subscription",
+            state={"client_state": "old"},
+            config={"resource": "/users/1/messages"},
+            expires_at=datetime(2026, 8, 28, tzinfo=timezone.utc),
+            updated_at=None,
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_resubscribe_replaces_provider_state_after_cleanup(monkeypatch):
+    source = _source()
+    db = MagicMock()
+    db.commit = AsyncMock()
+    replacement = SubscribeResult(
+        external_id="new-subscription",
+        state={"client_state": "new"},
+        expires_at=datetime(2026, 8, 31, tzinfo=timezone.utc),
+    )
+    adapter = SimpleNamespace(
+        requires_integration=None,
+        unsubscribe=AsyncMock(),
+        subscribe=AsyncMock(return_value=replacement),
+    )
+    registry = MagicMock()
+    registry.get.return_value = adapter
+    monkeypatch.setattr(
+        "src.services.webhooks.lifecycle.get_adapter_registry",
+        lambda: registry,
+    )
+
+    await resubscribe_provider(
+        db,
+        source,
+        "https://example.test/api/hooks/source-1",
+    )
+
+    adapter.unsubscribe.assert_awaited_once_with(
+        external_id="old-subscription",
+        state={"client_state": "old"},
+        integration=None,
+    )
+    adapter.subscribe.assert_awaited_once()
+    assert source.webhook_source.external_id == "new-subscription"
+    assert source.webhook_source.state == {"client_state": "new"}
+    assert source.error_message is None
+    assert db.commit.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_resubscribe_retains_source_and_records_recreation_failure(monkeypatch):
+    source = _source()
+    db = MagicMock()
+    db.commit = AsyncMock()
+    adapter = SimpleNamespace(
+        requires_integration=None,
+        unsubscribe=AsyncMock(),
+        subscribe=AsyncMock(side_effect=ValueError("callback rejected")),
+    )
+    registry = MagicMock()
+    registry.get.return_value = adapter
+    monkeypatch.setattr(
+        "src.services.webhooks.lifecycle.get_adapter_registry",
+        lambda: registry,
+    )
+
+    with pytest.raises(ValueError, match="callback rejected"):
+        await resubscribe_provider(
+            db,
+            source,
+            "https://example.test/api/hooks/source-1",
+        )
+
+    assert source.webhook_source.external_id is None
+    assert source.error_message == (
+        "Provider resubscription failed: callback rejected"
+    )
+    assert db.commit.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_unsubscribe_propagates_provider_failure(monkeypatch):
+    source = _source()
+    adapter = SimpleNamespace(
+        requires_integration=None,
+        unsubscribe=AsyncMock(side_effect=ValueError("Graph unavailable")),
+    )
+    registry = MagicMock()
+    registry.get.return_value = adapter
+    monkeypatch.setattr(
+        "src.services.webhooks.lifecycle.get_adapter_registry",
+        lambda: registry,
+    )
+
+    with pytest.raises(ValueError, match="Graph unavailable"):
+        await unsubscribe_provider(MagicMock(), source)

--- a/client/e2e/event-source-graph.admin.spec.ts
+++ b/client/e2e/event-source-graph.admin.spec.ts
@@ -82,6 +82,7 @@ test.describe.serial("Microsoft Graph event source", () => {
 								id: "user-1",
 								display_name: "Adele Vance",
 								user_principal_name: "adele@example.com",
+								label: "adele@example.com · Adele Vance",
 							},
 						],
 					}),
@@ -114,6 +115,12 @@ test.describe.serial("Microsoft Graph event source", () => {
 
 		await expect(dialog.getByText("Options did not load.")).toBeHidden();
 		await expect(dialog.getByText("Select User...")).toBeVisible();
+		await dialog.getByText("Select User...").click();
+		await expect(
+			page.getByRole("option", {
+				name: "adele@example.com · Adele Vance",
+			}),
+		).toBeVisible();
 		expect(requests.length).toBeGreaterThanOrEqual(2);
 		for (const request of requests) {
 			expect(request).toMatchObject({
@@ -205,7 +212,26 @@ test.describe.serial("Microsoft Graph event source", () => {
 				await route.fulfill({
 					status: 200,
 					contentType: "application/json",
-					body: JSON.stringify({ items: [], total: 0 }),
+					body: JSON.stringify({
+						items: [
+							{
+								id: "22222222-2222-4222-8222-222222222222",
+								event_source_id: sourceId,
+								event_source_name: source.name,
+								event_type: "01V6T7ZK0M0Q8SHJ4A1N5W2X9B.created",
+								received_at: "2026-08-27T20:30:00Z",
+								headers: {},
+								data: { change_type: "created" },
+								source_ip: "10.0.0.1",
+								status: "completed",
+								delivery_count: 0,
+								success_count: 0,
+								failed_count: 0,
+								created_at: "2026-08-27T20:30:00Z",
+							},
+						],
+						total: 1,
+					}),
 				});
 			},
 		);
@@ -213,7 +239,7 @@ test.describe.serial("Microsoft Graph event source", () => {
 		await page.goto("/event-sources");
 		await expect(page.getByText("Adele inbox changes")).toBeVisible();
 		await expect(
-			page.getByText("Adele Vance · Mail messages · created"),
+			page.getByText("adele@example.com · Mail messages · created"),
 		).toBeVisible();
 		await expect(page.getByText("Microsoft Graph")).toBeVisible();
 
@@ -223,6 +249,11 @@ test.describe.serial("Microsoft Graph event source", () => {
 		).toBeVisible();
 		await expect(page.getByText("adele@example.com")).toBeVisible();
 		await expect(page.getByText("Connected")).toBeVisible();
+		await page.getByRole("tab", { name: /Events/ }).click();
+		await expect(page.getByText("graph.messages.created")).toBeVisible();
+		await expect(
+			page.getByText("01V6T7ZK0M0Q8SHJ4A1N5W2X9B.created"),
+		).toBeHidden();
 
 		await page.getByRole("button", { name: "Resubscribe" }).click();
 		const confirmation = page.getByRole("alertdialog", {

--- a/client/e2e/event-source-graph.admin.spec.ts
+++ b/client/e2e/event-source-graph.admin.spec.ts
@@ -106,7 +106,9 @@ test.describe.serial("Microsoft Graph event source", () => {
 		await page.getByRole("option", { name: "Microsoft" }).click();
 
 		await expect(dialog.getByText("Options did not load.")).toBeVisible();
-		await expect(dialog.getByRole("button", { name: "Retry" })).toBeVisible();
+		await expect(
+			dialog.getByRole("button", { name: "Retry" }),
+		).toBeVisible();
 		tenantAvailable = true;
 		await dialog.getByRole("button", { name: "Retry" }).click();
 
@@ -120,5 +122,116 @@ test.describe.serial("Microsoft Graph event source", () => {
 				organization_id: organizationId,
 			});
 		}
+	});
+
+	test("shows Graph context and recreates the provider subscription", async ({
+		page,
+	}) => {
+		const sourceId = "11111111-1111-4111-8111-111111111111";
+		const source = {
+			id: sourceId,
+			name: "Adele inbox changes",
+			description: null,
+			source_type: "webhook",
+			organization_id: organizationId,
+			organization_name: organizationName,
+			is_active: true,
+			event_type: null,
+			webhook: {
+				adapter_name: "microsoft_graph",
+				integration_id: integrationId,
+				integration_name: "Microsoft",
+				config: {
+					user_id: "user-1",
+					resource: "/users/user-1/messages",
+					change_types: ["created"],
+				},
+				callback_url: `/api/events/webhook/${sourceId}`,
+				external_id: "graph-subscription-1",
+				provider_metadata: {
+					provider: "microsoft_graph",
+					user_id: "user-1",
+					user_display_name: "Adele Vance",
+					user_principal_name: "adele@example.com",
+					resource: "/users/user-1/messages",
+					change_types: ["created"],
+				},
+				expires_at: "2099-08-28T00:00:00Z",
+				rate_limit_per_minute: 60,
+				rate_limit_window_seconds: 60,
+				rate_limit_enabled: true,
+				rate_limited_count_24h: 0,
+			},
+			schedule: null,
+			subscription_count: 0,
+			event_count_24h: 1,
+			error_message: null,
+			created_at: "2026-08-27T20:00:00Z",
+			updated_at: "2026-08-27T20:00:00Z",
+		};
+		let resubscribeRequests = 0;
+
+		await page.route(/\/api\/events\/sources(?:\?.*)?$/, async (route) => {
+			await route.fulfill({
+				status: 200,
+				contentType: "application/json",
+				body: JSON.stringify({ items: [source], total: 1 }),
+			});
+		});
+		await page.route(
+			new RegExp(`/api/events/sources/${sourceId}/resubscribe$`),
+			async (route) => {
+				resubscribeRequests += 1;
+				await route.fulfill({
+					status: 200,
+					contentType: "application/json",
+					body: JSON.stringify(source),
+				});
+			},
+		);
+		await page.route(
+			new RegExp(`/api/events/sources/${sourceId}$`),
+			async (route) => {
+				await route.fulfill({
+					status: 200,
+					contentType: "application/json",
+					body: JSON.stringify(source),
+				});
+			},
+		);
+		await page.route(
+			new RegExp(`/api/events/sources/${sourceId}/events(?:\\?.*)?$`),
+			async (route) => {
+				await route.fulfill({
+					status: 200,
+					contentType: "application/json",
+					body: JSON.stringify({ items: [], total: 0 }),
+				});
+			},
+		);
+
+		await page.goto("/event-sources");
+		await expect(page.getByText("Adele inbox changes")).toBeVisible();
+		await expect(
+			page.getByText("Adele Vance · Mail messages · created"),
+		).toBeVisible();
+		await expect(page.getByText("Microsoft Graph")).toBeVisible();
+
+		await page.getByText("Adele inbox changes").click();
+		await expect(
+			page.getByRole("heading", { name: "Microsoft Graph" }),
+		).toBeVisible();
+		await expect(page.getByText("adele@example.com")).toBeVisible();
+		await expect(page.getByText("Connected")).toBeVisible();
+
+		await page.getByRole("button", { name: "Resubscribe" }).click();
+		const confirmation = page.getByRole("alertdialog", {
+			name: "Resubscribe to Microsoft Graph?",
+		});
+		await confirmation.getByRole("button", { name: "Resubscribe" }).click();
+		await expect.poll(() => resubscribeRequests).toBe(1);
+		await expect(
+			page.getByText("Microsoft Graph subscription recreated"),
+		).toBeVisible();
 	});
 });

--- a/client/e2e/event-source-graph.admin.spec.ts
+++ b/client/e2e/event-source-graph.admin.spec.ts
@@ -1,0 +1,124 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { test, expect } from "./fixtures/api-fixture";
+import type { AllCredentials } from "./setup/auth-helpers";
+
+test.describe.serial("Microsoft Graph event source", () => {
+	let integrationId: string;
+	let organizationId: string;
+	let organizationName: string;
+
+	test.beforeAll(async ({ api }) => {
+		const credentials = JSON.parse(
+			readFileSync(resolve("e2e/.auth/credentials.json"), "utf8"),
+		) as AllCredentials;
+		organizationId = credentials.org1.id;
+		organizationName = credentials.org1.name;
+
+		const integration = await api.post("/api/integrations", {
+			data: { name: "Microsoft" },
+		});
+		expect(integration.ok(), await integration.text()).toBe(true);
+		integrationId = ((await integration.json()) as { id: string }).id;
+
+		const oauth = await api.post("/api/oauth/connections", {
+			data: {
+				integration_id: integrationId,
+				oauth_flow_type: "client_credentials",
+				client_id: "playwright-client",
+				client_secret: "playwright-secret",
+				token_url:
+					"https://login.microsoftonline.com/{entity_id}/oauth2/v2.0/token",
+				scopes: "https://graph.microsoft.com/.default",
+			},
+		});
+		expect(oauth.ok(), await oauth.text()).toBe(true);
+
+		const mapping = await api.post(
+			`/api/integrations/${integrationId}/mappings`,
+			{
+				data: {
+					organization_id: organizationId,
+					entity_id: "playwright-tenant",
+					entity_name: "Playwright tenant",
+				},
+			},
+		);
+		expect(mapping.ok(), await mapping.text()).toBe(true);
+	});
+
+	test.afterAll(async ({ api }) => {
+		if (integrationId) {
+			await api.delete("/api/oauth/connections/Microsoft");
+			await api.delete(`/api/integrations/${integrationId}`);
+		}
+	});
+
+	test("loads the mapped tenant's users after a visible retry", async ({
+		page,
+	}) => {
+		const requests: Array<Record<string, unknown>> = [];
+		let tenantAvailable = false;
+		await page.route(
+			"**/api/events/adapters/microsoft_graph/dynamic-values",
+			async (route) => {
+				requests.push(route.request().postDataJSON());
+				if (!tenantAvailable) {
+					await route.fulfill({
+						status: 502,
+						contentType: "application/json",
+						body: JSON.stringify({
+							detail: "Tenant token unavailable",
+						}),
+					});
+					return;
+				}
+				await route.fulfill({
+					status: 200,
+					contentType: "application/json",
+					body: JSON.stringify({
+						items: [
+							{
+								id: "user-1",
+								display_name: "Adele Vance",
+								user_principal_name: "adele@example.com",
+							},
+						],
+					}),
+				});
+			},
+		);
+
+		await page.goto("/event-sources");
+		await page
+			.getByRole("button", { name: "Create Event Source" })
+			.first()
+			.click();
+		const dialog = page.getByRole("dialog", {
+			name: "Create Event Source",
+		});
+
+		await dialog.getByRole("combobox").first().click();
+		await page.getByRole("option", { name: organizationName }).click();
+		await dialog.getByRole("combobox", { name: "Webhook Adapter" }).click();
+		await page.getByRole("option", { name: "Microsoft Graph" }).click();
+		await dialog.getByRole("combobox", { name: "Integration" }).click();
+		await page.getByRole("option", { name: "Microsoft" }).click();
+
+		await expect(dialog.getByText("Options did not load.")).toBeVisible();
+		await expect(dialog.getByRole("button", { name: "Retry" })).toBeVisible();
+		tenantAvailable = true;
+		await dialog.getByRole("button", { name: "Retry" }).click();
+
+		await expect(dialog.getByText("Options did not load.")).toBeHidden();
+		await expect(dialog.getByText("Select User...")).toBeVisible();
+		expect(requests.length).toBeGreaterThanOrEqual(2);
+		for (const request of requests) {
+			expect(request).toMatchObject({
+				operation: "list_users",
+				integration_id: integrationId,
+				organization_id: organizationId,
+			});
+		}
+	});
+});

--- a/client/src/components/events/CreateEventSourceDialog.test.tsx
+++ b/client/src/components/events/CreateEventSourceDialog.test.tsx
@@ -11,13 +11,32 @@ import { renderWithProviders, screen, waitFor, fireEvent } from "@/test-utils";
 
 const mockCreate = vi.fn();
 const mockAuthFetch = vi.fn();
+const mockDynamicConfigForm = vi.fn();
+let mockIsPlatformAdmin = false;
 
 vi.mock("@/contexts/AuthContext", () => ({
-	useAuth: () => ({ isPlatformAdmin: false }),
+	useAuth: () => ({ isPlatformAdmin: mockIsPlatformAdmin }),
 }));
 
 vi.mock("@/components/forms/OrganizationSelect", () => ({
-	OrganizationSelect: () => <div data-marker="org-select" />,
+	OrganizationSelect: ({
+		value,
+		onChange,
+		showGlobal,
+	}: {
+		value: string | null;
+		onChange: (value: string | null) => void;
+		showGlobal?: boolean;
+	}) => (
+		<select
+			aria-label="Organization"
+			value={value ?? ""}
+			onChange={(event) => onChange(event.target.value || null)}
+		>
+			{showGlobal && <option value="">Global</option>}
+			<option value="org-1">Covi, Inc.</option>
+		</select>
+	),
 }));
 
 vi.mock("react-syntax-highlighter", () => ({
@@ -44,6 +63,13 @@ vi.mock("@/lib/api-client", () => ({
 	},
 }));
 
+vi.mock("./DynamicConfigForm", () => ({
+	DynamicConfigForm: (props: { organizationId?: string | null }) => {
+		mockDynamicConfigForm(props);
+		return <div>Dynamic config form {props.organizationId}</div>;
+	},
+}));
+
 vi.mock("@/services/events", async () => {
 	const actual =
 		await vi.importActual<typeof import("@/services/events")>(
@@ -64,8 +90,39 @@ vi.mock("@/services/events", async () => {
 						description: "Generic webhook adapter",
 						config_schema: {},
 					},
+					{
+						name: "microsoft_graph",
+						display_name: "Microsoft Graph",
+						description:
+							"Webhooks for Microsoft 365 services (Mail, Calendar, Teams, etc.)",
+						requires_integration: "Microsoft",
+						requires_organization: true,
+						config_schema: {
+							type: "object",
+							properties: {
+								user_id: {
+									type: "string",
+									title: "User",
+									description: "Graph user to subscribe to",
+									"x-dynamic-values": {
+										operation: "list_users",
+										value_path: "id",
+										label_path: "display_name",
+										depends_on: [],
+									},
+								},
+							},
+						},
+					},
 				],
 			},
+		}),
+		useDynamicValues: () => ({
+			data: { items: [] },
+			isLoading: false,
+			error: null,
+			refetch: vi.fn(),
+			isFetching: false,
 		}),
 		useTopics: () => ({
 			data: {
@@ -105,13 +162,24 @@ vi.mock("@/services/integrations", async () => {
 	>("@/services/integrations");
 	return {
 		...actual,
-		useIntegrations: () => ({ data: { items: [] } }),
+		useIntegrations: () => ({
+			data: {
+				items: [
+					{
+						id: "integration-1",
+						name: "Microsoft",
+					},
+				],
+			},
+		}),
 	};
 });
 
 import { CreateEventSourceDialog } from "./CreateEventSourceDialog";
 
 beforeEach(() => {
+	mockIsPlatformAdmin = false;
+	mockDynamicConfigForm.mockClear();
 	mockCreate.mockReset();
 	mockCreate.mockResolvedValue({});
 	mockAuthFetch.mockReset();
@@ -179,20 +247,28 @@ describe("CreateEventSourceDialog — webhook happy path", () => {
 });
 
 describe("CreateEventSourceDialog — webhook rate-limit section", () => {
-	it("renders rate-limit inputs for webhook sources", () => {
-		renderWithProviders(
+	it("keeps rate-limit inputs in Advanced for webhook sources", async () => {
+		const { user } = renderWithProviders(
 			<CreateEventSourceDialog open onOpenChange={() => {}} />,
 		);
+
+		expect(
+			screen.queryByLabelText(/^max events$/i),
+		).not.toBeInTheDocument();
+
+		await user.click(screen.getByRole("button", { name: /advanced/i }));
 
 		expect(screen.getByLabelText(/^max events$/i)).toBeInTheDocument();
 		expect(screen.getByLabelText(/per \(seconds\)/i)).toBeInTheDocument();
 		expect(screen.getByLabelText(/^enabled$/i)).toBeInTheDocument();
 	});
 
-	it("clears rate_limit_per_minute to empty string when field is cleared", () => {
-		renderWithProviders(
+	it("clears rate_limit_per_minute to empty string when field is cleared", async () => {
+		const { user } = renderWithProviders(
 			<CreateEventSourceDialog open onOpenChange={() => {}} />,
 		);
+
+		await user.click(screen.getByRole("button", { name: /advanced/i }));
 
 		const input = screen.getByLabelText(
 			/^max events$/i,
@@ -201,6 +277,69 @@ describe("CreateEventSourceDialog — webhook rate-limit section", () => {
 
 		fireEvent.change(input, { target: { value: "" } });
 		expect(input.value).toBe("");
+	});
+});
+
+describe("CreateEventSourceDialog — organization context", () => {
+	it("passes the selected organization to the dynamic webhook config form", async () => {
+		mockIsPlatformAdmin = true;
+		const { user } = renderWithProviders(
+			<CreateEventSourceDialog open onOpenChange={() => {}} />,
+		);
+
+		await user.selectOptions(
+			screen.getByLabelText(/^organization$/i),
+			"org-1",
+		);
+
+		await user.click(
+			screen.getByRole("combobox", { name: /webhook adapter/i }),
+		);
+		await user.click(
+			screen.getByRole("option", { name: /microsoft graph/i }),
+		);
+
+		await user.click(
+			screen.getByRole("combobox", { name: /integration/i }),
+		);
+		await user.click(screen.getByRole("option", { name: /microsoft/i }));
+
+		await waitFor(() =>
+			expect(mockDynamicConfigForm).toHaveBeenLastCalledWith(
+				expect.objectContaining({ organizationId: "org-1" }),
+			),
+		);
+	});
+
+	it("requires an organization when adapter metadata says one is required", async () => {
+		mockIsPlatformAdmin = true;
+		const { user } = renderWithProviders(
+			<CreateEventSourceDialog open onOpenChange={() => {}} />,
+		);
+
+		fireEvent.change(screen.getByLabelText(/^name$/i), {
+			target: { value: "Graph Subscription" },
+		});
+
+		await user.click(
+			screen.getByRole("combobox", { name: /webhook adapter/i }),
+		);
+		await user.click(
+			screen.getByRole("option", { name: /microsoft graph/i }),
+		);
+
+		await user.click(
+			screen.getByRole("combobox", { name: /integration/i }),
+		);
+		await user.click(screen.getByRole("option", { name: /microsoft/i }));
+
+		await user.click(
+			screen.getByRole("button", { name: /create event source/i }),
+		);
+
+		const alert = await screen.findByRole("alert");
+		expect(alert).toHaveTextContent(/select an organization/i);
+		expect(mockCreate).not.toHaveBeenCalled();
 	});
 });
 
@@ -272,10 +411,13 @@ describe("CreateEventSourceDialog — topic branch", () => {
 		expect(
 			await screen.findByText(/python workflow access/i),
 		).toBeVisible();
-		expect(screen.getAllByText(/from bifrost import workflow, context/i).length).toBeGreaterThan(
-			0,
-		);
-		expect(screen.getByText(/@workflow\(name="handle_builtin_event"\)/i)).toBeVisible();
+		expect(
+			screen.getAllByText(/from bifrost import workflow, context/i)
+				.length,
+		).toBeGreaterThan(0);
+		expect(
+			screen.getByText(/@workflow\(name="handle_builtin_event"\)/i),
+		).toBeVisible();
 		expect(screen.getByText(/user\.invited body/i)).toBeVisible();
 		expect(screen.getAllByText(/schema_version/i).length).toBeGreaterThan(
 			0,

--- a/client/src/components/events/CreateEventSourceDialog.tsx
+++ b/client/src/components/events/CreateEventSourceDialog.tsx
@@ -1,4 +1,10 @@
-import { useState, useEffect, useCallback, useMemo } from "react";
+import {
+	useState,
+	useEffect,
+	useCallback,
+	useMemo,
+	type ReactNode,
+} from "react";
 import {
 	Dialog,
 	DialogContent,
@@ -22,7 +28,12 @@ import {
 } from "@/components/ui/select";
 import { Switch } from "@/components/ui/switch";
 import { Alert, AlertDescription } from "@/components/ui/alert";
-import { AlertCircle, CheckCircle2, Loader2 } from "lucide-react";
+import { AlertCircle, CheckCircle2, ChevronDown, Loader2 } from "lucide-react";
+import {
+	Collapsible,
+	CollapsibleContent,
+	CollapsibleTrigger,
+} from "@/components/ui/collapsible";
 import { toast } from "sonner";
 import { formatDistanceToNow } from "date-fns";
 import { OrganizationSelect } from "@/components/forms/OrganizationSelect";
@@ -93,6 +104,30 @@ const COMMON_TIMEZONES = [
 	"Pacific/Auckland",
 ];
 
+function FormSection({
+	title,
+	description,
+	children,
+}: {
+	title: string;
+	description?: string;
+	children: ReactNode;
+}) {
+	return (
+		<section className="space-y-3 rounded-lg border bg-muted/20 p-4">
+			<div className="space-y-1">
+				<h3 className="text-sm font-semibold">{title}</h3>
+				{description && (
+					<p className="text-xs text-muted-foreground">
+						{description}
+					</p>
+				)}
+			</div>
+			<div className="space-y-4">{children}</div>
+		</section>
+	);
+}
+
 interface CreateEventSourceDialogProps {
 	open: boolean;
 	onOpenChange: (open: boolean) => void;
@@ -144,6 +179,7 @@ function CreateEventSourceDialogContent({
 	);
 	const [rateLimitWindowSeconds, setRateLimitWindowSeconds] = useState(60);
 	const [rateLimitEnabled, setRateLimitEnabled] = useState(true);
+	const [advancedOpen, setAdvancedOpen] = useState(false);
 
 	// Schedule state
 	const [cronExpression, setCronExpression] = useState("");
@@ -164,6 +200,9 @@ function CreateEventSourceDialogContent({
 
 	// Get selected adapter info
 	const selectedAdapter = adapters.find((a) => a.name === adapterName);
+	const selectedAdapterRequiresOrganization = Boolean(
+		selectedAdapter?.requires_organization,
+	);
 
 	// Filter integrations if adapter requires specific OAuth
 	const filteredIntegrations = selectedAdapter?.requires_integration
@@ -189,25 +228,28 @@ function CreateEventSourceDialogContent({
 	};
 
 	// Debounced cron validation
-	const validateCronExpression = useCallback(async (expr: string) => {
-		if (!expr.trim()) return;
+	const validateCronExpression = useCallback(
+		async (expr: string) => {
+			if (!expr.trim()) return;
 
-		try {
-			const response = await authFetch("/api/schedules/validate", {
-				method: "POST",
-				headers: { "Content-Type": "application/json" },
-				body: JSON.stringify({ expression: expr, timezone }),
-			});
-			const data = await response.json();
-			setCronValidation(data);
-		} catch {
-			setCronValidation({
-				valid: false,
-				human_readable: "Failed to validate",
-				error: "Unable to connect to validation service",
-			});
-		}
-	}, [timezone]);
+			try {
+				const response = await authFetch("/api/schedules/validate", {
+					method: "POST",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({ expression: expr, timezone }),
+				});
+				const data = await response.json();
+				setCronValidation(data);
+			} catch {
+				setCronValidation({
+					valid: false,
+					human_readable: "Failed to validate",
+					error: "Unable to connect to validation service",
+				});
+			}
+		},
+		[timezone],
+	);
 
 	useEffect(() => {
 		if (!cronExpression) {
@@ -250,6 +292,14 @@ function CreateEventSourceDialogContent({
 			newErrors.push(
 				`This adapter requires a ${selectedAdapter.requires_integration} integration`,
 			);
+		}
+
+		if (
+			selectedAdapterRequiresOrganization &&
+			isPlatformAdmin &&
+			!organizationId
+		) {
+			newErrors.push("Please select an organization for this adapter");
 		}
 
 		if (sourceType === "schedule") {
@@ -350,73 +400,74 @@ function CreateEventSourceDialogContent({
 					</Alert>
 				)}
 
-				{/* Organization (Platform Admin Only) */}
-				{isPlatformAdmin && (
+				<FormSection
+					title="Scope"
+					description="Choose where this event source is available."
+				>
+					{isPlatformAdmin && (
+						<div className="space-y-2">
+							<Label htmlFor="organization">Organization</Label>
+							<OrganizationSelect
+								value={organizationId}
+								onChange={(value) =>
+									setOrganizationId(value ?? null)
+								}
+								showGlobal
+							/>
+							<p className="text-xs text-muted-foreground">
+								Leave as Global to make this source available to
+								all organizations.
+							</p>
+						</div>
+					)}
+
 					<div className="space-y-2">
-						<Label htmlFor="organization">Organization</Label>
-						<OrganizationSelect
-							value={organizationId}
-							onChange={(value) =>
-								setOrganizationId(value ?? null)
+						<Label htmlFor="name">Name</Label>
+						<Input
+							id="name"
+							value={name}
+							onChange={(e) => setName(e.target.value)}
+							placeholder={
+								sourceType === "schedule"
+									? "e.g., Daily Sync Schedule"
+									: "e.g., GitHub Webhooks"
 							}
-							showGlobal
 						/>
-						<p className="text-xs text-muted-foreground">
-							Leave as Global to make this source available to all
-							organizations.
-						</p>
 					</div>
-				)}
+				</FormSection>
 
-				{/* Name */}
-				<div className="space-y-2">
-					<Label htmlFor="name">Name</Label>
-					<Input
-						id="name"
-						value={name}
-						onChange={(e) => setName(e.target.value)}
-						placeholder={
-							sourceType === "schedule"
-								? "e.g., Daily Sync Schedule"
-								: "e.g., GitHub Webhooks"
-						}
-					/>
-				</div>
-
-				{/* Source Type */}
-				<div className="space-y-2">
-					<Label htmlFor="source-type">Source Type</Label>
-					<Select
-						value={sourceType}
-						onValueChange={(value) => {
-							setSourceType(value as EventSourceType);
-							setTopicPickerValue("");
-							setCustomTopic("");
-							setTopicError(null);
-						}}
-					>
-						<SelectTrigger id="source-type">
-							<SelectValue />
-						</SelectTrigger>
-						<SelectContent>
-							<SelectItem value="webhook">Webhook</SelectItem>
-							<SelectItem value="schedule">Schedule</SelectItem>
-							<SelectItem value="topic">Topic</SelectItem>
-						</SelectContent>
-					</Select>
-				</div>
+				<FormSection
+					title="Trigger"
+					description="Pick how Bifrost receives or creates events."
+				>
+					<div className="space-y-2">
+						<Label htmlFor="source-type">Source Type</Label>
+						<Select
+							value={sourceType}
+							onValueChange={(value) => {
+								setSourceType(value as EventSourceType);
+								setTopicPickerValue("");
+								setCustomTopic("");
+								setTopicError(null);
+							}}
+						>
+							<SelectTrigger id="source-type" className="w-full">
+								<SelectValue />
+							</SelectTrigger>
+							<SelectContent>
+								<SelectItem value="webhook">Webhook</SelectItem>
+								<SelectItem value="schedule">
+									Schedule
+								</SelectItem>
+								<SelectItem value="topic">Topic</SelectItem>
+							</SelectContent>
+						</Select>
+					</div>
+				</FormSection>
 
 				{/* Topic Configuration */}
 				{sourceType === "topic" && (
-					<>
-						<div className="border-t pt-4">
-							<div className="mb-3">
-								<h4 className="text-sm font-medium">
-									Topic Configuration
-								</h4>
-							</div>
-						</div>
-
+					<FormSection title="Topic Configuration">
 						<div className="space-y-2">
 							<Label htmlFor="topic-picker">Topic</Label>
 							<Select
@@ -432,7 +483,10 @@ function CreateEventSourceDialogContent({
 									}
 								}}
 							>
-								<SelectTrigger id="topic-picker">
+								<SelectTrigger
+									id="topic-picker"
+									className="w-full"
+								>
 									<SelectValue placeholder="Select or enter a topic..." />
 								</SelectTrigger>
 								<SelectContent>
@@ -485,172 +539,197 @@ function CreateEventSourceDialogContent({
 								least one dot.
 							</p>
 						</div>
-					</>
+					</FormSection>
 				)}
 
 				{/* Webhook Adapter */}
 				{sourceType === "webhook" && (
-					<div className="space-y-2">
-						<Label htmlFor="adapter">Webhook Adapter</Label>
-						<Select
-							value={adapterName}
-							onValueChange={handleAdapterChange}
-						>
-							<SelectTrigger id="adapter">
-								<SelectValue placeholder="Select an adapter..." />
-							</SelectTrigger>
-							<SelectContent>
-								{adapters.map((adapter) => (
-									<SelectItem
-										key={adapter.name}
-										value={adapter.name}
-									>
-										{adapter.display_name}
-									</SelectItem>
-								))}
-							</SelectContent>
-						</Select>
-						{selectedAdapter?.description && (
-							<p className="text-xs text-muted-foreground">
-								{selectedAdapter.description}
-							</p>
-						)}
-					</div>
-				)}
+					<FormSection
+						title={
+							selectedAdapter?.name === "microsoft_graph"
+								? "Microsoft Graph Subscription"
+								: "Webhook Subscription"
+						}
+						description={
+							selectedAdapter?.name === "microsoft_graph"
+								? "Connect the Microsoft tenant, then choose the Graph resource to subscribe to."
+								: "Choose the adapter and connection details for incoming events."
+						}
+					>
+						<div className="space-y-2">
+							<Label htmlFor="adapter">Webhook Adapter</Label>
+							<Select
+								value={adapterName}
+								onValueChange={handleAdapterChange}
+							>
+								<SelectTrigger id="adapter" className="w-full">
+									<SelectValue placeholder="Select an adapter..." />
+								</SelectTrigger>
+								<SelectContent>
+									{adapters.map((adapter) => (
+										<SelectItem
+											key={adapter.name}
+											value={adapter.name}
+										>
+											{adapter.display_name}
+										</SelectItem>
+									))}
+								</SelectContent>
+							</Select>
+							{selectedAdapter?.description && (
+								<p className="text-xs text-muted-foreground">
+									{selectedAdapter.description}
+								</p>
+							)}
+						</div>
 
-				{/* Integration (if required by adapter) */}
-				{selectedAdapter?.requires_integration && (
-					<div className="space-y-2">
-						<Label htmlFor="integration">Integration</Label>
-						<Select
-							value={integrationId}
-							onValueChange={setIntegrationId}
-						>
-							<SelectTrigger id="integration">
-								<SelectValue placeholder="Select an integration..." />
-							</SelectTrigger>
-							<SelectContent>
-								{filteredIntegrations.map((integration) => (
-									<SelectItem
-										key={integration.id}
-										value={integration.id}
+						{selectedAdapter?.requires_integration && (
+							<div className="space-y-2">
+								<Label htmlFor="integration">Integration</Label>
+								<Select
+									value={integrationId}
+									onValueChange={setIntegrationId}
+								>
+									<SelectTrigger
+										id="integration"
+										className="w-full"
 									>
-										{integration.name}
-									</SelectItem>
-								))}
-							</SelectContent>
-						</Select>
-						<p className="text-xs text-muted-foreground">
-							This adapter requires a{" "}
-							{selectedAdapter.requires_integration} integration
-							for authentication.
-						</p>
-					</div>
-				)}
-
-				{/* Dynamic Config Form - For adapters with config_schema */}
-				{sourceType === "webhook" &&
-					hasDynamicConfig &&
-					selectedAdapter && (
-						<>
-							<div className="border-t pt-4">
-								<h4 className="text-sm font-medium mb-3">
-									Configuration
-								</h4>
+										<SelectValue placeholder="Select an integration..." />
+									</SelectTrigger>
+									<SelectContent>
+										{filteredIntegrations.map(
+											(integration) => (
+												<SelectItem
+													key={integration.id}
+													value={integration.id}
+												>
+													{integration.name}
+												</SelectItem>
+											),
+										)}
+									</SelectContent>
+								</Select>
+								<p className="text-xs text-muted-foreground">
+									This adapter requires a{" "}
+									{selectedAdapter.requires_integration}{" "}
+									integration for authentication.
+								</p>
 							</div>
+						)}
+
+						{hasDynamicConfig && selectedAdapter && (
 							<DynamicConfigForm
 								adapterName={selectedAdapter.name}
 								integrationId={integrationId || undefined}
+								requiresIntegration={Boolean(
+									selectedAdapter.requires_integration,
+								)}
+								organizationId={organizationId}
 								configSchema={
 									selectedAdapter.config_schema as unknown as ConfigSchema
 								}
 								config={webhookConfig}
 								onChange={setWebhookConfig}
 							/>
-						</>
-					)}
+						)}
+					</FormSection>
+				)}
 
 				{/* Rate Limiting */}
 				{sourceType === "webhook" && (
-					<>
-						<div className="border-t pt-4">
-							<h4 className="text-sm font-medium mb-3">
-								Rate limiting
-							</h4>
-						</div>
-
-						<div className="space-y-2">
-							<Label htmlFor="rate-limit-per-minute">
-								Max events
-							</Label>
-							<Input
-								id="rate-limit-per-minute"
-								type="number"
-								min={1}
-								value={rateLimitPerMinute ?? ""}
-								onChange={(e) => {
-									const val = e.target.value;
-									setRateLimitPerMinute(
-										val === "" ? null : Number(val),
-									);
-								}}
-								placeholder="60 (leave empty to disable)"
-							/>
-							<p className="text-xs text-muted-foreground">
-								Maximum events accepted within the window below.
-								Leave empty to disable the limit.
-							</p>
-						</div>
-
-						<div className="space-y-2">
-							<Label htmlFor="rate-limit-window">
-								Per (seconds)
-							</Label>
-							<Input
-								id="rate-limit-window"
-								type="number"
-								min={1}
-								value={rateLimitWindowSeconds}
-								onChange={(e) =>
-									setRateLimitWindowSeconds(
-										Number(e.target.value),
-									)
-								}
-							/>
-							<p className="text-xs text-muted-foreground">
-								Window duration. Default 60 means the limit
-								above applies per minute.
-							</p>
-						</div>
-
-						<div className="flex items-center justify-between">
-							<div className="space-y-0.5">
-								<Label htmlFor="rate-limit-enabled">
-									Enabled
-								</Label>
+					<Collapsible
+						open={advancedOpen}
+						onOpenChange={setAdvancedOpen}
+						className="rounded-lg border"
+					>
+						<CollapsibleTrigger asChild>
+							<Button
+								type="button"
+								variant="ghost"
+								className="flex w-full items-center justify-between px-4 py-3 text-sm font-medium [&[data-state=open]>svg]:rotate-180"
+							>
+								Advanced
+								<ChevronDown className="h-4 w-4 transition-transform" />
+							</Button>
+						</CollapsibleTrigger>
+						<CollapsibleContent className="space-y-4 px-4 pb-4">
+							<div className="space-y-1">
+								<h3 className="text-sm font-semibold">
+									Rate limiting
+								</h3>
 								<p className="text-xs text-muted-foreground">
-									Disable to bypass rate limiting for this
-									source.
+									Control how many events this source accepts
+									before throttling.
 								</p>
 							</div>
-							<Switch
-								id="rate-limit-enabled"
-								checked={rateLimitEnabled}
-								onCheckedChange={setRateLimitEnabled}
-							/>
-						</div>
-					</>
+
+							<div className="space-y-2">
+								<Label htmlFor="rate-limit-per-minute">
+									Max events
+								</Label>
+								<Input
+									id="rate-limit-per-minute"
+									type="number"
+									min={1}
+									value={rateLimitPerMinute ?? ""}
+									onChange={(e) => {
+										const val = e.target.value;
+										setRateLimitPerMinute(
+											val === "" ? null : Number(val),
+										);
+									}}
+									placeholder="60 (leave empty to disable)"
+								/>
+								<p className="text-xs text-muted-foreground">
+									Maximum events accepted within the window
+									below. Leave empty to disable the limit.
+								</p>
+							</div>
+
+							<div className="space-y-2">
+								<Label htmlFor="rate-limit-window">
+									Per (seconds)
+								</Label>
+								<Input
+									id="rate-limit-window"
+									type="number"
+									min={1}
+									value={rateLimitWindowSeconds}
+									onChange={(e) =>
+										setRateLimitWindowSeconds(
+											Number(e.target.value),
+										)
+									}
+								/>
+								<p className="text-xs text-muted-foreground">
+									Window duration. Default 60 means the limit
+									above applies per minute.
+								</p>
+							</div>
+
+							<div className="flex items-center justify-between gap-4">
+								<div className="space-y-0.5">
+									<Label htmlFor="rate-limit-enabled">
+										Enabled
+									</Label>
+									<p className="text-xs text-muted-foreground">
+										Disable to bypass rate limiting for this
+										source.
+									</p>
+								</div>
+								<Switch
+									id="rate-limit-enabled"
+									checked={rateLimitEnabled}
+									onCheckedChange={setRateLimitEnabled}
+								/>
+							</div>
+						</CollapsibleContent>
+					</Collapsible>
 				)}
 
 				{/* Schedule Configuration */}
 				{sourceType === "schedule" && (
-					<>
-						<div className="border-t pt-4">
-							<h4 className="text-sm font-medium mb-3">
-								Schedule Configuration
-							</h4>
-						</div>
-
+					<FormSection title="Schedule Configuration">
 						{/* Cron Expression */}
 						<div className="space-y-2">
 							<Label htmlFor="cron-expression">
@@ -771,7 +850,7 @@ function CreateEventSourceDialogContent({
 								value={timezone}
 								onValueChange={setTimezone}
 							>
-								<SelectTrigger id="timezone">
+								<SelectTrigger id="timezone" className="w-full">
 									<SelectValue />
 								</SelectTrigger>
 								<SelectContent>
@@ -801,7 +880,10 @@ function CreateEventSourceDialogContent({
 									)
 								}
 							>
-								<SelectTrigger id="overlap-policy">
+								<SelectTrigger
+									id="overlap-policy"
+									className="w-full"
+								>
 									<SelectValue />
 								</SelectTrigger>
 								<SelectContent>
@@ -818,7 +900,7 @@ function CreateEventSourceDialogContent({
 								reserved for future use.
 							</p>
 						</div>
-					</>
+					</FormSection>
 				)}
 			</div>
 

--- a/client/src/components/events/DynamicConfigForm.test.tsx
+++ b/client/src/components/events/DynamicConfigForm.test.tsx
@@ -7,30 +7,60 @@
  * the dependency-satisfied text-input branch renders deterministically.
  */
 
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { renderWithProviders, screen, fireEvent } from "@/test-utils";
 
+type DynamicValuesMockResult = {
+	data?: { items: Record<string, unknown>[] };
+	isLoading: boolean;
+	error: Error | null;
+	refetch: ReturnType<typeof vi.fn>;
+	isFetching: boolean;
+};
+
+const mockUseDynamicValues = vi.fn<
+	(...args: unknown[]) => DynamicValuesMockResult
+>(() => ({
+	data: { items: [] },
+	isLoading: false,
+	error: null,
+	refetch: vi.fn(),
+	isFetching: false,
+}));
+
 vi.mock("@/services/events", async () => {
-	const actual = await vi.importActual<typeof import("@/services/events")>(
-		"@/services/events",
-	);
+	const actual =
+		await vi.importActual<typeof import("@/services/events")>(
+			"@/services/events",
+		);
 	return {
 		...actual,
-		useDynamicValues: () => ({
-			data: { items: [] },
-			isLoading: false,
-			error: null,
-		}),
+		useDynamicValues: (...args: unknown[]) => mockUseDynamicValues(...args),
 	};
 });
 
 import { DynamicConfigForm, type ConfigSchema } from "./DynamicConfigForm";
 
-function renderForm(schema: ConfigSchema, config: Record<string, unknown> = {}) {
+beforeEach(() => {
+	mockUseDynamicValues.mockReset();
+	mockUseDynamicValues.mockReturnValue({
+		data: { items: [] },
+		isLoading: false,
+		error: null,
+		refetch: vi.fn(),
+		isFetching: false,
+	});
+});
+
+function renderForm(
+	schema: ConfigSchema,
+	config: Record<string, unknown> = {},
+) {
 	const onChange = vi.fn();
 	const utils = renderWithProviders(
 		<DynamicConfigForm
 			adapterName="test-adapter"
+			organizationId="org-1"
 			configSchema={schema}
 			config={config}
 			onChange={onChange}
@@ -123,5 +153,73 @@ describe("DynamicConfigForm — required markers", () => {
 			},
 		});
 		expect(screen.getByText("*")).toBeInTheDocument();
+	});
+});
+
+describe("DynamicConfigForm — dynamic values", () => {
+	it("passes organization context to dynamic value requests", () => {
+		renderForm({
+			type: "object",
+			properties: {
+				user_id: {
+					type: "string",
+					title: "User",
+					"x-dynamic-values": {
+						operation: "list_users",
+						value_path: "id",
+						label_path: "display_name",
+						depends_on: [],
+					},
+				},
+			},
+		});
+
+		expect(mockUseDynamicValues).toHaveBeenLastCalledWith(
+			"test-adapter",
+			"list_users",
+			undefined,
+			"org-1",
+			{},
+			true,
+		);
+	});
+
+	it("shows a retry action when dynamic options fail to load", async () => {
+		const refetch = vi.fn();
+		mockUseDynamicValues.mockReturnValueOnce({
+			data: undefined,
+			isLoading: false,
+			error: new Error("No tenant mapping was found"),
+			refetch,
+			isFetching: false,
+		});
+
+		const { user } = renderForm(
+			{
+				type: "object",
+				properties: {
+					user_id: {
+						type: "string",
+						title: "User",
+						"x-dynamic-values": {
+							operation: "list_users",
+							value_path: "id",
+							label_path: "display_name",
+							depends_on: [],
+						},
+					},
+				},
+			},
+			{ user_id: "user@example.com" },
+		);
+
+		expect(screen.getByRole("status")).toHaveTextContent(
+			/No tenant mapping was found/i,
+		);
+		expect(screen.getByLabelText(/user/i)).toHaveValue("user@example.com");
+
+		await user.click(screen.getByRole("button", { name: /retry/i }));
+
+		expect(refetch).toHaveBeenCalledTimes(1);
 	});
 });

--- a/client/src/components/events/DynamicConfigForm.test.tsx
+++ b/client/src/components/events/DynamicConfigForm.test.tsx
@@ -222,4 +222,37 @@ describe("DynamicConfigForm — dynamic values", () => {
 
 		expect(refetch).toHaveBeenCalledTimes(1);
 	});
+
+	it("shows FastAPI error details instead of the generic fallback", () => {
+		mockUseDynamicValues.mockReturnValueOnce({
+			data: undefined,
+			isLoading: false,
+			error: {
+				detail:
+					"Integration 'Microsoft' is not mapped to the selected organization",
+			} as unknown as Error,
+			refetch: vi.fn(),
+			isFetching: false,
+		});
+
+		renderForm({
+			type: "object",
+			properties: {
+				user_id: {
+					type: "string",
+					title: "User",
+					"x-dynamic-values": {
+						operation: "list_users",
+						value_path: "id",
+						label_path: "display_name",
+						depends_on: [],
+					},
+				},
+			},
+		});
+
+		expect(screen.getByRole("status")).toHaveTextContent(
+			/Integration 'Microsoft' is not mapped to the selected organization/i,
+		);
+	});
 });

--- a/client/src/components/events/DynamicConfigForm.tsx
+++ b/client/src/components/events/DynamicConfigForm.tsx
@@ -45,6 +45,7 @@ import {
 	TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
+import { getErrorMessage } from "@/lib/api-error";
 import { useDynamicValues } from "@/services/events";
 
 // x-dynamic-values extension in JSON Schema
@@ -244,10 +245,10 @@ function DynamicField({
 			!manualMode &&
 			(!requiresIntegration || !!integrationId),
 	);
-	const errorMessage =
-		error instanceof Error
-			? error.message
-			: "We could not load options for this field.";
+	const errorMessage = getErrorMessage(
+		error,
+		"We could not load options for this field.",
+	);
 
 	// Handle array enum types (like change_types)
 	if (property.type === "array" && property.items?.enum) {

--- a/client/src/components/events/DynamicConfigForm.tsx
+++ b/client/src/components/events/DynamicConfigForm.tsx
@@ -24,7 +24,7 @@ import {
 	SelectValue,
 } from "@/components/ui/select";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
-import { AlertCircle, ChevronDown, Info } from "lucide-react";
+import { AlertCircle, ChevronDown, Info, RefreshCw } from "lucide-react";
 import {
 	Popover,
 	PopoverContent,
@@ -134,6 +134,8 @@ export interface ConfigSchema {
 interface DynamicConfigFormProps {
 	adapterName: string;
 	integrationId?: string;
+	requiresIntegration?: boolean;
+	organizationId?: string | null;
 	configSchema: ConfigSchema;
 	config: Record<string, unknown>;
 	onChange: (config: Record<string, unknown>) => void;
@@ -192,6 +194,8 @@ function DynamicField({
 	value,
 	adapterName,
 	integrationId,
+	requiresIntegration,
+	organizationId,
 	currentConfig,
 	onChange,
 	isRequired,
@@ -201,6 +205,8 @@ function DynamicField({
 	value: unknown;
 	adapterName: string;
 	integrationId?: string;
+	requiresIntegration?: boolean;
+	organizationId?: string | null;
 	currentConfig: Record<string, unknown>;
 	onChange: (value: unknown) => void;
 	isRequired: boolean;
@@ -225,13 +231,23 @@ function DynamicField({
 		data: dynamicData,
 		isLoading,
 		error,
+		refetch,
+		isFetching,
 	} = useDynamicValues(
 		adapterName,
 		dynamicSpec?.operation,
 		integrationId,
+		organizationId,
 		currentConfig,
-		!!dynamicSpec && dependenciesSatisfied && !manualMode,
+		!!dynamicSpec &&
+			dependenciesSatisfied &&
+			!manualMode &&
+			(!requiresIntegration || !!integrationId),
 	);
+	const errorMessage =
+		error instanceof Error
+			? error.message
+			: "We could not load options for this field.";
 
 	// Handle array enum types (like change_types)
 	if (property.type === "array" && property.items?.enum) {
@@ -332,7 +348,7 @@ function DynamicField({
 					value={(value as string) || ""}
 					onValueChange={(val) => onChange(val || undefined)}
 				>
-					<SelectTrigger id={fieldName}>
+					<SelectTrigger id={fieldName} className="w-full">
 						<SelectValue
 							placeholder={`Select ${property.title || fieldName}...`}
 						/>
@@ -397,22 +413,22 @@ function DynamicField({
 		if (error || manualMode) {
 			return (
 				<div className="space-y-2">
-					<div className="flex items-center justify-between">
+					<div className="flex items-center justify-between gap-3">
 						<FieldLabel
 							htmlFor={fieldName}
 							title={property.title || fieldName}
 							isRequired={isRequired}
 							help={help}
 						/>
-						{error && !manualMode && (
-							<button
-								type="button"
-								className="text-xs text-muted-foreground hover:underline"
-								onClick={() => setManualMode(true)}
-							>
-								Enter manually
-							</button>
-						)}
+						<Button
+							type="button"
+							variant="ghost"
+							size="sm"
+							className="h-7 px-2 text-xs text-muted-foreground"
+							onClick={() => setManualMode((current) => !current)}
+						>
+							{manualMode ? "Use list" : "Enter manually"}
+						</Button>
 					</div>
 					<div className="flex items-center gap-2">
 						<Input
@@ -432,9 +448,51 @@ function DynamicField({
 						)}
 					</div>
 					{error && (
-						<p className="text-xs text-amber-600">
-							Failed to load options. Enter value manually.
-						</p>
+						<div
+							className="rounded-md border border-amber-500/40 bg-amber-500/10 p-3 text-xs text-amber-700 dark:text-amber-300"
+							role="status"
+							aria-live="polite"
+						>
+							<div className="flex items-start gap-2">
+								<AlertCircle className="mt-0.5 h-4 w-4 flex-shrink-0" />
+								<div className="min-w-0 flex-1 space-y-2">
+									<p className="font-medium">
+										Options did not load.
+									</p>
+									<p className="break-words">
+										{errorMessage}
+									</p>
+									<div className="flex flex-wrap gap-2">
+										<Button
+											type="button"
+											variant="outline"
+											size="sm"
+											className="h-7 px-2 text-xs"
+											onClick={() => void refetch()}
+											disabled={isFetching}
+										>
+											<RefreshCw
+												className={cn(
+													"mr-1.5 h-3 w-3",
+													isFetching &&
+														"animate-spin",
+												)}
+											/>
+											Retry
+										</Button>
+										<Button
+											type="button"
+											variant="ghost"
+											size="sm"
+											className="h-7 px-2 text-xs"
+											onClick={() => setManualMode(true)}
+										>
+											Enter manually
+										</Button>
+									</div>
+								</div>
+							</div>
+						</div>
 					)}
 				</div>
 			);
@@ -487,7 +545,10 @@ function DynamicField({
 							<ChevronDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
 						</Button>
 					</PopoverTrigger>
-					<PopoverContent className="w-[400px] p-0" align="start">
+					<PopoverContent
+						className="w-[var(--radix-popover-trigger-width)] max-w-[calc(100vw-2rem)] p-0"
+						align="start"
+					>
 						<Command>
 							<CommandInput
 								placeholder={`Search ${property.title || fieldName}...`}
@@ -586,6 +647,8 @@ function DynamicField({
 export function DynamicConfigForm({
 	adapterName,
 	integrationId,
+	requiresIntegration = false,
+	organizationId,
 	configSchema,
 	config,
 	onChange,
@@ -674,6 +737,8 @@ export function DynamicConfigForm({
 						value={config[fieldName]}
 						adapterName={adapterName}
 						integrationId={integrationId}
+						requiresIntegration={requiresIntegration}
+						organizationId={organizationId}
 						currentConfig={config}
 						onChange={(value) =>
 							handleFieldChange(fieldName, value)

--- a/client/src/components/events/EventSourceDetail.test.tsx
+++ b/client/src/components/events/EventSourceDetail.test.tsx
@@ -12,6 +12,7 @@ import { renderWithProviders, screen, waitFor } from "@/test-utils";
 const useEventSourceMock = vi.fn();
 const mockDelete = vi.fn();
 const mockUpdate = vi.fn();
+const mockResubscribe = vi.fn();
 let mockIsPlatformAdmin = true;
 
 vi.mock("@/contexts/AuthContext", () => ({
@@ -31,6 +32,10 @@ vi.mock("@/services/events", async () => {
 		}),
 		useUpdateEventSource: () => ({
 			mutateAsync: mockUpdate,
+			isPending: false,
+		}),
+		useResubscribeEventSource: () => ({
+			mutateAsync: mockResubscribe,
 			isPending: false,
 		}),
 	};
@@ -73,6 +78,8 @@ beforeEach(() => {
 	mockDelete.mockResolvedValue(undefined);
 	mockUpdate.mockReset();
 	mockUpdate.mockResolvedValue(undefined);
+	mockResubscribe.mockReset();
+	mockResubscribe.mockResolvedValue(undefined);
 	useEventSourceMock.mockReset();
 	mockIsPlatformAdmin = true;
 });
@@ -187,5 +194,57 @@ describe("EventSourceDetail — populated", () => {
 			.queryAllByRole("button")
 			.find((b) => b.getAttribute("title") === "Delete");
 		expect(deleteBtn).toBeUndefined();
+	});
+
+	it("shows Graph identity and recreates the provider subscription", async () => {
+		useEventSourceMock.mockReturnValue({
+			data: makeSource({
+				name: "Mailbox changes",
+				organization_id: "org-1",
+				organization_name: "Covi, Inc.",
+				webhook: {
+					adapter_name: "microsoft_graph",
+					callback_url: "/api/hooks/src-1",
+					external_id: "graph-subscription-1",
+					expires_at: "2030-08-30T00:00:00Z",
+					rate_limit_per_minute: 60,
+					rate_limit_window_seconds: 60,
+					rate_limit_enabled: true,
+					rate_limited_count_24h: 0,
+					config: {
+						resource: "/users/user-1/messages",
+						change_types: ["created"],
+					},
+					provider_metadata: {
+						user_display_name: "Ada Lovelace",
+						user_principal_name: "ada@example.com",
+					},
+				},
+			}),
+			isLoading: false,
+			refetch: vi.fn(),
+		});
+		const { user } = renderWithProviders(
+			<EventSourceDetail sourceId="src-1" onClose={() => {}} />,
+		);
+
+		expect(
+			screen.getByRole("heading", { name: "Microsoft Graph" }),
+		).toBeInTheDocument();
+		expect(screen.getByText("Ada Lovelace")).toBeInTheDocument();
+		expect(screen.getByText("Mail messages")).toBeInTheDocument();
+
+		await user.click(screen.getByRole("button", { name: "Resubscribe" }));
+		expect(
+			screen.getByRole("heading", {
+				name: /resubscribe to microsoft graph/i,
+			}),
+		).toBeInTheDocument();
+		await user.click(screen.getByRole("button", { name: "Resubscribe" }));
+
+		await waitFor(() => expect(mockResubscribe).toHaveBeenCalledTimes(1));
+		expect(mockResubscribe.mock.calls[0]![0]).toEqual({
+			params: { path: { source_id: "src-1" } },
+		});
 	});
 });

--- a/client/src/components/events/EventSourceDetail.tsx
+++ b/client/src/components/events/EventSourceDetail.tsx
@@ -541,7 +541,11 @@ export function EventSourceDetail({
 					value="events"
 					className="mt-4 flex-1 flex flex-col min-h-0"
 				>
-					<EventsTable sourceId={sourceId} initialEventId={eventId} />
+					<EventsTable
+						sourceId={sourceId}
+						source={source}
+						initialEventId={eventId}
+					/>
 				</TabsContent>
 			</Tabs>
 

--- a/client/src/components/events/EventSourceDetail.tsx
+++ b/client/src/components/events/EventSourceDetail.tsx
@@ -14,6 +14,10 @@ import {
 	AlertTriangle,
 	RefreshCw,
 	Pencil,
+	CircleCheck,
+	Clock3,
+	UserRound,
+	Radio,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -40,12 +44,20 @@ import {
 	useEventSource,
 	useDeleteEventSource,
 	useUpdateEventSource,
+	useResubscribeEventSource,
 	type EventSourceType,
 } from "@/services/events";
 import { Switch } from "@/components/ui/switch";
 import { SubscriptionsTable } from "./SubscriptionsTable";
 import { EventsTable } from "./EventsTable";
 import { EditEventSourceDialog } from "./EditEventSourceDialog";
+import { MicrosoftGraphIcon } from "./MicrosoftGraphIcon";
+import { getErrorMessage } from "@/lib/api-error";
+import {
+	getGraphSourceSummary,
+	isMicrosoftGraphSource,
+} from "@/lib/graph-source";
+import { formatDistanceToNow } from "date-fns";
 
 interface EventSourceDetailProps {
 	sourceId: string;
@@ -84,9 +96,11 @@ export function EventSourceDetail({
 	const [copied, setCopied] = useState(false);
 	const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
 	const [editDialogOpen, setEditDialogOpen] = useState(false);
+	const [resubscribeDialogOpen, setResubscribeDialogOpen] = useState(false);
 
 	const { data: source, isLoading, refetch } = useEventSource(sourceId);
 	const updateMutation = useUpdateEventSource();
+	const resubscribeMutation = useResubscribeEventSource();
 
 	// Toggle active status
 	const handleToggleActive = async () => {
@@ -141,8 +155,24 @@ export function EventSourceDetail({
 			});
 			toast.success("Event source deleted");
 			onClose();
-		} catch {
-			toast.error("Failed to delete event source");
+		} catch (error) {
+			toast.error(
+				getErrorMessage(error, "Failed to delete event source"),
+			);
+		}
+	};
+
+	const handleResubscribe = async () => {
+		try {
+			await resubscribeMutation.mutateAsync({
+				params: { path: { source_id: sourceId } },
+			});
+			setResubscribeDialogOpen(false);
+			toast.success("Microsoft Graph subscription recreated");
+		} catch (error) {
+			toast.error(
+				getErrorMessage(error, "Failed to recreate Graph subscription"),
+			);
 		}
 	};
 
@@ -180,6 +210,28 @@ export function EventSourceDetail({
 		);
 	}
 
+	const isGraph = isMicrosoftGraphSource(source);
+	const graphSummary = getGraphSourceSummary(source);
+	const graphStatus =
+		graphSummary?.health === "connected"
+			? {
+					label: "Connected",
+					icon: CircleCheck,
+					className: "text-emerald-700 dark:text-emerald-300",
+				}
+			: graphSummary?.health === "expired"
+				? {
+						label: "Expired",
+						icon: Clock3,
+						className: "text-destructive",
+					}
+				: {
+						label: "Needs attention",
+						icon: AlertTriangle,
+						className: "text-amber-700 dark:text-amber-300",
+					};
+	const GraphStatusIcon = graphStatus.icon;
+
 	return (
 		<div className="h-[calc(100vh-8rem)] flex flex-col space-y-4">
 			{/* Header row */}
@@ -189,7 +241,11 @@ export function EventSourceDetail({
 						<ArrowLeft className="h-4 w-4" />
 					</Button>
 					<div className="flex items-center gap-3 text-muted-foreground">
-						{getSourceTypeIcon(source.source_type)}
+						{isGraph ? (
+							<MicrosoftGraphIcon className="h-5 w-5 text-[#1686d9]" />
+						) : (
+							getSourceTypeIcon(source.source_type)
+						)}
 					</div>
 					<div>
 						<h1 className="text-2xl font-bold tracking-tight">
@@ -197,7 +253,9 @@ export function EventSourceDetail({
 						</h1>
 						<div className="flex items-center gap-2 text-sm text-muted-foreground">
 							<span>
-								{getSourceTypeLabel(source.source_type)}
+								{isGraph
+									? "Microsoft Graph"
+									: getSourceTypeLabel(source.source_type)}
 							</span>
 							<span>·</span>
 							{source.organization_id ? (
@@ -278,7 +336,9 @@ export function EventSourceDetail({
 				)}
 				{source.webhook?.adapter_name && (
 					<Badge variant="outline">
-						{source.webhook.adapter_name}
+						{isGraph
+							? "Microsoft Graph"
+							: source.webhook.adapter_name}
 					</Badge>
 				)}
 				<Badge variant="outline">
@@ -298,7 +358,11 @@ export function EventSourceDetail({
 							{source.schedule.timezone}
 						</Badge>
 						<Badge
-							variant={source.schedule.enabled ? "default" : "secondary"}
+							variant={
+								source.schedule.enabled
+									? "default"
+									: "secondary"
+							}
 							className={
 								source.schedule.enabled
 									? "bg-green-100 text-green-800 hover:bg-green-100 dark:bg-green-900 dark:text-green-200"
@@ -336,6 +400,116 @@ export function EventSourceDetail({
 					</Tooltip>
 				)}
 			</div>
+
+			{graphSummary && source.webhook && (
+				<section
+					aria-labelledby="graph-provider-heading"
+					className="border-y bg-muted/20 px-4 py-4"
+				>
+					<div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+						<div className="min-w-0 flex-1">
+							<div className="flex flex-wrap items-center gap-2">
+								<MicrosoftGraphIcon className="h-5 w-5 text-[#1686d9]" />
+								<h2
+									id="graph-provider-heading"
+									className="font-semibold"
+								>
+									Microsoft Graph
+								</h2>
+								<span
+									className={`inline-flex items-center gap-1.5 text-sm font-medium ${graphStatus.className}`}
+								>
+									<GraphStatusIcon className="h-4 w-4" />
+									{graphStatus.label}
+								</span>
+							</div>
+							<p className="mt-1 text-sm text-muted-foreground">
+								Provider subscription managed by Bifrost and
+								renewed automatically.
+							</p>
+
+							<dl className="mt-4 grid gap-x-8 gap-y-4 sm:grid-cols-2 xl:grid-cols-4">
+								<div className="min-w-0">
+									<dt className="flex items-center gap-1.5 text-xs font-medium text-muted-foreground">
+										<UserRound className="h-3.5 w-3.5" />{" "}
+										User
+									</dt>
+									<dd
+										className="mt-1 truncate text-sm font-medium"
+										title={
+											graphSummary.userSecondary ??
+											graphSummary.userLabel
+										}
+									>
+										{graphSummary.userLabel}
+									</dd>
+									{graphSummary.userSecondary && (
+										<div className="truncate text-xs text-muted-foreground">
+											{graphSummary.userSecondary}
+										</div>
+									)}
+								</div>
+								<div className="min-w-0">
+									<dt className="flex items-center gap-1.5 text-xs font-medium text-muted-foreground">
+										<Radio className="h-3.5 w-3.5" />{" "}
+										Resource
+									</dt>
+									<dd className="mt-1 text-sm font-medium">
+										{graphSummary.resourceLabel}
+									</dd>
+									{graphSummary.resourcePath && (
+										<div
+											className="truncate font-mono text-xs text-muted-foreground"
+											title={graphSummary.resourcePath}
+										>
+											{graphSummary.resourcePath}
+										</div>
+									)}
+								</div>
+								<div>
+									<dt className="text-xs font-medium text-muted-foreground">
+										Changes
+									</dt>
+									<dd className="mt-1 text-sm font-medium capitalize">
+										{graphSummary.changeLabel}
+									</dd>
+								</div>
+								<div>
+									<dt className="flex items-center gap-1.5 text-xs font-medium text-muted-foreground">
+										<Clock3 className="h-3.5 w-3.5" />{" "}
+										Provider expiry
+									</dt>
+									<dd className="mt-1 text-sm font-medium">
+										{source.webhook.expires_at
+											? formatDistanceToNow(
+													new Date(
+														source.webhook
+															.expires_at,
+													),
+													{ addSuffix: true },
+												)
+											: "Not registered"}
+									</dd>
+								</div>
+							</dl>
+						</div>
+
+						{isPlatformAdmin && (
+							<Button
+								variant="outline"
+								onClick={() => setResubscribeDialogOpen(true)}
+								disabled={resubscribeMutation.isPending}
+								className="shrink-0"
+							>
+								<RefreshCw
+									className={`mr-2 h-4 w-4 ${resubscribeMutation.isPending ? "animate-spin" : ""}`}
+								/>
+								Resubscribe
+							</Button>
+						)}
+					</div>
+				</section>
+			)}
 
 			{/* Error message if present */}
 			{source.error_message && (
@@ -389,7 +563,10 @@ export function EventSourceDetail({
 						<AlertDialogDescription>
 							Are you sure you want to delete "{source.name}"?
 							This will also delete all subscriptions and event
-							history. This action cannot be undone.
+							history. Provider-managed sources are removed from
+							the provider first; if that fails, the Bifrost
+							source is retained so you can retry. This action
+							cannot be undone.
 						</AlertDialogDescription>
 					</AlertDialogHeader>
 					<AlertDialogFooter>
@@ -399,6 +576,37 @@ export function EventSourceDetail({
 							className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
 						>
 							Delete
+						</AlertDialogAction>
+					</AlertDialogFooter>
+				</AlertDialogContent>
+			</AlertDialog>
+
+			<AlertDialog
+				open={resubscribeDialogOpen}
+				onOpenChange={setResubscribeDialogOpen}
+			>
+				<AlertDialogContent>
+					<AlertDialogHeader>
+						<AlertDialogTitle>
+							Resubscribe to Microsoft Graph?
+						</AlertDialogTitle>
+						<AlertDialogDescription>
+							Bifrost will remove the existing Graph registration
+							and create a new one using the current organization,
+							integration, user, resource, and callback URL. Use
+							this when events stop arriving or the provider
+							subscription has expired.
+						</AlertDialogDescription>
+					</AlertDialogHeader>
+					<AlertDialogFooter>
+						<AlertDialogCancel>Cancel</AlertDialogCancel>
+						<AlertDialogAction
+							onClick={handleResubscribe}
+							disabled={resubscribeMutation.isPending}
+						>
+							{resubscribeMutation.isPending
+								? "Resubscribing…"
+								: "Resubscribe"}
 						</AlertDialogAction>
 					</AlertDialogFooter>
 				</AlertDialogContent>

--- a/client/src/components/events/EventsTable.test.tsx
+++ b/client/src/components/events/EventsTable.test.tsx
@@ -31,7 +31,7 @@ vi.mock("./EventDetailDialog", () => ({
 }));
 
 import { EventsTable } from "./EventsTable";
-import type { Event } from "@/services/events";
+import type { Event, EventSource } from "@/services/events";
 
 function makeEvent(overrides: Partial<Event> = {}): Event {
 	return {
@@ -46,6 +46,21 @@ function makeEvent(overrides: Partial<Event> = {}): Event {
 		failed_count: 0,
 		...overrides,
 	} as unknown as Event;
+}
+
+function graphSource(): EventSource {
+	return {
+		id: "src-1",
+		name: "Mailbox changes",
+		source_type: "webhook",
+		webhook: {
+			adapter_name: "microsoft_graph",
+			config: {
+				resource: "/users/user-1/messages",
+			},
+			provider_metadata: {},
+		},
+	} as unknown as EventSource;
 }
 
 describe("EventsTable — empty", () => {
@@ -89,5 +104,28 @@ describe("EventsTable — populated", () => {
 		// Before filtering, both rows are present
 		expect(screen.getByText("ticket.created")).toBeInTheDocument();
 		expect(screen.getByText("ticket.updated")).toBeInTheDocument();
+	});
+
+	it("shows a compact type for historical Graph events", () => {
+		useEventsMock.mockReturnValue({
+			data: {
+				items: [
+					makeEvent({
+						event_type: "01V6T7ZK0M0Q8SHJ4A1N5W2X9B.created",
+						data: { change_type: "created" },
+					}),
+				],
+			},
+			isLoading: false,
+		});
+
+		renderWithProviders(
+			<EventsTable sourceId="src-1" source={graphSource()} />,
+		);
+
+		expect(screen.getByText("graph.messages.created")).toBeInTheDocument();
+		expect(
+			screen.queryByText("01V6T7ZK0M0Q8SHJ4A1N5W2X9B.created"),
+		).not.toBeInTheDocument();
 	});
 });

--- a/client/src/components/events/EventsTable.tsx
+++ b/client/src/components/events/EventsTable.tsx
@@ -20,7 +20,12 @@ import {
 } from "@/components/ui/data-table";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 import { format, subHours, subDays } from "date-fns";
-import { useEvents, type Event, type EventStatus } from "@/services/events";
+import {
+	useEvents,
+	type Event,
+	type EventSource,
+	type EventStatus,
+} from "@/services/events";
 import { EventDetailDialog } from "./EventDetailDialog";
 import { SearchBox } from "@/components/search/SearchBox";
 import { useSearch } from "@/hooks/useSearch";
@@ -38,9 +43,11 @@ import {
 	TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
+import { getGraphEventType } from "@/lib/graph-source";
 
 interface EventsTableProps {
 	sourceId: string;
+	source?: EventSource;
 	initialEventId?: string;
 }
 
@@ -109,7 +116,7 @@ interface EventWithMeta extends Event {
 	_isNew?: boolean;
 }
 
-export function EventsTable({ sourceId, initialEventId }: EventsTableProps) {
+export function EventsTable({ sourceId, source, initialEventId }: EventsTableProps) {
 	const navigate = useNavigate();
 	const [statusFilter, setStatusFilter] = useState<StatusFilter>("all");
 	const [dateRange, setDateRange] = useState<DateRangeFilter>("24h");
@@ -135,10 +142,12 @@ export function EventsTable({ sourceId, initialEventId }: EventsTableProps) {
 	}, [statusFilter, dateRange]);
 
 	const { data, isLoading } = useEvents(sourceId, filterParams);
-	const events = useMemo(
-		() => (data?.items || []) as EventWithMeta[],
-		[data?.items],
-	);
+	const events = useMemo(() => {
+		return ((data?.items || []) as EventWithMeta[]).map((event) => ({
+			...event,
+			event_type: getGraphEventType(source, event),
+		}));
+	}, [data?.items, source]);
 
 	// Connect to WebSocket for real-time updates
 	const { isConnected } = useEventStream(sourceId);

--- a/client/src/components/events/MicrosoftGraphIcon.tsx
+++ b/client/src/components/events/MicrosoftGraphIcon.tsx
@@ -1,0 +1,23 @@
+import type { SVGProps } from "react";
+
+export function MicrosoftGraphIcon({
+	className,
+	...props
+}: SVGProps<SVGSVGElement>) {
+	return (
+		<svg
+			viewBox="0 0 24 24"
+			fill="none"
+			stroke="currentColor"
+			strokeWidth="1.8"
+			strokeLinecap="round"
+			strokeLinejoin="round"
+			className={className}
+			aria-hidden="true"
+			{...props}
+		>
+			<path d="M7.2 7.5 12 4.8l4.8 2.7v5.4L12 15.6l-4.8-2.7Z" />
+			<path d="m7.2 12.9-3.7 2.2v4.1L7 21.1l3.8-2.2v-3.8M16.8 12.9l3.7 2.2v4.1L17 21.1l-3.8-2.2v-3.8" />
+		</svg>
+	);
+}

--- a/client/src/lib/graph-source.test.ts
+++ b/client/src/lib/graph-source.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+
+import type { EventSource } from "@/services/events";
+import {
+	getGraphSourceSummary,
+	isMicrosoftGraphSource,
+} from "./graph-source";
+
+function graphSource(overrides: Partial<EventSource> = {}): EventSource {
+	return {
+		id: "source-1",
+		name: "Mailbox changes",
+		source_type: "webhook",
+		is_active: true,
+		error_message: null,
+		webhook: {
+			adapter_name: "microsoft_graph",
+			external_id: "subscription-1",
+			expires_at: "2026-08-30T00:00:00Z",
+			config: {
+				user_id: "user-1",
+				resource: "/users/user-1/messages",
+				change_types: ["created", "updated"],
+			},
+			provider_metadata: {
+				user_display_name: "Ada Lovelace",
+				user_principal_name: "ada@example.com",
+			},
+		},
+		...overrides,
+	} as unknown as EventSource;
+}
+
+describe("Graph source presentation", () => {
+	it("recognizes Graph sources and returns operator-friendly identity", () => {
+		const source = graphSource();
+
+		expect(isMicrosoftGraphSource(source)).toBe(true);
+		expect(
+			getGraphSourceSummary(source, new Date("2026-08-29T00:00:00Z")),
+		).toEqual({
+			userLabel: "Ada Lovelace",
+			userSecondary: "ada@example.com",
+			resourceLabel: "Mail messages",
+			resourcePath: "/users/user-1/messages",
+			changeLabel: "created, updated",
+			health: "connected",
+		});
+	});
+
+	it("marks missing or expired provider registrations for attention", () => {
+		expect(
+			getGraphSourceSummary(
+				graphSource({
+					webhook: {
+						...graphSource().webhook!,
+						external_id: null,
+					},
+				}),
+				new Date("2026-08-29T00:00:00Z"),
+			)?.health,
+		).toBe("attention");
+		expect(
+			getGraphSourceSummary(
+				graphSource(),
+				new Date("2026-09-01T00:00:00Z"),
+			)?.health,
+		).toBe("expired");
+	});
+
+	it("does not manufacture Graph metadata for generic webhooks", () => {
+		const source = graphSource({
+			webhook: { ...graphSource().webhook!, adapter_name: "generic" },
+		});
+
+		expect(isMicrosoftGraphSource(source)).toBe(false);
+		expect(getGraphSourceSummary(source)).toBeNull();
+	});
+});

--- a/client/src/lib/graph-source.test.ts
+++ b/client/src/lib/graph-source.test.ts
@@ -2,9 +2,11 @@ import { describe, expect, it } from "vitest";
 
 import type { EventSource } from "@/services/events";
 import {
+	getGraphEventType,
 	getGraphSourceSummary,
 	isMicrosoftGraphSource,
 } from "./graph-source";
+import type { Event } from "@/services/events";
 
 function graphSource(overrides: Partial<EventSource> = {}): EventSource {
 	return {
@@ -39,13 +41,24 @@ describe("Graph source presentation", () => {
 		expect(
 			getGraphSourceSummary(source, new Date("2026-08-29T00:00:00Z")),
 		).toEqual({
-			userLabel: "Ada Lovelace",
-			userSecondary: "ada@example.com",
+			userLabel: "ada@example.com",
+			userSecondary: "Ada Lovelace",
 			resourceLabel: "Mail messages",
 			resourcePath: "/users/user-1/messages",
 			changeLabel: "created, updated",
 			health: "connected",
 		});
+	});
+
+	it("normalizes historical Graph event types from source and payload data", () => {
+		const event = {
+			event_type: "01V6T7ZK0M0Q8SHJ4A1N5W2X9B.created",
+			data: { change_type: "created" },
+		} as unknown as Event;
+
+		expect(getGraphEventType(graphSource(), event)).toBe(
+			"graph.messages.created",
+		);
 	});
 
 	it("marks missing or expired provider registrations for attention", () => {

--- a/client/src/lib/graph-source.ts
+++ b/client/src/lib/graph-source.ts
@@ -1,4 +1,4 @@
-import type { EventSource } from "@/services/events";
+import type { Event, EventSource } from "@/services/events";
 
 export type GraphSubscriptionHealth = "connected" | "expired" | "attention";
 
@@ -67,10 +67,10 @@ export function getGraphSourceSummary(
 
 	return {
 		userLabel:
-			displayName ?? principalName ?? (userId ? compactId(userId) : "Graph user"),
+			principalName ?? displayName ?? (userId ? compactId(userId) : "Graph user"),
 		userSecondary:
 			displayName && principalName && displayName !== principalName
-				? principalName
+				? displayName
 				: null,
 		resourceLabel:
 			(resourceKey && RESOURCE_LABELS[resourceKey]) ??
@@ -80,4 +80,24 @@ export function getGraphSourceSummary(
 		changeLabel: changes.length ? changes.join(", ") : "All changes",
 		health,
 	};
+}
+
+export function getGraphEventType(
+	source: EventSource | undefined,
+	event: Event,
+): string | null {
+	const rawType = stringValue(event.event_type);
+	if (!source || !isMicrosoftGraphSource(source)) return rawType;
+	if (rawType?.startsWith("graph.")) return rawType;
+
+	const changeType = stringValue(event.data?.change_type);
+	const metadata = source.webhook?.provider_metadata ?? {};
+	const config = source.webhook?.config ?? {};
+	const resourcePath =
+		stringValue(metadata.resource) ?? stringValue(config.resource);
+	const resourceKey = resourcePath?.replace(/\/$/, "").split("/").at(-1);
+
+	return resourceKey && changeType
+		? `graph.${resourceKey}.${changeType}`
+		: rawType;
 }

--- a/client/src/lib/graph-source.ts
+++ b/client/src/lib/graph-source.ts
@@ -1,0 +1,83 @@
+import type { EventSource } from "@/services/events";
+
+export type GraphSubscriptionHealth = "connected" | "expired" | "attention";
+
+export type GraphSourceSummary = {
+	userLabel: string;
+	userSecondary: string | null;
+	resourceLabel: string;
+	resourcePath: string | null;
+	changeLabel: string;
+	health: GraphSubscriptionHealth;
+};
+
+const RESOURCE_LABELS: Record<string, string> = {
+	messages: "Mail messages",
+	events: "Calendar events",
+	mailFolders: "Mail folders",
+	contacts: "Contacts",
+	callRecords: "Call records",
+};
+
+function stringValue(value: unknown): string | null {
+	return typeof value === "string" && value.trim() ? value : null;
+}
+
+function compactId(value: string): string {
+	return value.length > 16
+		? `${value.slice(0, 8)}…${value.slice(-4)}`
+		: value;
+}
+
+export function isMicrosoftGraphSource(source: EventSource): boolean {
+	return source.webhook?.adapter_name === "microsoft_graph";
+}
+
+export function getGraphSourceSummary(
+	source: EventSource,
+	now = new Date(),
+): GraphSourceSummary | null {
+	if (!isMicrosoftGraphSource(source) || !source.webhook) return null;
+
+	const metadata = source.webhook.provider_metadata ?? {};
+	const config = source.webhook.config ?? {};
+	const userId =
+		stringValue(metadata.user_id) ?? stringValue(config.user_id);
+	const displayName = stringValue(metadata.user_display_name);
+	const principalName =
+		stringValue(metadata.user_principal_name) ??
+		stringValue(metadata.user_mail);
+	const resourcePath =
+		stringValue(metadata.resource) ?? stringValue(config.resource);
+	const resourceKey = resourcePath?.replace(/\/$/, "").split("/").at(-1);
+	const rawChanges = metadata.change_types ?? config.change_types;
+	const changes = Array.isArray(rawChanges)
+		? rawChanges.filter((value): value is string => typeof value === "string")
+		: [];
+
+	let health: GraphSubscriptionHealth = "connected";
+	if (source.error_message || !source.webhook.external_id) {
+		health = "attention";
+	} else if (
+		source.webhook.expires_at &&
+		new Date(source.webhook.expires_at).getTime() <= now.getTime()
+	) {
+		health = "expired";
+	}
+
+	return {
+		userLabel:
+			displayName ?? principalName ?? (userId ? compactId(userId) : "Graph user"),
+		userSecondary:
+			displayName && principalName && displayName !== principalName
+				? principalName
+				: null,
+		resourceLabel:
+			(resourceKey && RESOURCE_LABELS[resourceKey]) ??
+			resourceKey ??
+			"Graph resource",
+		resourcePath,
+		changeLabel: changes.length ? changes.join(", ") : "All changes",
+		health,
+	};
+}

--- a/client/src/lib/v1.d.ts
+++ b/client/src/lib/v1.d.ts
@@ -7746,6 +7746,26 @@ export interface paths {
         patch: operations["update_source_api_events_sources__source_id__patch"];
         trace?: never;
     };
+    "/api/events/sources/{source_id}/resubscribe": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Recreate an event source provider subscription
+         * @description Replace the external webhook registration while preserving the Bifrost event source.
+         */
+        post: operations["resubscribe_source_api_events_sources__source_id__resubscribe_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/events/sources/{source_id}/subscriptions": {
         parameters: {
             query?: never;
@@ -26149,6 +26169,13 @@ export interface components {
              */
             external_id?: string | null;
             /**
+             * Provider Metadata
+             * @description Non-secret provider details for operations and display
+             */
+            provider_metadata?: {
+                [key: string]: unknown;
+            };
+            /**
              * Expires At
              * @description When the external subscription expires
              */
@@ -40727,6 +40754,37 @@ export interface operations {
                 "application/json": components["schemas"]["EventSourceUpdate"];
             };
         };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["EventSourceResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    resubscribe_source_api_events_sources__source_id__resubscribe_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                source_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
         responses: {
             /** @description Successful Response */
             200: {

--- a/client/src/lib/v1.d.ts
+++ b/client/src/lib/v1.d.ts
@@ -15082,6 +15082,11 @@ export interface components {
              */
             integration_id?: string | null;
             /**
+             * Organization Id
+             * @description Organization whose integration mapping supplies tenant context
+             */
+            organization_id?: string | null;
+            /**
              * Current Config
              * @description Config values selected so far (for dependent fields)
              */
@@ -26034,6 +26039,12 @@ export interface components {
              * @description Integration name required for this adapter (e.g., 'Microsoft')
              */
             requires_integration?: string | null;
+            /**
+             * Requires Organization
+             * @description Whether this adapter requires an organization-scoped tenant mapping
+             * @default false
+             */
+            requires_organization: boolean;
             /**
              * Config Schema
              * @description JSON Schema for adapter configuration

--- a/client/src/pages/AppCodeEditorPage.test.tsx
+++ b/client/src/pages/AppCodeEditorPage.test.tsx
@@ -1,7 +1,13 @@
 // @vitest-environment happy-dom
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { renderWithProviders, screen, waitFor, within } from "@/test-utils";
+import {
+	fireEvent,
+	renderWithProviders,
+	screen,
+	waitFor,
+	within,
+} from "@/test-utils";
 
 const mockUseApplication = vi.fn();
 const mockUsePublishApplication = vi.fn();
@@ -88,10 +94,9 @@ describe("AppCodeEditorPage publish flow", () => {
 
 		await user.click(screen.getByRole("button", { name: "Publish" }));
 		const dialog = screen.getByRole("dialog");
-		await user.type(
-			within(dialog).getByLabelText(/publish message/i),
-			"Release current source",
-		);
+		fireEvent.change(within(dialog).getByLabelText(/publish message/i), {
+			target: { value: "Release current source" },
+		});
 		await user.click(
 			within(dialog).getByRole("button", { name: "Publish" }),
 		);

--- a/client/src/pages/Events.test.tsx
+++ b/client/src/pages/Events.test.tsx
@@ -1,0 +1,75 @@
+import { describe, expect, it, vi } from "vitest";
+import { renderWithProviders, screen } from "@/test-utils";
+
+vi.mock("@/contexts/AuthContext", () => ({
+	useAuth: () => ({ isPlatformAdmin: true }),
+}));
+
+vi.mock("@/services/events", () => ({
+	useEventSources: () => ({
+		data: {
+			items: [
+				{
+					id: "source-1",
+					name: "Mailbox changes",
+					source_type: "webhook",
+					organization_id: "org-1",
+					organization_name: "Covi, Inc.",
+					is_active: true,
+					error_message: "Provider subscription renewal failed",
+					event_count_24h: 4,
+					created_at: "2026-08-27T00:00:00Z",
+					webhook: {
+						adapter_name: "microsoft_graph",
+						external_id: "subscription-1",
+						expires_at: "2030-08-30T00:00:00Z",
+						rate_limited_count_24h: 0,
+						config: {
+							resource: "/users/user-1/messages",
+							change_types: ["created"],
+						},
+						provider_metadata: {
+							user_display_name: "Ada Lovelace",
+						},
+					},
+				},
+			],
+			total: 1,
+		},
+		isLoading: false,
+		refetch: vi.fn(),
+	}),
+	useUpdateEventSource: () => ({ mutateAsync: vi.fn(), isPending: false }),
+	useDeleteEventSource: () => ({ mutateAsync: vi.fn(), isPending: false }),
+}));
+
+vi.mock("@/components/forms/OrganizationSelect", () => ({
+	OrganizationSelect: () => null,
+}));
+
+vi.mock("@/components/events/CreateEventSourceDialog", () => ({
+	CreateEventSourceDialog: () => null,
+}));
+
+vi.mock("@/components/events/EditEventSourceDialog", () => ({
+	EditEventSourceDialog: () => null,
+}));
+
+vi.mock("@/components/events/EventSourceDetail", () => ({
+	EventSourceDetail: () => null,
+}));
+
+import { Events } from "./Events";
+
+describe("Event sources list", () => {
+	it("identifies Microsoft Graph sources and their operational context", () => {
+		renderWithProviders(<Events />);
+
+		expect(screen.getByText("Mailbox changes")).toBeInTheDocument();
+		expect(screen.getByText("Microsoft Graph")).toBeInTheDocument();
+		expect(
+			screen.getByText(/Ada Lovelace · Mail messages · created/i),
+		).toBeInTheDocument();
+		expect(screen.getByText("Needs attention")).toBeInTheDocument();
+	});
+});

--- a/client/src/pages/Events.tsx
+++ b/client/src/pages/Events.tsx
@@ -10,6 +10,7 @@ import {
 	Building2,
 	Pencil,
 	Trash2,
+	TriangleAlert,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
@@ -45,15 +46,23 @@ import {
 	useUpdateEventSource,
 	useDeleteEventSource,
 	type EventSource,
-	type EventSourceType,
 } from "@/services/events";
 import { formatDistanceToNow } from "date-fns";
 import { EventSourceDetail } from "@/components/events/EventSourceDetail";
 import { CreateEventSourceDialog } from "@/components/events/CreateEventSourceDialog";
 import { EditEventSourceDialog } from "@/components/events/EditEventSourceDialog";
+import { MicrosoftGraphIcon } from "@/components/events/MicrosoftGraphIcon";
+import {
+	getGraphSourceSummary,
+	isMicrosoftGraphSource,
+} from "@/lib/graph-source";
+import { getErrorMessage } from "@/lib/api-error";
 
-function getSourceTypeIcon(type: EventSourceType) {
-	switch (type) {
+function getSourceTypeIcon(source: EventSource) {
+	if (isMicrosoftGraphSource(source)) {
+		return <MicrosoftGraphIcon className="h-4 w-4 text-[#1686d9]" />;
+	}
+	switch (source.source_type) {
 		case "webhook":
 			return <Webhook className="h-4 w-4" />;
 		case "schedule":
@@ -63,8 +72,9 @@ function getSourceTypeIcon(type: EventSourceType) {
 	}
 }
 
-function getSourceTypeLabel(type: EventSourceType) {
-	switch (type) {
+function getSourceTypeLabel(source: EventSource) {
+	if (isMicrosoftGraphSource(source)) return "Microsoft Graph";
+	switch (source.source_type) {
 		case "webhook":
 			return "Webhook";
 		case "schedule":
@@ -145,8 +155,8 @@ export function Events() {
 			});
 			toast.success("Event source deleted");
 			refetch();
-		} catch {
-			toast.error("Failed to delete event source");
+		} catch (error) {
+			toast.error(getErrorMessage(error, "Failed to delete event source"));
 		} finally {
 			setDeleteDialogOpen(false);
 			setSourceToDelete(null);
@@ -348,7 +358,9 @@ export function Events() {
 							</DataTableRow>
 						</DataTableHeader>
 						<DataTableBody>
-							{filteredSources.map((source) => (
+							{filteredSources.map((source) => {
+								const graphSummary = getGraphSourceSummary(source);
+								return (
 								<DataTableRow
 									key={source.id}
 									clickable
@@ -378,11 +390,24 @@ export function Events() {
 									)}
 									<DataTableCell className="font-medium">
 										<div className="flex items-center gap-2">
-											{getSourceTypeIcon(
-												source.source_type,
-											)}
-											<div className="flex flex-col">
+											{getSourceTypeIcon(source)}
+											<div className="min-w-0 flex flex-col">
 												<span>{source.name}</span>
+												{graphSummary && (
+													<span className="flex min-w-0 items-center gap-1.5 text-xs font-normal text-muted-foreground">
+														<span className="truncate">
+															{graphSummary.userLabel} ·{" "}
+															{graphSummary.resourceLabel} ·{" "}
+															{graphSummary.changeLabel}
+														</span>
+														{graphSummary.health !== "connected" && (
+															<span className="inline-flex shrink-0 items-center gap-1 text-amber-700 dark:text-amber-300">
+																<TriangleAlert className="h-3 w-3" />
+																Needs attention
+															</span>
+														)}
+													</span>
+												)}
 												{source.source_type === "topic" && source.event_type && (
 													<span className="text-xs text-muted-foreground font-mono">
 														{source.event_type}
@@ -392,7 +417,7 @@ export function Events() {
 										</div>
 									</DataTableCell>
 									<DataTableCell className="w-0 whitespace-nowrap">
-										{getSourceTypeLabel(source.source_type)}
+										{getSourceTypeLabel(source)}
 									</DataTableCell>
 									<DataTableCell className="w-0 whitespace-nowrap text-right">
 										{source.event_count_24h || 0}
@@ -468,7 +493,8 @@ export function Events() {
 										</>
 									)}
 								</DataTableRow>
-							))}
+								);
+							})}
 						</DataTableBody>
 					</DataTable>
 				</div>
@@ -498,9 +524,11 @@ export function Events() {
 						<AlertDialogTitle>Delete Event Source</AlertDialogTitle>
 						<AlertDialogDescription>
 							Are you sure you want to delete "
-							{sourceToDelete?.name}"? This will also remove all
-							subscriptions and event history. This action cannot
-							be undone.
+								{sourceToDelete?.name}"? This will also remove all
+								subscriptions and event history. Provider-managed sources are
+								removed from the provider first; if that fails, the Bifrost
+								source is retained so you can retry. This action cannot be
+								undone.
 						</AlertDialogDescription>
 					</AlertDialogHeader>
 					<AlertDialogFooter>

--- a/client/src/pages/audit/AuditLogPage.test.tsx
+++ b/client/src/pages/audit/AuditLogPage.test.tsx
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { renderWithProviders, screen, waitFor } from "@/test-utils";
+import { fireEvent, renderWithProviders, screen, waitFor } from "@/test-utils";
 
 const mockUseAuditLog = vi.fn();
 
@@ -93,9 +93,9 @@ describe("AuditLogPage policy filters", () => {
 		);
 		await user.click(screen.getByRole("combobox", { name: "Outcome filter" }));
 		await user.click(await screen.findByRole("option", { name: "Failure" }));
-		await user.type(
+		fireEvent.change(
 			screen.getByRole("searchbox", { name: "Search audit events" }),
-			filePath,
+			{ target: { value: filePath } },
 		);
 
 		await waitFor(() => {

--- a/client/src/services/events.test.ts
+++ b/client/src/services/events.test.ts
@@ -1,0 +1,47 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockUseQuery = vi.fn();
+
+vi.mock("@/lib/api-client", () => ({
+	$api: {
+		useQuery: (...args: unknown[]) => mockUseQuery(...args),
+	},
+}));
+
+vi.mock("@tanstack/react-query", () => ({
+	useQueryClient: () => ({ invalidateQueries: vi.fn() }),
+}));
+
+import { useDynamicValues } from "./events";
+
+describe("event dynamic values service", () => {
+	beforeEach(() => {
+		mockUseQuery.mockReset();
+		mockUseQuery.mockReturnValue({ data: undefined });
+	});
+
+	it("sends the selected organization with the integration context", () => {
+		useDynamicValues(
+			"microsoft_graph",
+			"list_users",
+			"integration-1",
+			"organization-1",
+			{ user_id: "user-1" },
+		);
+
+		expect(mockUseQuery).toHaveBeenCalledWith(
+			"post",
+			"/api/events/adapters/{adapter_name}/dynamic-values",
+			{
+				params: { path: { adapter_name: "microsoft_graph" } },
+				body: {
+					operation: "list_users",
+					integration_id: "integration-1",
+					organization_id: "organization-1",
+					current_config: { user_id: "user-1" },
+				},
+			},
+			{ enabled: true, staleTime: 5 * 60 * 1000 },
+		);
+	});
+});

--- a/client/src/services/events.test.ts
+++ b/client/src/services/events.test.ts
@@ -1,23 +1,28 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockUseQuery = vi.fn();
+const mockUseMutation = vi.fn();
+const mockInvalidateQueries = vi.fn();
 
 vi.mock("@/lib/api-client", () => ({
 	$api: {
 		useQuery: (...args: unknown[]) => mockUseQuery(...args),
+		useMutation: (...args: unknown[]) => mockUseMutation(...args),
 	},
 }));
 
 vi.mock("@tanstack/react-query", () => ({
-	useQueryClient: () => ({ invalidateQueries: vi.fn() }),
+	useQueryClient: () => ({ invalidateQueries: mockInvalidateQueries }),
 }));
 
-import { useDynamicValues } from "./events";
+import { useDynamicValues, useResubscribeEventSource } from "./events";
 
 describe("event dynamic values service", () => {
 	beforeEach(() => {
 		mockUseQuery.mockReset();
 		mockUseQuery.mockReturnValue({ data: undefined });
+		mockUseMutation.mockReset();
+		mockInvalidateQueries.mockReset();
 	});
 
 	it("sends the selected organization with the integration context", () => {
@@ -43,5 +48,20 @@ describe("event dynamic values service", () => {
 			},
 			{ enabled: true, staleTime: 5 * 60 * 1000 },
 		);
+	});
+
+	it("wires provider resubscription and refreshes source queries", () => {
+		useResubscribeEventSource();
+
+		expect(mockUseMutation).toHaveBeenCalledWith(
+			"post",
+			"/api/events/sources/{source_id}/resubscribe",
+			expect.objectContaining({ onSuccess: expect.any(Function) }),
+		);
+		const options = mockUseMutation.mock.calls[0]![2];
+		options.onSuccess(undefined, {
+			params: { path: { source_id: "source-1" } },
+		});
+		expect(mockInvalidateQueries).toHaveBeenCalledTimes(2);
 	});
 });

--- a/client/src/services/events.ts
+++ b/client/src/services/events.ts
@@ -199,6 +199,31 @@ export function useDeleteEventSource() {
 	});
 }
 
+/** Replace an event source's registration with its external provider. */
+export function useResubscribeEventSource() {
+	const queryClient = useQueryClient();
+
+	return $api.useMutation(
+		"post",
+		"/api/events/sources/{source_id}/resubscribe",
+		{
+			onSuccess: (_, variables) => {
+				const sourceId = variables.params.path.source_id;
+				queryClient.invalidateQueries({
+					queryKey: ["get", "/api/events/sources"],
+				});
+				queryClient.invalidateQueries({
+					queryKey: [
+						"get",
+						"/api/events/sources/{source_id}",
+						{ params: { path: { source_id: sourceId } } },
+					],
+				});
+			},
+		},
+	);
+}
+
 // ============================================================================
 // Event Subscriptions
 // ============================================================================

--- a/client/src/services/events.ts
+++ b/client/src/services/events.ts
@@ -77,6 +77,7 @@ export function useDynamicValues(
 	adapterName: string | undefined,
 	operation: string | undefined,
 	integrationId: string | undefined,
+	organizationId: string | null | undefined,
 	currentConfig: Record<string, unknown>,
 	enabled = true,
 ) {
@@ -90,6 +91,7 @@ export function useDynamicValues(
 			body: {
 				operation: operation!,
 				integration_id: integrationId || undefined,
+				organization_id: organizationId || undefined,
 				current_config: currentConfig,
 			},
 		},

--- a/client/vitest.config.ts
+++ b/client/vitest.config.ts
@@ -17,6 +17,9 @@ export default defineConfig({
 		include: ["src/**/*.test.{ts,tsx}"],
 		// Exclude Playwright e2e specs so they don't accidentally run here
 		exclude: ["e2e/**", "node_modules/**", "dist/**"],
+		// happy-dom suites are CPU-heavy; leave capacity for each worker so
+		// interaction tests do not lose their entire timeout to contention.
+		maxWorkers: "50%",
 		css: false,
 	},
 });

--- a/plugins/bifrost/skills/bifrost-build/generated/cli-reference.md
+++ b/plugins/bifrost/skills/bifrost-build/generated/cli-reference.md
@@ -628,14 +628,49 @@ Options:
   --help  Show this message and exit.
 
 Commands:
+  create-graph-source  Create a Microsoft Graph webhook source with...
   create-source        Create a new event source.
+  delete-source        Delete an event source after its provider...
   get-source           Get a single event source by UUID or name.
   get-subscription     Get a single subscription by source ref +...
   list-sources         List all event sources (wrapped ``{items, total}``...
   list-subscriptions   List subscriptions for an event source.
+  resubscribe-source   Replace an event source's external provider...
   subscribe            Subscribe a workflow or agent to an event source.
   update-source        Update an event source.
   update-subscription  Update an event subscription.
+```
+
+### `events create-graph-source`
+
+```
+Usage: events create-graph-source [OPTIONS]
+
+  Create a Microsoft Graph webhook source with first-class flags.
+
+  ``--user-id`` is the Microsoft Graph object ID, not a Bifrost user ID. HOME
+  scopes the source to the caller organization; use ``--org`` to target
+  another organization. Microsoft Graph sources cannot be global.
+
+Options:
+  --name TEXT                     Event source name.  [required]
+  --integration TEXT              Microsoft integration UUID or name.
+                                  [required]
+  --user-id TEXT                  Microsoft Graph user object ID.  [required]
+  --resource [messages|events|mailFolders|contacts]
+                                  User resource collection to monitor.
+                                  [required]
+  --change-type [created|updated|deleted]
+                                  Graph change type. Repeat for multiple
+                                  values.  [default: created]
+  --global                        Target global scope (org=NULL). Alias for
+                                  --org global.
+  --org, --organization, --scope TEXT
+                                  Org UUID/name, or 'none'/'global' for global
+                                  scope. Omit = your org. (--organization /
+                                  --scope are synonyms.)
+  --json                          Emit JSON instead of human-readable output.
+  --help                          Show this message and exit.
 ```
 
 ### `events create-source`
@@ -685,6 +720,18 @@ Options:
   --help                          Show this message and exit.
 ```
 
+### `events delete-source`
+
+```
+Usage: events delete-source [OPTIONS] REF
+
+  Delete an event source after its provider subscription is removed.
+
+Options:
+  --json  Emit JSON instead of human-readable output.
+  --help  Show this message and exit.
+```
+
 ### `events get-source`
 
 ```
@@ -732,6 +779,18 @@ Usage: events list-subscriptions [OPTIONS] SOURCE_REF
   List subscriptions for an event source.
 
   ``SOURCE_REF`` is a UUID or event source name.
+
+Options:
+  --json  Emit JSON instead of human-readable output.
+  --help  Show this message and exit.
+```
+
+### `events resubscribe-source`
+
+```
+Usage: events resubscribe-source [OPTIONS] REF
+
+  Replace an event source's external provider subscription.
 
 Options:
   --json  Emit JSON instead of human-readable output.

--- a/plugins/bifrost/skills/bifrost-build/generated/openapi-digest.md
+++ b/plugins/bifrost/skills/bifrost-build/generated/openapi-digest.md
@@ -157,6 +157,7 @@
 | GET | `/api/events/sources/{source_id}` |
 | PATCH | `/api/events/sources/{source_id}` |
 | GET | `/api/events/sources/{source_id}/events` |
+| POST | `/api/events/sources/{source_id}/resubscribe` |
 | GET | `/api/events/sources/{source_id}/subscriptions` |
 | POST | `/api/events/sources/{source_id}/subscriptions` |
 | DELETE | `/api/events/sources/{source_id}/subscriptions/{subscription_id}` |

--- a/test.sh
+++ b/test.sh
@@ -433,7 +433,13 @@ start_test_client() {
     if [ "${BIFROST_SKIP_BUILD:-0}" != "1" ]; then
         docker compose -f "$COMPOSE_FILE" build client
     fi
-    docker compose -f "$COMPOSE_FILE" --profile client up -d --no-build --no-deps client
+    # reset_state stops and starts the API, which can change its container IP.
+    # Nginx resolves the `api` upstream when it starts, so retaining a client
+    # from a previous browser run can pin it to a dead address and make every
+    # auth request fail with 502. Recreate the lightweight client container so
+    # each run resolves the current API container.
+    docker compose -f "$COMPOSE_FILE" --profile client up -d \
+        --force-recreate --no-build --no-deps client
     echo "Waiting for production client to be healthy..."
     for i in {1..120}; do
         local client_cid


### PR DESCRIPTION
Closes #659

## Summary
- authenticate Microsoft Graph webhooks through the canonical integration token context: organization mapping `entity_id` when present, otherwise the integration default tenant
- use the shared OAuth token machinery for dynamic user loading, subscription creation/deletion, scheduled renewal, and manual recovery
- commit the provisional source before asking Graph to subscribe, allowing the synchronous validation callback to resolve it; remove the source if provider creation fails
- expose Graph provider metadata without leaking credentials so the event source UI can identify the user, resource, change types, expiry, and provider health
- emit compact event types such as `graph.messages.created` instead of provider subscription IDs; presentation-normalize historical Graph events without changing their stored routing keys
- resolve and persist the Graph user's UPN, mail, and display name; show UPN first in pickers, source lists, and details
- refresh Graph identity metadata during renewal so pre-existing sources self-repair and renamed identities stay current
- add provider-first deletion: Graph must confirm deletion (or report it already absent) before the Bifrost event source is removed; otherwise the local source is retained with an actionable error
- add resubscription recovery in the API, UI, and CLI; replacement creation clears stale provider state and leaves a recoverable local source if Graph rejects it
- surface scheduled renewal failures on the event source instead of silently losing delivery
- add `events create-graph-source`, `events resubscribe-source`, and `events delete-source` CLI operations
- restructure the creation dialog with consistent full-width controls, clearer hierarchy, deferred advanced settings, and a visible retry/manual-entry recovery state
- make Graph sources recognizable in the list with a Graph icon and concise user/resource/change summary; add a focused Graph operations band to source details rather than a permanent provider-specific tab
- remove unsupported rich resource data configuration
- force-recreate the production test client between reset-backed Playwright runs so Nginx resolves the current API container instead of retaining a stale upstream IP
- bound Vitest worker concurrency so the full frontend suite does not produce random CPU-contention timeouts

## Live Graph proof
- Covi, Inc. loaded users through the Microsoft integration default tenant without an organization-specific mapping
- Covi Development created a real Microsoft Graph mail subscription after Graph validated the public callback
- a real notification arrived in Bifrost
- the current dev `Test` source was resubscribed successfully and resolved `jack@gocovi.dev`; no encryption key was exposed

## Recovery contract
- no events / expired subscription: use **Resubscribe** in the Graph operations band or `bifrost events resubscribe-source <source-id>`
- provider deletion failure: Bifrost retains the source and its error so `bifrost events delete-source <source-id>` can be retried safely
- creation automation: `bifrost events create-graph-source` accepts the integration, organization, user, resource, and change types directly
- callback, permission, tenant-mapping, and Graph API failures are returned and persisted as actionable source errors

## Verification
- `./test.sh pre-pr` passed at `5b0404cb48fd706449dccd75e93a99312f56e1d0`
  - backend unit/contract/integration: 5,812 passed, 3 skipped, 20 deselected
  - full backend E2E passed
  - frontend unit: 294 files / 1,883 tests passed
  - critical browser smoke passed
  - API/client lint and type checks passed (two pre-existing React compiler/dependency warnings remain)
  - production client and API image smoke checks passed
- focused Graph backend adapter and renewal coverage: 29 passed
- focused Graph frontend helpers/components: 8 passed
- focused Graph browser flow with screenshots: setup plus 2 Graph tests passed, including UPN-first identity and historical compact event display
- Impeccable static detector: clean

GitHub CI and CodeQL passed for the latest candidate. This PR has not been merged.
