### PR TITLE
fix(history): keep execution pagination timeline consistent

### DIFF
--- a/api/alembic/versions/20260827_execution_history_timeline.py
+++ b/api/alembic/versions/20260827_execution_history_timeline.py
@@ -1,0 +1,32 @@
+"""index execution history by its effective timeline timestamp
+
+Revision ID: 20260827_history_timeline
+Revises: 20260823_job_memory_profiles
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "20260827_history_timeline"
+down_revision: str | Sequence[str] = "20260823_job_memory_profiles"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.execute(
+            "CREATE INDEX CONCURRENTLY ix_executions_history_timeline "
+            "ON executions ("
+            "COALESCE(started_at, scheduled_at, completed_at, created_at) DESC, "
+            "id DESC"
+            ")"
+        )
+
+
+def downgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.execute(
+            "DROP INDEX CONCURRENTLY IF EXISTS ix_executions_history_timeline"
+        )

--- a/api/src/models/contracts/executions.py
+++ b/api/src/models/contracts/executions.py
@@ -96,6 +96,7 @@ class ExecutionSummary(BaseModel):
     started_at: datetime | None = None  # May be None if not started yet
     completed_at: datetime | None = None
     scheduled_at: datetime | None = None  # For Scheduled rows, when the row is due to promote
+    created_at: datetime | None = None  # Fallback timeline anchor before a run starts
     # CLI session tracking
     session_id: str | None = None  # CLI session ID if executed from local runner
     # Resource metrics (admin only, null for non-admins)
@@ -281,4 +282,3 @@ class ExecutionPublic(ExecutionBase):
     @field_serializer("created_at", "started_at", "completed_at")
     def serialize_dt(self, dt: datetime | None) -> str | None:
         return dt.isoformat() if dt else None
-

--- a/api/src/models/orm/executions.py
+++ b/api/src/models/orm/executions.py
@@ -8,7 +8,7 @@ from datetime import datetime, timezone
 from typing import TYPE_CHECKING
 from uuid import UUID, uuid4
 
-from sqlalchemy import BigInteger, Boolean, DateTime, Enum as SQLAlchemyEnum, Float, ForeignKey, Index, Integer, Numeric, String, Text, text
+from sqlalchemy import BigInteger, Boolean, DateTime, Enum as SQLAlchemyEnum, Float, ForeignKey, Index, Integer, Numeric, String, Text, func, text
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -108,6 +108,11 @@ class Execution(Base):
 
     __table_args__ = (
         Index("ix_executions_org_status", "organization_id", "status"),
+        Index(
+            "ix_executions_history_timeline",
+            func.coalesce(started_at, scheduled_at, completed_at, created_at).desc(),
+            id.desc(),
+        ),
         Index("ix_executions_created", "created_at"),
         Index("ix_executions_started_at", "started_at"),
         Index("ix_executions_user", "executed_by"),

--- a/api/src/routers/executions.py
+++ b/api/src/routers/executions.py
@@ -57,18 +57,18 @@ router = APIRouter(prefix="/api/executions", tags=["Executions"])
 # =============================================================================
 #
 # History pagination is keyset-based: the continuation token names the last
-# row the client saw — (started_at, id) — and the next page is "rows strictly
+# row the client saw — (timeline_at, id) — and the next page is "rows strictly
 # older than that". An offset token ("give me rows 26–50") re-serves the
 # previous page's tail whenever new executions land between page loads, which
 # on a busy instance is every pagination: users stepping into the past see
 # today's rows (and a "Today" day header) at the top of every page.
 
 
-def _encode_history_cursor(started_at: datetime | None, row_id: UUID) -> str:
+def _encode_history_cursor(timeline_at: datetime | None, row_id: UUID) -> str:
     """Encode the last-served row's position as an opaque token."""
     payload = {
         "v": 1,
-        "s": started_at.isoformat() if started_at else None,
+        "s": timeline_at.isoformat() if timeline_at else None,
         "i": str(row_id),
     }
     return base64.urlsafe_b64encode(json.dumps(payload).encode()).decode()
@@ -116,7 +116,7 @@ class ExecutionRepository:
     ) -> tuple[list[ExecutionSummary], str | None]:
         """List executions with filtering.
 
-        `cursor` is the keyset position (last row's started_at + id); `offset`
+        `cursor` is the keyset position (last row's timeline timestamp + id); `offset`
         is only honored for legacy numeric tokens still in flight from before
         the keyset change. New continuation tokens are always keyset.
         """
@@ -177,43 +177,42 @@ class ExecutionRepository:
         if exclude_local:
             query = query.where(ExecutionModel.is_local_execution == False)  # noqa: E712
 
-        # Order newest first with an id tiebreaker so the order is total:
-        # never-started rows (Scheduled/Pending, NULL started_at) sort first
-        # deterministically instead of "arbitrarily on the server" per page.
+        # Use the same timeline anchor as the History UI. This keeps old
+        # cancelled Scheduled rows from jumping onto page one merely because
+        # they never received a started_at timestamp. created_at is non-null
+        # and anchors Pending rows that have not started or been scheduled.
+        timeline_at = func.coalesce(
+            ExecutionModel.started_at,
+            ExecutionModel.scheduled_at,
+            ExecutionModel.completed_at,
+            ExecutionModel.created_at,
+        )
         query = query.order_by(
-            desc(ExecutionModel.started_at).nulls_first(),
+            desc(timeline_at),
             desc(ExecutionModel.id),
         )
 
         # Pagination: keyset when the caller has a cursor, legacy offset
         # otherwise (first page, or an old numeric token still in flight).
         if cursor is not None:
-            cursor_started, cursor_id = cursor
-            if cursor_started is None:
-                # Last row served was in the leading NULL block: continue
-                # through older NULL rows, then everything started.
+            cursor_timeline, cursor_id = cursor
+            if cursor_timeline is None:
+                # Defensive support for an old cursor minted from a row with
+                # NULL started_at. New cursors always carry a timeline value
+                # because created_at is non-null.
                 query = query.where(
-                    or_(
-                        and_(
-                            ExecutionModel.started_at.is_(None),
-                            ExecutionModel.id < cursor_id,
-                        ),
-                        ExecutionModel.started_at.is_not(None),
-                    )
+                    and_(timeline_at.is_(None), ExecutionModel.id < cursor_id)
                 )
             else:
                 # Strictly older than the cursor row. Excludes the NULL block
