### PR TITLE
feat(events): authenticate Microsoft Teams bot webhooks

### DIFF
--- a/api/src/services/webhooks/adapters/__init__.py
+++ b/api/src/services/webhooks/adapters/__init__.py
@@ -3,15 +3,20 @@ Built-in webhook adapters for the Bifrost event system.
 """
 
 from src.services.webhooks.adapters.generic import GenericWebhookAdapter
+from src.services.webhooks.adapters.microsoft_bot_framework import (
+    MicrosoftBotFrameworkAdapter,
+)
 from src.services.webhooks.adapters.microsoft_graph import MicrosoftGraphAdapter
 
 __all__ = [
     "GenericWebhookAdapter",
+    "MicrosoftBotFrameworkAdapter",
     "MicrosoftGraphAdapter",
 ]
 
 # Registry of built-in adapters
 BUILTIN_ADAPTERS: dict[str, type] = {
     "generic": GenericWebhookAdapter,
+    "microsoft_bot_framework": MicrosoftBotFrameworkAdapter,
     "microsoft_graph": MicrosoftGraphAdapter,
 }

--- a/api/src/services/webhooks/adapters/microsoft_bot_framework.py
+++ b/api/src/services/webhooks/adapters/microsoft_bot_framework.py
@@ -1,0 +1,234 @@
+"""Microsoft Bot Framework webhook adapter for Teams activity events."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from typing import Any
+from urllib.parse import urlparse
+
+import httpx
+import jwt
+
+from src.services.webhooks.protocol import (
+    Deliver,
+    HandleResult,
+    Rejected,
+    SubscribeResult,
+    WebhookAdapter,
+    WebhookRequest,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class MicrosoftBotFrameworkAdapter(WebhookAdapter):
+    """Validate and normalize Microsoft Teams Bot Framework activities."""
+
+    name = "microsoft_bot_framework"
+    display_name = "Microsoft Bot Framework"
+    description = "Authenticated Microsoft Teams bot activities"
+    requires_integration = None
+    renewal_interval = None
+
+    _OPENID_URL = "https://login.botframework.com/v1/.well-known/openidconfiguration"
+    _EXPECTED_ISSUER = "https://api.botframework.com"
+    _CACHE_TTL_SECONDS = 24 * 60 * 60
+    _UNKNOWN_KEY_REFRESH_INTERVAL_SECONDS = 5 * 60
+    _jwks: list[dict[str, Any]] | None = None
+    _jwks_expires_at = 0.0
+    _jwks_refreshed_at = 0.0
+    _jwks_lock = asyncio.Lock()
+
+    config_schema = {
+        "type": "object",
+        "required": ["app_id"],
+        "properties": {
+            "app_id": {
+                "type": "string",
+                "title": "Microsoft App ID",
+                "description": "Application/client ID registered for the Azure Bot.",
+            },
+        },
+    }
+
+    async def subscribe(
+        self,
+        callback_url: str,
+        config: dict[str, Any],
+        integration: Any | None,
+    ) -> SubscribeResult:
+        app_id = str(config.get("app_id") or "").strip()
+        if not app_id:
+            raise ValueError("Microsoft Bot Framework app_id is required")
+        return SubscribeResult()
+
+    async def unsubscribe(
+        self,
+        external_id: str | None,
+        state: dict[str, Any],
+        integration: Any | None,
+    ) -> None:
+        return None
+
+    async def handle_request(
+        self,
+        request: WebhookRequest,
+        config: dict[str, Any],
+        state: dict[str, Any],
+    ) -> HandleResult:
+        payload = request.json_body
+        if not isinstance(payload, dict):
+            return Rejected(message="Invalid Bot Framework activity", status_code=400)
+
+        app_id = str(config.get("app_id") or "").strip()
+        if not app_id:
+            return Rejected(
+                message="Bot Framework app ID is not configured", status_code=500
+            )
+
+        authorization = request.headers.get("authorization", "")
+        scheme, separator, token = authorization.partition(" ")
+        if not separator or scheme.lower() != "bearer" or not token.strip():
+            return Rejected(
+                message="Missing Bot Framework bearer token", status_code=401
+            )
+
+        try:
+            await self._validate_token(token.strip(), app_id, payload)
+        except (jwt.PyJWTError, KeyError, TypeError, ValueError) as exc:
+            logger.warning(
+                "Bot Framework token validation failed: %s", type(exc).__name__
+            )
+            return Rejected(
+                message="Invalid Bot Framework bearer token", status_code=401
+            )
+        except httpx.HTTPError:
+            logger.exception("Bot Framework signing metadata could not be loaded")
+            return Rejected(
+                message="Bot Framework authentication unavailable", status_code=503
+            )
+
+        activity_type = str(payload.get("type") or "unknown")
+        channel_data = payload.get("channelData") or {}
+        conversation = payload.get("conversation") or {}
+        sender = payload.get("from") or {}
+
+        return Deliver(
+            data={
+                "activity": payload,
+                "activity_type": activity_type,
+                "activity_id": payload.get("id"),
+                "service_url": payload.get("serviceUrl"),
+                "channel_id": payload.get("channelId"),
+                "tenant_id": (channel_data.get("tenant") or {}).get("id"),
+                "team_id": (channel_data.get("team") or {}).get("id"),
+                "conversation_id": conversation.get("id"),
+                "sender": sender,
+                "reply_to_id": payload.get("replyToId"),
+            },
+            event_type=f"microsoft_teams.{activity_type}",
+            raw_headers={
+                key: value
+                for key, value in request.headers.items()
+                if key not in {"authorization", "cookie"}
+            },
+        )
+
+    async def _validate_token(
+        self,
+        token: str,
+        app_id: str,
+        payload: dict[str, Any],
+    ) -> None:
+        header = jwt.get_unverified_header(token)
+        if header.get("alg") != "RS256":
+            raise ValueError("Unsupported signing algorithm")
+
+        kid = str(header.get("kid") or "")
+        if not kid:
+            raise ValueError("Missing signing key ID")
+
+        jwk = await self._get_signing_jwk(kid)
+        signing_key = jwt.PyJWK.from_dict(jwk, algorithm="RS256").key
+        claims = jwt.decode(
+            token,
+            key=signing_key,
+            algorithms=["RS256"],
+            audience=app_id,
+            issuer=self._EXPECTED_ISSUER,
+            leeway=300,
+            options={"require": ["exp", "iss", "aud"]},
+        )
+
+        service_url = str(payload.get("serviceUrl") or "")
+        claimed_service_url = str(
+            claims.get("serviceurl") or claims.get("serviceUrl") or ""
+        )
+        if not service_url or claimed_service_url != service_url:
+            raise ValueError("Bot Framework service URL mismatch")
+        if urlparse(service_url).scheme != "https":
+            raise ValueError("Bot Framework service URL must use HTTPS")
+
+        channel_id = str(payload.get("channelId") or "")
+        if channel_id != "msteams":
+            raise ValueError("Only Microsoft Teams activities are accepted")
+        endorsements = jwk.get("endorsements") or []
+        if channel_id not in endorsements:
+            raise ValueError("Signing key is not endorsed for Microsoft Teams")
+
+    async def _get_signing_jwk(self, kid: str) -> dict[str, Any]:
+        keys = await self._get_jwks()
+        match = next((key for key in keys if key.get("kid") == kid), None)
+        cache_age = time.monotonic() - self._jwks_refreshed_at
+        if match is None and cache_age >= self._UNKNOWN_KEY_REFRESH_INTERVAL_SECONDS:
+            keys = await self._get_jwks(force_refresh=True)
+            match = next((key for key in keys if key.get("kid") == kid), None)
+        if match is None:
+            raise ValueError("Unknown Bot Framework signing key")
+        return match
+
+    async def _get_jwks(self, force_refresh: bool = False) -> list[dict[str, Any]]:
+        now = time.monotonic()
+        if not force_refresh and self._jwks is not None and now < self._jwks_expires_at:
+            return self._jwks
+
+        async with self._jwks_lock:
+            now = time.monotonic()
+            if (
+                not force_refresh
+                and self._jwks is not None
+                and now < self._jwks_expires_at
+            ):
+                return self._jwks
+
+            async with httpx.AsyncClient(timeout=10.0) as client:
+                metadata_response = await client.get(self._OPENID_URL)
+                metadata_response.raise_for_status()
+                metadata = metadata_response.json()
+                if metadata.get("issuer") != self._EXPECTED_ISSUER:
+                    raise ValueError("Unexpected Bot Framework issuer metadata")
+                if "RS256" not in metadata.get(
+                    "id_token_signing_alg_values_supported", []
+                ):
+                    raise ValueError("Bot Framework metadata does not allow RS256")
+
+                jwks_uri = str(metadata.get("jwks_uri") or "")
+                parsed_uri = urlparse(jwks_uri)
+                if (
+                    parsed_uri.scheme != "https"
+                    or parsed_uri.hostname != "login.botframework.com"
+                ):
+                    raise ValueError("Unexpected Bot Framework signing-key URL")
+
+                keys_response = await client.get(jwks_uri)
+                keys_response.raise_for_status()
+                keys = keys_response.json().get("keys")
+                if not isinstance(keys, list) or not keys:
+                    raise ValueError("Bot Framework signing keys are unavailable")
+
+            self._jwks = keys
+            self._jwks_refreshed_at = time.monotonic()
+            self._jwks_expires_at = self._jwks_refreshed_at + self._CACHE_TTL_SECONDS
+            return keys

--- a/api/src/services/webhooks/adapters/microsoft_bot_framework.py
+++ b/api/src/services/webhooks/adapters/microsoft_bot_framework.py
@@ -43,12 +43,17 @@ class MicrosoftBotFrameworkAdapter(WebhookAdapter):
 
     config_schema = {
         "type": "object",
-        "required": ["app_id"],
+        "required": ["app_id", "tenant_id"],
         "properties": {
             "app_id": {
                 "type": "string",
                 "title": "Microsoft App ID",
                 "description": "Application/client ID registered for the Azure Bot.",
+            },
+            "tenant_id": {
+                "type": "string",
+                "title": "Microsoft Tenant ID",
+                "description": "Entra tenant ID allowed to send Teams activities.",
             },
         },
     }
@@ -62,6 +67,9 @@ class MicrosoftBotFrameworkAdapter(WebhookAdapter):
         app_id = str(config.get("app_id") or "").strip()
         if not app_id:
             raise ValueError("Microsoft Bot Framework app_id is required")
+        tenant_id = str(config.get("tenant_id") or "").strip()
+        if not tenant_id:
+            raise ValueError("Microsoft Bot Framework tenant_id is required")
         return SubscribeResult()
 
     async def unsubscribe(
@@ -87,6 +95,11 @@ class MicrosoftBotFrameworkAdapter(WebhookAdapter):
             return Rejected(
                 message="Bot Framework app ID is not configured", status_code=500
             )
+        tenant_id = str(config.get("tenant_id") or "").strip()
+        if not tenant_id:
+            return Rejected(
+                message="Bot Framework tenant ID is not configured", status_code=500
+            )
 
         authorization = request.headers.get("authorization", "")
         scheme, separator, token = authorization.partition(" ")
@@ -96,7 +109,7 @@ class MicrosoftBotFrameworkAdapter(WebhookAdapter):
             )
 
         try:
-            await self._validate_token(token.strip(), app_id, payload)
+            await self._validate_token(token.strip(), app_id, tenant_id, payload)
         except (jwt.PyJWTError, KeyError, TypeError, ValueError) as exc:
             logger.warning(
                 "Bot Framework token validation failed: %s", type(exc).__name__
@@ -140,6 +153,7 @@ class MicrosoftBotFrameworkAdapter(WebhookAdapter):
         self,
         token: str,
         app_id: str,
+        tenant_id: str,
         payload: dict[str, Any],
     ) -> None:
         header = jwt.get_unverified_header(token)
@@ -174,6 +188,14 @@ class MicrosoftBotFrameworkAdapter(WebhookAdapter):
         channel_id = str(payload.get("channelId") or "")
         if channel_id != "msteams":
             raise ValueError("Only Microsoft Teams activities are accepted")
+        channel_data = payload.get("channelData")
+        activity_tenant_id = (
+            (channel_data.get("tenant") or {}).get("id")
+            if isinstance(channel_data, dict)
+            else None
+        )
+        if activity_tenant_id != tenant_id:
+            raise ValueError("Microsoft Teams tenant mismatch")
         endorsements = jwk.get("endorsements") or []
         if channel_id not in endorsements:
             raise ValueError("Signing key is not endorsed for Microsoft Teams")

--- a/api/tests/e2e/api/test_events.py
+++ b/api/tests/e2e/api/test_events.py
@@ -520,7 +520,10 @@ class TestWebhookReceiver:
                 "organization_id": None,
                 "webhook": {
                     "adapter_name": "microsoft_bot_framework",
-                    "config": {"app_id": "11111111-1111-1111-1111-111111111111"},
+                    "config": {
+                        "app_id": "11111111-1111-1111-1111-111111111111",
+                        "tenant_id": "22222222-2222-2222-2222-222222222222",
+                    },
                 },
             },
         )

