### PR TITLE
fix(ai): make provider rate-limit retries burst resilient

### DIFF
--- a/api/src/routers/mcp.py
+++ b/api/src/routers/mcp.py
@@ -455,7 +455,10 @@ async def update_mcp_config(
         updated_by=current_user.email,
     )
 
-    # Invalidate cache so auth middleware picks up changes
+    # The request-scoped DB dependency commits after the response is sent.
+    # Commit this feature-flag transition before invalidating the cache and
+    # returning so the next gateway request cannot observe the old value.
+    await db.commit()
     invalidate_mcp_config_cache()
 
     return MCPConfigResponse(
@@ -490,7 +493,8 @@ async def delete_mcp_config(
     service = MCPConfigService(db)
     deleted = await service.delete_config()
 
-    # Invalidate cache
+    # Keep the reset visible before the caller can make its next MCP request.
+    await db.commit()
     invalidate_mcp_config_cache()
 
     if deleted:

--- a/api/src/services/agent_runtime/retry_transport.py
+++ b/api/src/services/agent_runtime/retry_transport.py
@@ -19,7 +19,6 @@ from pydantic_ai.models import get_user_agent
 from pydantic_ai.retries import (
     AsyncHTTPX2TenacityTransport,
     RetryConfig,
-    wait_retry_after,
 )
 from tenacity import (
     AsyncRetrying,
@@ -37,6 +36,11 @@ RETRYABLE_STATUS_CODES = frozenset({408, 429, 500, 502, 503, 504})
 FALLBACK_WAIT_INITIAL_SECONDS = 2.0
 FALLBACK_WAIT_MAX_SECONDS = 6.0
 FALLBACK_WAIT_JITTER_SECONDS = 2.0
+_FALLBACK_WAIT = wait_exponential_jitter(
+    initial=FALLBACK_WAIT_INITIAL_SECONDS,
+    max=FALLBACK_WAIT_MAX_SECONDS,
+    jitter=FALLBACK_WAIT_JITTER_SECONDS,
+)
 
 
 @dataclass(frozen=True)
@@ -95,6 +99,24 @@ def _should_retry(exc: BaseException) -> bool:
             return False
         return True
     return isinstance(exc, httpx2.TransportError)
+
+
+def _wait_for_retry(state: RetryCallState) -> float:
+    """Honor a useful Retry-After value, otherwise use bounded jitter.
+
+    A zero delta or an already-expired HTTP date is not a useful recovery
+    window. Treating either as authoritative synchronizes concurrent workers
+    into an immediate replay, which is precisely the burst pattern this
+    transport is intended to absorb.
+    """
+
+    exc = state.outcome.exception() if state.outcome is not None else None
+    response = getattr(exc, "response", None)
+    if response is not None:
+        retry_after = _retry_after_seconds(response)
+        if retry_after is not None and retry_after > 0:
+            return retry_after
+    return _FALLBACK_WAIT(state)
 
 
 def _log_before_sleep(state: RetryCallState) -> None:
@@ -200,14 +222,7 @@ def _create_retry_transport(
 ) -> AIRetryTransport:
     config = RetryConfig(
         retry=retry_if_exception(_should_retry),
-        wait=wait_retry_after(
-            fallback_strategy=wait_exponential_jitter(
-                initial=FALLBACK_WAIT_INITIAL_SECONDS,
-                max=FALLBACK_WAIT_MAX_SECONDS,
-                jitter=FALLBACK_WAIT_JITTER_SECONDS,
-            ),
-            max_wait=MAX_RETRY_AFTER_SECONDS,
-        ),
+        wait=_wait_for_retry,
         stop=stop_after_attempt(MAX_ATTEMPTS),
         before_sleep=_log_before_sleep,
         reraise=True,

--- a/api/src/services/agent_runtime/retry_transport.py
+++ b/api/src/services/agent_runtime/retry_transport.py
@@ -7,12 +7,12 @@ Agent ``retries`` remain reserved for malformed tool/output correction.
 from __future__ import annotations
 
 import logging
+from collections.abc import Awaitable, Callable, Iterator
 from contextlib import contextmanager
 from contextvars import ContextVar
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from email.utils import parsedate_to_datetime
-from typing import Iterator
 
 import httpx2
 from pydantic_ai.models import get_user_agent
@@ -22,10 +22,11 @@ from pydantic_ai.retries import (
     wait_retry_after,
 )
 from tenacity import (
+    AsyncRetrying,
     RetryCallState,
     retry_if_exception,
     stop_after_attempt,
-    wait_random_exponential,
+    wait_exponential_jitter,
 )
 
 logger = logging.getLogger(__name__)
@@ -33,6 +34,9 @@ logger = logging.getLogger(__name__)
 MAX_ATTEMPTS = 3
 MAX_RETRY_AFTER_SECONDS = 60.0
 RETRYABLE_STATUS_CODES = frozenset({408, 429, 500, 502, 503, 504})
+FALLBACK_WAIT_INITIAL_SECONDS = 2.0
+FALLBACK_WAIT_MAX_SECONDS = 6.0
+FALLBACK_WAIT_JITTER_SECONDS = 2.0
 
 
 @dataclass(frozen=True)
@@ -117,20 +121,101 @@ def _log_before_sleep(state: RetryCallState) -> None:
     )
 
 
+def _log_terminal(
+    exc: BaseException,
+    *,
+    attempt: int,
+    total_sleep_seconds: float,
+) -> None:
+    response = getattr(exc, "response", None)
+    context = _retry_context.get()
+    logger.warning(
+        "ai_provider_request_terminal",
+        extra={
+            "provider": context.provider if context else None,
+            "model": context.model if context else None,
+            "surface": context.surface if context else None,
+            "attempt": attempt,
+            "max_attempts": MAX_ATTEMPTS,
+            "status_code": getattr(response, "status_code", None),
+            "retry_after_seconds": (
+                _retry_after_seconds(response) if response is not None else None
+            ),
+            "sleep_seconds": None,
+            "total_sleep_seconds": total_sleep_seconds,
+            "error_type": type(exc).__name__,
+        },
+    )
+
+
+class AIRetryTransport(AsyncHTTPX2TenacityTransport):
+    """Retry transient failures while returning the final HTTP response.
+
+    Provider SDKs classify returned error responses themselves. Letting the
+    validation ``HTTPStatusError`` escape this lower transport boundary makes
+    OpenAI-compatible clients misclassify an exhausted 429 as a connection
+    failure instead of a rate-limit response.
+    """
+
+    async def handle_async_request(self, request: httpx2.Request) -> httpx2.Response:
+        retrying = AsyncRetrying(**self.config)
+        try:
+            async for attempt in retrying:
+                with attempt:
+                    response = await self.wrapped.handle_async_request(request)
+                    response.request = request
+                    if self.validate_response is None:
+                        return response
+                    try:
+                        self.validate_response(response)
+                    except httpx2.HTTPStatusError as exc:
+                        attempt_number = attempt.retry_state.attempt_number
+                        if (
+                            not _should_retry(exc)
+                            or attempt_number >= MAX_ATTEMPTS
+                        ):
+                            _log_terminal(
+                                exc,
+                                attempt=attempt_number,
+                                total_sleep_seconds=attempt.retry_state.idle_for,
+                            )
+                            return response
+                        await response.aclose()
+                        raise
+                    return response
+        except Exception as exc:
+            _log_terminal(
+                exc,
+                attempt=int(retrying.statistics.get("attempt_number", 1)),
+                total_sleep_seconds=float(retrying.statistics.get("idle_for", 0.0)),
+            )
+            raise
+        raise RuntimeError("AI retry transport made no request attempts")
+
+
 def _create_retry_transport(
     wrapped: httpx2.AsyncBaseTransport | None = None,
-) -> AsyncHTTPX2TenacityTransport:
-    return AsyncHTTPX2TenacityTransport(
-        config=RetryConfig(
-            retry=retry_if_exception(_should_retry),
-            wait=wait_retry_after(
-                fallback_strategy=wait_random_exponential(multiplier=1, max=4),
-                max_wait=MAX_RETRY_AFTER_SECONDS,
+    *,
+    sleep: Callable[[float], Awaitable[None]] | None = None,
+) -> AIRetryTransport:
+    config = RetryConfig(
+        retry=retry_if_exception(_should_retry),
+        wait=wait_retry_after(
+            fallback_strategy=wait_exponential_jitter(
+                initial=FALLBACK_WAIT_INITIAL_SECONDS,
+                max=FALLBACK_WAIT_MAX_SECONDS,
+                jitter=FALLBACK_WAIT_JITTER_SECONDS,
             ),
-            stop=stop_after_attempt(MAX_ATTEMPTS),
-            before_sleep=_log_before_sleep,
-            reraise=True,
+            max_wait=MAX_RETRY_AFTER_SECONDS,
         ),
+        stop=stop_after_attempt(MAX_ATTEMPTS),
+        before_sleep=_log_before_sleep,
+        reraise=True,
+    )
+    if sleep is not None:
+        config["sleep"] = sleep
+    return AIRetryTransport(
+        config=config,
         wrapped=wrapped,
         validate_response=_validate_response,
     )

--- a/api/src/services/agent_runtime/retry_transport.py
+++ b/api/src/services/agent_runtime/retry_transport.py
@@ -7,6 +7,7 @@ Agent ``retries`` remain reserved for malformed tool/output correction.
 from __future__ import annotations
 
 import logging
+import random
 from collections.abc import Awaitable, Callable, Iterator
 from contextlib import contextmanager
 from contextvars import ContextVar
@@ -24,23 +25,16 @@ from tenacity import (
     AsyncRetrying,
     RetryCallState,
     retry_if_exception,
-    stop_after_attempt,
-    wait_exponential_jitter,
 )
 
 logger = logging.getLogger(__name__)
 
-MAX_ATTEMPTS = 3
+MAX_ATTEMPTS = 6
 MAX_RETRY_AFTER_SECONDS = 60.0
+MAX_RETRY_WINDOW_SECONDS = 60.0
 RETRYABLE_STATUS_CODES = frozenset({408, 429, 500, 502, 503, 504})
 FALLBACK_WAIT_INITIAL_SECONDS = 2.0
-FALLBACK_WAIT_MAX_SECONDS = 6.0
-FALLBACK_WAIT_JITTER_SECONDS = 2.0
-_FALLBACK_WAIT = wait_exponential_jitter(
-    initial=FALLBACK_WAIT_INITIAL_SECONDS,
-    max=FALLBACK_WAIT_MAX_SECONDS,
-    jitter=FALLBACK_WAIT_JITTER_SECONDS,
-)
+FALLBACK_WAIT_MAX_SECONDS = 10.0
 
 
 @dataclass(frozen=True)
@@ -69,6 +63,13 @@ def ai_retry_context(*, provider: str, model: str, surface: str) -> Iterator[Non
 
 
 def _retry_after_seconds(response: httpx2.Response) -> float | None:
+    retry_after_ms = response.headers.get("Retry-After-Ms")
+    if retry_after_ms:
+        try:
+            return max(0.0, float(retry_after_ms) / 1000)
+        except ValueError:
+            pass
+
     raw = response.headers.get("Retry-After")
     if not raw:
         return None
@@ -85,6 +86,11 @@ def _retry_after_seconds(response: httpx2.Response) -> float | None:
 
 
 def _validate_response(response: httpx2.Response) -> None:
+    provider_retry = response.headers.get("x-should-retry", "").lower()
+    if provider_retry == "false":
+        return
+    if provider_retry == "true":
+        response.raise_for_status()
     if response.status_code in RETRYABLE_STATUS_CODES:
         response.raise_for_status()
 
@@ -92,6 +98,12 @@ def _validate_response(response: httpx2.Response) -> None:
 def _should_retry(exc: BaseException) -> bool:
     if isinstance(exc, httpx2.HTTPStatusError):
         response = exc.response
+        provider_retry = response.headers.get("x-should-retry", "").lower()
+        if provider_retry == "false":
+            return False
+        if provider_retry == "true":
+            retry_after = _retry_after_seconds(response)
+            return retry_after is None or retry_after <= MAX_RETRY_AFTER_SECONDS
         if response.status_code not in RETRYABLE_STATUS_CODES:
             return False
         retry_after = _retry_after_seconds(response)
@@ -99,6 +111,18 @@ def _should_retry(exc: BaseException) -> bool:
             return False
         return True
     return isinstance(exc, httpx2.TransportError)
+
+
+def _retry_elapsed_seconds(state: RetryCallState) -> float:
+    return max(state.seconds_since_start or 0.0, state.idle_for)
+
+
+def _fallback_wait(state: RetryCallState) -> float:
+    exponential_cap = min(
+        FALLBACK_WAIT_INITIAL_SECONDS * (2 ** (state.attempt_number - 1)),
+        FALLBACK_WAIT_MAX_SECONDS,
+    )
+    return random.uniform(exponential_cap / 2, exponential_cap)
 
 
 def _wait_for_retry(state: RetryCallState) -> float:
@@ -112,11 +136,37 @@ def _wait_for_retry(state: RetryCallState) -> float:
 
     exc = state.outcome.exception() if state.outcome is not None else None
     response = getattr(exc, "response", None)
+    delay: float | None = None
     if response is not None:
         retry_after = _retry_after_seconds(response)
         if retry_after is not None and retry_after > 0:
-            return retry_after
-    return _FALLBACK_WAIT(state)
+            delay = retry_after
+    if delay is None:
+        delay = _fallback_wait(state)
+    remaining = max(0.0, MAX_RETRY_WINDOW_SECONDS - _retry_elapsed_seconds(state))
+    return min(delay, remaining)
+
+
+def _stop_retrying(state: RetryCallState) -> bool:
+    if state.attempt_number >= MAX_ATTEMPTS:
+        return True
+    elapsed = _retry_elapsed_seconds(state)
+    if elapsed >= MAX_RETRY_WINDOW_SECONDS:
+        return True
+    return elapsed + state.upcoming_sleep > MAX_RETRY_WINDOW_SECONDS
+
+
+def _http_retry_budget_available(
+    exc: httpx2.HTTPStatusError,
+    state: RetryCallState,
+) -> bool:
+    if state.attempt_number >= MAX_ATTEMPTS:
+        return False
+    elapsed = _retry_elapsed_seconds(state)
+    if elapsed >= MAX_RETRY_WINDOW_SECONDS:
+        return False
+    retry_after = _retry_after_seconds(exc.response)
+    return retry_after is None or elapsed + retry_after <= MAX_RETRY_WINDOW_SECONDS
 
 
 def _log_before_sleep(state: RetryCallState) -> None:
@@ -194,7 +244,10 @@ class AIRetryTransport(AsyncHTTPX2TenacityTransport):
                         attempt_number = attempt.retry_state.attempt_number
                         if (
                             not _should_retry(exc)
-                            or attempt_number >= MAX_ATTEMPTS
+                            or not _http_retry_budget_available(
+                                exc,
+                                attempt.retry_state,
+                            )
                         ):
                             _log_terminal(
                                 exc,
@@ -223,7 +276,7 @@ def _create_retry_transport(
     config = RetryConfig(
         retry=retry_if_exception(_should_retry),
         wait=_wait_for_retry,
-        stop=stop_after_attempt(MAX_ATTEMPTS),
+        stop=_stop_retrying,
         before_sleep=_log_before_sleep,
         reraise=True,
     )

--- a/api/tests/unit/services/test_ai_retry_transport.py
+++ b/api/tests/unit/services/test_ai_retry_transport.py
@@ -31,11 +31,13 @@ async def _no_sleep(_delay: float) -> None:
 
 def _client(
     handler: Callable[[httpx2.Request], Awaitable[httpx2.Response]],
+    *,
+    sleep: Callable[[float], Awaitable[None]] = _no_sleep,
 ) -> httpx2.AsyncClient:
     return httpx2.AsyncClient(
         transport=_create_retry_transport(
             httpx2.MockTransport(handler),
-            sleep=_no_sleep,
+            sleep=sleep,
         )
     )
 
@@ -71,6 +73,37 @@ async def test_retries_429_with_retry_after_and_logs_context(caplog) -> None:
     assert record.status_code == 429
     assert record.retry_after_seconds == 5
     assert record.sleep_seconds == 5
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "retry_after",
+    ["0", "Wed, 21 Oct 2015 07:28:00 GMT"],
+)
+async def test_non_positive_retry_after_uses_bounded_fallback_jitter(
+    retry_after: str,
+    monkeypatch,
+) -> None:
+    attempts = 0
+    delays: list[float] = []
+    monkeypatch.setattr("tenacity.wait.random.uniform", lambda _start, _end: 0.75)
+
+    async def record_sleep(delay: float) -> None:
+        delays.append(delay)
+
+    async def handler(request: httpx2.Request) -> httpx2.Response:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            return httpx2.Response(429, headers={"Retry-After": retry_after})
+        return httpx2.Response(200, json={"ok": True})
+
+    async with _client(handler, sleep=record_sleep) as client:
+        response = await client.get("https://openrouter.example.test/model")
+
+    assert response.status_code == 200
+    assert attempts == 2
+    assert delays == [FALLBACK_WAIT_INITIAL_SECONDS + 0.75]
 
 
 @pytest.mark.asyncio

--- a/api/tests/unit/services/test_ai_retry_transport.py
+++ b/api/tests/unit/services/test_ai_retry_transport.py
@@ -2,21 +2,41 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
+from collections.abc import Awaitable, Callable
 
 import httpx2
 import pytest
+from openai import AsyncOpenAI
+from pydantic_ai.exceptions import ModelHTTPError
+from pydantic_ai.messages import ModelRequest, UserPromptPart
+from pydantic_ai.models import ModelRequestParameters
+from pydantic_ai.models.openai import OpenAIChatModel
+from pydantic_ai.providers.openai import OpenAIProvider
 
 from src.services.agent_runtime.retry_transport import (
+    FALLBACK_WAIT_INITIAL_SECONDS,
+    FALLBACK_WAIT_JITTER_SECONDS,
+    FALLBACK_WAIT_MAX_SECONDS,
     MAX_ATTEMPTS,
     _create_retry_transport,
     ai_retry_context,
 )
 
 
-def _client(handler) -> httpx2.AsyncClient:
+async def _no_sleep(_delay: float) -> None:
+    pass
+
+
+def _client(
+    handler: Callable[[httpx2.Request], Awaitable[httpx2.Response]],
+) -> httpx2.AsyncClient:
     return httpx2.AsyncClient(
-        transport=_create_retry_transport(httpx2.MockTransport(handler))
+        transport=_create_retry_transport(
+            httpx2.MockTransport(handler),
+            sleep=_no_sleep,
+        )
     )
 
 
@@ -28,7 +48,7 @@ async def test_retries_429_with_retry_after_and_logs_context(caplog) -> None:
         nonlocal attempts
         attempts += 1
         if attempts == 1:
-            return httpx2.Response(429, headers={"Retry-After": "0"})
+            return httpx2.Response(429, headers={"Retry-After": "5"})
         return httpx2.Response(200, json={"ok": True})
 
     async with _client(handler) as client:
@@ -49,11 +69,14 @@ async def test_retries_429_with_retry_after_and_logs_context(caplog) -> None:
     assert record.model == "test-model"
     assert record.surface == "test"
     assert record.status_code == 429
-    assert record.retry_after_seconds == 0
+    assert record.retry_after_seconds == 5
+    assert record.sleep_seconds == 5
 
 
 @pytest.mark.asyncio
-async def test_exhaustion_is_bounded_to_three_total_attempts() -> None:
+async def test_exhaustion_returns_final_response_and_logs_terminal_context(
+    caplog,
+) -> None:
     attempts = 0
 
     async def handler(request: httpx2.Request) -> httpx2.Response:
@@ -62,10 +85,28 @@ async def test_exhaustion_is_bounded_to_three_total_attempts() -> None:
         return httpx2.Response(503, headers={"Retry-After": "0"})
 
     async with _client(handler) as client:
-        with pytest.raises(httpx2.HTTPStatusError):
-            await client.get("https://api.example.test/model")
+        with (
+            caplog.at_level(logging.WARNING),
+            ai_retry_context(
+                provider="openrouter",
+                model="test-model",
+                surface="test",
+            ),
+        ):
+            response = await client.get("https://api.example.test/model")
 
+    assert response.status_code == 503
     assert attempts == MAX_ATTEMPTS
+    record = next(
+        r for r in caplog.records if r.message == "ai_provider_request_terminal"
+    )
+    assert record.provider == "openrouter"
+    assert record.model == "test-model"
+    assert record.surface == "test"
+    assert record.attempt == MAX_ATTEMPTS
+    assert record.status_code == 503
+    assert record.total_sleep_seconds >= 0
+    assert record.error_type == "HTTPStatusError"
 
 
 @pytest.mark.asyncio
@@ -94,9 +135,9 @@ async def test_retry_after_over_limit_is_terminal() -> None:
         return httpx2.Response(429, headers={"Retry-After": "61"})
 
     async with _client(handler) as client:
-        with pytest.raises(httpx2.HTTPStatusError):
-            await client.get("https://api.example.test/model")
+        response = await client.get("https://api.example.test/model")
 
+    assert response.status_code == 429
     assert attempts == 1
 
 
@@ -126,7 +167,105 @@ async def test_invalid_retry_after_falls_back_to_bounded_retry() -> None:
         return httpx2.Response(429, headers={"Retry-After": "not-a-delay"})
 
     async with _client(handler) as client:
-        with pytest.raises(httpx2.HTTPStatusError):
-            await client.get("https://api.example.test/model")
+        response = await client.get("https://api.example.test/model")
+
+    assert response.status_code == 429
+    assert attempts == MAX_ATTEMPTS
+
+
+@pytest.mark.asyncio
+async def test_exhausted_429_remains_rate_limit_error_through_pydantic_adapter() -> None:
+    attempts = 0
+
+    async def handler(request: httpx2.Request) -> httpx2.Response:
+        nonlocal attempts
+        attempts += 1
+        return httpx2.Response(
+            429,
+            headers={"Retry-After": "0"},
+            json={
+                "error": {
+                    "message": "provider rate limit reached",
+                    "type": "rate_limit_error",
+                    "code": "rate_limit",
+                }
+            },
+        )
+
+    async with _client(handler) as http_client:
+        openai_client = AsyncOpenAI(
+            api_key="test-key",
+            base_url="https://openrouter.example.test/v1",
+            http_client=http_client,
+            max_retries=0,
+        )
+        model = OpenAIChatModel(
+            "test-model",
+            provider=OpenAIProvider(openai_client=openai_client),
+        )
+
+        with pytest.raises(ModelHTTPError) as exc_info:
+            await model.request(
+                [ModelRequest(parts=[UserPromptPart(content="hello")])],
+                None,
+                ModelRequestParameters(),
+            )
 
     assert attempts == MAX_ATTEMPTS
+    assert exc_info.value.status_code == 429
+    assert "provider rate limit reached" in str(exc_info.value)
+    assert "Connection error" not in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_concurrent_429_bursts_use_divergent_bounded_fallback_schedules(
+    caplog,
+    monkeypatch,
+) -> None:
+    jitter_values = iter((0.0, 0.5, 1.0, 0.0, 0.5, 1.0))
+    monkeypatch.setattr(
+        "tenacity.wait.random.uniform",
+        lambda _start, _end: next(jitter_values),
+    )
+
+    async def recover_after_burst(worker: int) -> int:
+        attempts = 0
+
+        async def handler(request: httpx2.Request) -> httpx2.Response:
+            nonlocal attempts
+            attempts += 1
+            if attempts < MAX_ATTEMPTS:
+                return httpx2.Response(429)
+            return httpx2.Response(200, json={"ok": True})
+
+        async with _client(handler) as client:
+            with ai_retry_context(
+                provider="openrouter",
+                model="test-model",
+                surface=f"burst-{worker}",
+            ):
+                response = await client.get(
+                    f"https://openrouter.example.test/workers/{worker}"
+                )
+        assert response.status_code == 200
+        return attempts
+
+    with caplog.at_level(logging.WARNING):
+        attempts = await asyncio.gather(*(recover_after_burst(i) for i in range(3)))
+
+    assert attempts == [MAX_ATTEMPTS] * 3
+    schedules: dict[str, list[float]] = {}
+    for record in caplog.records:
+        if record.message == "ai_provider_request_retry":
+            schedules.setdefault(record.surface, []).append(record.sleep_seconds)
+
+    assert set(schedules) == {"burst-0", "burst-1", "burst-2"}
+    assert all(len(delays) == MAX_ATTEMPTS - 1 for delays in schedules.values())
+    totals = [sum(delays) for delays in schedules.values()]
+    minimum_total = FALLBACK_WAIT_INITIAL_SECONDS * 3
+    maximum_total = min(
+        FALLBACK_WAIT_INITIAL_SECONDS + FALLBACK_WAIT_JITTER_SECONDS,
+        FALLBACK_WAIT_MAX_SECONDS,
+    ) + FALLBACK_WAIT_MAX_SECONDS
+    assert all(minimum_total <= total <= maximum_total for total in totals)
+    assert len(set(totals)) == len(totals)

--- a/api/tests/unit/services/test_ai_retry_transport.py
+++ b/api/tests/unit/services/test_ai_retry_transport.py
@@ -17,9 +17,9 @@ from pydantic_ai.providers.openai import OpenAIProvider
 
 from src.services.agent_runtime.retry_transport import (
     FALLBACK_WAIT_INITIAL_SECONDS,
-    FALLBACK_WAIT_JITTER_SECONDS,
     FALLBACK_WAIT_MAX_SECONDS,
     MAX_ATTEMPTS,
+    MAX_RETRY_WINDOW_SECONDS,
     _create_retry_transport,
     ai_retry_context,
 )
@@ -86,7 +86,10 @@ async def test_non_positive_retry_after_uses_bounded_fallback_jitter(
 ) -> None:
     attempts = 0
     delays: list[float] = []
-    monkeypatch.setattr("tenacity.wait.random.uniform", lambda _start, _end: 0.75)
+    monkeypatch.setattr(
+        "src.services.agent_runtime.retry_transport.random.uniform",
+        lambda start, end: start + ((end - start) * 0.75),
+    )
 
     async def record_sleep(delay: float) -> None:
         delays.append(delay)
@@ -103,7 +106,33 @@ async def test_non_positive_retry_after_uses_bounded_fallback_jitter(
 
     assert response.status_code == 200
     assert attempts == 2
-    assert delays == [FALLBACK_WAIT_INITIAL_SECONDS + 0.75]
+    assert delays == [FALLBACK_WAIT_INITIAL_SECONDS * 0.875]
+
+
+@pytest.mark.asyncio
+async def test_retry_after_milliseconds_takes_precedence() -> None:
+    attempts = 0
+    delays: list[float] = []
+
+    async def record_sleep(delay: float) -> None:
+        delays.append(delay)
+
+    async def handler(request: httpx2.Request) -> httpx2.Response:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            return httpx2.Response(
+                429,
+                headers={"Retry-After-Ms": "1250", "Retry-After": "5"},
+            )
+        return httpx2.Response(200)
+
+    async with _client(handler, sleep=record_sleep) as client:
+        response = await client.get("https://api.example.test/model")
+
+    assert response.status_code == 200
+    assert attempts == 2
+    assert delays == [1.25]
 
 
 @pytest.mark.asyncio
@@ -159,6 +188,36 @@ async def test_non_retryable_400_is_returned_once() -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("status_code", "provider_guidance", "expected_attempts"),
+    [(429, "false", 1), (400, "true", 2)],
+)
+async def test_provider_retry_guidance_overrides_status_default(
+    status_code: int,
+    provider_guidance: str,
+    expected_attempts: int,
+) -> None:
+    attempts = 0
+
+    async def handler(request: httpx2.Request) -> httpx2.Response:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            return httpx2.Response(
+                status_code,
+                headers={"x-should-retry": provider_guidance},
+            )
+        return httpx2.Response(200)
+
+    async with _client(handler) as client:
+        response = await client.get("https://api.example.test/model")
+
+    expected_status = 200 if expected_attempts > 1 else status_code
+    assert response.status_code == expected_status
+    assert attempts == expected_attempts
+
+
+@pytest.mark.asyncio
 async def test_retry_after_over_limit_is_terminal() -> None:
     attempts = 0
 
@@ -172,6 +231,28 @@ async def test_retry_after_over_limit_is_terminal() -> None:
 
     assert response.status_code == 429
     assert attempts == 1
+
+
+@pytest.mark.asyncio
+async def test_repeated_retry_after_is_bounded_by_total_retry_window() -> None:
+    attempts = 0
+    delays: list[float] = []
+
+    async def record_sleep(delay: float) -> None:
+        delays.append(delay)
+
+    async def handler(request: httpx2.Request) -> httpx2.Response:
+        nonlocal attempts
+        attempts += 1
+        return httpx2.Response(429, headers={"Retry-After": "30"})
+
+    async with _client(handler, sleep=record_sleep) as client:
+        response = await client.get("https://api.example.test/model")
+
+    assert response.status_code == 429
+    assert attempts == 3
+    assert delays == [30, 30]
+    assert sum(delays) == MAX_RETRY_WINDOW_SECONDS
 
 
 @pytest.mark.asyncio
@@ -255,10 +336,10 @@ async def test_concurrent_429_bursts_use_divergent_bounded_fallback_schedules(
     caplog,
     monkeypatch,
 ) -> None:
-    jitter_values = iter((0.0, 0.5, 1.0, 0.0, 0.5, 1.0))
+    jitter_fractions = iter(([0.0] * 5) + ([0.5] * 5) + ([1.0] * 5))
     monkeypatch.setattr(
-        "tenacity.wait.random.uniform",
-        lambda _start, _end: next(jitter_values),
+        "src.services.agent_runtime.retry_transport.random.uniform",
+        lambda start, end: start + ((end - start) * next(jitter_fractions)),
     )
 
     async def recover_after_burst(worker: int) -> int:
@@ -295,10 +376,11 @@ async def test_concurrent_429_bursts_use_divergent_bounded_fallback_schedules(
     assert set(schedules) == {"burst-0", "burst-1", "burst-2"}
     assert all(len(delays) == MAX_ATTEMPTS - 1 for delays in schedules.values())
     totals = [sum(delays) for delays in schedules.values()]
-    minimum_total = FALLBACK_WAIT_INITIAL_SECONDS * 3
-    maximum_total = min(
-        FALLBACK_WAIT_INITIAL_SECONDS + FALLBACK_WAIT_JITTER_SECONDS,
-        FALLBACK_WAIT_MAX_SECONDS,
-    ) + FALLBACK_WAIT_MAX_SECONDS
+    caps = [
+        min(FALLBACK_WAIT_INITIAL_SECONDS * (2**attempt), FALLBACK_WAIT_MAX_SECONDS)
+        for attempt in range(MAX_ATTEMPTS - 1)
+    ]
+    minimum_total = sum(cap / 2 for cap in caps)
+    maximum_total = sum(caps)
     assert all(minimum_total <= total <= maximum_total for total in totals)
     assert len(set(totals)) == len(totals)

--- a/docs/architecture/pydantic-ai-runtime-recovery.md
+++ b/docs/architecture/pydantic-ai-runtime-recovery.md
@@ -20,16 +20,22 @@ Bifrost still owns:
 Approved retry policy:
 
 - Pydantic AI native transport is the sole model-request retry layer.
-- Model requests retry at most 3 attempts total.
+- Model requests retry at most 6 attempts total and never spend more than 60
+  seconds in the transport retry window.
 - Retryable statuses are 408, 429, 500, 502, 503, and 504; transport
   timeouts and connection failures are also retryable.
-- When a 429 includes a positive `Retry-After`, honor it if the value is
-  `<= 60` seconds.
+- When a 429 includes a positive `Retry-After-Ms` or `Retry-After`, honor it if
+  the value is `<= 60` seconds and fits in the remaining retry window.
+- Honor explicit provider `x-should-retry` guidance while retaining the same
+  attempt and elapsed-time bounds.
 - When `Retry-After` is missing, invalid, zero, or already expired, use bounded
-  exponential jitter: the two fallback delays span 2-4 seconds and 4-6
-  seconds. A valid value greater than 60 seconds is terminal at the transport
-  layer rather than occupying a worker or retrying before the provider permits
-  it.
+  equal-jitter exponential backoff. Five fallback delays span 1-2, 2-4, 4-8,
+  5-10, and 5-10 seconds, for a total fallback window of 17-34 seconds. The
+  non-zero floor prevents a worker from exhausting its retry budget almost
+  immediately, while the independently sampled upper half separates workers
+  after synchronized bursts. A valid value greater than 60 seconds, or one
+  that does not fit in the remaining retry window, is terminal rather than
+  occupying a worker or retrying before the provider permits it.
 - After the transport budget is exhausted, return the final HTTP response to
   the provider adapter so its status identity (especially 429) is preserved.
   Only genuine timeout and connection exceptions leave the transport as such.
@@ -155,6 +161,9 @@ be treated as a generalized recover-and-rerun mechanism.
 
 - The runtime still depends on provider-specific behavior for rate limiting and
   retry headers.
+- Request-local backoff disperses bursts but does not enforce a fleet-wide
+  provider quota. Coordinated admission control needs an explicit quota and a
+  credential/account scope; provider/model alone is not a safe limiter key.
 - Direct OpenRouter media-catalog and pricing GETs remain best-effort raw HTTP
   calls and do not yet share the model-request transport.
 - Raw media POSTs do not yet retry even an explicit 429. They remain terminal

--- a/docs/architecture/pydantic-ai-runtime-recovery.md
+++ b/docs/architecture/pydantic-ai-runtime-recovery.md
@@ -23,12 +23,13 @@ Approved retry policy:
 - Model requests retry at most 3 attempts total.
 - Retryable statuses are 408, 429, 500, 502, 503, and 504; transport
   timeouts and connection failures are also retryable.
-- When a 429 includes `Retry-After`, honor it if the value is `<= 60`
-  seconds.
-- When `Retry-After` is missing or invalid, use bounded exponential jitter:
-  the two fallback delays span 2-4 seconds and 4-6 seconds. A valid value
-  greater than 60 seconds is terminal at the transport layer rather than
-  occupying a worker or retrying before the provider permits it.
+- When a 429 includes a positive `Retry-After`, honor it if the value is
+  `<= 60` seconds.
+- When `Retry-After` is missing, invalid, zero, or already expired, use bounded
+  exponential jitter: the two fallback delays span 2-4 seconds and 4-6
+  seconds. A valid value greater than 60 seconds is terminal at the transport
+  layer rather than occupying a worker or retrying before the provider permits
+  it.
 - After the transport budget is exhausted, return the final HTTP response to
   the provider adapter so its status identity (especially 429) is preserved.
   Only genuine timeout and connection exceptions leave the transport as such.

--- a/docs/architecture/pydantic-ai-runtime-recovery.md
+++ b/docs/architecture/pydantic-ai-runtime-recovery.md
@@ -25,9 +25,13 @@ Approved retry policy:
   timeouts and connection failures are also retryable.
 - When a 429 includes `Retry-After`, honor it if the value is `<= 60`
   seconds.
-- When `Retry-After` is missing or invalid, use exponential jitter. A valid
-  value greater than 60 seconds is terminal at the transport layer rather
-  than occupying a worker or retrying before the provider permits it.
+- When `Retry-After` is missing or invalid, use bounded exponential jitter:
+  the two fallback delays span 2-4 seconds and 4-6 seconds. A valid value
+  greater than 60 seconds is terminal at the transport layer rather than
+  occupying a worker or retrying before the provider permits it.
+- After the transport budget is exhausted, return the final HTTP response to
+  the provider adapter so its status identity (especially 429) is preserved.
+  Only genuine timeout and connection exceptions leave the transport as such.
 - Streaming calls do not get a separate replay path; if a stream fails, the
   failure is surfaced rather than retried as a stream.
 - Raw media POSTs are not model requests. Image/video upload and generation


### PR DESCRIPTION
## Summary
- preserve terminal provider 429 responses instead of converting retry exhaustion into connection failures
- honor bounded provider retry guidance and use a six-attempt, equal-jitter exponential recovery window for synchronized bursts
- document the request-local reliability boundary and add focused regression coverage
- commit MCP configuration changes before cache invalidation to close the product race exposed by the pre-PR suite

## Testing
- `./test.sh tests/unit/services/test_ai_retry_transport.py tests/unit/services/test_agent_runtime.py tests/unit/test_model_selection.py -v`
- `./test.sh tests/e2e/api-integration/test_mcp_endpoints.py::TestMCPConfigToolFiltering::test_disabled_config_blocks_gateway_rest_surface -v`
- `./test.sh tests/unit/services/test_mcp_tools.py -v`
- `./test.sh quality api`
- `./test.sh pre-pr` on `02c4aaecb033ad53042786abb5238bc6537188cc`

Fixes #656