### PR TITLE
Use Pydantic's default OpenAI transport

### DIFF
--- a/api/src/services/agent_runtime/model_factory.py
+++ b/api/src/services/agent_runtime/model_factory.py
@@ -6,7 +6,7 @@ scheduler import boundary while giving every agent surface one model abstraction
 
 from decimal import Decimal, InvalidOperation
 
-from pydantic_ai.models import Model
+from pydantic_ai.models import Model, infer_model
 from pydantic_ai.usage import RequestUsage
 
 from src.services.agent_runtime.retry_transport import get_ai_retry_http_client
@@ -34,6 +34,8 @@ def agent_model_settings(
         settings["max_tokens"] = resolved_max_tokens
     if is_openrouter_endpoint(config.endpoint):
         settings["extra_body"] = {"session_id": session_id[:256]}
+    elif config.provider == "openai":
+        settings["openai_store"] = False
     return settings
 
 
@@ -141,7 +143,6 @@ def create_agent_model(config: LLMConfig, *, model: str | None = None) -> Model:
             )
 
         from openai import AsyncOpenAI
-        from pydantic_ai.models.openai import OpenAIChatModel
         from pydantic_ai.providers.openai import OpenAIProvider
 
         client = AsyncOpenAI(
@@ -151,7 +152,10 @@ def create_agent_model(config: LLMConfig, *, model: str | None = None) -> Model:
             max_retries=0,
         )
         provider = OpenAIProvider(openai_client=client)
-        return OpenAIChatModel(model_name, provider=provider)
+        return infer_model(
+            f"openai:{model_name}",
+            provider_factory=lambda _provider_name: provider,
+        )
 
     if config.provider == "anthropic":
         from anthropic import AsyncAnthropic

--- a/api/src/services/llm/pydantic_client.py
+++ b/api/src/services/llm/pydantic_client.py
@@ -26,7 +26,7 @@ from pydantic_ai.messages import (
     UserContent,
 )
 from pydantic_ai.models import ModelRequestParameters