--- a/api/tests/e2e/api/test_events.py
+++ b/api/tests/e2e/api/test_events.py
@@ -163,6 +163,7 @@ class TestEventSourceCRUD:
         # Should have at least the generic adapter
         adapter_names = [a["name"] for a in data["adapters"]]
         assert "generic" in adapter_names
+        assert "microsoft_bot_framework" in adapter_names
 
     def test_create_webhook_source(self, e2e_client, platform_admin):
         """Platform admin creates webhook event source."""
@@ -505,6 +506,42 @@ class TestWebhookReceiver:
 
         assert response.status_code == 202, f"Expected 202, got {response.status_code}: {response.text}"
         assert response.text == "Accepted"
+
+    def test_teams_bot_webhook_requires_microsoft_bearer_token(
+        self, e2e_client, platform_admin
+    ):
+        """Teams bot sources reject unauthenticated public requests."""
+        create_response = e2e_client.post(
+            "/api/events/sources",
+            headers=platform_admin.headers,
+            json={
+                "name": f"E2E Teams Bot {uuid.uuid4().hex[:8]}",
+                "source_type": "webhook",
+                "organization_id": None,
+                "webhook": {
+                    "adapter_name": "microsoft_bot_framework",
+                    "config": {"app_id": "11111111-1111-1111-1111-111111111111"},
+                },
+            },
+        )
+        assert create_response.status_code == 201, create_response.text
+        source = create_response.json()
+
+        try:
+            response = e2e_client.post(
+                f"/api/hooks/{source['id']}",
+                json={
+                    "type": "message",
+                    "channelId": "msteams",
+                    "serviceUrl": "https://smba.trafficmanager.net/amer/",
+                },
+            )
+            assert response.status_code == 401, response.text
+        finally:
+            e2e_client.delete(
+                f"/api/events/sources/{source['id']}",
+                headers=platform_admin.headers,
+            )
 
     def test_webhook_creates_event(self, e2e_client, platform_admin, event_source):
         """Webhook POST creates Event record."""

