### PR TITLE
Route multitenant webhooks by integration mapping

### DIFF
--- a/api/src/models/contracts/events.py
+++ b/api/src/models/contracts/events.py
@@ -451,6 +451,10 @@ class EventResponse(BaseModel):
 
     id: UUID = Field(..., description="Event ID")
     event_source_id: UUID = Field(..., description="Event source ID")
+    organization_id: UUID | None = Field(
+        default=None,
+        description="Organization selected for processing this event",
+    )
     event_source_name: str | None = Field(
         default=None,
         description="Event source name (for display)",

--- a/api/src/routers/events.py
+++ b/api/src/routers/events.py
@@ -1126,6 +1126,7 @@ async def list_events(
             EventResponse(
                 id=event.id,
                 event_source_id=event.event_source_id,
+                organization_id=event.organization_id,
                 event_source_name=source.name,
                 event_type=event.event_type,
                 received_at=event.received_at,
@@ -1257,6 +1258,7 @@ async def get_event(
     return EventResponse(
         id=event.id,
         event_source_id=event.event_source_id,
+        organization_id=event.organization_id,
         event_source_name=source.name if source else None,
         event_type=event.event_type,
         received_at=event.received_at,

--- a/api/src/services/events/processor.py
+++ b/api/src/services/events/processor.py
@@ -33,6 +33,7 @@ from src.models.orm.events import (
     EventSubscription,
     WebhookSource,
 )
+from src.models.orm.integrations import IntegrationMapping
 from src.repositories.events import (
     EventDeliveryRepository,
     EventRepository,
@@ -468,11 +469,52 @@ class EventProcessor:
         Creates event record, finds subscriptions, creates deliveries,
         and queues workflow executions.
         """
+        event_organization_id = event_source.organization_id
+        if deliver.integration_entity_id is not None:
+            if webhook_source.integration_id is None:
+                logger.error(
+                    "Webhook delivery requested integration routing without a linked integration",
+                    extra={"event_source_id": str(event_source.id)},
+                )
+                return Rejected(
+                    message="Webhook integration routing is not configured",
+                    status_code=500,
+                )
+
+            mapping_result = await self.session.execute(
+                sa.select(IntegrationMapping).where(
+                    IntegrationMapping.integration_id == webhook_source.integration_id,
+                    IntegrationMapping.entity_id == deliver.integration_entity_id,
+                    IntegrationMapping.organization_id.is_not(None),
+                )
+            )
+            mappings = list(mapping_result.scalars().all())
+            if not mappings:
+                logger.warning(
+                    "Webhook tenant has no integration mapping",
+                    extra={"event_source_id": str(event_source.id)},
+                )
+                return Rejected(
+                    message="Webhook tenant is not configured",
+                    status_code=403,
+                )
+            if len(mappings) > 1:
+                logger.error(
+                    "Webhook tenant has ambiguous integration mappings",
+                    extra={"event_source_id": str(event_source.id)},
+                )
+                return Rejected(
+                    message="Webhook tenant routing is ambiguous",
+                    status_code=500,
+                )
+            event_organization_id = mappings[0].organization_id
+
         # Create event record
         event = Event(
             id=uuid.uuid4(),
             event_source_id=event_source.id,
             event_type=deliver.event_type,
+            organization_id=event_organization_id,
             received_at=datetime.now(timezone.utc),
             headers=deliver.raw_headers,
             data=deliver.data,
@@ -531,6 +573,22 @@ class EventProcessor:
                         f"Subscription {subscription.id} has no workflow, skipping"
                     )
                     continue
+
+            target = subscription.agent if target_type == "agent" else subscription.workflow
+            target_org_id = getattr(target, "organization_id", None)
+            if (
+                event.organization_id is not None
+                and target_org_id is not None
+                and target_org_id != event.organization_id
+            ):
+                logger.warning(
+                    "Skipping cross-organization event subscription",
+                    extra={
+                        "event_id": str(event.id),
+                        "subscription_id": str(subscription.id),
+                    },
+                )
+                continue
 
             delivery, filter_matches = self._build_subscription_delivery(
                 event,
@@ -782,13 +840,15 @@ class EventProcessor:
             received_at=event.received_at.isoformat() if event.received_at else "",
         )
 
-        # Use the centralized system execution helper
-        # Use workflow's org_id so org-scoped workflows only access their org's data
+        # Org-scoped workflows always retain their own scope. A global workflow
+        # receiving an integration-routed event executes in the mapped customer
+        # organization so its integrations, tables, and files resolve there.
+        execution_org_id = workflow.organization_id or event.organization_id
         execution_id = await enqueue_system_workflow_execution(
             workflow_id=str(workflow.id),
             parameters=parameters,
             source="Event System",
-            org_id=str(workflow.organization_id) if workflow.organization_id else None,
+            org_id=str(execution_org_id) if execution_org_id else None,
             event=event_context,
         )
 
@@ -841,7 +901,8 @@ class EventProcessor:
             "source_ip": event.source_ip,
         }
 
-        org_id = str(agent.organization_id) if agent.organization_id else None
+        execution_org_id = agent.organization_id or event.organization_id
+        org_id = str(execution_org_id) if execution_org_id else None
 
         run_id = await enqueue_agent_run(
             agent_id=str(agent.id),

--- a/api/src/services/webhooks/adapters/local_fixture.py
+++ b/api/src/services/webhooks/adapters/local_fixture.py
@@ -49,7 +49,14 @@ class LocalFixtureWebhookAdapter(WebhookAdapter):
         config: dict[str, Any],
         state: dict[str, Any],
     ) -> HandleResult:
-        return Deliver(event_type="local.fixture", data={})
+        integration_entity_id = str(
+            config.get("integration_entity_id") or ""
+        ).strip() or None
+        return Deliver(
+            event_type="local.fixture",
+            data={"integration_entity_id": integration_entity_id},
+            integration_entity_id=integration_entity_id,
+        )
 
     async def renew(
         self,

--- a/api/src/services/webhooks/adapters/microsoft_bot_framework.py
+++ b/api/src/services/webhooks/adapters/microsoft_bot_framework.py
@@ -43,7 +43,7 @@ class MicrosoftBotFrameworkAdapter(WebhookAdapter):
 
     config_schema = {
         "type": "object",
-        "required": ["app_id", "tenant_id"],
+        "required": ["app_id"],
         "properties": {
             "app_id": {
                 "type": "string",
@@ -53,7 +53,11 @@ class MicrosoftBotFrameworkAdapter(WebhookAdapter):
             "tenant_id": {
                 "type": "string",
                 "title": "Microsoft Tenant ID",
-                "description": "Entra tenant ID allowed to send Teams activities.",
+                "description": (
+                    "Optional fixed Entra tenant ID. Omit it on a multitenant "
+                    "source linked to an Integration; the signed activity tenant "
+                    "is then resolved through that Integration's mappings."
+                ),
             },
         },
     }
@@ -67,9 +71,6 @@ class MicrosoftBotFrameworkAdapter(WebhookAdapter):
         app_id = str(config.get("app_id") or "").strip()
         if not app_id:
             raise ValueError("Microsoft Bot Framework app_id is required")
-        tenant_id = str(config.get("tenant_id") or "").strip()
-        if not tenant_id:
-            raise ValueError("Microsoft Bot Framework tenant_id is required")
         return SubscribeResult()
 
     async def unsubscribe(
@@ -95,11 +96,7 @@ class MicrosoftBotFrameworkAdapter(WebhookAdapter):
             return Rejected(
                 message="Bot Framework app ID is not configured", status_code=500
             )
-        tenant_id = str(config.get("tenant_id") or "").strip()
-        if not tenant_id:
-            return Rejected(
-                message="Bot Framework tenant ID is not configured", status_code=500
-            )
+        tenant_id = str(config.get("tenant_id") or "").strip() or None
 
         authorization = request.headers.get("authorization", "")
         scheme, separator, token = authorization.partition(" ")
@@ -109,7 +106,9 @@ class MicrosoftBotFrameworkAdapter(WebhookAdapter):
             )
 
         try:
-            await self._validate_token(token.strip(), app_id, tenant_id, payload)
+            activity_tenant_id = await self._validate_token(
+                token.strip(), app_id, tenant_id, payload
+            )
         except (jwt.PyJWTError, KeyError, TypeError, ValueError) as exc:
             logger.warning(
                 "Bot Framework token validation failed: %s", type(exc).__name__
@@ -142,6 +141,7 @@ class MicrosoftBotFrameworkAdapter(WebhookAdapter):
                 "reply_to_id": payload.get("replyToId"),
             },
             event_type=f"microsoft_teams.{activity_type}",
+            integration_entity_id=(activity_tenant_id if tenant_id is None else None),
             raw_headers={
                 key: value
                 for key, value in request.headers.items()
@@ -153,9 +153,9 @@ class MicrosoftBotFrameworkAdapter(WebhookAdapter):
         self,
         token: str,
         app_id: str,
-        tenant_id: str,
+        tenant_id: str | None,
         payload: dict[str, Any],
-    ) -> None:
+    ) -> str:
         header = jwt.get_unverified_header(token)
         if header.get("alg") != "RS256":
             raise ValueError("Unsupported signing algorithm")
@@ -194,11 +194,14 @@ class MicrosoftBotFrameworkAdapter(WebhookAdapter):
             if isinstance(channel_data, dict)
             else None
         )
-        if activity_tenant_id != tenant_id:
+        if not isinstance(activity_tenant_id, str) or not activity_tenant_id.strip():
+            raise ValueError("Microsoft Teams activity tenant is required")
+        if tenant_id is not None and activity_tenant_id != tenant_id:
             raise ValueError("Microsoft Teams tenant mismatch")
         endorsements = jwk.get("endorsements") or []
         if channel_id not in endorsements:
             raise ValueError("Signing key is not endorsed for Microsoft Teams")
+        return activity_tenant_id
 
     async def _get_signing_jwk(self, kid: str) -> dict[str, Any]:
         keys = await self._get_jwks()

--- a/api/src/services/webhooks/protocol.py
+++ b/api/src/services/webhooks/protocol.py
@@ -145,6 +145,15 @@ class Deliver:
     raw_headers: dict[str, str] | None = None
     """Original request headers (for logging)."""
 
+    integration_entity_id: str | None = None
+    """External tenant/entity ID used to resolve the destination organization.
+
+    When present, the webhook source must be linked to an Integration and the
+    processor resolves an organization-specific IntegrationMapping before it
+    records or dispatches the event. This keeps multitenant webhook routing
+    behind the same allowlist that integration calls use.
+    """
+
 
 @dataclass
 class Rejected:

--- a/api/tests/e2e/api/test_events.py
+++ b/api/tests/e2e/api/test_events.py
@@ -546,6 +546,75 @@ class TestWebhookReceiver:
                 headers=platform_admin.headers,
             )
 
+    def test_integration_mapped_webhook_stamps_customer_organization(
+        self, e2e_client, platform_admin, org1
+    ):
+        """A global webhook routes an external tenant into its mapped org."""
+        integration_response = e2e_client.post(
+            "/api/integrations",
+            headers=platform_admin.headers,
+            json={"name": f"E2E routed webhook {uuid.uuid4().hex[:8]}"},
+        )
+        assert integration_response.status_code == 201, integration_response.text
+        integration = integration_response.json()
+
+        source = None
+        try:
+            mapping_response = e2e_client.post(
+                f"/api/integrations/{integration['id']}/mappings",
+                headers=platform_admin.headers,
+                json={
+                    "organization_id": org1["id"],
+                    "entity_id": "customer-tenant",
+                    "entity_name": "Customer Tenant",
+                },
+            )
+            assert mapping_response.status_code == 201, mapping_response.text
+
+            source_response = e2e_client.post(
+                "/api/events/sources",
+                headers=platform_admin.headers,
+                json={
+                    "name": f"E2E routed source {uuid.uuid4().hex[:8]}",
+                    "source_type": "webhook",
+                    "organization_id": None,
+                    "webhook": {
+                        "adapter_name": "local_fixture",
+                        "integration_id": integration["id"],
+                        "config": {"integration_entity_id": "customer-tenant"},
+                    },
+                },
+            )
+            assert source_response.status_code == 201, source_response.text
+            source = source_response.json()
+
+            webhook_response = e2e_client.post(f"/api/hooks/{source['id']}", json={})
+            assert webhook_response.status_code == 202, webhook_response.text
+
+            def find_event():
+                response = e2e_client.get(
+                    f"/api/events/sources/{source['id']}/events",
+                    headers=platform_admin.headers,
+                )
+                if response.status_code != 200:
+                    return None
+                events = response.json()["items"]
+                return events[0] if events else None
+
+            event = poll_until(find_event, max_wait=5.0)
+            assert event is not None
+            assert event["organization_id"] == org1["id"]
+        finally:
+            if source is not None:
+                e2e_client.delete(
+                    f"/api/events/sources/{source['id']}",
+                    headers=platform_admin.headers,
+                )
+            e2e_client.delete(
+                f"/api/integrations/{integration['id']}",
+                headers=platform_admin.headers,
+            )
+
     def test_webhook_creates_event(self, e2e_client, platform_admin, event_source):
         """Webhook POST creates Event record."""
         source_id = event_source["id"]

--- a/api/tests/unit/services/test_event_processor_agents.py
+++ b/api/tests/unit/services/test_event_processor_agents.py
@@ -15,6 +15,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from src.models.enums import EventDeliveryStatus
+from src.services.webhooks.protocol import Deliver, Rejected, WebhookRequest
 
 if TYPE_CHECKING:
     from src.services.events.processor import EventProcessor
@@ -24,6 +25,7 @@ def _make_event(
     event_id: uuid.UUID | None = None,
     event_type: str = "ticket.created",
     data: dict | None = None,
+    organization_id: uuid.UUID | None = None,
 ) -> MagicMock:
     event = MagicMock()
     event.id = event_id or uuid.uuid4()
@@ -34,6 +36,7 @@ def _make_event(
     event.received_at = datetime(2026, 1, 1, tzinfo=timezone.utc)
     event.source_ip = "10.0.0.1"
     event.status = "processing"
+    event.organization_id = organization_id
     return event
 
 
@@ -227,3 +230,119 @@ async def test_queue_agent_run_calls_enqueue():
         assert input_data["_event"]["body"] == event.data
         assert input_data["_event"]["headers"] == event.headers
         assert input_data["_event"]["source_ip"] == event.source_ip
+
+
+@pytest.mark.asyncio
+async def test_global_workflow_uses_integration_routed_event_organization():
+    """A global event handler resolves integrations in the mapped customer org."""
+    processor = _create_processor()
+    workflow = MagicMock()
+    workflow.id = uuid.uuid4()
+    workflow.organization_id = None
+    delivery = _make_delivery(target_type="workflow", workflow=workflow)
+    customer_org_id = uuid.uuid4()
+    event = _make_event(organization_id=customer_org_id)
+    execution_id = uuid.uuid4()
+
+    with patch(
+        "src.services.execution.async_executor.enqueue_system_workflow_execution",
+        new_callable=AsyncMock,
+        return_value=str(execution_id),
+    ) as mock_enqueue:
+        await processor._queue_workflow_execution(delivery, event)
+
+    assert mock_enqueue.await_args.kwargs["org_id"] == str(customer_org_id)
+    assert delivery.execution_id == execution_id
+
+
+@pytest.mark.asyncio
+async def test_global_agent_uses_integration_routed_event_organization():
+    """A global event agent runs in the mapped customer organization."""
+    processor = _create_processor()
+    agent = MagicMock()
+    agent.id = uuid.uuid4()
+    agent.organization_id = None
+    delivery = _make_delivery(target_type="agent", agent=agent)
+    customer_org_id = uuid.uuid4()
+    event = _make_event(organization_id=customer_org_id)
+
+    with patch(
+        "src.services.execution.agent_run_service.enqueue_agent_run",
+        new_callable=AsyncMock,
+        return_value=str(uuid.uuid4()),
+    ) as mock_enqueue:
+        await processor._queue_agent_run(delivery, event)
+
+    assert mock_enqueue.await_args.kwargs["org_id"] == str(customer_org_id)
+
+
+@pytest.mark.asyncio
+async def test_webhook_integration_mapping_stamps_customer_organization():
+    """The authenticated external tenant selects the event's customer org."""
+    processor = _create_processor()
+    processor.session.add = MagicMock()
+    customer_org_id = uuid.uuid4()
+    mapping_result = MagicMock()
+    mapping_result.scalars.return_value.all.return_value = [
+        MagicMock(organization_id=customer_org_id)
+    ]
+    processor.session.execute = AsyncMock(return_value=mapping_result)
+    processor._subscription_repo.get_active_for_event = AsyncMock(return_value=[])
+    processor._broadcast_event_update = AsyncMock()
+    event_source = MagicMock(
+        id=uuid.uuid4(),
+        organization_id=None,
+    )
+    webhook_source = MagicMock(integration_id=uuid.uuid4())
+    deliver = Deliver(
+        data={"tenant_id": "customer-tenant"},
+        event_type="microsoft_teams.message",
+        integration_entity_id="customer-tenant",
+    )
+    request = WebhookRequest(
+        method="POST",
+        path=f"/api/hooks/{event_source.id}",
+        headers={},
+        query_params={},
+        body=b"{}",
+        client_ip="10.0.0.1",
+    )
+
+    result = await processor._process_delivery(
+        webhook_source, event_source, deliver, request
+    )
+
+    assert isinstance(result, Deliver)
+    event = processor.session.add.call_args.args[0]
+    assert event.organization_id == customer_org_id
+    assert event.data["tenant_id"] == "customer-tenant"
+
+
+@pytest.mark.asyncio
+async def test_webhook_integration_mapping_rejects_unknown_tenant():
+    """A signed Teams activity is still denied unless its tenant is mapped."""
+    processor = _create_processor()
+    processor.session.add = MagicMock()
+    mapping_result = MagicMock()
+    mapping_result.scalars.return_value.all.return_value = []
+    processor.session.execute = AsyncMock(return_value=mapping_result)
+    event_source = MagicMock(id=uuid.uuid4(), organization_id=None)
+    webhook_source = MagicMock(integration_id=uuid.uuid4())
+    request = WebhookRequest(
+        method="POST",
+        path=f"/api/hooks/{event_source.id}",
+        headers={},
+        query_params={},
+        body=b"{}",
+    )
+
+    result = await processor._process_delivery(
+        webhook_source,
+        event_source,
+        Deliver(data={}, integration_entity_id="unknown-tenant"),
+        request,
+    )
+
+    assert isinstance(result, Rejected)
+    assert result.status_code == 403
+    processor.session.add.assert_not_called()

--- a/api/tests/unit/services/test_webhook_adapters.py
+++ b/api/tests/unit/services/test_webhook_adapters.py
@@ -300,6 +300,18 @@ async def test_local_fixture_adapter_rejects_unknown_subscription():
     assert result is None
 
 
+@pytest.mark.asyncio
+async def test_local_fixture_adapter_exposes_integration_routing_key():
+    result = await LocalFixtureWebhookAdapter().handle_request(
+        _make_request(),
+        {"integration_entity_id": "tenant-customer"},
+        {},
+    )
+
+    assert isinstance(result, Deliver)
+    assert result.integration_entity_id == "tenant-customer"
+
+
 def test_local_fixture_adapter_is_registered_only_outside_production(monkeypatch):
     monkeypatch.setattr(
         webhook_registry,
@@ -618,11 +630,12 @@ class TestMicrosoftBotFrameworkAdapter:
             await adapter.subscribe("https://example.com/hook", {}, None)
 
     @pytest.mark.asyncio
-    async def test_subscribe_requires_tenant_id(self, adapter):
-        with pytest.raises(ValueError, match="tenant_id"):
-            await adapter.subscribe(
-                "https://example.com/hook", {"app_id": self.app_id}, None
-            )
+    async def test_subscribe_allows_integration_mapped_tenant_routing(self, adapter):
+        result = await adapter.subscribe(
+            "https://example.com/hook", {"app_id": self.app_id}, None
+        )
+
+        assert result.state == {}
 
     @pytest.mark.asyncio
     async def test_missing_bearer_token_is_rejected(self, adapter):
@@ -652,8 +665,25 @@ class TestMicrosoftBotFrameworkAdapter:
         assert result.data["conversation_id"] == "conversation-1"
         assert result.data["tenant_id"] == "tenant-1"
         assert result.data["team_id"] == "team-1"
+        assert result.integration_entity_id is None
         assert "authorization" not in result.raw_headers
         assert "cookie" not in result.raw_headers
+
+    @pytest.mark.asyncio
+    async def test_multitenant_activity_exposes_signed_tenant_for_mapping(
+        self, adapter, signing_material
+    ):
+        private_key, jwk = signing_material
+        adapter._get_signing_jwk = AsyncMock(return_value=jwk)
+
+        result = await adapter.handle_request(
+            self._request(self._activity(), self._token(private_key)),
+            {"app_id": self.app_id},
+            {},
+        )
+
+        assert isinstance(result, Deliver)
+        assert result.integration_entity_id == self.tenant_id
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(

--- a/client/src/lib/v1.d.ts
+++ b/client/src/lib/v1.d.ts
@@ -15636,6 +15636,11 @@ export interface components {
              */
             event_source_id: string;
             /**
+             * Organization Id
+             * @description Organization selected for processing this event
+             */
+            organization_id?: string | null;
+            /**
              * Event Source Name
              * @description Event source name (for display)
              */


### PR DESCRIPTION
## Summary
- let webhook adapters supply a signed external tenant/entity ID
- resolve that ID through the source integration mapping and stamp the event organization
- execute global workflow/agent targets in the mapped customer organization while preventing cross-org delivery
- expose the resolved organization on event API responses
- preserve fixed-tenant Microsoft Bot Framework sources

## Verification
- 47 focused unit tests passed
- integration-routed webhook E2E passed
- legacy fixed-tenant Teams auth E2E passed
- 64 DTO/contract tests passed
- API pyright + ruff passed
- client TypeScript passed
- generated OpenAPI client types updated