-                # (already served on page one) — new Scheduled rows don't
-                # inject themselves into the middle of a pagination either.
+                # and prevents new rows from injecting themselves into the
+                # middle of an in-progress pagination.
                 query = query.where(
-                    and_(
-                        ExecutionModel.started_at.is_not(None),
-                        or_(
-                            ExecutionModel.started_at < cursor_started,
-                            and_(
-                                ExecutionModel.started_at == cursor_started,
-                                ExecutionModel.id < cursor_id,
-                            ),
+                    or_(
+                        timeline_at < cursor_timeline,
+                        and_(
+                            timeline_at == cursor_timeline,
+                            ExecutionModel.id < cursor_id,
                         ),
                     )
                 )
@@ -234,7 +233,13 @@ class ExecutionRepository:
         next_token = None
         if has_more and executions:
             last = executions[-1]
-            next_token = _encode_history_cursor(last.started_at, last.id)
+            last_timeline = (
+                last.started_at
+                or last.scheduled_at
+                or last.completed_at
+                or last.created_at
+            )
+            next_token = _encode_history_cursor(last_timeline, last.id)
 
         return [ExecutionRepository._to_summary(e) for e in executions], next_token
 
@@ -618,6 +623,7 @@ class ExecutionRepository:
             started_at=execution.started_at,
             completed_at=execution.completed_at,
             scheduled_at=execution.scheduled_at,
+            created_at=execution.created_at,
             session_id=str(execution.session_id) if execution.session_id else None,
         )
 
@@ -655,6 +661,7 @@ class ExecutionRepository:
             started_at=execution.started_at,
             completed_at=execution.completed_at,
             scheduled_at=execution.scheduled_at,
+            created_at=execution.created_at,
             logs=None,  # Fetched separately via /logs endpoint
             variables=execution.variables if is_admin else None,
             execution_context=execution.execution_context if is_admin else None,

--- a/api/tests/e2e/platform/test_execution_history_pagination.py
+++ b/api/tests/e2e/platform/test_execution_history_pagination.py
@@ -1,0 +1,102 @@
+"""Execution History ordering and keyset pagination regressions."""
+
+from datetime import datetime, timedelta, timezone
+from uuid import uuid4
+
+import pytest
+
+from src.core.principal import UserPrincipal
+from src.models.enums import ExecutionStatus
+from src.models.orm.executions import Execution
+from src.routers.executions import ExecutionRepository, _decode_history_cursor
+
+pytestmark = pytest.mark.e2e
+
+
+def _execution(
+    *,
+    name: str,
+    status: ExecutionStatus,
+    created_at: datetime,
+    started_at: datetime | None = None,
+    completed_at: datetime | None = None,
+    scheduled_at: datetime | None = None,
+) -> Execution:
+    return Execution(
+        id=uuid4(),
+        workflow_name=name,
+        status=status,
+        parameters={},
+        executed_by=None,
+        executed_by_name="History pagination test",
+        created_at=created_at,
+        started_at=started_at,
+        completed_at=completed_at,
+        scheduled_at=scheduled_at,
+    )
+
+
+@pytest.mark.asyncio
+async def test_history_pages_use_the_display_timeline_without_gaps(db_session):
+    now = datetime(2026, 8, 27, 18, 0, tzinfo=timezone.utc)
+    recent = [
+        _execution(
+            name=f"recent-{index:02d}",
+            status=ExecutionStatus.SUCCESS,
+            created_at=now - timedelta(minutes=index, seconds=5),
+            started_at=now - timedelta(minutes=index),
+            completed_at=now - timedelta(minutes=index) + timedelta(seconds=2),
+        )
+        for index in range(30)
+    ]
+    pending = _execution(
+        name="pending-with-created-at",
+        status=ExecutionStatus.PENDING,
+        created_at=now - timedelta(seconds=30),
+    )
+    future_scheduled = _execution(
+        name="future-scheduled",
+        status=ExecutionStatus.SCHEDULED,
+        created_at=now,
+        scheduled_at=now + timedelta(days=1),
+    )
+    stale_cancelled = _execution(
+        name="stale-cancelled-scheduled",
+        status=ExecutionStatus.CANCELLED,
+        created_at=now - timedelta(days=77, minutes=5),
+        scheduled_at=now - timedelta(days=77),
+    )
+    rows = [*recent, pending, future_scheduled, stale_cancelled]
+    db_session.add_all(rows)
+    await db_session.flush()
+
+    principal = UserPrincipal(
+        user_id=uuid4(),
+        email="history-admin@example.com",
+        organization_id=None,
+        is_superuser=True,
+    )
+    repository = ExecutionRepository(db_session)
+
+    first_page, token = await repository.list_executions(
+        user=principal,
+        org_id=None,
+        limit=25,
+    )
+    assert token is not None
+    assert len(first_page) == 25
+    assert first_page[0].execution_id == str(future_scheduled.id)
+    assert first_page[-1].execution_id != str(stale_cancelled.id)
+
+    second_page, final_token = await repository.list_executions(
+        user=principal,
+        org_id=None,
+        limit=25,
+        cursor=_decode_history_cursor(token),
+    )
+
+    all_ids = [row.execution_id for row in [*first_page, *second_page]]
+    assert len(all_ids) == len(rows)
+    assert len(set(all_ids)) == len(rows)
+    assert all_ids[-1] == str(stale_cancelled.id)
+    assert final_token is None

--- a/api/tests/e2e/platform/test_execution_history_pagination.py
+++ b/api/tests/e2e/platform/test_execution_history_pagination.py
@@ -1,13 +1,15 @@
 """Execution History ordering and keyset pagination regressions."""
 
 from datetime import datetime, timedelta, timezone
-from uuid import uuid4
+from uuid import UUID, uuid4
 
 import pytest
 
+from src.core.constants import PROVIDER_ORG_ID
 from src.core.principal import UserPrincipal
 from src.models.enums import ExecutionStatus
 from src.models.orm.executions import Execution
+from src.models.orm.users import User
 from src.routers.executions import ExecutionRepository, _decode_history_cursor
 
 pytestmark = pytest.mark.e2e
@@ -18,6 +20,7 @@ def _execution(
     name: str,
     status: ExecutionStatus,
     created_at: datetime,
+    executed_by: UUID,
     started_at: datetime | None = None,
     completed_at: datetime | None = None,
     scheduled_at: datetime | None = None,
@@ -27,7 +30,7 @@ def _execution(
         workflow_name=name,
         status=status,
         parameters={},
-        executed_by=None,
+        executed_by=executed_by,
         executed_by_name="History pagination test",
         created_at=created_at,
         started_at=started_at,
@@ -39,11 +42,21 @@ def _execution(
 @pytest.mark.asyncio
 async def test_history_pages_use_the_display_timeline_without_gaps(db_session):
     now = datetime(2026, 8, 27, 18, 0, tzinfo=timezone.utc)
+    user_id = uuid4()
+    db_session.add(
+        User(
+            id=user_id,
+            email=f"history-pagination-{user_id}@example.com",
+            name="History pagination test",
+            organization_id=PROVIDER_ORG_ID,
+        )
+    )
     recent = [
         _execution(
             name=f"recent-{index:02d}",
             status=ExecutionStatus.SUCCESS,
             created_at=now - timedelta(minutes=index, seconds=5),
+            executed_by=user_id,
             started_at=now - timedelta(minutes=index),
             completed_at=now - timedelta(minutes=index) + timedelta(seconds=2),
         )
@@ -53,17 +66,20 @@ async def test_history_pages_use_the_display_timeline_without_gaps(db_session):
         name="pending-with-created-at",
         status=ExecutionStatus.PENDING,
         created_at=now - timedelta(seconds=30),
+        executed_by=user_id,
     )
     future_scheduled = _execution(
         name="future-scheduled",
         status=ExecutionStatus.SCHEDULED,
         created_at=now,
+        executed_by=user_id,
         scheduled_at=now + timedelta(days=1),
     )
     stale_cancelled = _execution(
         name="stale-cancelled-scheduled",
         status=ExecutionStatus.CANCELLED,
         created_at=now - timedelta(days=77, minutes=5),
+        executed_by=user_id,
         scheduled_at=now - timedelta(days=77),
     )
     rows = [*recent, pending, future_scheduled, stale_cancelled]
@@ -71,10 +87,10 @@ async def test_history_pages_use_the_display_timeline_without_gaps(db_session):
     await db_session.flush()
 
     principal = UserPrincipal(
-        user_id=uuid4(),
+        user_id=user_id,
         email="history-admin@example.com",
-        organization_id=None,
-        is_superuser=True,
+        organization_id=PROVIDER_ORG_ID,
+        is_superuser=False,
     )
     repository = ExecutionRepository(db_session)
 

--- a/api/tests/unit/routers/test_executions_list_payload.py
+++ b/api/tests/unit/routers/test_executions_list_payload.py
@@ -23,6 +23,7 @@ def _summary_row() -> SimpleNamespace:
         started_at=datetime.now(timezone.utc),
         completed_at=datetime.now(timezone.utc),
         scheduled_at=None,
+        created_at=datetime.now(timezone.utc),
         session_id=None,
     )
 

--- a/api/tests/unit/routers/test_executions_pagination.py
+++ b/api/tests/unit/routers/test_executions_pagination.py
@@ -10,23 +10,23 @@ from datetime import datetime, timezone
 from uuid import uuid4
 
 
-def test_cursor_round_trips_started_row() -> None:
+def test_cursor_round_trips_timeline_timestamp() -> None:
     from src.routers.executions import (
         _decode_history_cursor,
         _encode_history_cursor,
     )
 
-    started = datetime(2026, 7, 10, 12, 30, 45, 123456, tzinfo=timezone.utc)
+    timeline_at = datetime(2026, 7, 10, 12, 30, 45, 123456, tzinfo=timezone.utc)
     row_id = uuid4()
 
-    token = _encode_history_cursor(started, row_id)
+    token = _encode_history_cursor(timeline_at, row_id)
     decoded = _decode_history_cursor(token)
 
-    assert decoded == (started, row_id)
+    assert decoded == (timeline_at, row_id)
 
 
-def test_cursor_round_trips_null_started_row() -> None:
-    """Scheduled/Pending rows have no started_at; the cursor must carry that."""
+def test_cursor_round_trips_legacy_null_timestamp() -> None:
+    """Cursors minted before timeline anchors may still carry a null value."""
     from src.routers.executions import (
         _decode_history_cursor,
         _encode_history_cursor,

--- a/client/e2e/executions.admin.spec.ts
+++ b/client/e2e/executions.admin.spec.ts
@@ -47,6 +47,11 @@ test.describe("Execution History", () => {
 		await expect(historyRegion).toBeVisible({ timeout: 10000 });
 		const wideBounds = await historyRegion.boundingBox();
 		expect(wideBounds?.width).toBeLessThanOrEqual(1280);
+		expect(
+			await page.locator("main").evaluate(
+				(element) => element.scrollHeight <= element.clientHeight,
+			),
+		).toBe(true);
 
 		const statusTabs = page.getByRole("tablist").first();
 		await expect(statusTabs).toBeVisible();
@@ -85,6 +90,23 @@ test.describe("Execution History", () => {
 				).toBeHidden();
 			}
 		}
+
+		await page.goto("/history?type=agents");
+		await expect(
+			page.getByText("View agent run history across the fleet"),
+		).toBeVisible({ timeout: 10000 });
+		expect(
+			await page.locator("main").evaluate(
+				(element) => element.scrollHeight <= element.clientHeight,
+			),
+		).toBe(true);
+		expect(
+			await page.evaluate(
+				() =>
+					document.documentElement.scrollWidth <=
+					document.documentElement.clientWidth,
+			),
+		).toBe(true);
 	});
 
 	test("should list executions", async ({ page }) => {

--- a/client/e2e/executions.admin.spec.ts
+++ b/client/e2e/executions.admin.spec.ts
@@ -37,6 +37,41 @@ test.describe("Execution History", () => {
 		).toBeVisible({ timeout: 10000 });
 	});
 
+	test("should fit the execution history page on a narrow viewport", async ({
+		page,
+	}) => {
+		await page.setViewportSize({ width: 375, height: 812 });
+		await page.goto("/history");
+
+		await expect(
+			page.getByRole("heading", { name: /history|executions/i }).first(),
+		).toBeVisible({ timeout: 10000 });
+		await expect
+			.poll(() =>
+				page.evaluate(
+					() =>
+						document.documentElement.scrollWidth <=
+							document.documentElement.clientWidth,
+				),
+			)
+			.toBe(true);
+
+		const table = page.getByRole("table").first();
+		if (await table.isVisible().catch(() => false)) {
+			await expect(
+				table.getByRole("columnheader", { name: "Workflow" }),
+			).toBeVisible();
+			await expect(
+				table.getByRole("columnheader", { name: "Status" }),
+			).toBeVisible();
+			for (const name of ["Organization", "Run by", "Started", "Duration"]) {
+				await expect(
+					table.getByRole("columnheader", { name }),
+				).toBeHidden();
+			}
+		}
+	});
+
 	test("should list executions", async ({ page }) => {
 		await page.goto("/history");
 

--- a/client/e2e/executions.admin.spec.ts
+++ b/client/e2e/executions.admin.spec.ts
@@ -37,11 +37,26 @@ test.describe("Execution History", () => {
 		).toBeVisible({ timeout: 10000 });
 	});
 
-	test("should fit the execution history page on a narrow viewport", async ({
+	test("should cap wide layouts and fit narrow viewports", async ({
 		page,
 	}) => {
-		await page.setViewportSize({ width: 375, height: 812 });
+		await page.setViewportSize({ width: 2048, height: 900 });
 		await page.goto("/history");
+
+		const historyRegion = page.getByRole("region", { name: "History" });
+		await expect(historyRegion).toBeVisible({ timeout: 10000 });
+		const wideBounds = await historyRegion.boundingBox();
+		expect(wideBounds?.width).toBeLessThanOrEqual(1280);
+
+		const statusTabs = page.getByRole("tablist").first();
+		await expect(statusTabs).toBeVisible();
+		expect(
+			await statusTabs.evaluate(
+				(element) => getComputedStyle(element.parentElement!).overflowX,
+			),
+		).toBe("visible");
+
+		await page.setViewportSize({ width: 375, height: 812 });
 
 		await expect(
 			page.getByRole("heading", { name: /history|executions/i }).first(),

--- a/client/src/components/agents/AgentRunsPanel.test.tsx
+++ b/client/src/components/agents/AgentRunsPanel.test.tsx
@@ -55,6 +55,41 @@ beforeEach(() => {
 });
 
 describe("AgentRunsPanel", () => {
+	it("constrains the table and progressively collapses secondary columns", () => {
+		renderWithProviders(
+			<Routes>
+				<Route path="/history" element={<AgentRunsPanel />} />
+			</Routes>,
+			{ initialEntries: ["/history?type=agents"] },
+		);
+
+		const table = screen.getByRole("table");
+		expect(table.parentElement?.parentElement).toHaveClass(
+			"min-h-0",
+			"min-w-0",
+		);
+		expect(screen.getByRole("columnheader", { name: "Agent" })).toHaveClass(
+			"w-full",
+			"sm:w-40",
+		);
+		expect(screen.getByRole("columnheader", { name: "Asked" })).toHaveClass(
+			"hidden",
+			"sm:table-cell",
+		);
+		expect(screen.getByRole("columnheader", { name: "Duration" })).toHaveClass(
+			"hidden",
+			"lg:table-cell",
+		);
+		expect(screen.getByRole("columnheader", { name: "Verdict" })).toHaveClass(
+			"hidden",
+			"xl:table-cell",
+		);
+		expect(screen.getByRole("columnheader", { name: "Started" })).toHaveClass(
+			"hidden",
+			"xl:table-cell",
+		);
+	});
+
 	it("keeps fleet run history as the origin when opening a run", async () => {
 		const { user } = renderWithProviders(
 			<Routes>
@@ -67,7 +102,9 @@ describe("AgentRunsPanel", () => {
 			{ initialEntries: ["/history?type=agents"] },
 		);
 
-		await user.click(screen.getByText("Triage ticket 428950"));
+		await user.click(
+			screen.getByRole("row", { name: /Service Desk Triage.*Completed/i }),
+		);
 		expect(screen.getByTestId("navigation-state")).toHaveTextContent(
 			JSON.stringify({
 				agentRunOrigin: {

--- a/client/src/components/agents/AgentRunsPanel.test.tsx
+++ b/client/src/components/agents/AgentRunsPanel.test.tsx
@@ -7,7 +7,7 @@ const mockUseInfiniteAgentRuns = vi.hoisted(() => vi.fn());
 const mockUseRerunAgentRun = vi.hoisted(() => vi.fn());
 
 vi.mock("@/services/agentRuns", () => ({
-	useInfiniteAgentRuns: () => mockUseInfiniteAgentRuns(),
+	useInfiniteAgentRuns: (params: unknown) => mockUseInfiniteAgentRuns(params),
 	useAgentRunListStream: () => undefined,
 	useRerunAgentRun: () => mockUseRerunAgentRun(),
 }));
@@ -39,6 +39,11 @@ const run = {
 	created_at: "2026-07-23T12:00:00Z",
 	started_at: "2026-07-23T12:00:00Z",
 };
+const secondPageRun = {
+	...run,
+	id: "run-26",
+	asked: "Triage ticket 428976",
+};
 
 beforeEach(() => {
 	mockUseInfiniteAgentRuns.mockReturnValue({
@@ -55,6 +60,41 @@ beforeEach(() => {
 });
 
 describe("AgentRunsPanel", () => {
+	it("uses the same 25-run Previous and Next pagination as workflows", async () => {
+		mockUseInfiniteAgentRuns.mockReturnValue({
+			data: {
+				pages: [
+					{ items: [run], total: 50 },
+					{ items: [secondPageRun], total: 50 },
+				],
+			},
+			isLoading: false,
+			hasNextPage: false,
+			isFetchingNextPage: false,
+			fetchNextPage: vi.fn(),
+		});
+
+		const { user } = renderWithProviders(
+			<Routes>
+				<Route path="/history" element={<AgentRunsPanel />} />
+			</Routes>,
+			{ initialEntries: ["/history?type=agents"] },
+		);
+
+		expect(mockUseInfiniteAgentRuns).toHaveBeenCalledWith({ pageSize: 25 });
+		expect(screen.getByRole("row", { name: /428950/ })).toBeInTheDocument();
+		expect(screen.queryByRole("row", { name: /428976/ })).not.toBeInTheDocument();
+		expect(screen.getByText("1")).toHaveAttribute("aria-current", "page");
+
+		await user.click(screen.getByLabelText("Go to next page"));
+		expect(screen.queryByRole("row", { name: /428950/ })).not.toBeInTheDocument();
+		expect(screen.getByRole("row", { name: /428976/ })).toBeInTheDocument();
+		expect(screen.getByText("2")).toHaveAttribute("aria-current", "page");
+
+		await user.click(screen.getByLabelText("Go to previous page"));
+		expect(screen.getByRole("row", { name: /428950/ })).toBeInTheDocument();
+	});
+
 	it("constrains the table and progressively collapses secondary columns", () => {
 		renderWithProviders(
 			<Routes>

--- a/client/src/components/agents/AgentRunsPanel.tsx
+++ b/client/src/components/agents/AgentRunsPanel.tsx
@@ -9,6 +9,7 @@
  * runs tab.
  */
 
+import { useState } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import { toast } from "sonner";
 import {
@@ -32,10 +33,17 @@ import {
 	DataTableHead,
 	DataTableHeader,
 	DataTableRow,
+	DataTableFooter,
 } from "@/components/ui/data-table";
 import { Skeleton } from "@/components/ui/skeleton";
-
-import { InfiniteScrollSentinel } from "@/components/ui/infinite-scroll-sentinel";
+import {
+	Pagination,
+	PaginationContent,
+	PaginationItem,
+	PaginationLink,
+	PaginationNext,
+	PaginationPrevious,
+} from "@/components/ui/pagination";
 import {
 	useAgentRunListStream,
 	useInfiniteAgentRuns,
@@ -49,6 +57,7 @@ import { formatDate, formatDuration } from "@/lib/utils";
 import type { components } from "@/lib/v1";
 
 type AgentRun = components["schemas"]["AgentRunResponse"];
+const PAGE_SIZE = 25;
 
 function RunStatusBadge({ status }: { status: string }) {
 	switch (status) {
@@ -94,6 +103,7 @@ function VerdictGlyph({ verdict }: { verdict: AgentRun["verdict"] }) {
 export function AgentRunsPanel() {
 	const navigate = useNavigate();
 	const location = useLocation();
+	const [pageIndex, setPageIndex] = useState(0);
 	const runNavigationState = createAgentRunNavigationState({
 		href: getLocationHref(location),
 		label: "Back to run history",
@@ -104,7 +114,7 @@ export function AgentRunsPanel() {
 		hasNextPage,
 		isFetchingNextPage,
 		fetchNextPage,
-	} = useInfiniteAgentRuns({ pageSize: 50 });
+	} = useInfiniteAgentRuns({ pageSize: PAGE_SIZE });
 	const rerun = useRerunAgentRun();
 
 	// Subscribe to real-time updates; the hook patches the shared
@@ -112,8 +122,23 @@ export function AgentRunsPanel() {
 	// status changes (queued → running → completed) reflect live.
 	useAgentRunListStream({ enabled: true });
 
-	const runs: AgentRun[] = (data?.pages.flatMap((p) => p.items) ??
-		[]) as AgentRun[];
+	const runs = (data?.pages[pageIndex]?.items ?? []) as AgentRun[];
+	const total = data?.pages[0]?.total ?? 0;
+	const hasPreviousPage = pageIndex > 0;
+	const hasFollowingPage = (pageIndex + 1) * PAGE_SIZE < total;
+
+	async function handleNextPage() {
+		const nextPageIndex = pageIndex + 1;
+		if (data?.pages[nextPageIndex]) {
+			setPageIndex(nextPageIndex);
+			return;
+		}
+		if (!hasNextPage || isFetchingNextPage) return;
+		const result = await fetchNextPage();
+		if (result.data?.pages[nextPageIndex]) {
+			setPageIndex(nextPageIndex);
+		}
+	}
 
 	function handleRerun(runId: string) {
 		rerun.mutate(
@@ -259,12 +284,58 @@ export function AgentRunsPanel() {
 						</DataTableRow>
 					))}
 				</DataTableBody>
+				{total > PAGE_SIZE && (
+					<DataTableFooter>
+						<DataTableRow>
+							<DataTableCell colSpan={7} className="p-0">
+								<div className="flex items-center justify-center px-6 py-3">
+									<Pagination>
+										<PaginationContent>
+											<PaginationItem>
+												<PaginationPrevious
+													onClick={(event) => {
+														event.preventDefault();
+														if (hasPreviousPage) {
+															setPageIndex((current) => current - 1);
+														}
+													}}
+													className={
+														hasPreviousPage
+															? "cursor-pointer"
+															: "pointer-events-none opacity-50"
+													}
+													aria-disabled={!hasPreviousPage}
+												/>
+											</PaginationItem>
+											<PaginationItem>
+												<PaginationLink isActive>
+													{pageIndex + 1}
+												</PaginationLink>
+											</PaginationItem>
+											<PaginationItem>
+												<PaginationNext
+													onClick={(event) => {
+														event.preventDefault();
+														void handleNextPage();
+													}}
+													className={
+														hasFollowingPage && !isFetchingNextPage
+															? "cursor-pointer"
+															: "pointer-events-none opacity-50"
+													}
+													aria-disabled={
+														!hasFollowingPage || isFetchingNextPage
+													}
+												/>
+											</PaginationItem>
+										</PaginationContent>
+									</Pagination>
+								</div>
+							</DataTableCell>
+						</DataTableRow>
+					</DataTableFooter>
+				)}
 			</DataTable>
-			<InfiniteScrollSentinel
-				hasNext={!!hasNextPage}
-				isLoading={isFetchingNextPage}
-				onLoadMore={() => fetchNextPage()}
-			/>
 		</div>
 	);
 }

--- a/client/src/components/agents/AgentRunsPanel.tsx
+++ b/client/src/components/agents/AgentRunsPanel.tsx
@@ -161,19 +161,22 @@ export function AgentRunsPanel() {
 	}
 
 	return (
-		<div data-testid="agent-runs-panel">
-			<DataTable>
+		<div
+			className="flex min-h-0 min-w-0 flex-1 flex-col"
+			data-testid="agent-runs-panel"
+		>
+			<DataTable className="min-h-0 min-w-0 [&_table]:table-fixed xl:[&_table]:table-auto">
 				<DataTableHeader>
 					<DataTableRow>
-						<DataTableHead>Agent</DataTableHead>
-						<DataTableHead>Asked</DataTableHead>
-						<DataTableHead className="w-0 whitespace-nowrap">Status</DataTableHead>
-						<DataTableHead className="w-0 whitespace-nowrap text-right">
+						<DataTableHead className="w-full px-2 sm:w-40 sm:px-4">Agent</DataTableHead>
+						<DataTableHead className="hidden w-full sm:table-cell">Asked</DataTableHead>
+						<DataTableHead className="w-28 whitespace-nowrap px-2 sm:w-0 sm:px-4">Status</DataTableHead>
+						<DataTableHead className="hidden w-0 whitespace-nowrap text-right lg:table-cell">
 							Duration
 						</DataTableHead>
-						<DataTableHead className="w-0 whitespace-nowrap">Verdict</DataTableHead>
-						<DataTableHead className="w-0 whitespace-nowrap">Started</DataTableHead>
-						<DataTableHead className="w-0 whitespace-nowrap"></DataTableHead>
+						<DataTableHead className="hidden w-0 whitespace-nowrap xl:table-cell">Verdict</DataTableHead>
+						<DataTableHead className="hidden w-0 whitespace-nowrap xl:table-cell">Started</DataTableHead>
+						<DataTableHead className="w-11 whitespace-nowrap px-2 sm:px-4"></DataTableHead>
 					</DataTableRow>
 				</DataTableHeader>
 				<DataTableBody>
@@ -188,29 +191,48 @@ export function AgentRunsPanel() {
 								)
 							}
 						>
-							<DataTableCell>
-								<div className="flex items-center gap-2">
+							<DataTableCell className="min-w-0 overflow-hidden px-2 sm:px-4">
+								<div className="flex min-w-0 items-center gap-2">
 									<Bot className="h-3.5 w-3.5 text-muted-foreground" />
-									<span className="font-medium">
+									<span className="truncate font-medium">
 										{run.agent_name ?? "Agent"}
 									</span>
+									<span className="xl:hidden">
+										<VerdictGlyph verdict={run.verdict} />
+									</span>
+								</div>
+								<p className="mt-1 truncate text-xs text-muted-foreground sm:hidden">
+									{run.asked || run.did || "—"}
+								</p>
+								<div className="mt-1 flex min-w-0 flex-wrap items-center gap-x-3 gap-y-1 overflow-hidden text-xs text-muted-foreground xl:hidden">
+									<span className="inline-flex min-w-0 items-center gap-1">
+										<Clock className="h-3 w-3 shrink-0" />
+										<span className="truncate">
+											{run.started_at ? formatDate(run.started_at) : "—"}
+										</span>
+									</span>
+									{run.duration_ms != null && (
+										<span className="tabular-nums lg:hidden">
+											{formatDuration(run.duration_ms)}
+										</span>
+									)}
 								</div>
 							</DataTableCell>
-							<DataTableCell className="max-w-md truncate">
+							<DataTableCell className="hidden max-w-md truncate sm:table-cell">
 								{run.asked || run.did || "—"}
 							</DataTableCell>
-							<DataTableCell className="w-0 whitespace-nowrap">
+							<DataTableCell className="w-28 whitespace-nowrap px-2 sm:w-0 sm:px-4">
 								<RunStatusBadge status={run.status} />
 							</DataTableCell>
-							<DataTableCell className="w-0 whitespace-nowrap text-right tabular-nums">
+							<DataTableCell className="hidden w-0 whitespace-nowrap text-right tabular-nums lg:table-cell">
 								{run.duration_ms != null
 									? formatDuration(run.duration_ms)
 									: "—"}
 							</DataTableCell>
-							<DataTableCell className="w-0 whitespace-nowrap">
+							<DataTableCell className="hidden w-0 whitespace-nowrap xl:table-cell">
 								<VerdictGlyph verdict={run.verdict} />
 							</DataTableCell>
-							<DataTableCell className="w-0 whitespace-nowrap text-xs text-muted-foreground">
+							<DataTableCell className="hidden w-0 whitespace-nowrap text-xs text-muted-foreground xl:table-cell">
 								<span className="inline-flex items-center gap-1">
 									<Clock className="h-3 w-3" />
 									{run.started_at
@@ -219,12 +241,12 @@ export function AgentRunsPanel() {
 								</span>
 							</DataTableCell>
 							<DataTableCell
-								className="w-0 whitespace-nowrap"
+								className="w-11 whitespace-nowrap px-2 sm:w-0 sm:px-4"
 								onClick={(e) => e.stopPropagation()}
 							>
 								<Button
 									type="button"
-									size="sm"
+									size="icon-sm"
 									variant="ghost"
 									data-testid={`rerun-${run.id}`}
 									disabled={rerun.isPending}

--- a/client/src/components/ui/date-range-picker.tsx
+++ b/client/src/components/ui/date-range-picker.tsx
@@ -28,14 +28,14 @@ export function DateRangePicker({
 	};
 
 	return (
-		<div className={cn("flex gap-2", className)}>
+		<div className={cn("flex min-w-0 gap-2", className)}>
 			<Popover>
 				<PopoverTrigger asChild>
 					<Button
 						id="date"
 						variant={"outline"}
 						className={cn(
-							"w-[300px] justify-start text-left font-normal",
+							"w-full justify-start text-left font-normal sm:w-[300px]",
 							!dateRange && "text-muted-foreground",
 						)}
 					>

--- a/client/src/hooks/executionHistoryCache.test.ts
+++ b/client/src/hooks/executionHistoryCache.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "vitest";
+
+import type { HistoryUpdate } from "@/services/websocket";
+import {
+	mergeExecutionHistoryPage,
+	type ExecutionHistoryPage,
+} from "./executionHistoryCache";
+
+function row(id: string, startedAt: string) {
+	return {
+		execution_id: id,
+		workflow_name: `workflow-${id}`,
+		status: "Success",
+		started_at: startedAt,
+		created_at: startedAt,
+	};
+}
+
+function update(id: string, startedAt: string): HistoryUpdate {
+	return {
+		execution_id: id,
+		workflow_name: `workflow-${id}`,
+		status: "Running",
+		executed_by: "user-1",
+		executed_by_name: "Test User",
+		started_at: startedAt,
+		timestamp: startedAt,
+	};
+}
+
+function decodeCursor(token: string) {
+	const base64 = token.replace(/-/g, "+").replace(/_/g, "/");
+	return JSON.parse(globalThis.atob(base64)) as {
+		v: number;
+		s: string;
+		i: string;
+	};
+}
+
+describe("mergeExecutionHistoryPage", () => {
+	it("caps a paginated first page and moves its cursor to the visible tail", () => {
+		const page: ExecutionHistoryPage = {
+			executions: [
+				row("a", "2026-08-27T18:00:00.000000Z"),
+				row("b", "2026-08-27T17:59:00.000000Z"),
+				row("c", "2026-08-27T17:58:00.000000Z"),
+			],
+			continuation_token: "old-token",
+		};
+
+		const result = mergeExecutionHistoryPage(
+			page,
+			update("new", "2026-08-27T18:01:00.000000Z"),
+			true,
+		);
+
+		expect(result.executions.map((execution) => execution.execution_id)).toEqual([
+			"new",
+			"a",
+			"b",
+		]);
+		expect(decodeCursor(result.continuation_token!)).toEqual({
+			v: 1,
+			s: "2026-08-27T17:59:00.000000Z",
+			i: "b",
+		});
+	});
+
+	it("updates an existing row without changing the page boundary", () => {
+		const page: ExecutionHistoryPage = {
+			executions: [row("a", "2026-08-27T18:00:00Z")],
+			continuation_token: "server-token",
+		};
+
+		const result = mergeExecutionHistoryPage(
+			page,
+			{ ...update("a", "2026-08-27T18:00:00Z"), status: "Success" },
+			true,
+		);
+
+		expect(result.executions[0].status).toBe("Success");
+		expect(result.continuation_token).toBe("server-token");
+	});
+
+	it("does not insert an unseen row into a filtered page", () => {
+		const page: ExecutionHistoryPage = {
+			executions: [row("a", "2026-08-27T18:00:00Z")],
+			continuation_token: null,
+		};
+
+		expect(
+			mergeExecutionHistoryPage(
+				page,
+				update("new", "2026-08-27T18:01:00Z"),
+				false,
+			),
+		).toBe(page);
+	});
+
+	it("prepends without trimming when the server says there is no next page", () => {
+		const page: ExecutionHistoryPage = {
+			executions: [row("a", "2026-08-27T18:00:00Z")],
+			continuation_token: null,
+		};
+
+		const result = mergeExecutionHistoryPage(
+			page,
+			update("new", "2026-08-27T18:01:00Z"),
+			true,
+		);
+
+		expect(result.executions).toHaveLength(2);
+		expect(result.continuation_token).toBeNull();
+	});
+});
+

--- a/client/src/hooks/executionHistoryCache.ts
+++ b/client/src/hooks/executionHistoryCache.ts
@@ -1,0 +1,84 @@
+import type { HistoryUpdate } from "@/services/websocket";
+
+export interface HistoryExecutionRecord extends Record<string, unknown> {
+	execution_id: string;
+	started_at?: string | null;
+	scheduled_at?: string | null;
+	completed_at?: string | null;
+	created_at?: string | null;
+}
+
+export interface ExecutionHistoryPage {
+	executions: HistoryExecutionRecord[];
+	continuation_token: string | null;
+}
+
+function encodeHistoryCursor(execution: HistoryExecutionRecord): string {
+	const timelineAt =
+		execution.started_at ??
+		execution.scheduled_at ??
+		execution.completed_at ??
+		execution.created_at;
+	const payload = JSON.stringify({
+		v: 1,
+		s: timelineAt,
+		i: execution.execution_id,
+	});
+	return globalThis
+		.btoa(payload)
+		.replace(/\+/g, "-")
+		.replace(/\//g, "_");
+}
+
+/** Apply one History WebSocket event without corrupting the server page boundary. */
+export function mergeExecutionHistoryPage(
+	page: ExecutionHistoryPage,
+	update: HistoryUpdate,
+	allowInsert: boolean,
+): ExecutionHistoryPage {
+	const existingIndex = page.executions.findIndex(
+		(execution) => execution.execution_id === update.execution_id,
+	);
+
+	if (existingIndex >= 0) {
+		const executions = [...page.executions];
+		executions[existingIndex] = {
+			...executions[existingIndex],
+			status: update.status,
+			...(update.started_at && { started_at: update.started_at }),
+			completed_at: update.completed_at,
+			duration_ms: update.duration_ms,
+		};
+		return { ...page, executions };
+	}
+
+	if (!allowInsert) return page;
+
+	const inserted: HistoryExecutionRecord = {
+		execution_id: update.execution_id,
+		workflow_name: update.workflow_name,
+		status: update.status,
+		executed_by: update.executed_by,
+		executed_by_name: update.executed_by_name,
+		org_id: update.org_id,
+		started_at: update.started_at,
+		completed_at: update.completed_at,
+		created_at: update.timestamp,
+		duration_ms: update.duration_ms,
+	};
+
+	if (page.continuation_token === null) {
+		return { ...page, executions: [inserted, ...page.executions] };
+	}
+
+	const executions = [inserted, ...page.executions].slice(
+		0,
+		page.executions.length,
+	);
+	return {
+		...page,
+		executions,
+		continuation_token: encodeHistoryCursor(executions[executions.length - 1]),
+	};
+}
+

--- a/client/src/hooks/useExecutionStream.ts
+++ b/client/src/hooks/useExecutionStream.ts
@@ -17,6 +17,10 @@ import {
 	type StreamingLog,
 	type ExecutionStatus,
 } from "@/stores/executionStreamStore";
+import {
+	mergeExecutionHistoryPage,
+	type ExecutionHistoryPage,
+} from "@/hooks/executionHistoryCache";
 
 interface UseExecutionStreamOptions {
 	/**
@@ -308,10 +312,7 @@ export function useExecutionHistory(
 
 						// Optimistically update ALL executions queries (handles different filters/pages)
 						// Query key is ["get", "/api/executions", { params: ... }]
-						const caches = queryClient.getQueriesData<{
-							executions: Array<Record<string, unknown>>;
-							continuation_token: string | null;
-						}>({
+						const caches = queryClient.getQueriesData<ExecutionHistoryPage>({
 							queryKey: ["get", "/api/executions"],
 						});
 
@@ -330,6 +331,8 @@ export function useExecutionHistory(
 												status?: string;
 												startDate?: string;
 												endDate?: string;
+												workflowId?: string;
+												workflow_name?: string;
 											};
 										};
 								  }
@@ -340,62 +343,21 @@ export function useExecutionHistory(
 								return;
 							}
 
-							const existingIndex = oldData.executions.findIndex(
-								(exec) =>
-									exec["execution_id"] ===
-									update["execution_id"],
-							);
-
-							if (existingIndex >= 0) {
-								// Update existing execution - React will handle reconciliation via key={execution_id}
-								const newExecutions = [...oldData.executions];
-								newExecutions[existingIndex] = {
-									...newExecutions[existingIndex],
-									status: update.status,
-									// Only update started_at if we have a value (handles Pending -> Running transition)
-									...(update.started_at && {
-										started_at: update.started_at,
-									}),
-									completed_at: update.completed_at,
-									duration_ms: update.duration_ms,
-								};
-
-								queryClient.setQueryData(queryKey, {
-									...oldData,
-									executions: newExecutions,
-								});
-							} else {
-								// New execution - add to beginning of list (only if no filters active)
-								// Check if query has status/date filters that might exclude this execution
-								const queryParams = params?.params?.query || {};
-								const hasFilters =
-									queryParams.status ||
+							const queryParams = params?.params?.query || {};
+							const hasFilters = Boolean(
+								queryParams.status ||
 									queryParams.startDate ||
-									queryParams.endDate;
-
-								if (!hasFilters) {
-									queryClient.setQueryData(queryKey, {
-										...oldData,
-										executions: [
-											{
-												execution_id:
-													update.execution_id,
-												workflow_name:
-													update.workflow_name,
-												status: update.status,
-												executed_by: update.executed_by,
-												executed_by_name:
-													update.executed_by_name,
-												org_id: update.org_id,
-												started_at: update.started_at,
-												completed_at:
-													update.completed_at,
-												duration_ms: update.duration_ms,
-											},
-											...oldData.executions,
-										],
-									});
-								}
+									queryParams.endDate ||
+									queryParams.workflowId ||
+									queryParams.workflow_name,
+							);
+							const nextData = mergeExecutionHistoryPage(
+								oldData,
+								update,
+								!hasFilters,
+							);
+							if (nextData !== oldData) {
+								queryClient.setQueryData(queryKey, nextData);
 							}
 						});
 					},

--- a/client/src/lib/v1.d.ts
+++ b/client/src/lib/v1.d.ts
@@ -16113,6 +16113,8 @@ export interface components {
             completed_at?: string | null;
             /** Scheduled At */
             scheduled_at?: string | null;
+            /** Created At */
+            created_at?: string | null;
             /** Session Id */
             session_id?: string | null;
             /** Peak Memory Bytes */
@@ -26257,6 +26259,8 @@ export interface components {
             completed_at?: string | null;
             /** Scheduled At */
             scheduled_at?: string | null;
+            /** Created At */
+            created_at?: string | null;
             /** Session Id */
             session_id?: string | null;
             /** Peak Memory Bytes */

--- a/client/src/pages/ExecutionHistory.test.tsx
+++ b/client/src/pages/ExecutionHistory.test.tsx
@@ -440,7 +440,14 @@ describe("ExecutionHistory — feed rendering", () => {
 
 		expect(
 			screen.getByRole("region", { name: "History" }),
-		).toHaveClass("mx-auto", "w-full", "max-w-7xl");
+		).toHaveClass(
+			"mx-auto",
+			"h-full",
+			"min-h-0",
+			"w-full",
+			"max-w-7xl",
+			"pb-1",
+		);
 		expect(
 			screen.getByRole("columnheader", { name: "Workflow" }),
 		).toHaveClass("w-full");
@@ -465,6 +472,9 @@ describe("ExecutionHistory — feed rendering", () => {
 			"sm:overflow-visible",
 		);
 		expect(screen.getByRole("tablist")).not.toHaveClass("overflow-x-auto");
+		expect(
+			screen.getByRole("tablist").closest('[data-slot="tabs"]'),
+		).toHaveClass("min-h-0", "flex-1");
 		expect(screen.getByText("by Test User")).toBeInTheDocument();
 	});
 

--- a/client/src/pages/ExecutionHistory.test.tsx
+++ b/client/src/pages/ExecutionHistory.test.tsx
@@ -424,6 +424,36 @@ describe("ExecutionHistory — summary rollup", () => {
 });
 
 describe("ExecutionHistory — feed rendering", () => {
+	it("keeps metadata columns content-sized and lets Workflow fill the table", async () => {
+		mockAuth.mockReturnValue({
+			isPlatformAdmin: true,
+			user: { id: "user-1", email: "u@example.com" },
+		});
+		mockUseExecutions.mockReturnValue({
+			data: { executions: [makeRow()], continuation_token: null },
+			isFetching: false,
+			isError: false,
+			refetch: mockRefetch,
+		});
+
+		await renderPage();
+
+		expect(
+			screen.getByRole("columnheader", { name: "Workflow" }),
+		).toHaveClass("w-full");
+		for (const name of [
+			"Organization",
+			"Status",
+			"Run by",
+			"Started",
+			"Duration",
+		]) {
+			expect(screen.getByRole("columnheader", { name })).toHaveClass(
+				"w-px",
+			);
+		}
+	});
+
 	it("groups rows under day separator rows", async () => {
 		const today = new Date();
 		today.setHours(9, 0, 0, 0);

--- a/client/src/pages/ExecutionHistory.test.tsx
+++ b/client/src/pages/ExecutionHistory.test.tsx
@@ -424,7 +424,7 @@ describe("ExecutionHistory — summary rollup", () => {
 });
 
 describe("ExecutionHistory — feed rendering", () => {
-	it("keeps metadata columns content-sized and lets Workflow fill the table", async () => {
+	it("keeps Workflow flexible and progressively collapses metadata columns", async () => {
 		mockAuth.mockReturnValue({
 			isPlatformAdmin: true,
 			user: { id: "user-1", email: "u@example.com" },
@@ -441,17 +441,22 @@ describe("ExecutionHistory — feed rendering", () => {
 		expect(
 			screen.getByRole("columnheader", { name: "Workflow" }),
 		).toHaveClass("w-full");
-		for (const name of [
-			"Organization",
-			"Status",
-			"Run by",
-			"Started",
-			"Duration",
-		]) {
-			expect(screen.getByRole("columnheader", { name })).toHaveClass(
-				"w-px",
-			);
-		}
+		expect(
+			screen.getByRole("columnheader", { name: "Organization" }),
+		).toHaveClass("hidden", "xl:table-cell");
+		expect(
+			screen.getByRole("columnheader", { name: "Status" }),
+		).toHaveClass("w-px");
+		expect(
+			screen.getByRole("columnheader", { name: "Run by" }),
+		).toHaveClass("hidden", "xl:table-cell");
+		expect(
+			screen.getByRole("columnheader", { name: "Started" }),
+		).toHaveClass("hidden", "lg:table-cell");
+		expect(
+			screen.getByRole("columnheader", { name: "Duration" }),
+		).toHaveClass("hidden", "xl:table-cell");
+		expect(screen.getByText("by Test User")).toBeInTheDocument();
 	});
 
 	it("groups rows under day separator rows", async () => {

--- a/client/src/pages/ExecutionHistory.test.tsx
+++ b/client/src/pages/ExecutionHistory.test.tsx
@@ -439,6 +439,9 @@ describe("ExecutionHistory — feed rendering", () => {
 		await renderPage();
 
 		expect(
+			screen.getByRole("region", { name: "History" }),
+		).toHaveClass("mx-auto", "w-full", "max-w-7xl");
+		expect(
 			screen.getByRole("columnheader", { name: "Workflow" }),
 		).toHaveClass("w-full");
 		expect(
@@ -456,6 +459,12 @@ describe("ExecutionHistory — feed rendering", () => {
 		expect(
 			screen.getByRole("columnheader", { name: "Duration" }),
 		).toHaveClass("hidden", "xl:table-cell");
+		expect(screen.getByRole("tablist").parentElement).toHaveClass(
+			"no-scrollbar",
+			"overflow-x-auto",
+			"sm:overflow-visible",
+		);
+		expect(screen.getByRole("tablist")).not.toHaveClass("overflow-x-auto");
 		expect(screen.getByText("by Test User")).toBeInTheDocument();
 	});
 

--- a/client/src/pages/ExecutionHistory.tsx
+++ b/client/src/pages/ExecutionHistory.tsx
@@ -885,18 +885,18 @@ export function ExecutionHistory() {
 							<DataTableHeader>
 								<DataTableRow>
 									{isPlatformAdmin && (
-										<DataTableHead>
+										<DataTableHead className="w-px">
 											Organization
 										</DataTableHead>
 									)}
-									<DataTableHead>Workflow</DataTableHead>
-									<DataTableHead>Status</DataTableHead>
-									<DataTableHead>Run by</DataTableHead>
-									<DataTableHead>Started</DataTableHead>
-									<DataTableHead className="text-right">
+									<DataTableHead className="w-full">Workflow</DataTableHead>
+									<DataTableHead className="w-px">Status</DataTableHead>
+									<DataTableHead className="w-px">Run by</DataTableHead>
+									<DataTableHead className="w-px">Started</DataTableHead>
+									<DataTableHead className="w-px text-right">
 										Duration
 									</DataTableHead>
-									<DataTableHead className="text-right"></DataTableHead>
+									<DataTableHead className="w-px text-right"></DataTableHead>
 								</DataTableRow>
 							</DataTableHeader>
 							<DataTableBody>
@@ -960,7 +960,7 @@ export function ExecutionHistory() {
 													}}
 												>
 													{isPlatformAdmin && (
-														<DataTableCell className="text-sm text-muted-foreground">
+														<DataTableCell className="w-px whitespace-nowrap text-sm text-muted-foreground">
 															{isGlobalExecution ? (
 																<span className="inline-flex items-center gap-1.5">
 																	<Globe className="h-3.5 w-3.5" />
@@ -974,7 +974,7 @@ export function ExecutionHistory() {
 														</DataTableCell>
 													)}
 													<DataTableCell
-														className="max-w-md"
+														className="w-full max-w-0"
 														data-testid="execution-workflow-cell"
 													>
 														<div className="truncate font-mono text-sm font-medium">
@@ -994,7 +994,7 @@ export function ExecutionHistory() {
 															</div>
 														)}
 													</DataTableCell>
-													<DataTableCell>
+													<DataTableCell className="w-px whitespace-nowrap">
 														<RunStatusBadge
 															status={displayStatus}
 															scheduledAt={
@@ -1002,11 +1002,11 @@ export function ExecutionHistory() {
 															}
 														/>
 													</DataTableCell>
-													<DataTableCell className="text-sm text-muted-foreground">
+													<DataTableCell className="w-px whitespace-nowrap text-sm text-muted-foreground">
 														{execution.executed_by_name}
 													</DataTableCell>
 													<DataTableCell
-														className="whitespace-nowrap text-sm text-muted-foreground"
+														className="w-px whitespace-nowrap text-sm text-muted-foreground"
 														title={
 															anchor
 																? formatDate(anchor)
@@ -1019,7 +1019,7 @@ export function ExecutionHistory() {
 																)
 															: "—"}
 													</DataTableCell>
-													<DataTableCell className="whitespace-nowrap text-right text-sm tabular-nums text-muted-foreground">
+													<DataTableCell className="w-px whitespace-nowrap text-right text-sm tabular-nums text-muted-foreground">
 														{duration ?? "—"}
 													</DataTableCell>
 													<DataTableCell className="w-px text-right">

--- a/client/src/pages/ExecutionHistory.tsx
+++ b/client/src/pages/ExecutionHistory.tsx
@@ -481,11 +481,11 @@ export function ExecutionHistory() {
 	const showPaginationFooter = hasMore || pageStack.length > 0;
 
 	return (
-		<div className="h-full flex flex-col space-y-6">
+		<div className="flex h-full min-w-0 flex-col space-y-4 sm:space-y-6">
 			{/* Header */}
-			<div className="flex items-center justify-between">
-				<div className="flex items-center gap-4">
-					<h1 className="text-4xl font-extrabold tracking-tight">
+			<div className="flex items-start justify-between gap-3 sm:items-center">
+				<div className="flex min-w-0 flex-col gap-3 sm:flex-row sm:items-center sm:gap-4">
+					<h1 className="text-3xl font-extrabold tracking-tight sm:text-4xl">
 						History
 					</h1>
 					{isPlatformAdmin ? (
@@ -662,7 +662,7 @@ export function ExecutionHistory() {
 			</div>
 			{/* Summary line: the rollup an operator actually scans for. */}
 			<p
-				className="-mt-4 text-sm text-muted-foreground"
+				className="-mt-2 text-sm text-muted-foreground sm:-mt-4"
 				data-testid="history-summary"
 			>
 				{historyType === "agents" ? (
@@ -698,14 +698,14 @@ export function ExecutionHistory() {
 			<>
 			{/* Filters: search first and widest, entity filters grouped,
 			    mode/debug toggles demoted to the end of the row. */}
-			<div className="flex items-center gap-3">
+			<div className="grid min-w-0 grid-cols-1 gap-3 sm:grid-cols-2 xl:flex xl:items-center">
 				<SearchBox
 					value={searchTerm}
 					onChange={setSearchTerm}
 					placeholder={viewMode === "logs"
 						? "Search by workflow name..."
 						: "Search by workflow name, user, or execution ID..."}
-					className="flex-1 max-w-md"
+					className="w-full sm:col-span-2 xl:max-w-md xl:flex-1"
 				/>
 				{isPlatformAdmin && (
 					<WorkflowSelector
@@ -726,11 +726,11 @@ export function ExecutionHistory() {
 						variant="combobox"
 						allowClear={true}
 						placeholder="All workflows"
-						className="w-48"
+						className="w-full xl:w-48"
 					/>
 				)}
 				{isPlatformAdmin && (
-					<div className="w-56">
+					<div className="w-full xl:w-56">
 						<OrganizationSelect
 							value={filterOrgId}
 							onChange={setFilterOrgId}
@@ -743,8 +743,9 @@ export function ExecutionHistory() {
 				<DateRangePicker
 					dateRange={dateRange}
 					onDateRangeChange={setDateRange}
+					className="w-full sm:w-auto"
 				/>
-				<div className="ml-auto flex items-center gap-3">
+				<div className="flex flex-wrap items-center gap-3 sm:col-span-2 xl:ml-auto">
 					{/* Show Local Executions - only for executions view */}
 					{viewMode === "executions" && (
 						<div className="flex items-center gap-2">
@@ -799,7 +800,7 @@ export function ExecutionHistory() {
 					className="flex flex-col flex-1 min-h-0"
 				>
 					{/* Log Level Tabs */}
-					<TabsList className="w-fit">
+					<TabsList className="max-w-full justify-start overflow-x-auto">
 						<TabsTrigger value="all">All</TabsTrigger>
 						<TabsTrigger value="DEBUG">Debug</TabsTrigger>
 						<TabsTrigger value="INFO">Info</TabsTrigger>
@@ -822,9 +823,9 @@ export function ExecutionHistory() {
 					onValueChange={(v) =>
 						setStatusFilter(v as ExecutionStatus | "all")
 					}
-					className="flex flex-col flex-1 min-h-0"
+					className="flex min-w-0 flex-1 flex-col"
 				>
-				<TabsList className="w-fit">
+				<TabsList className="max-w-full justify-start overflow-x-auto">
 					<TabsTrigger value="all">All</TabsTrigger>
 					<TabsTrigger value="Success">Completed</TabsTrigger>
 					<TabsTrigger value="Running">Running</TabsTrigger>
@@ -881,19 +882,19 @@ export function ExecutionHistory() {
 							))}
 						</div>
 					) : filteredExecutions.length > 0 ? (
-						<DataTable>
+						<DataTable className="min-w-0">
 							<DataTableHeader>
 								<DataTableRow>
 									{isPlatformAdmin && (
-										<DataTableHead className="w-px">
+										<DataTableHead className="hidden w-px xl:table-cell">
 											Organization
 										</DataTableHead>
 									)}
 									<DataTableHead className="w-full">Workflow</DataTableHead>
 									<DataTableHead className="w-px">Status</DataTableHead>
-									<DataTableHead className="w-px">Run by</DataTableHead>
-									<DataTableHead className="w-px">Started</DataTableHead>
-									<DataTableHead className="w-px text-right">
+									<DataTableHead className="hidden w-px xl:table-cell">Run by</DataTableHead>
+									<DataTableHead className="hidden w-px lg:table-cell">Started</DataTableHead>
+									<DataTableHead className="hidden w-px text-right xl:table-cell">
 										Duration
 									</DataTableHead>
 									<DataTableHead className="w-px text-right"></DataTableHead>
@@ -960,7 +961,7 @@ export function ExecutionHistory() {
 													}}
 												>
 													{isPlatformAdmin && (
-														<DataTableCell className="w-px whitespace-nowrap text-sm text-muted-foreground">
+														<DataTableCell className="hidden w-px whitespace-nowrap text-sm text-muted-foreground xl:table-cell">
 															{isGlobalExecution ? (
 																<span className="inline-flex items-center gap-1.5">
 																	<Globe className="h-3.5 w-3.5" />
@@ -993,6 +994,28 @@ export function ExecutionHistory() {
 																}
 															</div>
 														)}
+														<div
+															className="mt-1 flex flex-wrap items-center gap-x-2 gap-y-0.5 text-xs text-muted-foreground xl:hidden"
+														>
+															{isPlatformAdmin && (
+																<span>
+																	{isGlobalExecution
+																		? "Global"
+																		: getOrgName(execution.org_id)}
+																</span>
+															)}
+															<span className="xl:hidden">
+																by {execution.executed_by_name}
+															</span>
+															<span className="lg:hidden">
+																{anchorIso
+																	? formatRunTime(anchorIso)
+																	: "Not started"}
+															</span>
+															<span className="xl:hidden">
+																{duration ?? "No duration"}
+															</span>
+														</div>
 													</DataTableCell>
 													<DataTableCell className="w-px whitespace-nowrap">
 														<RunStatusBadge
@@ -1002,11 +1025,11 @@ export function ExecutionHistory() {
 															}
 														/>
 													</DataTableCell>
-													<DataTableCell className="w-px whitespace-nowrap text-sm text-muted-foreground">
+													<DataTableCell className="hidden w-px whitespace-nowrap text-sm text-muted-foreground xl:table-cell">
 														{execution.executed_by_name}
 													</DataTableCell>
 													<DataTableCell
-														className="w-px whitespace-nowrap text-sm text-muted-foreground"
+														className="hidden w-px whitespace-nowrap text-sm text-muted-foreground lg:table-cell"
 														title={
 															anchor
 																? formatDate(anchor)
@@ -1019,7 +1042,7 @@ export function ExecutionHistory() {
 																)
 															: "—"}
 													</DataTableCell>
-													<DataTableCell className="w-px whitespace-nowrap text-right text-sm tabular-nums text-muted-foreground">
+													<DataTableCell className="hidden w-px whitespace-nowrap text-right text-sm tabular-nums text-muted-foreground xl:table-cell">
 														{duration ?? "—"}
 													</DataTableCell>
 													<DataTableCell className="w-px text-right">
@@ -1066,7 +1089,7 @@ export function ExecutionHistory() {
 																</Button>
 															)}
 															<ChevronRight
-																className="h-4 w-4 text-muted-foreground/50"
+																className="hidden h-4 w-4 text-muted-foreground/50 sm:block"
 																aria-hidden="true"
 															/>
 														</div>

--- a/client/src/pages/ExecutionHistory.tsx
+++ b/client/src/pages/ExecutionHistory.tsx
@@ -481,11 +481,17 @@ export function ExecutionHistory() {
 	const showPaginationFooter = hasMore || pageStack.length > 0;
 
 	return (
-		<div className="flex h-full min-w-0 flex-col space-y-4 sm:space-y-6">
+		<section
+			aria-labelledby="history-heading"
+			className="mx-auto flex h-full w-full max-w-7xl min-w-0 flex-col space-y-4 sm:space-y-6"
+		>
 			{/* Header */}
 			<div className="flex items-start justify-between gap-3 sm:items-center">
 				<div className="flex min-w-0 flex-col gap-3 sm:flex-row sm:items-center sm:gap-4">
-					<h1 className="text-3xl font-extrabold tracking-tight sm:text-4xl">
+					<h1
+						id="history-heading"
+						className="text-3xl font-extrabold tracking-tight sm:text-4xl"
+					>
 						History
 					</h1>
 					{isPlatformAdmin ? (
@@ -800,14 +806,16 @@ export function ExecutionHistory() {
 					className="flex flex-col flex-1 min-h-0"
 				>
 					{/* Log Level Tabs */}
-					<TabsList className="max-w-full justify-start overflow-x-auto">
-						<TabsTrigger value="all">All</TabsTrigger>
-						<TabsTrigger value="DEBUG">Debug</TabsTrigger>
-						<TabsTrigger value="INFO">Info</TabsTrigger>
-						<TabsTrigger value="WARNING">Warning</TabsTrigger>
-						<TabsTrigger value="ERROR">Error</TabsTrigger>
-						<TabsTrigger value="CRITICAL">Critical</TabsTrigger>
-					</TabsList>
+					<div className="no-scrollbar w-fit max-w-full overflow-x-auto sm:overflow-visible">
+						<TabsList className="w-max justify-start">
+							<TabsTrigger value="all">All</TabsTrigger>
+							<TabsTrigger value="DEBUG">Debug</TabsTrigger>
+							<TabsTrigger value="INFO">Info</TabsTrigger>
+							<TabsTrigger value="WARNING">Warning</TabsTrigger>
+							<TabsTrigger value="ERROR">Error</TabsTrigger>
+							<TabsTrigger value="CRITICAL">Critical</TabsTrigger>
+						</TabsList>
+					</div>
 
 					{/* Logs View */}
 					<LogsView
@@ -825,14 +833,16 @@ export function ExecutionHistory() {
 					}
 					className="flex min-w-0 flex-1 flex-col"
 				>
-				<TabsList className="max-w-full justify-start overflow-x-auto">
-					<TabsTrigger value="all">All</TabsTrigger>
-					<TabsTrigger value="Success">Completed</TabsTrigger>
-					<TabsTrigger value="Running">Running</TabsTrigger>
-					<TabsTrigger value="Failed">Failed</TabsTrigger>
-					<TabsTrigger value="Pending">Pending</TabsTrigger>
-					<TabsTrigger value="Scheduled">Scheduled</TabsTrigger>
-				</TabsList>
+				<div className="no-scrollbar w-fit max-w-full overflow-x-auto sm:overflow-visible">
+					<TabsList className="w-max justify-start">
+						<TabsTrigger value="all">All</TabsTrigger>
+						<TabsTrigger value="Success">Completed</TabsTrigger>
+						<TabsTrigger value="Running">Running</TabsTrigger>
+						<TabsTrigger value="Failed">Failed</TabsTrigger>
+						<TabsTrigger value="Pending">Pending</TabsTrigger>
+						<TabsTrigger value="Scheduled">Scheduled</TabsTrigger>
+					</TabsList>
+				</div>
 
 				<TabsContent
 					value={statusFilter}
@@ -1247,6 +1257,6 @@ export function ExecutionHistory() {
 				onOpenChange={setDrawerOpen}
 				onExecutionChange={setDrawerExecutionId}
 			/>
-		</div>
+		</section>
 	);
 }

--- a/client/src/pages/ExecutionHistory.tsx
+++ b/client/src/pages/ExecutionHistory.tsx
@@ -483,7 +483,7 @@ export function ExecutionHistory() {
 	return (
 		<section
 			aria-labelledby="history-heading"
-			className="mx-auto flex h-full w-full max-w-7xl min-w-0 flex-col space-y-4 sm:space-y-6"
+			className="mx-auto flex h-full min-h-0 w-full max-w-7xl min-w-0 flex-col space-y-4 pb-1 sm:space-y-6"
 		>
 			{/* Header */}
 			<div className="flex items-start justify-between gap-3 sm:items-center">
@@ -831,7 +831,7 @@ export function ExecutionHistory() {
 					onValueChange={(v) =>
 						setStatusFilter(v as ExecutionStatus | "all")
 					}
-					className="flex min-w-0 flex-1 flex-col"
+					className="flex min-h-0 min-w-0 flex-1 flex-col"
 				>
 				<div className="no-scrollbar w-fit max-w-full overflow-x-auto sm:overflow-visible">
 					<TabsList className="w-max justify-start">

--- a/client/src/pages/ExecutionHistory/components/historyView.test.ts
+++ b/client/src/pages/ExecutionHistory/components/historyView.test.ts
@@ -28,7 +28,7 @@ function run(overrides: Record<string, unknown> = {}) {
 }
 
 describe("runAnchorDate", () => {
-	it("prefers started_at, then scheduled_at, then completed_at", () => {
+	it("prefers started_at, then scheduled_at, then completed_at, then created_at", () => {
 		expect(
 			runAnchorDate(
 				run({ started_at: "2026-06-11T10:00:00Z" }),
@@ -52,6 +52,16 @@ describe("runAnchorDate", () => {
 				}),
 			)?.toISOString(),
 		).toBe("2026-06-10T08:00:00.000Z");
+		expect(
+			runAnchorDate(
+				run({
+					started_at: null,
+					scheduled_at: null,
+					completed_at: null,
+					created_at: "2026-06-09T08:00:00Z",
+				}),
+			)?.toISOString(),
+		).toBe("2026-06-09T08:00:00.000Z");
 	});
 
 	it("returns null when no timestamp exists", () => {
@@ -68,6 +78,27 @@ describe("runAnchorDate", () => {
 });
 
 describe("groupExecutionsByDay", () => {
+	it("uses created_at for a pending execution that has not started", () => {
+		const createdAt = "2026-06-11T14:00:00Z";
+		const groups = groupExecutionsByDay(
+			[
+				run({
+					execution_id: "pending",
+					status: "Pending",
+					started_at: null,
+					scheduled_at: null,
+					completed_at: null,
+					created_at: createdAt,
+				}),
+			],
+			new Date("2026-06-11T16:00:00Z"),
+		);
+
+		expect(groups).toHaveLength(1);
+		expect(groups[0].key).not.toBe("unknown");
+		expect(groups[0].executions[0].execution_id).toBe("pending");
+	});
+
 	it("groups consecutive same-day runs and labels Today/Yesterday", () => {
 		// Use a fixed "now" at local noon so day boundaries are stable.
 		const now = new Date(2026, 5, 11, 12, 0, 0); // local Jun 11, 2026

--- a/client/src/pages/ExecutionHistory/components/historyView.ts
+++ b/client/src/pages/ExecutionHistory/components/historyView.ts
@@ -13,6 +13,7 @@ export interface HistoryRunLike {
 	started_at?: string | null;
 	completed_at?: string | null;
 	scheduled_at?: string | null;
+	created_at?: string | null;
 }
 
 export interface DayGroup<T extends HistoryRunLike> {
@@ -25,7 +26,11 @@ export interface DayGroup<T extends HistoryRunLike> {
 
 /** The timestamp that anchors a run on the timeline. */
 export function runAnchorDate(run: HistoryRunLike): Date | null {
-	const iso = run.started_at ?? run.scheduled_at ?? run.completed_at;
+	const iso =
+		run.started_at ??
+		run.scheduled_at ??
+		run.completed_at ??
+		run.created_at;
 	if (!iso) return null;
 	const date = parseBackendDate(iso);
 	return Number.isNaN(date.getTime()) ? null : date;

--- a/client/src/services/websocket.ts
+++ b/client/src/services/websocket.ts
@@ -125,7 +125,7 @@ export interface NewExecution {
 	executed_by: string;
 	executed_by_name: string;
 	status: string;
-	started_at: string;
+	started_at: string | null;
 	timestamp: string;
 }
 


### PR DESCRIPTION
## Summary

- order History rows and keyset cursors by the same effective timeline timestamp used by the UI
- add a concurrent expression index so the corrected ordering remains efficient in production
- keep live first-page cache updates capped to the server page size and advance the continuation cursor to the visible tail
- expose `created_at` as the fallback anchor for executions that have not started
- restore the History table sizing contract: Workflow flexes while Organization, Status, Run by, Started, Duration, and actions remain content-sized
- adapt the full History surface for narrow screens: reflow filters, scroll overflowing status tabs, collapse secondary table columns, and preserve their values beneath Workflow
- center and cap the History workspace at `max-w-7xl` on wide displays, and limit status-tab overflow behavior to mobile widths where the tabs genuinely exceed the viewport
- keep both History tabs bounded to the available viewport height with bottom breathing room, so the table body scrolls instead of the whole page
- make the Agents table responsive too, preserving run metadata inline as secondary columns collapse
- give Agent runs the same explicit 25-row Previous/Next pagination model as Workflow executions instead of infinite scrolling

## Production evidence

Production page one contained one cancelled scheduled execution with `started_at = NULL` and `scheduled_at = 2026-06-12`. PostgreSQL placed it in the leading null block; the UI regrouped it under June 12 at the bottom of the otherwise-current page.

## Verification

- `./test.sh tests/e2e/platform/test_execution_history_pagination.py tests/unit/routers/test_executions_pagination.py tests/unit/routers/test_executions_list_payload.py -v` — 8 passed
- `./test.sh tests/unit/routers/test_executions_list_payload.py tests/unit/test_dto_flags.py tests/unit/test_contract_version.py -v` — 67 passed
- `./test.sh client unit src/hooks/executionHistoryCache.test.ts src/pages/ExecutionHistory/components/historyView.test.ts src/pages/ExecutionHistory.test.tsx` — 31 passed before the column regression test was added
- `./test.sh client unit src/pages/ExecutionHistory.test.tsx` — 15 passed with the column sizing regression test
- `./test.sh client unit src/pages/ExecutionHistory.test.tsx src/components/agents/AgentRunsPanel.test.tsx` — 18 passed
- `./test.sh client e2e e2e/executions.admin.spec.ts` — all 12 setup and execution-history Playwright tests passed
- `./test.sh quality api` — pyright and ruff passed
- `npm run tsc -- --pretty false` — passed
- `npm run lint` — passed with two existing warnings in untouched files
- regenerated `client/src/lib/v1.d.ts` from this worktree's running API
- seeded 82 mixed executions in the debug stack and verified API + rendered UI pagination as `25 / 25 / 25 / 7`, with 82 unique IDs and the stale June row appearing only as the final row on page 4
- browser-verified the seeded History page at 1440, 1024, 768, and 375 px: Workflow absorbed available width, secondary metadata moved inline at narrower breakpoints, and neither the document nor table overflowed
- browser-verified a 2048 px viewport caps the centered History surface at exactly 1280 px; status-tab overflow computes to `visible` from 640 px upward and `auto` only on mobile
- seeded 82 agent runs (80 completed, one failed, one running) and browser-verified both tabs at 1440×900 and 375×812: document/main scroll heights equal their client heights, result tables own vertical scrolling, bottom spacing remains visible, and the mobile Agents table has no horizontal overflow
- browser-verified Agent pagination across the seeded run history as `25 / 25 / 25 / 8`
- Impeccable UI detector — no findings
- `./test.sh pre-pr` — passed against candidate `7ab3c95055e6`: production builds, TypeScript, lint, 1,869 client tests, 5,788 backend unit tests, 1,780 backend E2E tests, four Playwright smoke tests, and production API smoke

The full Playwright suite was not run locally; the focused 12-test execution-history suite and the four-test pre-PR smoke suite passed. All other required local pre-PR gates passed.

Fixes #661