--- a/api/tests/unit/services/test_webhook_adapters.py
+++ b/api/tests/unit/services/test_webhook_adapters.py
@@ -551,6 +551,7 @@ class TestMicrosoftBotFrameworkAdapter:
     """Tests Microsoft Bot Framework authentication and normalization."""
 
     app_id = "11111111-1111-1111-1111-111111111111"
+    tenant_id = "tenant-1"
     service_url = "https://smba.trafficmanager.net/amer/"
 
     @pytest.fixture
@@ -617,9 +618,18 @@ class TestMicrosoftBotFrameworkAdapter:
             await adapter.subscribe("https://example.com/hook", {}, None)
 
     @pytest.mark.asyncio
+    async def test_subscribe_requires_tenant_id(self, adapter):
+        with pytest.raises(ValueError, match="tenant_id"):
+            await adapter.subscribe(
+                "https://example.com/hook", {"app_id": self.app_id}, None
+            )
+
+    @pytest.mark.asyncio
     async def test_missing_bearer_token_is_rejected(self, adapter):
         result = await adapter.handle_request(
-            self._request(self._activity()), {"app_id": self.app_id}, {}
+            self._request(self._activity()),
+            {"app_id": self.app_id, "tenant_id": self.tenant_id},
+            {},
         )
 
         assert isinstance(result, Rejected)