-from pydantic_ai.settings import ModelSettings
+from pydantic_ai.models.openai import OpenAIResponsesModelSettings
 from pydantic_ai.tools import ToolDefinition as PydanticToolDefinition
 
 from src.services.agent_runtime.model_factory import (
@@ -139,9 +139,9 @@ class PydanticAIClient(BaseLLMClient):
             logger.error("Pydantic AI streaming error: %s", exc)
             yield LLMStreamChunk(type="error", error=str(exc))
 
-    def _model_settings(self, max_tokens: int | None) -> ModelSettings:
+    def _model_settings(self, max_tokens: int | None) -> OpenAIResponsesModelSettings:
         resolved_max_tokens = request_max_tokens(self.config, max_tokens)
-        settings = ModelSettings()
+        settings = OpenAIResponsesModelSettings()
         if resolved_max_tokens is not None:
             settings["max_tokens"] = resolved_max_tokens
         if self.provider_name == "openai":

--- a/api/src/services/llm/pydantic_client.py
+++ b/api/src/services/llm/pydantic_client.py
@@ -141,9 +141,12 @@ class PydanticAIClient(BaseLLMClient):
 
     def _model_settings(self, max_tokens: int | None) -> ModelSettings:
         resolved_max_tokens = request_max_tokens(self.config, max_tokens)
-        if resolved_max_tokens is None:
-            return ModelSettings()
-        return ModelSettings(max_tokens=resolved_max_tokens)
+        settings = ModelSettings()
+        if resolved_max_tokens is not None:
+            settings["max_tokens"] = resolved_max_tokens
+        if self.provider_name == "openai":
+            settings["openai_store"] = False
+        return settings
 
     @staticmethod
     def _request_parameters(

--- a/api/tests/unit/services/test_agent_runtime.py
+++ b/api/tests/unit/services/test_agent_runtime.py
@@ -593,6 +593,57 @@ async def test_legacy_complete_uses_stream_transport_for_large_output_limits() -
 
 
 @pytest.mark.asyncio
+async def test_direct_openai_complete_and_stream_disable_storage() -> None:
+    response = ModelResponse(
+        parts=[TextPart("hello")],
+        usage=RequestUsage(input_tokens=12, output_tokens=3),
+        model_name="test-model",
+        provider_name="openai",
+        finish_reason="stop",
+    )
+
+    class FakeStream:
+        def __aiter__(self):
+            async def events():
+                if False:
+                    yield None
+
+            return events()
+
+        def get(self):
+            return response
+
+    class FakeStreamContext:
+        async def __aenter__(self):
+            return FakeStream()
+
+        async def __aexit__(self, *args):
+            return False
+
+    client = PydanticAIClient(
+        LLMConfig(provider="openai", model="test-model", api_key="test-key")
+    )
+    with patch(
+        "src.services.llm.pydantic_client.create_agent_model",
+        return_value=MagicMock(),
+    ), patch(
+        "src.services.llm.pydantic_client.model_request_stream",
+        side_effect=[FakeStreamContext(), FakeStreamContext()],
+    ) as request_stream:
+        await client.complete([LLMMessage(role="user", content="hello")])
+        _ = [
+            chunk
+            async for chunk in client.stream(
+                [LLMMessage(role="user", content="hello")]
+            )
+        ]
+
+    assert request_stream.call_count == 2
+    for call in request_stream.call_args_list:
+        assert call.kwargs["model_settings"]["openai_store"] is False
+
+
+@pytest.mark.asyncio
 async def test_toolset_preserves_stored_json_schema_and_emits_lifecycle_events() -> None:
     calls: list[tuple[str, dict]] = []
     events = []

--- a/api/tests/unit/services/test_agent_runtime.py
+++ b/api/tests/unit/services/test_agent_runtime.py
@@ -172,6 +172,24 @@ def test_create_agent_model_supports_every_configured_provider(
         assert provider_client.max_retries == 0
 
 
+def test_openai_uses_pydantic_default_model() -> None:
+    from pydantic_ai.models.openai import OpenAIResponsesModel
+
+    config = LLMConfig(
+        provider="openai",
+        model="gpt-5.6-luna",
+        api_key="test-key",
+        endpoint="https://foundry.example.test/openai/v1",
+    )
+
+    model = create_agent_model(config)
+
+    assert isinstance(model, OpenAIResponsesModel)
+    assert agent_model_settings(config, max_tokens=None, session_id="run-1").get(
+        "openai_store"
+    ) is False
+
+
 def test_create_agent_model_uses_native_openrouter_adapter() -> None:
     from pydantic_ai.models.openrouter import OpenRouterModel, OpenRouterModelSettings
 
@@ -215,7 +233,9 @@ def test_runtime_uses_provider_output_defaults_except_when_api_requires_limit() 
     openai = LLMConfig(provider="openai", model="gpt-5", api_key="test-key")
     anthropic = LLMConfig(provider="anthropic", model="claude-sonnet", api_key="test-key")
 
-    assert agent_model_settings(openai, max_tokens=None, session_id="run-123") == {}
+    assert agent_model_settings(openai, max_tokens=None, session_id="run-123") == {
+        "openai_store": False,
+    }
     assert agent_model_settings(anthropic, max_tokens=None, session_id="run-123") == {
         "max_tokens": 16_384,
     }


### PR DESCRIPTION
## Summary

- let Pydantic AI choose its default OpenAI model transport
- preserve Bifrost's injected OpenAI-compatible client and provider configuration
- disable OpenAI Responses API server-side storage across agent and direct-client paths
- remove the proposed profile transport setting, migration, API plumbing, and UI selector

This follows maintainer feedback: Bifrost should not force transport selection when Pydantic AI can negotiate the current default. With Pydantic AI 2.33.0, the `openai:` inference path selects `OpenAIResponsesModel` while retaining Bifrost's custom Foundry endpoint/client.

Closes #666.

Fork implementation and production context:
- https://github.com/MTG-Thomas/bifrost/issues/618
- https://github.com/MTG-Thomas/bifrost/pull/620

## Verification

- `29 passed` in `api/tests/unit/services/test_agent_runtime.py`
- focused Pyright and Ruff passed
- live Microsoft Foundry plain, tool, two-tool, and structured-output checks passed for DeepSeek V4 Flash 0731, GPT-5.6 Terra, and GPT-5.4 Mini
- GPT-5.6 Luna passed plain, one-tool, and structured-output checks; an 8-way concurrent two-tool burst completed 7/8 runs, with one 60-second timeout and successful runs completing in about 5-9 seconds
- every live run resolved through `OpenAIResponsesModel`

The Luna timeout appears to be an isolated concurrency/latency signal rather than a transport-selection failure: the same chain passed before and after the burst.