@@ -633,7 +643,7 @@ class TestMicrosoftBotFrameworkAdapter:
 
         result = await adapter.handle_request(
             self._request(self._activity(), token),
-            {"app_id": self.app_id},
+            {"app_id": self.app_id, "tenant_id": self.tenant_id},
             {},
         )
 
@@ -667,7 +677,9 @@ class TestMicrosoftBotFrameworkAdapter:
         token = self._token(private_key, **claim_overrides)
 
         result = await adapter.handle_request(
-            self._request(activity, token), {"app_id": self.app_id}, {}
+            self._request(activity, token),
+            {"app_id": self.app_id, "tenant_id": self.tenant_id},
+            {},
         )
 
         assert isinstance(result, Rejected)
@@ -681,7 +693,25 @@ class TestMicrosoftBotFrameworkAdapter:
 
         result = await adapter.handle_request(
             self._request(self._activity(), self._token(private_key)),
-            {"app_id": self.app_id},
+            {"app_id": self.app_id, "tenant_id": self.tenant_id},
+            {},
+        )
+
+        assert isinstance(result, Rejected)
+        assert result.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_activity_from_another_tenant_is_rejected(
+        self, adapter, signing_material
+    ):
+        private_key, jwk = signing_material
+        adapter._get_signing_jwk = AsyncMock(return_value=jwk)
+        activity = self._activity()
+        activity["channelData"]["tenant"]["id"] = "other-tenant"
+
+        result = await adapter.handle_request(
+            self._request(activity, self._token(private_key)),
+            {"app_id": self.app_id, "tenant_id": self.tenant_id},
             {},
         )
 

--- a/api/tests/unit/services/test_webhook_adapters.py
+++ b/api/tests/unit/services/test_webhook_adapters.py
@@ -7,15 +7,21 @@ request handling logic.
 
 import hashlib
 import hmac
-from datetime import datetime, timezone
+import json
+from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 from uuid import uuid4
 
+import jwt
 import pytest
+from cryptography.hazmat.primitives.asymmetric import rsa
 
 from src.services.webhooks.adapters.generic import GenericWebhookAdapter
 from src.services.webhooks.adapters.local_fixture import LocalFixtureWebhookAdapter
+from src.services.webhooks.adapters.microsoft_bot_framework import (
+    MicrosoftBotFrameworkAdapter,
+)
 from src.services.webhooks.adapters.microsoft_graph import MicrosoftGraphAdapter
 from src.services.webhooks import registry as webhook_registry
 from src.services.webhooks.protocol import (
@@ -539,3 +545,145 @@ class TestGenericWebhookAdapterSubscribe:
         )
 
         assert result.state == {}
+
+
+class TestMicrosoftBotFrameworkAdapter:
+    """Tests Microsoft Bot Framework authentication and normalization."""
+
+    app_id = "11111111-1111-1111-1111-111111111111"
+    service_url = "https://smba.trafficmanager.net/amer/"
+
+    @pytest.fixture
+    def adapter(self):
+        return MicrosoftBotFrameworkAdapter()
+
+    @pytest.fixture
+    def signing_material(self):
+        private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+        jwk = json.loads(jwt.algorithms.RSAAlgorithm.to_jwk(private_key.public_key()))
+        jwk.update({"kid": "teams-test-key", "endorsements": ["msteams"]})
+        return private_key, jwk
+
+    def _activity(self) -> dict:
+        return {
+            "type": "message",
+            "id": "activity-1",
+            "serviceUrl": self.service_url,
+            "channelId": "msteams",
+            "conversation": {"id": "conversation-1"},
+            "from": {"id": "user-1", "name": "Test User"},
+            "channelData": {
+                "tenant": {"id": "tenant-1"},
+                "team": {"id": "team-1"},
+            },
+        }
+
+    def _token(self, private_key, **claim_overrides) -> str:
+        claims = {
+            "iss": "https://api.botframework.com",
+            "aud": self.app_id,
+            "exp": datetime.now(timezone.utc) + timedelta(minutes=5),
+            "serviceurl": self.service_url,
+        }
+        claims.update(claim_overrides)
+        return jwt.encode(
+            claims,
+            private_key,
+            algorithm="RS256",
+            headers={"kid": "teams-test-key"},
+        )
+
+    def _request(self, activity: dict, token: str | None = None) -> WebhookRequest:
+        headers = {"content-type": "application/json", "cookie": "private"}
+        if token:
+            headers["authorization"] = f"Bearer {token}"
+        return WebhookRequest(
+            method="POST",
+            path="/api/hooks/test",
+            headers=headers,
+            body=json.dumps(activity).encode(),
+            query_params={},
+        )
+
+    def test_adapter_is_registered(self):
+        assert (
+            webhook_registry.AdapterRegistry().get("microsoft_bot_framework")
+            is not None
+        )
+
+    @pytest.mark.asyncio
+    async def test_subscribe_requires_app_id(self, adapter):
+        with pytest.raises(ValueError, match="app_id"):
+            await adapter.subscribe("https://example.com/hook", {}, None)
+
+    @pytest.mark.asyncio
+    async def test_missing_bearer_token_is_rejected(self, adapter):
+        result = await adapter.handle_request(
+            self._request(self._activity()), {"app_id": self.app_id}, {}
+        )
+
+        assert isinstance(result, Rejected)
+        assert result.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_valid_teams_activity_is_normalized(self, adapter, signing_material):
+        private_key, jwk = signing_material
+        adapter._get_signing_jwk = AsyncMock(return_value=jwk)
+        token = self._token(private_key)
+
+        result = await adapter.handle_request(
+            self._request(self._activity(), token),
+            {"app_id": self.app_id},
+            {},
+        )
+
+        assert isinstance(result, Deliver)
+        assert result.event_type == "microsoft_teams.message"
+        assert result.data["conversation_id"] == "conversation-1"
+        assert result.data["tenant_id"] == "tenant-1"
+        assert result.data["team_id"] == "team-1"
+        assert "authorization" not in result.raw_headers
+        assert "cookie" not in result.raw_headers
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("claim_overrides", "activity_overrides"),
+        [
+            ({"aud": "wrong-app"}, {}),
+            ({"serviceurl": "https://example.com/other"}, {}),
+            ({}, {"channelId": "webchat"}),
+        ],
+    )
+    async def test_invalid_token_or_activity_is_rejected(
+        self,
+        adapter,
+        signing_material,
+        claim_overrides,
+        activity_overrides,
+    ):
+        private_key, jwk = signing_material
+        adapter._get_signing_jwk = AsyncMock(return_value=jwk)
+        activity = {**self._activity(), **activity_overrides}
+        token = self._token(private_key, **claim_overrides)
+
+        result = await adapter.handle_request(
+            self._request(activity, token), {"app_id": self.app_id}, {}
+        )
+
+        assert isinstance(result, Rejected)
+        assert result.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_key_must_be_endorsed_for_teams(self, adapter, signing_material):
+        private_key, jwk = signing_material
+        jwk["endorsements"] = ["webchat"]
+        adapter._get_signing_jwk = AsyncMock(return_value=jwk)
+
+        result = await adapter.handle_request(
+            self._request(self._activity(), self._token(private_key)),
+            {"app_id": self.app_id},
+            {},
+        )
+
+        assert isinstance(result, Rejected)
+        assert result.status_code == 401


### PR DESCRIPTION
## Summary
- add a Microsoft Bot Framework webhook adapter for Teams activities
- validate Bot Framework JWTs against the official OpenID metadata and JWKS
- require the configured application and tenant, Teams channel endorsement, and matching activity tenant
- emit normalized `microsoft_teams.*` event types without forwarding authorization headers or cookies

## Verification
- `./test.sh pre-pr`
- 36 targeted adapter unit tests
- targeted Teams webhook API E2E test

## Production plan
- deploy the merged API image
- create an org-scoped Teams webhook event source with app and tenant restrictions
- update the Azure Bot messaging endpoint to the new production callback
- verify unauthorized requests are rejected and Azure reads back the endpoint