### PR TITLE
Support independently deployed V2 Apps

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "bifrost",
-  "description": "Bifrost — MSP automation platform. Skills for building workflows, forms, agents, apps, tables, and files with the Bifrost SDK + CLI. Includes :build (create and debug artifacts), :setup (install CLI, authenticate, configure MCP), and :copilot-cowork-package (package Bifrost agents as Microsoft 365 Copilot Cowork plugins), :migrate (move a legacy v1 inline app + its backing entities into an installable v2 Solution).",
-  "version": "1.2.2",
+  "description": "Bifrost — MSP automation platform. Skills for building workflows, forms, agents, independent Apps, Solutions, tables, and files with the Bifrost SDK + CLI. Includes :build, :setup, :copilot-cowork-package, and :migrate for moving legacy v1 Apps into independent V2 projects or installable Solutions.",
+  "version": "1.2.3",
   "author": {
     "name": "Jack Musick",
     "url": "https://github.com/gobifrost/bifrost"

--- a/.claude/skills/bifrost-build/SKILL.md
+++ b/.claude/skills/bifrost-build/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: build
-description: Build or modify Bifrost apps, workflows, forms, agents, tables, managed files, configs, integrations, events, and related platform resources. Use for Solution-owned v2 projects, loose instance _repo/v1 content, local preview and testing, deployment planning, or MCP-only Bifrost work. Covers instance and install targeting, source ownership, access controls, testing, app design and theming, visual QA, and deployment handoff.
+description: Build or modify Bifrost apps, workflows, forms, agents, tables, managed files, configs, integrations, events, and related platform resources. Use for independent or Solution-owned V2 Apps, loose instance _repo/v1 content, local preview and testing, deployment planning, or MCP-only Bifrost work. Covers instance and install targeting, source ownership, access controls, testing, app design and theming, visual QA, and deployment handoff.
 ---
 
 # Bifrost Build
@@ -13,7 +13,7 @@ Follow the process below for every task. Load only the references routed for the
 
 ## Prerequisites
 
-This Solution workflow requires Bifrost CLI 1.2.2 or newer. The selected
+These App and Solution workflows require Bifrost CLI 1.2.3 or newer. The selected
 instance may enforce a newer minimum through `/api/version`; when the CLI gate
 blocks, install the CLI served by that instance before continuing.
 
@@ -32,37 +32,39 @@ A sandbox may be unable to read the host credential store. If authentication app
 
 ### 1. Choose the working model and target
 
-First choose which of three working models owns the change. `Workspace` here means the selected instance's loose `_repo` source and live loose entities; it does not mean global entity scope.
+First choose which of four working models owns the change. `Workspace` here means the selected instance's loose `_repo` source and live loose entities; it does not mean global entity scope.
 
 | Working model | Use it when | Authoring and lifecycle | Read next |
 |---|---|---|---|
 | **Workspace** | Maintaining a v1 app, building a loose workflow/entity, or intentionally creating source/resources shared at the instance level | Edit `_repo` source with `bifrost files`; create and mutate its scoped entity records directly with dedicated CLI commands. Commands target the selected instance directly; v1 app source remains draft until published. | `references/repository.md` |
+| **App** | Building one normal Vite/React App in its own git repository while workflows, tables, files, configs, and integrations remain live platform resources | Create or bind with `bifrost app create` / `app bind`; develop with `bifrost app start`; deliver only the App bundle with `bifrost app deploy`. Source stays local and never enters `_repo` or a manifest. | `references/apps-independent.md` |
 | **Solution** | Building a cohesive, portable, versioned app or automation package that should own and deploy its definitions together | Edit local source and `.bifrost` manifests; preview with `bifrost solution start`; deliver with `bifrost solution deploy`. Keep `global_repo_access: false`. | `references/solutions.md` |
 | **Solution supported by the Workspace** | A Solution intentionally depends on eligible shared `_repo` modules, registered loose workflows, tables, or files | Author and deploy Solution-owned definitions locally, but manage each shared Workspace dependency separately through its own CLI/file path. Set `global_repo_access: true`; this adds runtime fallback, not ownership or permission. | `references/solutions.md` and `references/solution-resource-access.md` |
 
-Use `bifrost.solution.yaml` at the project root as the ownership marker. If it exists, inspect `global_repo_access` to distinguish the second and third models. If it does not exist, use the Workspace model. If starting inside a nested folder, locate the root with ordinary file discovery; do not use a custom shell loop.
+Use `bifrost.solution.yaml` at the project root as the Solution ownership marker. If it exists, inspect `global_repo_access` to distinguish the two Solution models. Without it, a project-level `.env` containing `BIFROST_APP_ID` identifies an independent App; an ordinary loose checkout without either marker uses the Workspace model. If starting inside a nested folder, locate the root with ordinary file discovery; do not use a custom shell loop.
 
-For net-new work, confirm the model with the user before scaffolding. Prefer a Solution for a new product or package that should be portable and lifecycle-managed. Use the Workspace for deliberately loose, shared, or existing v1 content. Enable Workspace support for a Solution only when the shared dependencies are intentional and understood, never as a default convenience.
+For net-new work, confirm the model with the user before scaffolding. Use an App when one independently deployed frontend should consume live platform resources. Prefer a Solution when the frontend and its workflows, tables, configs, or other definitions must travel and reconcile as one installable package. Use the Workspace for deliberately loose, shared, or existing v1 content. Enable Workspace support for a Solution only when the shared dependencies are intentional and understood, never as a default convenience.
 
 Then establish the exact instance and, for either Solution model, the install that the CLI resolves. Read `.env` in the intended CLI invocation directory, normally the project or Solution root. Parent-directory `.env` files are not selected implicitly. Inspect these optional fields when present:
 
 - `BIFROST_API_URL`
+- `BIFROST_APP_ID`
 - `BIFROST_SOLUTION_ID`
 - `BIFROST_SOLUTION_SLUG`
 - `BIFROST_SOLUTION_ORG_ID`
 - `BIFROST_SOLUTION_SCOPE`
 
-Treat `.env` as optional local instance/install selection, not portable source. Do not commit it. A normal Bifrost project `.env` should not contain access or refresh tokens; report only the selector and binding fields above. Without an explicit install binding, Solution commands resolve a unique install by portable slug and print `--solution <id>` choices when several are available. If deploy finds no install, it requires `--org <ref>` or `--global` before creating one.
+Treat `.env` as local instance/App/install selection, not portable source. Do not commit it. A normal Bifrost project `.env` should not contain access or refresh tokens; report only the selector and binding fields above. An App clone uses `bifrost app bind` to recreate `BIFROST_API_URL` and `BIFROST_APP_ID`. Without an explicit install binding, Solution commands resolve a unique install by portable slug and print `--solution <id>` choices when several are available. If Solution deploy finds no install, it requires `--org <ref>` or `--global` before creating one.
 
 Compare `Current connection` and `Default connection` from `bifrost auth default`:
 
 - If `.env` selects a non-default instance, tell the user which instance and install are selected and offer the saved default before material work.
-- Removing `BIFROST_API_URL` from `.env` returns that directory to the saved default connection. Use `--url` for a one-command override; use `solution bind` only when intentionally remembering one install.
+- Removing `BIFROST_API_URL` from `.env` returns that directory to the saved default connection. Use `--url` for a one-command override; use `app bind` or `solution bind` only when intentionally remembering a target.
 - Never change the user's saved default merely to target one project.
 
 ### 2. Understand and plan the change
 
-If this is a Solution, state its name/slug, selected instance, resolved install, and install scope. Then confirm the requested outcome and intended users.
+If this is an App, state its local project, selected instance, bound App, and intended runtime organizations. If this is a Solution, state its name/slug, selected instance, resolved install, and install scope. Then confirm the requested outcome and intended users.
 
 For every material change, present a concise plan and get confirmation before editing. A small, well-bounded bug fix does not need ceremony. The plan must identify:
 
@@ -77,13 +79,13 @@ Keep the access tuple `(organization, access_level, role_ids)` compatible across
 
 ### 3. Build in the correct ownership model
 
-Load the artifact references routed below and follow the working model selected in step 1. Use curated references for the method and generated appendices or `--help` for exact syntax; never infer a familiar command or flag. Do not mix authoring paths: Workspace entities mutate live; Solution-owned definitions change through local source and deploy. If a Solution supported by the Workspace needs changes on both sides, track them as separate change sets with separate ownership, access, verification, and delivery effects.
+Load the artifact references routed below and follow the working model selected in step 1. Use curated references for the method and generated appendices or `--help` for exact syntax; never infer a familiar command or flag. Do not mix authoring paths: Workspace entities mutate live; independent App source changes locally and only its compiled artifact deploys; Solution-owned definitions change through local source and deploy. If an App or a Solution supported by the Workspace needs changes on both sides, track them as separate change sets with separate ownership, access, verification, and delivery effects.
 
 Use test-driven development for behavior: define the acceptance result, write a focused failing test when useful, implement the change, and make it pass. Do not create contrived tests for visual-only acceptance; verify the rendered result instead.
 
 Before adding workflow logic, search for an existing module that already owns the domain or integration behavior. Keep workflows as thin orchestration; put reusable business and integration logic in modules.
 
-Treat local Solution preview as connected development, not a data sandbox. Table, managed-file, config, and integration writes can affect the selected instance.
+Treat `app start` and `solution start` as connected development, not data sandboxes. Table, managed-file, config, and integration writes can affect the selected instance.
 
 ### 4. Verify the complete experience
 
@@ -107,8 +109,8 @@ Summarize what changed and what was verified. Separate source changes from live 
 
 Keep these layers distinct:
 
-- **Working model and source ownership** determine where definitions are edited: instance `_repo`/live records or local Solution source.
-- **Lifecycle ownership** determines how definitions reach the platform: immediate Workspace mutation or Solution deploy.
+- **Working model and source ownership** determine where definitions are edited: instance `_repo`/live records, one local App repository, or local Solution source.
+- **Lifecycle ownership** determines how definitions reach the platform: immediate Workspace mutation, App artifact deploy, or Solution full-replace deploy.
 - **Dependency resolution** determines where running code may look after its own resources miss. `global_repo_access` changes this layer only.
 - **Authorization** determines whether a resolved entity or row/file operation is allowed. Organization, access level, roles, policies, and external-user rules always apply.
 - **Environment data** such as table rows, runtime files, config values, and integration mappings can be live even while Solution source is running locally.
@@ -118,6 +120,7 @@ Therefore, a Solution supported by the Workspace may call an eligible loose work
 These relationships produce the following hard boundaries:
 
 - Solution-owned apps, workflows, forms, agents, tables, configs, claims, and file-location declarations change through local source plus `bifrost solution deploy`; do not live-mutate their managed records.
+- Independent App source changes only in its local repository. `bifrost app deploy` builds and activates the App artifact; it does not capture, copy, or own the live workflows, tables, files, configs, or integrations the App calls.
 - Instance `_repo` source changes through direct `bifrost files` commands. Writing source does not replace entity creation or workflow registration.
 - `.bifrost/*.yaml` is Solution source inside a Solution. Outside a Solution, discover and mutate live entities with their CLI commands rather than treating an exported manifest as live state.
 - `global_repo_access` is a runtime fallback gate, not install scope, global entity permission, or an authorization bypass.
@@ -128,10 +131,11 @@ These relationships produce the following hard boundaries:
 
 | Need | Load for the task |
 |---|---|
+| Create, bind, start, deploy, or migrate an independent App | `references/apps-independent.md`, `references/apps-v2.md`, `references/app-quality.md`, and `references/web-sdk-v2.md` |
 | Create, bind, start, capture, deploy, export, or install a Solution | `references/solutions.md` |
 | Read or write instance `_repo` source; maintain loose modules, workflows, or v1 apps | `references/repository.md` |
 | Author, register, execute, rename, or expose a Python workflow | `references/workflows.md` and the relevant section of `references/python-sdk.md` |
-| Build or modify a v2 Solution app | `references/apps-v2.md`, `references/app-quality.md`, and `references/web-sdk-v2.md` |
+| Build or modify a V2 App inside a Solution | `references/apps-v2.md`, `references/app-quality.md`, and `references/web-sdk-v2.md` |
 | Maintain an existing inline v1 app | Read `references/apps-v1.md` and `references/app-quality.md`; search `references/platform-api.md` only for the exact v1 export being used |
 | Create or change forms, agents, configs, integrations, events, orgs, roles, or claims | `references/entities.md` |
 | Define a table, write policies, or use table data | `references/tables.md` |

--- a/.claude/skills/bifrost-build/generated/cli-reference.md
+++ b/.claude/skills/bifrost-build/generated/cli-reference.md
@@ -158,6 +158,107 @@ Options:
   --help                          Show this message and exit.
 ```
 
+## `app`
+
+```
+Usage: app [OPTIONS] COMMAND [ARGS]...
+
+  Create, bind, run, and deploy an App project.
+
+Options:
+  --help  Show this message and exit.
+
+Commands:
+  bind        Bind a cloned Vite project to an existing App.
+  create      Create a Vite project and its remote App record.
+  deploy      Build and atomically deploy the current App project.
+  migrate     Migrate a pulled v1 App directory into an independent V2...
+  start       Run the local Vite App against live Bifrost resources.
+  swap-slugs  Atomically exchange v1 and independent V2 App slugs during...
+```
+
+### `app bind`
+
+```
+Usage: app bind [OPTIONS] REF [PATH]
+
+  Bind a cloned Vite project to an existing App.
+
+Options:
+  --url TEXT  Bifrost instance URL.
+  --help      Show this message and exit.
+```
+
+### `app create`
+
+```
+Usage: app create [OPTIONS] [PATH]
+
+  Create a Vite project and its remote App record.
+
+Options:
+  --name TEXT  App display name (default: directory name).
+  --slug TEXT  URL slug (default: derived from name).
+  --org TEXT   Organization UUID or name.
+  --global     Create a globally visible App.
+  --url TEXT   Bifrost instance URL.
+  --help       Show this message and exit.
+```
+
+### `app deploy`
+
+```
+Usage: app deploy [OPTIONS] [PATH]
+
+  Build and atomically deploy the current App project.
+
+Options:
+  --help  Show this message and exit.
+```
+
+### `app migrate`
+
+```
+Usage: app migrate [OPTIONS] SOURCE PATH
+
+  Migrate a pulled v1 App directory into an independent V2 App project.
+
+Options:
+  --name TEXT  App display name (default: destination name).
+  --slug TEXT  Temporary V2 URL slug (default: derived from name).
+  --org TEXT   Organization UUID or name.
+  --global     Create a globally visible App.
+  --url TEXT   Bifrost instance URL.
+  --help       Show this message and exit.
+```
+
+### `app start`
+
+```
+Usage: app start [OPTIONS] [PATH]
+
+  Run the local Vite App against live Bifrost resources.
+
+Options:
+  --org TEXT         Run against another authorized organization.
+  --port INTEGER     [default: 3000]
+  --host TEXT        [default: 127.0.0.1]
+  --public-url TEXT
+  --help             Show this message and exit.
+```
+
+### `app swap-slugs`
+
+```
+Usage: app swap-slugs [OPTIONS] APP_A APP_B
+
+  Atomically exchange v1 and independent V2 App slugs during cutover.
+
+Options:
+  --url TEXT  Bifrost instance URL.
+  --help      Show this message and exit.
+```
+
 ## `apps`
 
 ```
@@ -1833,7 +1934,7 @@ Commands:
   export        Download a Solution's workspace zip (shareable or full...
   init          Alias for `solution create`: scaffold and create a remote...
   install       Install a Solution from a workspace zip (drag-and-drop...
-  migrate-app   Migrate a v1 inline app dir to a scaffolded standalone_v2...
+  migrate-app   Migrate a v1 inline App directory to a scaffolded V2 App:...
   pull          Pull captured entities into the local .bifrost/ manifest...
   scaffold-app  Scaffold a standalone_v2 React app (package.json, vite,...
   sdk           Manage the app's vendored Bifrost SDK.
@@ -2009,8 +2110,8 @@ Options:
 ```
 Usage: solution migrate-app [OPTIONS] SOURCE V2_SLUG
 
-  Migrate a v1 inline app dir to a scaffolded standalone_v2 app: scaffold +
-  port source + rewrite imports + install shadcn. STOPS before build/wire and
+  Migrate a v1 inline App directory to a scaffolded V2 App: scaffold + port
+  source + rewrite imports + install shadcn. STOPS before build/wire and
   prints a checklist of the judgment steps left to you.
 
 Options:

--- a/.claude/skills/bifrost-build/generated/openapi-digest.md
+++ b/.claude/skills/bifrost-build/generated/openapi-digest.md
@@ -84,6 +84,7 @@
 | GET | `/api/applications/{app_id}/bundle-manifest` |
 | GET | `/api/applications/{app_id}/dependencies` |
 | PUT | `/api/applications/{app_id}/dependencies` |
+| POST | `/api/applications/{app_id}/deploy` |
 | GET | `/api/applications/{app_id}/dist/{path}` |
 | GET | `/api/applications/{app_id}/draft` |
 | PUT | `/api/applications/{app_id}/draft` |

--- a/.claude/skills/bifrost-build/references/apps-independent.md
+++ b/.claude/skills/bifrost-build/references/apps-independent.md
@@ -1,0 +1,104 @@
+# Independent Apps
+
+Use this model for one V2 frontend that lives in its own ordinary git repository while its workflows, tables, files, configs, and integrations remain live Bifrost resources. Use a Solution instead when those definitions must be packaged, installed, versioned, and reconciled together.
+
+## Source and binding
+
+Create a project and remote App record together:
+
+```bash
+bifrost app create operations --name "Operations"
+cd operations
+npm install
+```
+
+The directory is a normal Vite project. Its only Bifrost-specific local state is a gitignored `.env`:
+
+```dotenv
+BIFROST_API_URL=https://bifrost.example.com
+BIFROST_APP_ID=<uuid>
+```
+
+There is no Solution descriptor, `.bifrost` manifest, source YAML, `_repo` App directory, draft, preview, or publish step. A clean clone restores its local binding with:
+
+```bash
+bifrost app bind <app-id-or-slug> . --url https://bifrost.example.com
+```
+
+Never commit `.env`, access tokens, or refresh tokens.
+
+## Connected development
+
+Run the local App against the selected instance's live platform resources:
+
+```bash
+bifrost app start
+```
+
+`app start` runs Vite behind an authenticated Bifrost proxy. It does not execute local Python workflows. Workflow refs resolve against the live registered workflows visible to the App and selected organization. Tables, managed files, configs, integrations, and `_repo` modules are live as well; writes are real.
+
+Run `app start` before the first standalone `npm run build` in a clean checkout. Start installs the selected instance's SDK into `node_modules` transiently; it is intentionally absent from the portable `package.json` and git history. Server deploy installs the same instance-matched SDK in its isolated build directory.
+
+App identity and runtime organization scope are separate. The default organization is the current viewer's selected organization. An authorized provider/admin can troubleshoot another organization without rebinding or editing source:
+
+```bash
+bifrost app start --org "Customer Org"
+```
+
+This override does not bypass App, workflow, table, file, role, policy, or external-user authorization.
+
+## Deploy
+
+Deploy from the bound project root:
+
+```bash
+bifrost app deploy
+```
+
+The CLI excludes `.env`, ignored files, dependencies, and build output, then uploads source only for the duration of a durable server-side build. The server stores an immutable compiled artifact, atomically activates it, and discards uploaded source. A failed build leaves the previous deployment active.
+
+Deploy changes only the App artifact. It does not capture or mutate live backing resources. Confirm required workflows and policies exist in every organization where the App will run.
+
+## Global and organization-scoped Apps
+
+Choose visibility when creating the remote record:
+
+```bash
+bifrost app create operations --org "Customer Org"
+bifrost app create shared-portal --global
+```
+
+Both forms use the viewer's active organization as runtime data scope. The App record's organization controls visibility; it is not a hardcoded data-scope override. Verify the complete access tuple across the App and every resource it calls.
+
+## Migrate a v1 App
+
+Pull the legacy `_repo/apps/<slug>` source to a local directory, then create an independent V2 project with the deterministic import rewrite:
+
+```bash
+bifrost app migrate ./legacy-source ./operations-v2 \
+  --name "Operations" --slug operations-v2
+```
+
+The command ports pages/components, rewrites v1 platform imports, installs detected UI and browser dependencies, binds the new App, and prints the remaining route/design/access checklist. It does not move backing entities because independent Apps intentionally continue using live resources.
+
+After browser acceptance and deploy, preserve the live URL with an atomic slug swap:
+
+```bash
+bifrost app deploy ./operations-v2
+bifrost app swap-slugs operations operations-v2
+```
+
+The old v1 App remains parked under the temporary slug for rollback. Do not delete it until the V2 App has been verified with realistic users and organizations.
+
+## Acceptance
+
+Before handoff:
+
+- run tests, type checking, and `npm run build`;
+- inspect every route through the `app start` proxy, including refresh/deep links;
+- verify loading, empty, denied, error, disabled, and success states;
+- exercise live workflow, table, and file behavior in the default organization;
+- exercise `--org` with an authorized operator and confirm an unauthorized viewer cannot override scope;
+- deploy, launch from the Apps UI, and verify the same resource behavior;
+- intentionally fail a build once and confirm the previous deployment remains live;
+- confirm `.env` and App source are absent from permanent platform storage.

--- a/.claude/skills/bifrost-build/references/apps-v1.md
+++ b/.claude/skills/bifrost-build/references/apps-v1.md
@@ -1,6 +1,6 @@
 # Inline v1 Apps
 
-Use this reference only to maintain an existing `inline_v1` app or when the user explicitly requires a loose instance app. Build new apps as v2 apps inside a Solution.
+Use this reference only to maintain an existing `inline_v1` App. Build new Apps as V2 projects, either independently or inside a Solution according to ownership needs.
 
 ## Ownership
 
@@ -69,4 +69,4 @@ Publication queues the production rebuild. Verify its result and the published r
 
 Apply `app-quality.md` to v1 changes as well. Use semantic platform tokens where the runtime supports them, verify the actual rendered preview, and test all affected states.
 
-When converting to v2, use `bifrost solution migrate-app <source-slug> <v2-slug>` and then complete the judgment work it reports: real package imports, local shadcn components, provider/mount lifecycle, portable workflow refs, state replacement, full theming, and visual QA. Do not perform a mechanical import rewrite and call the migration complete.
+When converting to V2, choose ownership first. Use `bifrost app migrate <source-dir> <destination>` when the frontend should remain backed by live platform resources. Use `bifrost solution migrate-app <source-dir> <v2-slug>` when the App and selected backing definitions should become one installable package. Both commands stop before judgment-heavy route wiring, access review, theming, and visual QA; do not perform a mechanical import rewrite and call the migration complete.

--- a/.claude/skills/bifrost-build/references/apps-v2.md
+++ b/.claude/skills/bifrost-build/references/apps-v2.md
@@ -1,6 +1,6 @@
-# v2 Solution Apps
+# V2 Apps
 
-Use `standalone_v2` for every new Bifrost app. A v2 app is a normal React/TypeScript/Vite project owned by a Solution and deployed from source.
+A V2 App is a normal React/TypeScript/Vite project. It can be independently deployed from its own repository or owned and deployed as part of a Solution. Choose the ownership model before scaffolding; read `apps-independent.md` for independent App lifecycle and `solutions.md` for Solution lifecycle.
 
 Read `app-quality.md` before designing user-visible UI and `web-sdk-v2.md` when using Bifrost data or workflows.
 
@@ -12,10 +12,16 @@ From a Solution root:
 bifrost solution scaffold-app operations
 ```
 
-Use the scaffolded structure instead of recreating it from memory:
+For an independent App repository:
+
+```bash
+bifrost app create operations --name "Operations"
+```
+
+Both commands create the same App project structure; a Solution nests it under `apps/<slug>/` and adds its descriptor/manifests:
 
 ```text
-apps/operations/
+operations/                    # independent repo root, or apps/operations in a Solution
 ├── package.json
 ├── vite.config.ts
 ├── tsconfig.json
@@ -28,6 +34,8 @@ apps/operations/
     ├── components/
     ├── lib/
     └── pages/
+
+# Solution ownership adds these outside the App directory:
 functions/
 .bifrost/apps.yaml
 bifrost.solution.yaml
@@ -35,7 +43,7 @@ bifrost.solution.yaml
 
 Keep the scaffold's `index.html` and reusable `mount()` lifecycle in `src/main.tsx`. It registers the app module, receives per-mount URL/token/org/app/theme bootstrap data, wraps the app in `BifrostProvider`, and mounts the router at the host-provided basename. Hand-written legacy entrypoints often work locally and fail when the platform mounts the app more than once.
 
-The scaffold creates the app manifest entry. App metadata, source path, logo path, and dependencies deploy from the Solution; do not create or update the managed app record live.
+The Solution scaffold creates an App manifest entry; its metadata and source deploy with the Solution. The independent scaffold creates and binds the remote App record but stores no manifest or remote source. Do not cross these ownership models.
 
 ## Import boundaries
 
@@ -65,7 +73,7 @@ Use `../generated/web-sdk-surface.md` to confirm SDK exports. Do not guess an ex
 
 ## App-to-workflow contract
 
-Reference Solution workflows with portable workspace-root-relative locators:
+Reference workflows with portable path/function locators:
 
 ```tsx
 const query = useWorkflowQuery("functions/list_clients.py::run", { status: "active" });
@@ -74,34 +82,36 @@ const save = useWorkflowMutation("functions/save_client.py::run");
 
 Prefer `useWorkflowQuery` for reads that run on mount and `useWorkflowMutation` for explicit actions. Guard nullable initial data, render the hook's error, and prevent duplicate mutations while loading.
 
-Enforce authorization and integration access in the workflow. Client-side hiding is a convenience, not a security boundary. Keep config secrets and OAuth tokens out of browser code.
+Solution Apps resolve their own deployed workflows first. Independent Apps resolve live registered workflows in the selected organization. Enforce authorization and integration access in the workflow. Client-side hiding is a convenience, not a security boundary. Keep config secrets and OAuth tokens out of browser code.
 
 ## Dependencies and components
 
 Use the app's normal package manifest for browser dependencies. Install shadcn components into the app and import their local source; the platform does not inject the host client's private component tree into v2 apps.
 
-The scaffold intentionally omits an instance-specific `bifrost` dependency. `bifrost solution start` installs the selected instance's SDK transiently without changing `package.json`; deployed builds inject the SDK shipped by the serving instance.
+The scaffold intentionally omits an instance-specific `bifrost` dependency. `bifrost app start` and `bifrost solution start` install the selected instance's SDK transiently without changing `package.json`; deployed builds inject the SDK shipped by the serving instance.
 
 Prefer dependencies that are actively maintained, browser-safe, and compatible with the app's React version. Do not introduce a library for behavior that the platform or browser already provides simply because an old example used it.
 
 ## Local development
 
-Run the Solution's connected development server:
+Run the lifecycle's connected development server:
 
 ```bash
 bifrost solution start operations
+# or, from an independent App root:
+bifrost app start
 ```
 
 Open the proxy origin printed by the command, not Vite's internal port. App and workflow code hot-reload behind the same origin.
 
-The preview uses the bound install and selected live instance. Reads and writes to tables, managed files, configs, integrations, and fallback resources use real instance state. Seed disposable data or obtain permission before exercising production-sensitive mutations.
+Both paths use live instance data. A Solution start can run local Solution workflows; an independent App start never runs local workflows and proxies workflow calls to the live platform. Reads and writes to tables, managed files, configs, integrations, and shared resources use real instance state. Seed disposable data or obtain permission before exercising production-sensitive mutations.
 
 ## Completion checks
 
 Before offering deploy:
 
 - run the app's tests, type check, and production build;
-- exercise local workflows through the app, not only as isolated Python functions;
+- exercise workflow calls through the App; for an independent App those calls must hit the live platform rather than local Python;
 - inspect every changed route and important state using `app-quality.md`;
 - verify `supportsTheme` only after both themes pass;
 - confirm the app and supporting entities share compatible organization/access/roles;

--- a/.claude/skills/bifrost-build/references/sources.yaml
+++ b/.claude/skills/bifrost-build/references/sources.yaml
@@ -16,15 +16,27 @@ references:
       - api/bifrost/commands/apps.py
       - api/bifrost/platform_names.py
       - client/src/lib/app-code-runtime.ts
-    verified_at_sha: 3b29c703c87059b382aad7c90b41c9054d3c719e
+    verified_at_sha: b70a55c77024659b69536842335b515f629dd45e
 
   - file: references/apps-v2.md
     source_globs:
+      - api/bifrost/commands/app.py
       - api/bifrost/commands/solution.py
       - api/bifrost/manifest.py
       - client/src/lib/app-sdk/*.ts
       - client/src/lib/app-sdk/*.tsx
-    verified_at_sha: 3b29c703c87059b382aad7c90b41c9054d3c719e
+    verified_at_sha: b70a55c77024659b69536842335b515f629dd45e
+
+  - file: references/apps-independent.md
+    source_globs:
+      - api/bifrost/app_binding.py
+      - api/bifrost/app_migration.py
+      - api/bifrost/commands/app.py
+      - api/src/jobs/platform/application_deploy.py
+      - api/src/routers/applications.py
+      - client/src/lib/app-sdk/*.ts
+      - client/src/lib/app-sdk/*.tsx
+    verified_at_sha: b70a55c77024659b69536842335b515f629dd45e
 
   - file: references/entities.md
     source_globs:
@@ -113,7 +125,7 @@ references:
       - client/src/lib/app-sdk/use-files.ts
       - client/src/lib/app-sdk/use-table.ts
       - client/src/lib/app-sdk/use-workflow*.ts
-    verified_at_sha: 3b29c703c87059b382aad7c90b41c9054d3c719e
+    verified_at_sha: b70a55c77024659b69536842335b515f629dd45e
 
   - file: references/workflows.md
     source_globs:

--- a/.claude/skills/bifrost-build/references/web-sdk-v2.md
+++ b/.claude/skills/bifrost-build/references/web-sdk-v2.md
@@ -1,16 +1,14 @@
 # Web SDK v2
 
-The instance-served `bifrost` package is the runtime SDK for `standalone_v2` Solution apps. Use `../generated/web-sdk-surface.md` for the exact export/type surface. Read `apps-v2.md` for project structure and `app-quality.md` for UI completion.
+The instance-served `bifrost` package is the runtime SDK for V2 Apps, both independent and Solution-owned. Use `../generated/web-sdk-surface.md` for the exact export/type surface. Read `apps-v2.md` for project structure and `app-quality.md` for UI completion.
 
 ## Keeping an existing app current
 
-The web SDK is vendored into each app. A platform deployment does not update an existing app's installed SDK automatically. When a reported behavior is fixed in the web SDK, or an app predates the SDK behavior it now relies on, refresh that app before rebuilding it:
+The CLI installs the selected instance's web SDK into local dependencies for development, and each server-side deploy builds with that instance's SDK. When a reported behavior is fixed in the web SDK, or an App predates the SDK behavior it now relies on, refresh it before rebuilding:
 
-```bash
-bifrost solution sdk update [PATH] --app <app-slug>
-```
+For a Solution App, run `bifrost solution sdk update [PATH] --app <app-slug>`. For an independent App, `bifrost app start` installs the selected instance's current SDK transiently; remove a stale `node_modules/bifrost` only when the CLI reports a contract mismatch, then start again.
 
-Omit `--app` for a single-app Solution. This command downloads the SDK from the connected Bifrost instance and reinstalls the vendored package; do not hand-edit the generated SDK files. After updating, run the app's typecheck, tests, and production build, then redeploy it. API-only execution fixes and host-shell asset fixes do not require an app SDK update.
+Omit `--app` for a single-App Solution. The Solution command downloads the SDK from the connected Bifrost instance and reinstalls the vendored package; do not hand-edit generated SDK files. After updating, run the App's typecheck, tests, and production build, then redeploy it. API-only execution fixes and host-shell asset fixes do not require an App SDK update.
 
 ## Provider and context
 
@@ -55,7 +53,7 @@ await createOrder.mutate({ customerId, lines });
 
 Initial query data is nullable. Render loading and error states before accessing it. Keep query parameter objects stable so ordinary renders do not create accidental refetch loops. For mutations, expose progress, handle rejection, and prevent duplicate action where necessary.
 
-Workflow hooks resolve within the current app/Solution context. A UUID is environment-specific; a bare name can be ambiguous and may proxy to a deployed copy during local work.
+Workflow hooks resolve within the current App context. Solution Apps prefer their install's workflows; independent Apps use live registered workflows in the selected organization. A UUID is environment-specific, so prefer a portable path/function ref.
 
 ## Tables
 
@@ -88,7 +86,7 @@ const reports = useFiles("reports/", {
 await files.write("reports/status.txt", "ready", { location: "documents" });
 ```
 
-Solution locations must be declared. Render denied separately from empty, and use signed upload/download behavior for large binary data. Read `files.md`.
+Solution locations must be declared. Independent Apps use live managed-file locations and policies. Render denied separately from empty, and use signed upload/download behavior for large binary data. Read `files.md`.
 
 ## Errors
 

--- a/.claude/skills/bifrost-migrate/SKILL.md
+++ b/.claude/skills/bifrost-migrate/SKILL.md
@@ -1,36 +1,38 @@
 ---
 name: migrate
-description: Migrate a legacy Bifrost v1 (inline) app and its backing entities into a clean, installable v2 Solution. Use when the user wants to move an existing _repo app into Solutions, modernize a v1 inline app to standalone_v2, capture loose workflows/tables/configs into a Solution, or standardize/rename a messy workspace. Trigger phrases — "migrate this app to a solution", "move X into a solution", "v1 to v2", "/migrate", "convert my app to standalone v2", "capture these workflows into a solution".
+description: Migrate a legacy Bifrost v1 inline App into either an independent V2 App backed by live platform resources or a clean, installable V2 Solution with captured backing entities. Use for v1-to-v2 modernization, App cutover, Solution capture, or workspace cleanup. Trigger phrases — "migrate this app", "migrate this app to a solution", "move X into a solution", "v1 to v2", "/migrate", "convert my app to v2", "capture these workflows into a solution".
 ---
 
-# Bifrost Migrate (v1 → v2 Solution)
+# Bifrost Migrate (v1 → V2 App or Solution)
 
-Move a legacy inline (`inline_v1`) app and its non-shared backing entities into a clean,
-installable **Solution** (`standalone_v2`), with standardized folders and renamed workflows.
+Move a legacy inline (`inline_v1`) App into one of two explicit ownership models:
+
+- an **independent V2 App** in a normal git repository, continuing to use live workflows, tables, files, configs, and integrations; or
+- an installable **Solution** that owns the V2 App and selected non-shared backing definitions together.
 
 This skill is **judgment-heavy orchestration**, not a one-shot command. It drives existing
-primitives (`bifrost solution migrate-app`, `bifrost solution scaffold-app`, `bifrost solution
-start`, `bifrost solution swap-slugs`, `bifrost solution capture`) and makes the per-app calls a
+primitives (`bifrost app migrate`, `bifrost app start`, `bifrost app deploy`, `bifrost app swap-slugs`, `bifrost solution migrate-app`, `bifrost solution scaffold-app`, `bifrost solution
+start`, `bifrost solution swap-slugs`, `bifrost solution capture`) and makes the per-App calls a
 deterministic command can't: which shadcn components to add, whether layout/theme translate, what
 is safe to capture vs. irreducibly shared.
 
-## The hard rule of why this exists (read first)
+## Choose ownership before migrating
 
-- **A v1 app CANNOT live in a Solution.** Deploy hard-rejects non-`standalone_v2`. Capture refuses
-  inline_v1 apps (it would build an uninstallable bundle). So you do **not** "capture the app" —
-  you **re-author it as v2** and capture its **backing tables/workflows/configs**.
+- Choose an **independent App** when only the frontend should move local and deploy independently while existing platform resources remain live and shared. There is no manifest, capture, or Solution install.
+- Choose a **Solution** when the App and its non-shared backing definitions must be portable, installable, and lifecycle-managed together.
+- **A v1 App cannot be captured into a Solution.** Re-author the frontend as V2, then capture only the selected backing tables/workflows/configs. Independent migration captures nothing by design.
 - **The v1→v2 import surface gap is large.** v1 `import … from "bifrost"` injects ~40 shadcn UI
   components + React + react-router + lucide + `cn`/`format` at runtime. The v2 `bifrost` SDK
   exports only: `BifrostProvider`, `useBifrostContext`, `BifrostHeader`, `useWorkflow`, `useTable`,
   `useInfiniteTable`, `tables`. **No UI components, no React, no router.** Nearly every v1 import
-  line must be rewritten — that's what `bifrost solution migrate-app` does (deterministically).
+  line must be rewritten — both `bifrost app migrate` and `bifrost solution migrate-app` use the same deterministic rewrite.
 
 ## Who runs what
 
 | Action | Who | Why |
 |---|---|---|
-| `bifrost solution migrate-app`, `bifrost solution scaffold-app`, `solution capture --dry-run`/apply, `solution swap-slugs`, `bifrost api GET …`, `npx shadcn add`, file writes under the new app dir | **Agent** | non-interactive, scoped |
-| `bifrost solution start` | **Agent** starts it; **user** drives the browser | long-running dev server; user confirms design |
+| `bifrost app migrate`, `app deploy`, `app swap-slugs`, `bifrost solution migrate-app`, `solution capture --dry-run`/apply, `solution swap-slugs`, `bifrost api GET …`, `npx shadcn add`, file writes under the new App dir | **Agent** | non-interactive, scoped |
+| `bifrost app start` or `bifrost solution start` | **Agent** starts it; **user** drives the browser | long-running dev server; user confirms design |
 | `bifrost watch` / `sync` / `push` / `git push` | **User** | broad blast radius, deploy cadence |
 
 ## Gather org preferences up front (AskUserQuestion)
@@ -41,8 +43,7 @@ Before touching code, collect the conventions — they shape every later step:
    `orders_sync_records`). Renames MUST rewrite every ref (this skill does that — see step 6).
 2. **Folder layout.** Default: flat `workflows/` + flat `modules/` (NOT nested "feature" dirs).
    Standardize whatever mess `_repo` is in.
-3. **Which app(s)** to migrate, and the **target Solution** (existing install id, or create and bind
-   a new one with `bifrost solution create` / `init`).
+3. **Which App(s)** to migrate and the **target ownership model**. For an independent App, choose its destination repo/path, temporary slug, visibility, and org/global App scope. For a Solution, choose the existing install or create/bind one with `bifrost solution create`.
 4. **Confirm-in-browser or skip.** Offer to skip the browser-confirm loop once the user trusts the
    output.
 
@@ -54,7 +55,43 @@ the dev environment"). All `bifrost` calls below use that scratch CLI.
 
 ---
 
-## Per-app migration flow
+## Independent App migration flow
+
+Use this path when backing resources intentionally stay live rather than becoming Solution-owned.
+
+### 1. Read the v1 App and inventory dependencies
+
+- Pull/read the v1 source under `_repo/{repo_path}/`.
+- Inventory every workflow, table, managed-file location, config, and integration the App uses, plus the App/workflow/table/file access tuple in each target organization.
+- Identify UUID workflow refs and rewrite them to portable `path::function` refs. Independent deploy does not remap or capture backing entities.
+
+### 2. Create and port the independent V2 project
+
+```bash
+bifrost app migrate /path/to/pulled/v1-source ./<new-slug> \
+  --name "<Title>" --slug <new-slug> [--org <ref> | --global]
+```
+
+This creates the remote V2 App, writes its gitignored `.env` binding, scaffolds a normal Vite project, ports source, rewrites imports, installs detected dependencies, and prints the remaining judgment checklist. It does not write App source to `_repo`, create YAML, or capture platform resources.
+
+### 3. Wire, build, and browser-confirm
+
+- Complete route/layout wiring, v1-only hook replacement, theming, and error/loading/empty states.
+- Run `bifrost app start` first so the selected instance's SDK is installed transiently. Confirm every route, deep-link refresh, and core interaction in a browser, then run `npm run build`.
+- Exercise live workflow, table, and file behavior in the current org, then use `bifrost app start --org <ref>` as an authorized operator. Confirm an ordinary viewer cannot override scope.
+
+### 4. Deploy and cut over
+
+```bash
+bifrost app deploy
+bifrost app swap-slugs <old-v1-slug> <new-v2-slug>
+```
+
+Deploy before swapping. Launch the deployed App and repeat the browser/resource checks. The swap is atomic and parks the v1 App at the temporary slug for rollback. A failed deploy must leave the prior V2 artifact active. There is no capture step.
+
+---
+
+## Solution migration flow
 
 Do ONE app at a time, fully, before the next. Each step gates the following.
 
@@ -233,7 +270,23 @@ A's Solution would orphan B's reference across the scope boundary. Report it; le
 
 ## Verification before declaring done
 
-- The v2 app builds + runs under `bifrost solution start`, every page works.
+For either ownership model:
+
+- The V2 App builds and every route works in a real browser through the correct `start` command.
+- If theme support is present, every page and overlay is visually verified in both light and dark mode.
+- Workflow refs are portable, and live/deployed calls were exercised through the App rather than only in isolation.
+- The live slug serves the V2 row after the atomic swap, while the v1 row remains available under the parked slug until rollback is no longer needed.
+
+For an independent App:
+
+- `.env` is ignored; no App source or metadata YAML exists in `_repo` or permanent upload storage.
+- Default and authorized alternate-org runtime scopes were verified, including denial for an unauthorized viewer.
+- Live workflows, tables, and files work locally and after deploy; none became Solution-owned.
+- A deliberately broken redeploy leaves the active artifact unchanged.
+
+For a Solution:
+
+- The V2 App builds + runs under `bifrost solution start`, every page works.
 - If `supportsTheme` is present, every page and overlay is visually verified in both light and dark
   mode and uses theme tokens throughout; otherwise the theme toggle is absent.
 - Capture `--dry-run` shows no dangling refs after rename (refs rewritten).

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "bifrost",
-  "version": "1.2.2",
-  "description": "Bifrost — MSP automation platform. Skills for building workflows, forms, agents, apps, tables, and files with the Bifrost SDK + CLI, setting up local Bifrost development, and packaging Bifrost agents as Microsoft 365 Copilot Cowork plugins, :migrate (move a legacy v1 inline app + its backing entities into an installable v2 Solution).",
+  "version": "1.2.3",
+  "description": "Bifrost — MSP automation platform. Skills for building workflows, forms, agents, independent Apps, Solutions, tables, and files with the Bifrost SDK + CLI, including v1 migration into either V2 ownership model.",
   "author": {
     "name": "Jack Musick",
     "url": "https://github.com/gobifrost/bifrost"
@@ -13,7 +13,7 @@
   "interface": {
     "displayName": "Bifrost",
     "shortDescription": "Build, set up, and package Bifrost automation artifacts",
-    "longDescription": "Use Bifrost skills to build workflows, forms, agents, apps, tables, and files with the Bifrost SDK and CLI; set up local Bifrost development; and package Bifrost agents as Microsoft 365 Copilot Cowork plugins.",
+    "longDescription": "Use Bifrost skills to build workflows, forms, agents, independent Apps, Solutions, tables, and files with the Bifrost SDK and CLI; migrate legacy Apps; set up local development; and package Bifrost agents as Microsoft 365 Copilot Cowork plugins.",
     "developerName": "Jack Musick",
     "category": "Engineering",
     "capabilities": [
@@ -22,7 +22,7 @@
       "Write"
     ],
     "defaultPrompt": [
-      "Help me build a Bifrost workflow, form, agent, app, table, or file-backed Solution.",
+      "Help me build an independent Bifrost App, Solution, workflow, form, agent, table, or managed-file experience.",
       "Set up this project for local Bifrost development.",
       "Package a Bifrost agent as a Microsoft 365 Copilot Cowork plugin."
     ],

--- a/api/alembic/versions/20260829_independent_app_deployments.py
+++ b/api/alembic/versions/20260829_independent_app_deployments.py
@@ -1,0 +1,30 @@
+"""Add atomic deployment pointer for independent apps.
+
+Revision ID: 20260829_app_deployments
+Revises: 20260827_history_timeline
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "20260829_app_deployments"
+down_revision: str | None = "20260827_history_timeline"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.alter_column("applications", "repo_path", existing_type=sa.String(500), nullable=True)
+    op.add_column("applications", sa.Column("active_deployment_id", sa.Uuid(), nullable=True))
+    op.add_column(
+        "applications",
+        sa.Column("deployed_at", sa.DateTime(timezone=True), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("applications", "deployed_at")
+    op.drop_column("applications", "active_deployment_id")
+    op.alter_column("applications", "repo_path", existing_type=sa.String(500), nullable=False)

--- a/api/bifrost/app_binding.py
+++ b/api/bifrost/app_binding.py
@@ -1,0 +1,61 @@
+"""Standard ``.env`` binding for an independently managed App project."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+APP_ENV_KEYS = {"BIFROST_API_URL", "BIFROST_APP_ID"}
+
+
+@dataclass(frozen=True)
+class AppBinding:
+    api_url: str
+    app_id: str
+
+
+def _parse_env_line(line: str) -> tuple[str, str] | None:
+    stripped = line.strip()
+    if not stripped or stripped.startswith("#") or "=" not in stripped:
+        return None
+    if stripped.startswith("export "):
+        stripped = stripped.removeprefix("export ")
+    key, value = stripped.split("=", 1)
+    return key.strip(), value.strip().strip('"').strip("'")
+
+
+def read_app_binding(root: Path) -> AppBinding | None:
+    path = root / ".env"
+    if not path.is_file():
+        return None
+    values: dict[str, str] = {}
+    for line in path.read_text(encoding="utf-8").splitlines():
+        parsed = _parse_env_line(line)
+        if parsed:
+            values[parsed[0]] = parsed[1]
+    api_url = values.get("BIFROST_API_URL")
+    app_id = values.get("BIFROST_APP_ID")
+    return AppBinding(api_url=api_url, app_id=app_id) if api_url and app_id else None
+
+
+def write_app_binding(root: Path, binding: AppBinding) -> None:
+    path = root / ".env"
+    existing = path.read_text(encoding="utf-8").splitlines() if path.is_file() else []
+    kept = []
+    for line in existing:
+        parsed = _parse_env_line(line)
+        if parsed is None or parsed[0] not in APP_ENV_KEYS:
+            kept.append(line)
+    additions = [
+        f"BIFROST_API_URL={binding.api_url.rstrip('/')}",
+        f"BIFROST_APP_ID={binding.app_id}",
+    ]
+    path.write_text("\n".join([*kept, *additions]).rstrip() + "\n", encoding="utf-8")
+
+
+def find_app_root(start: Path) -> Path | None:
+    current = start.resolve()
+    for candidate in (current, *current.parents):
+        if (candidate / "package.json").is_file() and read_app_binding(candidate):
+            return candidate
+    return None

--- a/api/bifrost/app_migration.py
+++ b/api/bifrost/app_migration.py
@@ -265,8 +265,9 @@ def migrate_v1_source(
         )
     else:
         click.echo(
-            "  5. `npm run build`, then `bifrost app start` and inspect every "
-            "route against the intended live organization."
+            "  5. Run `bifrost app start` first so the instance-matched SDK is "
+            "installed, inspect every route against the intended live organization, "
+            "then run `npm run build`."
         )
         click.echo(
             "  6. Deploy with `bifrost app deploy`. The App keeps using live "

--- a/api/bifrost/app_migration.py
+++ b/api/bifrost/app_migration.py
@@ -1,0 +1,280 @@
+"""Shared v1-to-v2 source migration for Solution and independent Apps."""
+
+from __future__ import annotations
+
+import pathlib
+import shutil
+import subprocess
+from typing import Literal
+
+import click
+
+MigrationLifecycle = Literal["solution", "app"]
+
+
+COMBOBOX_WRAPPER = '''\
+import { useState } from "react";
+import { Check, ChevronsUpDown } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+import {
+  Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList,
+} from "@/components/ui/command";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+
+export interface ComboboxOption { value: string; label: string; }
+export interface ComboboxProps {
+  options: ComboboxOption[];
+  value?: string;
+  onValueChange?: (value: string) => void;
+  placeholder?: string;
+  searchPlaceholder?: string;
+  emptyText?: string;
+  className?: string;
+}
+
+export function Combobox({
+  options, value, onValueChange, placeholder = "Select…",
+  searchPlaceholder = "Search…", emptyText = "No results.", className,
+}: ComboboxProps) {
+  const [open, setOpen] = useState(false);
+  const selected = options.find((o) => o.value === value);
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button variant="outline" role="combobox" aria-expanded={open}
+          className={cn("w-full justify-between font-normal", className)}>
+          {selected ? selected.label : placeholder}
+          <ChevronsUpDown className="opacity-50" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-(--radix-popover-trigger-width) p-0">
+        <Command>
+          <CommandInput placeholder={searchPlaceholder} />
+          <CommandList>
+            <CommandEmpty>{emptyText}</CommandEmpty>
+            <CommandGroup>
+              {options.map((o) => (
+                <CommandItem key={o.value} value={o.label}
+                  onSelect={() => { onValueChange?.(o.value); setOpen(false); }}>
+                  <Check className={cn(value === o.value ? "opacity-100" : "opacity-0")} />
+                  {o.label}
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}
+'''
+
+
+def migrate_v1_source(
+    source: pathlib.Path,
+    app_dir: pathlib.Path,
+    *,
+    title: str,
+    lifecycle: MigrationLifecycle,
+) -> None:
+    """Port and deterministically rewrite a pulled v1 App directory.
+
+    The remaining route, authorization, design, and cutover work is deliberately
+    printed as a checklist because those decisions cannot be inferred safely.
+    """
+    src_dir = source.resolve()
+    notes: list[str] = []
+    (app_dir / "src" / "pages").mkdir(parents=True, exist_ok=True)
+    (app_dir / "src" / "components").mkdir(parents=True, exist_ok=True)
+
+    ported = 0
+    source_extensions = {".tsx", ".ts", ".jsx", ".js", ".css", ".json"}
+    for sub in ("pages", "components"):
+        srcsub = src_dir / sub
+        if not srcsub.is_dir():
+            continue
+        for file in srcsub.rglob("*"):
+            if (
+                not file.is_file()
+                or ".tmp." in file.name
+                or file.suffix not in source_extensions
+            ):
+                continue
+            destination = app_dir / "src" / sub / file.relative_to(srcsub)
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy(file, destination)
+            ported += 1
+
+    layout_source = src_dir / "_layout.tsx"
+    has_layout = layout_source.is_file()
+    if has_layout:
+        shutil.copy(layout_source, app_dir / "src" / "_layout.tsx")
+        ported += 1
+
+    extras = [
+        path.name
+        for path in src_dir.iterdir()
+        if path.name not in ("pages", "components", "_layout.tsx")
+        and not path.name.startswith(".")
+    ]
+    if extras:
+        notes.append(
+            "v1 App had non-standard top-level entries not auto-ported: "
+            f"{extras} — review by hand."
+        )
+
+    from bifrost.migrate_imports import load_lucide_icon_names
+    from bifrost.migrate_v2 import (
+        compute_shadcn_adds,
+        is_ui_source,
+        rewrite_v2_imports,
+        scan_third_party_deps,
+    )
+
+    lucide = frozenset(load_lucide_icon_names())
+    tsx_files = [
+        path
+        for path in sorted((app_dir / "src").rglob("*.tsx"))
+        if not is_ui_source(path)
+    ]
+    sources = {path: path.read_text(encoding="utf-8") for path in tsx_files}
+    shadcn_adds = compute_shadcn_adds(list(sources.values()))
+    for path, source_text in sources.items():
+        rewritten = rewrite_v2_imports(source_text, lucide)
+        if rewritten != source_text:
+            path.write_text(rewritten, encoding="utf-8")
+
+    all_source = [
+        path.read_text(encoding="utf-8")
+        for path in (app_dir / "src").rglob("*")
+        if path.is_file()
+        and path.suffix in {".tsx", ".ts", ".jsx", ".js"}
+        and not is_ui_source(path)
+    ]
+    third_party = scan_third_party_deps(all_source)
+    unresolved = [
+        path.name for path in sources if "TODO(migrate)" in path.read_text()
+    ]
+    no_v2_hooks = sorted(
+        {
+            hook
+            for text in (path.read_text() for path in tsx_files)
+            for hook in ("useUser", "useAppState", "RequireRole")
+            if hook in text
+        }
+    )
+
+    click.echo("Installing dependencies …")
+    subprocess.run(
+        ["npm", "install"], cwd=app_dir, check=False, capture_output=True
+    )
+    if shadcn_adds:
+        click.echo(f"shadcn components: {' '.join(shadcn_adds)}")
+        subprocess.run(
+            ["npx", "shadcn@latest", "add", *shadcn_adds, "--yes"],
+            cwd=app_dir,
+            check=False,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["npm", "install", "radix-ui", "sonner"],
+            cwd=app_dir,
+            check=False,
+            capture_output=True,
+        )
+        if "combobox" in shadcn_adds:
+            (app_dir / "src" / "components" / "ui" / "combobox.tsx").write_text(
+                COMBOBOX_WRAPPER, encoding="utf-8"
+            )
+    if third_party:
+        click.echo(f"third-party deps (direct v1 imports): {' '.join(third_party)}")
+        subprocess.run(
+            ["npm", "install", *third_party],
+            cwd=app_dir,
+            check=False,
+            capture_output=True,
+        )
+
+    click.echo("")
+    click.echo(
+        f"✓ Ported {ported} file(s), {len(shadcn_adds)} shadcn component(s), "
+        f"{len(third_party)} third-party dep(s)."
+    )
+    click.echo("")
+    click.echo("NEXT (human judgment — migrate-app stops here ON PURPOSE):")
+    click.echo(
+        "  1. Wire src/App.tsx routes from the ported pages. v1 used FILE-BASED "
+        "routing;"
+    )
+    click.echo(
+        '     recreate it with react-router: pages/foo.tsx → <Route path="foo">, '
+    )
+    click.echo(
+        '     pages/a/b.tsx → path="a/b", pages/x/[id].tsx → path="x/:id" '
+        "(useParams())."
+    )
+    click.echo(f'     Add <BifrostHeader title="{title}"/> + <Toaster/> at the top.')
+    if has_layout:
+        click.echo(
+            "     src/_layout.tsx is the v1 shared nav chrome — make it the "
+            "RootLayout: a"
+        )
+        click.echo(
+            "     parent <Route element={<RootLayout/>}> whose RootLayout renders "
+            "the nav +"
+        )
+        click.echo(
+            "     <Outlet/>; nest the section pages under it. "
+            "(It already uses <Outlet/>.)"
+        )
+    if unresolved:
+        click.echo(
+            f"  2. Resolve TODO(migrate) imports in: {unresolved} "
+            "(no auto-mapping found)."
+        )
+    if no_v2_hooks:
+        click.echo(
+            f"  3. Port v1-only hooks (NO v2 SDK equivalent): {no_v2_hooks}. "
+            "There is no"
+        )
+        click.echo(
+            "     useUser in v2 — use `useBifrostContext()` from \"bifrost\" for "
+            "token/org/"
+        )
+        click.echo(
+            "     logout/theme; decode the JWT in ctx.token if you need the "
+            "user's email."
+        )
+    click.echo(
+        "  4. Workflow refs: rewrite UUIDs to portable path::function refs and "
+        "verify access in every target organization."
+    )
+    for note in notes:
+        click.echo(f"  • {note}")
+    if lifecycle == "solution":
+        click.echo(
+            "  5. `npm run build`, then `bifrost solution start` and screenshot "
+            "at least 2 routes."
+        )
+        click.echo(
+            "  6. Cutover: `bifrost solution swap-slugs <old> <new>`, then "
+            "`bifrost solution capture` LAST (capture is terminal — deploy after "
+            "it wipes captures)."
+        )
+    else:
+        click.echo(
+            "  5. `npm run build`, then `bifrost app start` and inspect every "
+            "route against the intended live organization."
+        )
+        click.echo(
+            "  6. Deploy with `bifrost app deploy`. The App keeps using live "
+            "workflows, tables, files, configs, and integrations; none are captured."
+        )
+        click.echo(
+            "  7. Cut over bookmarks with `bifrost app swap-slugs <old-v1> "
+            "<new-v2>` only after the deployed V2 App passes browser acceptance."
+        )
+
+    click.echo(f"\nApp at {app_dir}")

--- a/api/bifrost/cli.py
+++ b/api/bifrost/cli.py
@@ -709,6 +709,10 @@ def main(args: list[str] | None = None) -> int:
             from bifrost.commands.solution import handle_solution
             return handle_solution(args[1:])
 
+        if command == "app":
+            from bifrost.commands.app import handle_app
+            return handle_app(args[1:])
+
         if command == "deploy":
             from bifrost.commands.solution import handle_deploy
             return handle_deploy(args[1:])
@@ -743,6 +747,7 @@ Commands:
   push        Push local files to Bifrost platform (alias for sync)
   pull        Pull files from Bifrost platform to local directory (alias for sync)
   solution    Manage Solution installs (create, bind, scaffold-app, start, deploy, install)
+  app         Create, bind, start, and deploy an App project
   deploy      Deploy the current Solution workspace (alias for 'solution deploy')
   watch       Watch for file changes and auto-push
   api         Generic authenticated API request

--- a/api/bifrost/commands/app.py
+++ b/api/bifrost/commands/app.py
@@ -85,25 +85,17 @@ async def _find_app(client: BifrostClient, ref: str) -> dict:
     return match
 
 
-@app_group.command("create")
-@click.argument("path", default=".", type=click.Path(file_okay=False))
-@click.option("--name", default=None, help="App display name (default: directory name).")
-@click.option("--slug", default=None, help="URL slug (default: derived from name).")
-@click.option("--org", "org_ref", default=None, help="Organization UUID or name.")
-@click.option("--global", "is_global", is_flag=True, help="Create a globally visible App.")
-@click.option("--url", "api_url", default=None, help="Bifrost instance URL.")
-def create_cmd(
-    path: str,
+def _create_project(
+    root: pathlib.Path,
+    *,
     name: str | None,
     slug: str | None,
     org_ref: str | None,
     is_global: bool,
     api_url: str | None,
-) -> None:
-    """Create a Vite project and its remote App record."""
+) -> tuple[dict, str]:
     if org_ref and is_global:
         raise click.UsageError("Use either --org or --global, not both.")
-    root = pathlib.Path(path).resolve()
     if root.exists() and any(root.iterdir()):
         raise click.ClickException(f"{root} is not empty.")
     display_name = name or (root.name if root.name not in {"", "."} else "my-app")
@@ -135,8 +127,77 @@ def create_cmd(
         # The remote row is intentionally retained: deleting it automatically
         # would be a destructive side effect after a local filesystem failure.
         raise
+    return app, app_slug
+
+
+@app_group.command("create")
+@click.argument("path", default=".", type=click.Path(file_okay=False))
+@click.option("--name", default=None, help="App display name (default: directory name).")
+@click.option("--slug", default=None, help="URL slug (default: derived from name).")
+@click.option("--org", "org_ref", default=None, help="Organization UUID or name.")
+@click.option("--global", "is_global", is_flag=True, help="Create a globally visible App.")
+@click.option("--url", "api_url", default=None, help="Bifrost instance URL.")
+def create_cmd(
+    path: str,
+    name: str | None,
+    slug: str | None,
+    org_ref: str | None,
+    is_global: bool,
+    api_url: str | None,
+) -> None:
+    """Create a Vite project and its remote App record."""
+    root = pathlib.Path(path).resolve()
+    app, _ = _create_project(
+        root,
+        name=name,
+        slug=slug,
+        org_ref=org_ref,
+        is_global=is_global,
+        api_url=api_url,
+    )
     click.echo(f"Created App {app['id']} in {root}")
     click.echo("Run `npm install`, then `bifrost app start`.")
+
+
+@app_group.command("migrate")
+@click.argument("source", type=click.Path(exists=True, file_okay=False))
+@click.argument("path", type=click.Path(file_okay=False))
+@click.option("--name", default=None, help="App display name (default: destination name).")
+@click.option("--slug", default=None, help="Temporary V2 URL slug (default: derived from name).")
+@click.option("--org", "org_ref", default=None, help="Organization UUID or name.")
+@click.option("--global", "is_global", is_flag=True, help="Create a globally visible App.")
+@click.option("--url", "api_url", default=None, help="Bifrost instance URL.")
+def migrate_cmd(
+    source: str,
+    path: str,
+    name: str | None,
+    slug: str | None,
+    org_ref: str | None,
+    is_global: bool,
+    api_url: str | None,
+) -> None:
+    """Migrate a pulled v1 App directory into an independent V2 App project."""
+    source_root = pathlib.Path(source).resolve()
+    root = pathlib.Path(path).resolve()
+    if source_root == root or source_root in root.parents:
+        raise click.ClickException("Migration destination must be outside the v1 source directory.")
+    app, app_slug = _create_project(
+        root,
+        name=name,
+        slug=slug,
+        org_ref=org_ref,
+        is_global=is_global,
+        api_url=api_url,
+    )
+    from bifrost.app_migration import migrate_v1_source
+
+    migrate_v1_source(
+        source_root,
+        root,
+        title=name or app_slug,
+        lifecycle="app",
+    )
+    click.echo(f"Created migrated App {app['id']} in {root}")
 
 
 @app_group.command("bind")
@@ -185,6 +246,45 @@ def _zip_project(root: pathlib.Path, destination: pathlib.Path) -> None:
             included += 1
     if included == 0:
         raise click.ClickException("The App project contains no deployable files.")
+
+
+async def swap_app_slugs(client: BifrostClient, app_a: str, app_b: str) -> None:
+    """Resolve two App refs and atomically exchange their public slugs."""
+    from uuid import UUID
+
+    async def resolve(ref: str) -> str:
+        try:
+            UUID(ref)
+            return ref
+        except (TypeError, ValueError):
+            response = await client.get(f"/api/applications/{ref}")
+            if response.status_code != 200:
+                raise click.ClickException(
+                    f"No application '{ref}' ({response.status_code}): "
+                    f"{response.text[:160]}"
+                )
+            return str(response.json()["id"])
+
+    response = await client.post(
+        "/api/applications/swap-slugs",
+        json={"app_a": await resolve(app_a), "app_b": await resolve(app_b)},
+    )
+    if response.status_code not in (200, 201):
+        raise click.ClickException(
+            f"Slug swap failed ({response.status_code}): {response.text[:300]}"
+        )
+    for app in response.json().get("applications", []):
+        click.echo(f"  {app['name']} → /apps/{app['slug']}")
+    click.echo("Slug swap complete.")
+
+
+@app_group.command("swap-slugs")
+@click.argument("app_a")
+@click.argument("app_b")
+@click.option("--url", "api_url", default=None, help="Bifrost instance URL.")
+def swap_slugs_cmd(app_a: str, app_b: str, api_url: str | None) -> None:
+    """Atomically exchange v1 and independent V2 App slugs during cutover."""
+    asyncio.run(swap_app_slugs(_client(api_url), app_a, app_b))
 
 
 async def _wait_for_deploy(client: BifrostClient, job_id: str) -> dict:

--- a/api/bifrost/commands/app.py
+++ b/api/bifrost/commands/app.py
@@ -1,0 +1,344 @@
+"""Local lifecycle for independently managed V2 Apps."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import pathlib
+import shutil
+import subprocess
+import tempfile
+import time
+import zipfile
+
+import click
+
+from bifrost.app_binding import AppBinding, find_app_root, read_app_binding, write_app_binding
+from bifrost.client import BifrostClient
+from bifrost.refs import RefResolver
+
+APP_DEPLOY_TIMEOUT_SECONDS = 20 * 60
+
+
+@click.group(name="app")
+def app_group() -> None:
+    """Create, bind, run, and deploy an App project."""
+
+
+def _client(api_url: str | None = None) -> BifrostClient:
+    return BifrostClient.get_instance(require_auth=True, api_url=api_url)
+
+
+def _slugify(value: str) -> str:
+    import re
+
+    slug = re.sub(r"[^a-z0-9]+", "-", value.lower()).strip("-")
+    if not slug or not slug[0].isalpha():
+        raise click.ClickException("App slug must begin with a letter.")
+    return slug
+
+
+def _scaffold(root: pathlib.Path, slug: str) -> None:
+    if root.exists() and any(root.iterdir()):
+        raise click.ClickException(f"{root} is not empty.")
+    root.mkdir(parents=True, exist_ok=True)
+    # The V2 runtime skeleton is shared with Solution Apps; only its local
+    # workflow/deploy language differs. This keeps both runtimes on one SDK
+    # mount contract while App projects remain ordinary Vite repositories.
+    from bifrost.commands.solution import _v2_scaffold_files
+
+    replacements = {
+        "bifrost solution start": "bifrost app start",
+        "bifrost deploy": "bifrost app deploy",
+        "standalone_v2 app": "V2 App",
+        "this Solution's own workflow": "the live platform workflow",
+        "THIS install's own workflow": "the live platform workflow",
+        "both from your local files": "against your live Bifrost environment",
+        '"functions/hello.py::main",\n  // shipped with this scaffold) or a workflow name — both resolve to THIS\n  // install\'s own workflow when deployed, and `bifrost app start` runs\n  // against your live Bifrost environment. (Avoid raw UUID refs: deploy remaps entity\n  // ids per install, so a hardcoded UUID won\'t resolve on a deployed install.)':
+            '"workflows/hello.py::main") or a workflow name. Replace this sample\n  // with a workflow that exists in the live Bifrost environment selected by\n  // `bifrost app start`. App identity and runtime organization scope are passed\n  // separately, so the same source can be debugged against an authorized org.',
+        '"functions/hello.py::main")': '"workflows/hello.py::main")',
+    }
+    for rel, content in _v2_scaffold_files(slug).items():
+        for old, new in replacements.items():
+            content = content.replace(old, new)
+        dest = root / rel
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_text(content, encoding="utf-8")
+    gitignore = root / ".gitignore"
+    gitignore.write_text(".env\nnode_modules/\ndist/\n", encoding="utf-8")
+
+
+async def _resolve_org(client: BifrostClient, ref: str) -> str:
+    return await RefResolver(client).resolve("org", ref)
+
+
+async def _find_app(client: BifrostClient, ref: str) -> dict:
+    app_id = await RefResolver(client).resolve("app", ref)
+    response = await client.get("/api/applications")
+    response.raise_for_status()
+    apps = response.json().get("applications", [])
+    match = next((app for app in apps if str(app.get("id")) == app_id), None)
+    if match is None:
+        raise click.ClickException(f"App {app_id} is not visible in the current scope.")
+    if match.get("app_model") != "standalone_v2" or match.get("is_solution_managed"):
+        raise click.ClickException("The selected App is not independently managed.")
+    return match
+
+
+@app_group.command("create")
+@click.argument("path", default=".", type=click.Path(file_okay=False))
+@click.option("--name", default=None, help="App display name (default: directory name).")
+@click.option("--slug", default=None, help="URL slug (default: derived from name).")
+@click.option("--org", "org_ref", default=None, help="Organization UUID or name.")
+@click.option("--global", "is_global", is_flag=True, help="Create a globally visible App.")
+@click.option("--url", "api_url", default=None, help="Bifrost instance URL.")
+def create_cmd(
+    path: str,
+    name: str | None,
+    slug: str | None,
+    org_ref: str | None,
+    is_global: bool,
+    api_url: str | None,
+) -> None:
+    """Create a Vite project and its remote App record."""
+    if org_ref and is_global:
+        raise click.UsageError("Use either --org or --global, not both.")
+    root = pathlib.Path(path).resolve()
+    if root.exists() and any(root.iterdir()):
+        raise click.ClickException(f"{root} is not empty.")
+    display_name = name or (root.name if root.name not in {"", "."} else "my-app")
+    app_slug = slug or _slugify(display_name)
+
+    async def run() -> tuple[dict, str]:
+        client = _client(api_url)
+        body: dict[str, object] = {
+            "name": display_name,
+            "slug": app_slug,
+            "app_model": "standalone_v2",
+        }
+        if org_ref:
+            body["organization_id"] = await _resolve_org(client, org_ref)
+        elif is_global:
+            body["organization_id"] = None
+        response = await client.post("/api/applications", json=body)
+        response.raise_for_status()
+        return response.json(), client.api_url
+
+    app, selected_api_url = asyncio.run(run())
+    try:
+        _scaffold(root, app_slug)
+        write_app_binding(
+            root,
+            AppBinding(api_url=selected_api_url, app_id=str(app["id"])),
+        )
+    except Exception:
+        # The remote row is intentionally retained: deleting it automatically
+        # would be a destructive side effect after a local filesystem failure.
+        raise
+    click.echo(f"Created App {app['id']} in {root}")
+    click.echo("Run `npm install`, then `bifrost app start`.")
+
+
+@app_group.command("bind")
+@click.argument("ref")
+@click.argument("path", default=".", type=click.Path(exists=True, file_okay=False))
+@click.option("--url", "api_url", default=None, help="Bifrost instance URL.")
+def bind_cmd(ref: str, path: str, api_url: str | None) -> None:
+    """Bind a cloned Vite project to an existing App."""
+    root = pathlib.Path(path).resolve()
+    if not (root / "package.json").is_file():
+        raise click.ClickException(f"{root} is not a Vite project (package.json missing).")
+
+    async def run() -> tuple[dict, BifrostClient]:
+        client = _client(api_url)
+        return await _find_app(client, ref), client
+
+    app, client = asyncio.run(run())
+    write_app_binding(root, AppBinding(client.api_url, str(app["id"])))
+    click.echo(f"Bound App {app['id']} in {root / '.env'}")
+
+
+def _bound_project(path: str) -> tuple[pathlib.Path, AppBinding]:
+    requested = pathlib.Path(path).resolve()
+    root = find_app_root(requested) if path == "." else requested
+    binding = read_app_binding(root) if root else None
+    if root is None or binding is None:
+        raise click.ClickException(
+            "No App binding found. Run `bifrost app create` or `bifrost app bind`."
+        )
+    return root, binding
+
+
+def _zip_project(root: pathlib.Path, destination: pathlib.Path) -> None:
+    from bifrost.cli import _build_file_filter
+
+    matcher = _build_file_filter(root)
+    included = 0
+    with zipfile.ZipFile(destination, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+        for file in sorted(root.rglob("*")):
+            if not file.is_file():
+                continue
+            rel = file.relative_to(root).as_posix()
+            if matcher.match_file(rel):
+                continue
+            archive.write(file, rel)
+            included += 1
+    if included == 0:
+        raise click.ClickException("The App project contains no deployable files.")
+
+
+async def _wait_for_deploy(client: BifrostClient, job_id: str) -> dict:
+    deadline = time.monotonic() + APP_DEPLOY_TIMEOUT_SECONDS
+    last_phase = None
+    while time.monotonic() < deadline:
+        response = await client.get(f"/api/platform-jobs/{job_id}")
+        response.raise_for_status()
+        job = response.json()
+        phase = (job.get("progress") or {}).get("phase")
+        if phase and phase != last_phase:
+            click.echo(phase, err=True)
+            last_phase = phase
+        if job.get("status") == "succeeded":
+            return job
+        if job.get("status") in {"failed", "cancelled"}:
+            error = (job.get("error") or {}).get("message") or job.get("status")
+            raise click.ClickException(f"App deploy failed: {error}")
+        await asyncio.sleep(2)
+    raise click.ClickException(f"App deploy timed out; job {job_id} is still running.")
+
+
+@app_group.command("deploy")
+@click.argument("path", default=".", type=click.Path(exists=True, file_okay=False))
+def deploy_cmd(path: str) -> None:
+    """Build and atomically deploy the current App project."""
+    root, binding = _bound_project(path)
+
+    async def run(zip_path: pathlib.Path) -> dict:
+        client = _client(binding.api_url)
+        with zip_path.open("rb") as source:
+            response = await client.post(
+                f"/api/applications/{binding.app_id}/deploy",
+                files={"source": ("app-source.zip", source, "application/zip")},
+            )
+        response.raise_for_status()
+        accepted = response.json()
+        click.echo(f"Deploy job {accepted['job_id']}", err=True)
+        return await _wait_for_deploy(client, str(accepted["job_id"]))
+
+    with tempfile.TemporaryDirectory(prefix="bifrost-app-cli-") as tmp:
+        zip_path = pathlib.Path(tmp) / "source.zip"
+        _zip_project(root, zip_path)
+        job = asyncio.run(run(zip_path))
+    click.echo(f"App deployed: {job.get('result', {}).get('application_id', binding.app_id)}")
+
+
+@app_group.command("start")
+@click.argument("path", default=".", type=click.Path(exists=True, file_okay=False))
+@click.option("--org", "org_ref", default=None, help="Run against another authorized organization.")
+@click.option("--port", default=3000, show_default=True, type=int)
+@click.option("--host", "bind_host", default="127.0.0.1", show_default=True)
+@click.option("--public-url", default=None)
+def start_cmd(
+    path: str,
+    org_ref: str | None,
+    port: int,
+    bind_host: str,
+    public_url: str | None,
+) -> None:
+    """Run the local Vite App against live Bifrost resources."""
+    from bifrost.commands.solution import (
+        _ensure_port_free,
+        _terminate_process_group,
+        _vite_child_env,
+        _wait_for_vite,
+    )
+    from bifrost.solution_dev.proxy import DevProxyConfig, build_dev_app
+    from aiohttp import web
+
+    root, binding = _bound_project(path)
+
+    async def scope() -> tuple[BifrostClient, str | None]:
+        client = _client(binding.api_url)
+        if org_ref:
+            return client, await _resolve_org(client, org_ref)
+        response = await client.get("/api/sdk/context")
+        response.raise_for_status()
+        organization = response.json().get("organization") or {}
+        return client, str(organization.get("id")) if organization.get("id") else None
+
+    client, org_id = asyncio.run(scope())
+    npm = shutil.which("npm")
+    if npm is None:
+        raise click.ClickException("npm not found on PATH — install Node.js first.")
+    vite_port = port + 1
+    _ensure_port_free(port)
+    _ensure_port_free(vite_port)
+
+    if not (root / "node_modules").is_dir() or not (root / "node_modules/bifrost").is_dir():
+        sdk = f"bifrost@{client.api_url.rstrip('/')}/api/sdk/download"
+        click.echo("Installing App dependencies and this instance's SDK…")
+        subprocess.run(
+            [npm, "install", "--no-save", "--package-lock=false", sdk],
+            cwd=root,
+            check=True,
+        )
+
+    env = _vite_child_env(
+        dict(os.environ),
+        app_id=binding.app_id,
+        org_id=org_id,
+        access_token=client._access_token,
+    )
+    vite = subprocess.Popen(
+        [npm, "run", "dev", "--", "--port", str(vite_port), "--strictPort"],
+        cwd=root,
+        env=env,
+        start_new_session=True,
+    )
+    try:
+        _wait_for_vite(vite, vite_port)
+        cfg = DevProxyConfig(
+            upstream_url=client.api_url,
+            token=client._access_token,
+            app_id=binding.app_id,
+            org_id=org_id,
+            solution_id=None,
+            global_repo_access=True,
+            local_workflows=False,
+            refresh_token=client.refresh_access_token,
+        )
+
+        async def serve() -> None:
+            app = build_dev_app(cfg, None, f"http://127.0.0.1:{vite_port}")
+            runner = web.AppRunner(app)
+            await runner.setup()
+            await web.TCPSite(runner, bind_host, port).start()
+            origin = (public_url or f"http://127.0.0.1:{port}").rstrip("/")
+            click.echo(f"\n  Bifrost App → {origin}")
+            click.echo(f"  Live organization scope: {org_id or 'current user'}")
+            click.echo("  Press Ctrl-C to stop.\n")
+            try:
+                while True:
+                    await asyncio.sleep(3600)
+            except (KeyboardInterrupt, asyncio.CancelledError):
+                pass
+            finally:
+                await runner.cleanup()
+
+        asyncio.run(serve())
+    finally:
+        _terminate_process_group(vite)
+
+
+def handle_app(args: list[str]) -> int:
+    try:
+        app_group.main(args=args, standalone_mode=False, prog_name="bifrost app")
+        return 0
+    except click.exceptions.Exit as exc:
+        return exc.exit_code
+    except click.ClickException as exc:
+        exc.show()
+        return exc.exit_code
+
+
+__all__ = ["app_group", "handle_app"]

--- a/api/bifrost/commands/solution.py
+++ b/api/bifrost/commands/solution.py
@@ -2996,71 +2996,9 @@ def capture_cmd(
         raise SystemExit(rc)
 
 
-# Composed shadcn "recipe" components (not a single `add`): primitives + a small
-# vendored wrapper. migrate-app vendors the combobox wrapper from this template.
-_COMBOBOX_WRAPPER = '''\
-import { useState } from "react";
-import { Check, ChevronsUpDown } from "lucide-react";
-
-import { cn } from "@/lib/utils";
-import { Button } from "@/components/ui/button";
-import {
-  Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList,
-} from "@/components/ui/command";
-import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
-
-export interface ComboboxOption { value: string; label: string; }
-export interface ComboboxProps {
-  options: ComboboxOption[];
-  value?: string;
-  onValueChange?: (value: string) => void;
-  placeholder?: string;
-  searchPlaceholder?: string;
-  emptyText?: string;
-  className?: string;
-}
-
-export function Combobox({
-  options, value, onValueChange, placeholder = "Select…",
-  searchPlaceholder = "Search…", emptyText = "No results.", className,
-}: ComboboxProps) {
-  const [open, setOpen] = useState(false);
-  const selected = options.find((o) => o.value === value);
-  return (
-    <Popover open={open} onOpenChange={setOpen}>
-      <PopoverTrigger asChild>
-        <Button variant="outline" role="combobox" aria-expanded={open}
-          className={cn("w-full justify-between font-normal", className)}>
-          {selected ? selected.label : placeholder}
-          <ChevronsUpDown className="opacity-50" />
-        </Button>
-      </PopoverTrigger>
-      <PopoverContent className="w-(--radix-popover-trigger-width) p-0">
-        <Command>
-          <CommandInput placeholder={searchPlaceholder} />
-          <CommandList>
-            <CommandEmpty>{emptyText}</CommandEmpty>
-            <CommandGroup>
-              {options.map((o) => (
-                <CommandItem key={o.value} value={o.label}
-                  onSelect={() => { onValueChange?.(o.value); setOpen(false); }}>
-                  <Check className={cn(value === o.value ? "opacity-100" : "opacity-0")} />
-                  {o.label}
-                </CommandItem>
-              ))}
-            </CommandGroup>
-          </CommandList>
-        </Command>
-      </PopoverContent>
-    </Popover>
-  );
-}
-'''
-
-
 @solution_group.command(
     name="migrate-app",
-    help="Migrate a v1 inline app dir to a scaffolded standalone_v2 app: scaffold "
+    help="Migrate a v1 inline App directory to a scaffolded V2 App: scaffold "
     "+ port source + rewrite imports + install shadcn. STOPS before build/wire and "
     "prints a checklist of the judgment steps left to you.",
 )
@@ -3076,135 +3014,12 @@ def migrate_app_cmd(source: str, v2_slug: str, title: str | None) -> None:
     v1 layout (``pages/`` + ``components/``); anything else is reported, not
     guessed.
     """
-    import shutil as _shutil
-    import subprocess as _sp
-
     src_dir = pathlib.Path(source).resolve()
     title = title or v2_slug
-
-    # 1. Scaffold the v2 skeleton (Tailwind v4 + radix-rhea + theme already wired).
     app_dir = _scaffold_app(v2_slug, None)
+    from bifrost.app_migration import migrate_v1_source
 
-    # 2. Port v1 source. v1 layout = pages/ + components/ (+ _layout.tsx). Copy
-    #    what exists; report anything unexpected rather than guessing.
-    notes: list[str] = []
-    (app_dir / "src" / "pages").mkdir(parents=True, exist_ok=True)
-    (app_dir / "src" / "components").mkdir(parents=True, exist_ok=True)
-    # Port ALL source files under pages/ + components/ — not just .tsx. A page or
-    # component routinely imports a sibling .ts helper (e.g. metricDefinitions.ts),
-    # a .css, or a .tsx that's a util; dropping those silently breaks the build.
-    ported = 0
-    _SRC_EXT = {".tsx", ".ts", ".jsx", ".js", ".css", ".json"}
-    for sub in ("pages", "components"):
-        srcsub = src_dir / sub
-        if srcsub.is_dir():
-            for f in srcsub.rglob("*"):
-                if not f.is_file() or ".tmp." in f.name or f.suffix not in _SRC_EXT:
-                    continue
-                rel = f.relative_to(srcsub)
-                dest = app_dir / "src" / sub / rel
-                dest.parent.mkdir(parents=True, exist_ok=True)
-                _shutil.copy(f, dest)
-                ported += 1
-    # The v1 _layout.tsx defines the app's shared nav chrome (NavLink sections +
-    # <Outlet/>). It's NOT auto-wired — port it next to the pages so it's visible,
-    # and the checklist tells the human to turn it into the v2 RootLayout.
-    layout_src = src_dir / "_layout.tsx"
-    has_layout = layout_src.is_file()
-    if has_layout:
-        _shutil.copy(layout_src, app_dir / "src" / "_layout.tsx")
-        ported += 1
-    # Flag non-standard top-level files (e.g. app.yaml, extra dirs) NOT ported.
-    extras = [
-        p.name for p in src_dir.iterdir()
-        if p.name not in ("pages", "components", "_layout.tsx")
-        and not p.name.startswith(".")
-    ]
-    if extras:
-        notes.append(f"v1 app had non-standard top-level entries not auto-ported: {extras} — review by hand.")
-
-    # 3. Deterministic import rewrite (--v2) — compute the shadcn-add list + split.
-    from bifrost.migrate_v2 import (
-        compute_shadcn_adds,
-        is_ui_source,
-        rewrite_v2_imports,
-        scan_third_party_deps,
-    )
-    from bifrost.migrate_imports import load_lucide_icon_names
-
-    lucide = frozenset(load_lucide_icon_names())
-    tsx_files = [
-        p for p in sorted((app_dir / "src").rglob("*.tsx")) if not is_ui_source(p)
-    ]
-    sources = {p: p.read_text(encoding="utf-8") for p in tsx_files}
-    adds = compute_shadcn_adds(list(sources.values()))
-    for p, srctext in sources.items():
-        new = rewrite_v2_imports(srctext, lucide)
-        if new != srctext:
-            p.write_text(new, encoding="utf-8")
-    # Third-party deps the v1 app imports DIRECTLY (not from bifrost) — the rewrite
-    # leaves these alone, so they must be npm-installed or the build breaks on e.g.
-    # recharts. Scan the post-rewrite sources (so our own @/ + sonner additions
-    # don't count) across ALL ported source, not just tsx.
-    all_src = [p.read_text() for p in (app_dir / "src").rglob("*")
-               if p.is_file() and p.suffix in {".tsx", ".ts", ".jsx", ".js"}
-               and not is_ui_source(p)]
-    third_party = scan_third_party_deps(all_src)
-    # Collect TODO markers (unresolved v1 imports) + no-v2-equivalent hooks.
-    unresolved = [p.name for p, _ in sources.items() if "TODO(migrate)" in p.read_text()]
-    no_v2_hook = sorted({
-        h for txt in (p.read_text() for p in tsx_files)
-        for h in ("useUser", "useAppState", "RequireRole") if h in txt
-    })
-
-    # 4. Install shadcn components (real radix-rhea source) + recipe + third-party.
-    click.echo("Installing dependencies …")
-    _sp.run(["npm", "install"], cwd=app_dir, check=False, capture_output=True)
-    if adds:
-        click.echo(f"shadcn components: {' '.join(adds)}")
-        _sp.run(["npx", "shadcn@latest", "add", *adds, "--yes"],
-                cwd=app_dir, check=False, capture_output=True)
-        _sp.run(["npm", "install", "radix-ui", "sonner"],
-                cwd=app_dir, check=False, capture_output=True)
-        # Vendor the combobox recipe wrapper if the app uses it.
-        if "combobox" in adds:
-            (app_dir / "src" / "components" / "ui" / "combobox.tsx").write_text(_COMBOBOX_WRAPPER)
-    if third_party:
-        click.echo(f"third-party deps (direct v1 imports): {' '.join(third_party)}")
-        _sp.run(["npm", "install", *third_party], cwd=app_dir, check=False, capture_output=True)
-
-    # 5. STOP. Print the judgment checklist — never silently build/wire/deploy.
-    click.echo("")
-    click.echo(f"✓ Ported {ported} file(s), {len(adds)} shadcn component(s), "
-               f"{len(third_party)} third-party dep(s).")
-    click.echo("")
-    click.echo("NEXT (human judgment — migrate-app stops here ON PURPOSE):")
-    # Route wiring — the load-bearing step. v1 used FILE-BASED routing
-    # (pages/<path>.tsx → /<path>, [id].tsx → :id, _layout.tsx = shared chrome).
-    # v2 uses plain react-router, so the routes must be authored explicitly.
-    click.echo("  1. Wire src/App.tsx routes from the ported pages. v1 used FILE-BASED routing;")
-    click.echo("     recreate it with react-router: pages/foo.tsx → <Route path=\"foo\">, ")
-    click.echo("     pages/a/b.tsx → path=\"a/b\", pages/x/[id].tsx → path=\"x/:id\" (useParams()).")
-    click.echo(f"     Add <BifrostHeader title=\"{title}\"/> + <Toaster/> at the top.")
-    if has_layout:
-        click.echo("     src/_layout.tsx is the v1 shared nav chrome — make it the RootLayout: a")
-        click.echo("     parent <Route element={<RootLayout/>}> whose RootLayout renders the nav +")
-        click.echo("     <Outlet/>; nest the section pages under it. (It already uses <Outlet/>.)")
-    if unresolved:
-        click.echo(f"  2. Resolve TODO(migrate) imports in: {unresolved} (no auto-mapping found).")
-    if no_v2_hook:
-        click.echo(f"  3. Port v1-only hooks (NO v2 SDK equivalent): {no_v2_hook}. There is no")
-        click.echo("     useUser in v2 — use `useBifrostContext()` from \"bifrost\" for token/org/")
-        click.echo("     logout/theme; decode the JWT in ctx.token if you need the user's email.")
-    click.echo("  4. Workflow refs: rewrite any UUID refs to portable path::fn (and ensure "
-               "those workflows exist in the target env).")
-    for n in notes:
-        click.echo(f"  • {n}")
-    click.echo("  5. `npm run build` (must pass — a build error names the missing import), then")
-    click.echo("     `bifrost solution start` AND screenshot at least 2 routes (render ≠ build).")
-    click.echo("  6. Cutover: `bifrost solution swap-slugs <old> <new>`, then `bifrost solution "
-               "capture` LAST (capture is terminal — deploy after it wipes captures).")
-    click.echo(f"\nApp at {app_dir}")
+    migrate_v1_source(src_dir, app_dir, title=title, lifecycle="solution")
 
 
 @solution_group.command(
@@ -3222,43 +3037,13 @@ def swap_slugs_cmd(app_a: str, app_b: str) -> None:
     is a deploy-owned property for those).
     """
 
-    async def _run() -> int:
-        client = BifrostClient.get_instance(require_auth=True)
+    from bifrost.commands.app import swap_app_slugs
 
-        async def _resolve(ref: str) -> str:
-            # An id passes straight through; a slug resolves via GET /{slug}.
-            try:
-                import uuid as _uuid
-
-                _uuid.UUID(ref)
-                return ref
-            except (ValueError, AttributeError):
-                pass
-            resp = await client.get(f"/api/applications/{ref}")
-            if resp.status_code != 200:
-                raise click.ClickException(
-                    f"No application '{ref}' ({resp.status_code}): {resp.text[:160]}"
-                )
-            return resp.json()["id"]
-
-        a_id = await _resolve(app_a)
-        b_id = await _resolve(app_b)
-        resp = await client.post(
-            "/api/applications/swap-slugs", json={"app_a": a_id, "app_b": b_id}
+    asyncio.run(
+        swap_app_slugs(
+            BifrostClient.get_instance(require_auth=True), app_a, app_b
         )
-        if resp.status_code not in (200, 201):
-            raise click.ClickException(
-                f"Slug swap failed ({resp.status_code}): {resp.text[:300]}"
-            )
-        apps = resp.json().get("applications", [])
-        for app in apps:
-            click.echo(f"  {app['name']} → /apps/{app['slug']}")
-        click.echo("Slug swap complete.")
-        return 0
-
-    rc = asyncio.run(_run())
-    if rc:
-        raise SystemExit(rc)
+    )
 
 
 _SDK_DOWNLOAD_SUFFIX = "/api/sdk/download"

--- a/api/bifrost/solution_dev/proxy.py
+++ b/api/bifrost/solution_dev/proxy.py
@@ -699,13 +699,17 @@ async def _ws_proxy(request: web.Request, target_ws_url: str) -> web.WebSocketRe
             # both would leave the surviving pump (and this handler, the
             # ClientSession, and the upstream socket) alive forever on every
             # browser reload.
-            _, pending = await asyncio.wait(
+            done, pending = await asyncio.wait(
                 [asyncio.ensure_future(c2s()), asyncio.ensure_future(s2c())],
                 return_when=asyncio.FIRST_COMPLETED,
             )
             for task in pending:
                 task.cancel()
-            await asyncio.gather(*pending, return_exceptions=True)
+            # Retrieve both pumps' outcomes. The completed pump can fail when
+            # the browser closes while an upstream frame is in flight; leaving
+            # that result unread emits "Task exception was never retrieved"
+            # during an otherwise clean `app start` / `solution start` stop.
+            await asyncio.gather(*done, *pending, return_exceptions=True)
             await ws_client.close()
             await ws_server.close()
     finally:

--- a/api/bifrost/solution_dev/proxy.py
+++ b/api/bifrost/solution_dev/proxy.py
@@ -120,6 +120,9 @@ class DevProxyConfig:
     # workflow ref that misses locally may fall back to the platform's shared
     # _repo/ content at all. Mirrors the module-loader semantics (§3.5).
     global_repo_access: bool = False
+    # Independent Apps always execute the platform's live workflows. Solution
+    # start leaves this true so it can keep its local FunctionHost behavior.
+    local_workflows: bool = True
     refresh_token: Callable[[str], Awaitable[str | None]] | None = None
     auth_expired: bool = False
     branding: dict[str, Any] | None = None
@@ -762,6 +765,33 @@ async def _execute_handler(request: web.Request) -> web.Response:
     host = request.app[_HOST]
     body = await request.json()
     ref = str(body.get("workflow_id", ""))
+
+    if not cfg.local_workflows:
+        # App start is a live-data development loop. App identity and runtime
+        # organization are separate inputs: the former is carried by app_id /
+        # X-Bifrost-App; the latter is an explicit execution override that the
+        # API independently authorizes.
+        body["app_id"] = cfg.app_id
+        if cfg.org_id:
+            body["org_id"] = cfg.org_id
+        try:
+            resp = await _authed_upstream_request(
+                request,
+                "POST",
+                f"{cfg.upstream_url}/api/workflows/execute",
+                json=body,
+            )
+        except httpx.HTTPError:
+            return web.json_response(
+                {"detail": f"Dev API unreachable at {cfg.upstream_url}"}, status=502
+            )
+        if resp is None:
+            return _dev_auth_expired_json_response()
+        return web.Response(
+            body=resp.content,
+            status=resp.status_code,
+            headers=_passthrough_headers(resp, "application/json"),
+        )
 
     if not ref:
         # Inline `code` execution (no workflow ref) — nothing to resolve

--- a/api/scripts/skill-truth/generate.py
+++ b/api/scripts/skill-truth/generate.py
@@ -36,11 +36,12 @@ def _walk_group(name: str, group: click.Group, lines: list[str], depth: int = 0)
 
 def gen_cli_reference() -> str:
     from bifrost.commands import ENTITY_GROUPS
+    from bifrost.commands.app import app_group
     from bifrost.commands.solution import solution_group
 
     lines: list[str] = ["# CLI Reference (generated — do not edit)\n"]
     lines.append("> Regenerate: `python api/scripts/skill-truth/generate.py`. CI enforces freshness.\n")
-    groups = {**ENTITY_GROUPS, "solution": solution_group}
+    groups = {**ENTITY_GROUPS, "app": app_group, "solution": solution_group}
     for name in sorted(groups):
         _walk_group(name, groups[name], lines)
     return "\n".join(lines) + "\n"

--- a/api/scripts/skill-truth/lint_claims.py
+++ b/api/scripts/skill-truth/lint_claims.py
@@ -54,9 +54,10 @@ class Finding:
 
 def _load_groups() -> dict[str, "click.Group"]:
     from bifrost.commands import ENTITY_GROUPS
+    from bifrost.commands.app import app_group
     from bifrost.commands.solution import solution_group
 
-    return {**ENTITY_GROUPS, "solution": solution_group}
+    return {**ENTITY_GROUPS, "app": app_group, "solution": solution_group}
 
 
 def _block_mode(filename: str, info: str) -> str:

--- a/api/src/jobs/platform/application_deploy.py
+++ b/api/src/jobs/platform/application_deploy.py
@@ -1,0 +1,167 @@
+"""Durable server-side build and atomic activation for independent Apps."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import subprocess
+import tempfile
+import zipfile
+from datetime import datetime, timezone
+from pathlib import Path, PurePosixPath
+from uuid import UUID
+
+from pydantic import BaseModel
+
+from src.core.database import get_db_context
+from src.jobs.platform.base import (
+    PlatformJobContext,
+    PlatformJobDefinition,
+    PlatformJobFailure,
+    PlatformJobPolicy,
+)
+from src.models.orm.applications import Application
+from src.services.application_deploy_storage import ApplicationDeployStorage
+from src.services.solutions.app_build import SolutionAppBuilder
+
+logger = logging.getLogger(__name__)
+MAX_EXPANDED_SOURCE_BYTES = 256 * 1024 * 1024
+
+
+class ApplicationDeployPayload(BaseModel):
+    application_id: UUID
+    deployment_id: UUID
+    input_sha256: str
+
+
+def _read_source_zip(path: Path) -> dict[str, bytes]:
+    files: dict[str, bytes] = {}
+    expanded = 0
+    try:
+        archive = zipfile.ZipFile(path)
+    except zipfile.BadZipFile as exc:
+        raise PlatformJobFailure("invalid_app_source", "App source is not a valid zip file.") from exc
+    with archive:
+        for info in archive.infolist():
+            rel = PurePosixPath(info.filename)
+            if info.is_dir():
+                continue
+            if rel.is_absolute() or ".." in rel.parts or not rel.parts:
+                raise PlatformJobFailure(
+                    "invalid_app_source", f"Unsafe path in App source: {info.filename}"
+                )
+            expanded += info.file_size
+            if expanded > MAX_EXPANDED_SOURCE_BYTES:
+                raise PlatformJobFailure(
+                    "app_source_too_large",
+                    "Expanded App source exceeds the 256 MiB limit.",
+                )
+            files[rel.as_posix()] = archive.read(info)
+    if "package.json" not in files or "index.html" not in files:
+        raise PlatformJobFailure(
+            "invalid_app_source",
+            "App source must be a Vite project with package.json and index.html at its root.",
+        )
+    return files
+
+
+async def run_application_deploy(
+    context: PlatformJobContext, payload: ApplicationDeployPayload
+) -> dict[str, str]:
+    storage = ApplicationDeployStorage(context.job_id)
+    builder = SolutionAppBuilder()
+    activated = False
+    old_deployment_id: UUID | None = None
+    try:
+        await context.report("Loading App source", percent=5)
+        with tempfile.TemporaryDirectory(prefix="bifrost-app-deploy-") as tmp:
+            source_zip = Path(tmp) / "source.zip"
+            await storage.copy_to_path(
+                source_zip, expected_sha256=payload.input_sha256
+            )
+            source_files = _read_source_zip(source_zip)
+
+        await context.report("Building App", percent=20)
+        try:
+            dist = await asyncio.to_thread(
+                builder.compile_dist,
+                payload.application_id,
+                source_files,
+                {},
+            )
+        except PlatformJobFailure:
+            raise
+        except subprocess.CalledProcessError as exc:
+            detail = (exc.stderr or exc.stdout or b"").decode(errors="replace")[-4000:]
+            raise PlatformJobFailure(
+                "app_build_failed",
+                f"Vite build failed.\n{detail}" if detail else "Vite build failed.",
+            ) from exc
+        except Exception as exc:
+            raise PlatformJobFailure("app_build_failed", str(exc)) from exc
+
+        await context.report("Uploading App artifact", percent=70)
+        await builder.upload_deployment(
+            payload.application_id, payload.deployment_id, dist
+        )
+
+        await context.report("Activating App", percent=95)
+        async with get_db_context() as db:
+            app = await db.get(Application, payload.application_id)
+            if app is None or app.solution_id is not None or app.app_model != "standalone_v2":
+                raise PlatformJobFailure(
+                    "app_not_deployable", "The App no longer supports independent deployment."
+                )
+            old_deployment_id = app.active_deployment_id
+            app.active_deployment_id = payload.deployment_id
+            app.deployed_at = datetime.now(timezone.utc)
+            await db.flush()
+        activated = True
+
+        if old_deployment_id and old_deployment_id != payload.deployment_id:
+            try:
+                await builder.delete_deployment(payload.application_id, old_deployment_id)
+            except Exception:
+                logger.warning(
+                    "Failed to remove superseded App deployment %s",
+                    old_deployment_id,
+                    exc_info=True,
+                )
+        await context.report("App deployed", percent=100)
+        return {
+            "application_id": str(payload.application_id),
+            "deployment_id": str(payload.deployment_id),
+        }
+    finally:
+        try:
+            await storage.delete()
+        except Exception:
+            logger.warning(
+                "Failed to delete transient App source for job %s",
+                context.job_id,
+                exc_info=True,
+            )
+        if not activated:
+            try:
+                await builder.delete_deployment(
+                    payload.application_id, payload.deployment_id
+                )
+            except Exception:
+                logger.warning(
+                    "Failed to clean incomplete App deployment %s",
+                    payload.deployment_id,
+                    exc_info=True,
+                )
+
+
+APPLICATION_DEPLOY_DEFINITION = PlatformJobDefinition(
+    job_type="application.deploy",
+    payload_version=1,
+    payload_model=ApplicationDeployPayload,
+    handler=run_application_deploy,
+    policy=PlatformJobPolicy(
+        timeout_seconds=20 * 60,
+        max_attempts=1,
+        min_memory_headroom_mb=512,
+    ),
+)

--- a/api/src/jobs/platform/registry.py
+++ b/api/src/jobs/platform/registry.py
@@ -3,6 +3,7 @@
 from src.jobs.platform.application_publish import (
     APPLICATION_PUBLISH_DEFINITION,
 )
+from src.jobs.platform.application_deploy import APPLICATION_DEPLOY_DEFINITION
 from src.jobs.platform.base import PlatformJobDefinition
 from src.jobs.platform.system_maintenance import (
     ARTIFACT_RETENTION_CLEANUP_DEFINITION,
@@ -23,6 +24,7 @@ from src.jobs.platform.video_generation import (
 )
 
 _DEFINITIONS = {
+    APPLICATION_DEPLOY_DEFINITION.job_type: APPLICATION_DEPLOY_DEFINITION,
     APPLICATION_PUBLISH_DEFINITION.job_type: APPLICATION_PUBLISH_DEFINITION,
     OAUTH_REFRESH_DEFINITION.job_type: OAUTH_REFRESH_DEFINITION,
     WEBHOOK_RENEWAL_DEFINITION.job_type: WEBHOOK_RENEWAL_DEFINITION,

--- a/api/src/models/contracts/applications.py
+++ b/api/src/models/contracts/applications.py
@@ -145,6 +145,10 @@ class ApplicationPublic(ApplicationBase):
     slug: str
     organization_id: UUID | None
     published_at: datetime | None
+    deployed_at: datetime | None = Field(
+        default=None,
+        description="When the currently active app artifact was deployed.",
+    )
     created_at: datetime
     updated_at: datetime
     created_by: str | None
@@ -155,8 +159,9 @@ class ApplicationPublic(ApplicationBase):
     is_solution_managed: bool = Field(default=False, description="True if managed by a deployed Solution (read-only on platform)")
     solution_id: UUID | None = Field(default=None, description="UUID of the owning Solution install (null if not solution-managed)")
     role_ids: list[UUID] = Field(default_factory=list)
-    repo_path: str = Field(
-        description="Workspace-relative path to the app's source directory. Mutated via POST /api/applications/{id}/replace."
+    repo_path: str | None = Field(
+        default=None,
+        description="Workspace source path for legacy or Solution-owned apps. Independent apps have no server-side source path.",
     )
     logo: str | None = Field(
         default=None,

--- a/api/src/models/orm/applications.py
+++ b/api/src/models/orm/applications.py
@@ -41,7 +41,10 @@ class Application(Base):
     id: Mapped[UUID] = mapped_column(primary_key=True, default=uuid4)
     name: Mapped[str] = mapped_column(String(255), nullable=False)
     slug: Mapped[str] = mapped_column(String(255), nullable=False)
-    repo_path: Mapped[str] = mapped_column(String(500), nullable=False)
+    # Legacy inline apps and Solution-owned apps have source in the workspace.
+    # Independently deployed v2 apps deliberately do not: their source only
+    # exists on the developer's machine and as transient deploy input.
+    repo_path: Mapped[str | None] = mapped_column(String(500), nullable=True)
     organization_id: Mapped[UUID | None] = mapped_column(
         ForeignKey("organizations.id", ondelete="CASCADE"), default=None
     )
@@ -62,6 +65,14 @@ class Application(Base):
     # NULL = never published, empty dict = published with no files
     published_snapshot: Mapped[dict | None] = mapped_column(
         JSON, default=None, nullable=True
+    )
+
+    # Independent v2 deployments are immutable, versioned artifacts. Switching
+    # this pointer after a complete upload makes activation atomic and leaves
+    # the previous deployment live if a build or upload fails.
+    active_deployment_id: Mapped[UUID | None] = mapped_column(nullable=True)
+    deployed_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), default=None, nullable=True
     )
 
     # Access control (follows same pattern as forms)
@@ -116,15 +127,16 @@ class Application(Base):
     def is_published(self) -> bool:
         """Whether the app is live/openable.
 
-        standalone_v2 apps have NO publish concept — there is no draft→live
-        editor flow; a v2 app is source-built and served, so created == published
-        (it's "published" by existing). The publish/draft model is v1-only, so
-        is_published is unconditionally True for v2 and the v1 "Not Published"
-        gate never applies to it. For inline_v1 it stays "published at least once"
-        (a published_snapshot exists).
+        standalone_v2 apps have no publish concept: Solution-owned apps are
+        launchable after their Solution deploy, while independently managed
+        apps are launchable after their first App deploy. ``is_published`` is a
+        compatibility field for existing launch gates. For inline_v1 it still
+        means "published at least once" (a published_snapshot exists).
         """
         if self.app_model == "standalone_v2":
-            return True
+            # Solution deployments still use the original unversioned artifact
+            # path. Detached apps become launchable only after app deploy.
+            return self.solution_id is not None or self.active_deployment_id is not None
         return self.published_snapshot is not None
 
     @property
@@ -146,4 +158,6 @@ class Application(Base):
     @property
     def repo_prefix(self) -> str:
         """Return the repo path prefix for this app, with trailing slash."""
+        if self.repo_path is None:
+            raise ValueError("This app has no server-side source path")
         return f"{self.repo_path.rstrip('/')}/"

--- a/api/src/repositories/applications.py
+++ b/api/src/repositories/applications.py
@@ -178,22 +178,6 @@ class ApplicationRepository(OrgScopedRepository[Application]):
         if existing:
             raise ValueError(f"Application with slug '{data.slug}' already exists")
 
-        # standalone_v2 apps render only from a built dist, and the ONLY thing
-        # that builds + serves that dist is a Solution deploy (deploy.py builds
-        # to _apps/{id}/). A bare `apps create` makes a LOOSE (non-solution) app
-        # — solution apps are created by deploy, not here — so a v2 app created
-        # this way could never render. Bark instead of silently making a dead
-        # app. v2 = a Solutions thing: scaffold with `bifrost solution
-        # scaffold-app` and deploy. inline_v1 is the standalone/legacy model.
-        if data.app_model == "standalone_v2":
-            raise ValueError(
-                "standalone_v2 apps live in a Solution (only a Solution deploy "
-                "builds + serves their dist). Create one with "
-                "`bifrost solution scaffold-app <slug>` inside a Solution "
-                "workspace, then `bifrost solution deploy`. To make a legacy "
-                "standalone app here, pass app_model='inline_v1' explicitly."
-            )
-
         application = Application(
             name=data.name,
             slug=data.slug,
@@ -203,13 +187,15 @@ class ApplicationRepository(OrgScopedRepository[Application]):
             created_by=created_by,
             access_level=data.access_level,
             app_model=data.app_model,
-            repo_path=f"apps/{data.slug}",
+            repo_path=(f"apps/{data.slug}" if data.app_model == "inline_v1" else None),
         )
         self.session.add(application)
         await self.session.flush()
 
-        # Scaffold initial files via FileStorageService
-        await self._scaffold_code_files(application.slug)
+        # V1 source remains workspace-owned. V2 source is local-only and is
+        # uploaded transiently by `bifrost app deploy`.
+        if data.app_model == "inline_v1":
+            await self._scaffold_code_files(application.slug)
 
         # Add role associations if role_based access
         if data.access_level == "role_based" and data.role_ids:

--- a/api/src/routers/app_code_files.py
+++ b/api/src/routers/app_code_files.py
@@ -268,6 +268,15 @@ class FileMode(str, Enum):
     live = "live"
 
 
+def _server_source_prefix(app: Application) -> str:
+    if app.repo_path is None:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="This App's source is local and is not stored by Bifrost.",
+        )
+    return app.repo_prefix
+
+
 # =============================================================================
 # S3-backed App File Endpoints
 # =============================================================================
@@ -296,7 +305,7 @@ async def list_app_files(
     repo = RepoStorage()
 
     # List source files from S3 (source of truth)
-    repo_prefix = app.repo_prefix
+    repo_prefix = _server_source_prefix(app)
     source_paths = await repo.list(repo_prefix)
 
     if not source_paths:
@@ -360,7 +369,7 @@ async def read_app_file(
     app_storage = AppStorageService()
 
     # Source from S3 (_repo/)
-    repo_path = f"{app.repo_prefix}{file_path}"
+    repo_path = f"{_server_source_prefix(app)}{file_path}"
     repo = RepoStorage()
     try:
         source = (await repo.read(repo_path)).decode("utf-8", errors="replace")
@@ -415,7 +424,7 @@ async def write_app_file(
     # Validate path conventions
     validate_file_path(file_path)
 
-    prefix = app.repo_prefix
+    prefix = _server_source_prefix(app)
     full_path = f"{prefix}{file_path}"
     source = data.source or ""
 
@@ -459,7 +468,7 @@ async def delete_app_file(
     app = await get_application_or_404(ctx, app_id)
     # Read-only for solution-managed apps (S3 delete bypasses the ORM backstop).
     await assert_entity_id_not_solution_managed(ctx.db, Application, app_id)
-    prefix = app.repo_prefix
+    prefix = _server_source_prefix(app)
     full_path = f"{prefix}{file_path}"
 
     storage = get_file_storage_service(ctx.db)
@@ -609,7 +618,13 @@ async def get_bundle_manifest(
         css: str | None = None
         runtime_contract: str | None = None
         try:
-            html = (await SolutionAppBuilder().read_dist(app_id_str, "index.html")).decode()
+            html = (
+                await SolutionAppBuilder().read_dist(
+                    app_id_str,
+                    "index.html",
+                    deployment_id=app.active_deployment_id,
+                )
+            ).decode()
             if m := re.search(r'<script[^>]+type="module"[^>]+src="([^"]+)"', html):
                 entry = m.group(1).split("/dist/")[-1].lstrip("/")
             if m := re.search(r'<link[^>]+rel="stylesheet"[^>]+href="([^"]+)"', html):
@@ -821,7 +836,9 @@ async def get_v2_dist_asset(
     app = await get_application_or_404(ctx, app_id)
     rel = path or "index.html"
     try:
-        data = await SolutionAppBuilder().read_dist(str(app.id), rel)
+        data = await SolutionAppBuilder().read_dist(
+            str(app.id), rel, deployment_id=app.active_deployment_id
+        )
     except ClientError as exc:
         # read_dist surfaces a missing key as the raw botocore ClientError from
         # get_object (Code=NoSuchKey). Only THAT is a 404 — anything else is a

--- a/api/src/routers/applications.py
+++ b/api/src/routers/applications.py
@@ -16,7 +16,9 @@ import asyncio
 import base64
 import logging
 import re
-from uuid import UUID
+import tempfile
+from pathlib import Path
+from uuid import UUID, uuid4
 
 from fastapi import APIRouter, File, HTTPException, Query, UploadFile, status
 from fastapi.responses import Response
@@ -24,7 +26,7 @@ from pydantic import BaseModel
 from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 
-from src.core.auth import Context, CurrentUser
+from src.core.auth import Context, CurrentSuperuser, CurrentUser
 from src.core.log_safety import log_safe
 from src.core.org_filter import resolve_org_filter
 from src.core.pubsub import publish_app_draft_update
@@ -44,6 +46,10 @@ from src.jobs.platform.application_publish import (
     APPLICATION_PUBLISH_DEFINITION,
     ApplicationPublishPayload,
 )
+from src.jobs.platform.application_deploy import (
+    APPLICATION_DEPLOY_DEFINITION,
+    ApplicationDeployPayload,
+)
 from src.models.contracts.platform_jobs import PlatformJobAccepted
 from src.models.orm.applications import Application
 from src.services.platform_jobs import (
@@ -51,6 +57,7 @@ from src.services.platform_jobs import (
     ensure_platform_job_notification,
     publish_platform_job_update,
 )
+from src.services.application_deploy_storage import ApplicationDeployStorage
 from src.services.solutions.guard import assert_entity_id_not_solution_managed
 from src.core.exceptions import AccessDeniedError
 from shared.logo_processing import (
@@ -143,6 +150,7 @@ async def application_to_public(
         icon=application.icon,
         organization_id=application.organization_id,
         published_at=application.published_at,
+        deployed_at=application.deployed_at,
         created_at=application.created_at,
         updated_at=application.updated_at,
         created_by=application.created_by,
@@ -475,6 +483,8 @@ async def delete_application(
 ) -> None:
     """Delete an application by ID."""
     await assert_entity_id_not_solution_managed(ctx.db, Application, app_id)
+    application = await get_application_by_id_or_404(ctx, app_id)
+    active_deployment_id = application.active_deployment_id
     repo = ApplicationRepository(
         ctx.db,
         ctx.org_id,
@@ -489,6 +499,18 @@ async def delete_application(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"Application '{app_id}' not found",
         )
+    await ctx.db.commit()
+    if active_deployment_id is not None:
+        from src.services.solutions.app_build import SolutionAppBuilder
+
+        try:
+            await SolutionAppBuilder().delete_deployment(app_id, active_deployment_id)
+        except Exception:
+            logger.warning(
+                "Failed to remove deleted App deployment %s",
+                active_deployment_id,
+                exc_info=True,
+            )
 
 
 # =============================================================================
@@ -519,6 +541,11 @@ async def get_draft(
         is_external=user.is_external,
     )
     app = await get_application_by_id_or_404(ctx, app_id)
+    if app.repo_path is None:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="This App's source is local. Use `bifrost app deploy`.",
+        )
     export_data = await repo.export_application(app)
     return ApplicationDefinition(
         definition=export_data,
@@ -552,6 +579,11 @@ async def save_draft(
         is_external=user.is_external,
     )
     app = await get_application_by_id_or_404(ctx, app_id)
+    if app.repo_path is None:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="This App has no server-side draft or editor.",
+        )
 
     # Extract files from definition and update
     files_data = data.definition.get("files", [])
@@ -568,6 +600,106 @@ async def save_draft(
 # =============================================================================
 # Publish Endpoint
 # =============================================================================
+
+
+@router.post(
+    "/{app_id}/deploy",
+    response_model=PlatformJobAccepted,
+    status_code=status.HTTP_202_ACCEPTED,
+    summary="Deploy an App",
+)
+async def deploy_application(
+    app_id: UUID,
+    source: UploadFile = File(...),
+    *,
+    ctx: Context,
+    user: CurrentSuperuser,
+    response: Response,
+) -> PlatformJobAccepted:
+    """Build local App source and atomically activate the resulting artifact.
+
+    Source is staged only for the platform job and is deleted whether the job
+    succeeds or fails. The Application row and object storage retain compiled
+    ``dist`` files only.
+    """
+    application = await get_application_by_id_or_404(ctx, app_id)
+    if application.solution_id is not None or application.app_model != "standalone_v2":
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Only independently managed V2 Apps can be deployed with this command.",
+        )
+
+    job_id = uuid4()
+    deployment_id = uuid4()
+    storage = ApplicationDeployStorage(job_id)
+    worker_owns_source = False
+    tmp = tempfile.NamedTemporaryFile(
+        prefix="bifrost-app-upload-", suffix=".zip", delete=False
+    )
+    tmp_path = Path(tmp.name)
+    try:
+        with tmp:
+            while chunk := await source.read(8 * 1024 * 1024):
+                tmp.write(chunk)
+        input_sha256, _size = await storage.write_path(tmp_path)
+        job, reused = await enqueue_platform_job(
+            ctx.db,
+            APPLICATION_DEPLOY_DEFINITION,
+            ApplicationDeployPayload(
+                application_id=application.id,
+                deployment_id=deployment_id,
+                input_sha256=input_sha256,
+            ),
+            job_id=job_id,
+            dedupe_key=str(application.id),
+            resource_lock_key=f"application:{application.id}",
+            organization_id=application.organization_id,
+            requested_by_user_id=user.user_id,
+            requested_by_email=user.email,
+            requested_by_name=user.name or user.email or "Unknown",
+            resource_type="application",
+            resource_id=str(application.id),
+            title=f"Deploying {application.name}",
+            action_url=f"/apps/{application.slug}",
+        )
+        if reused:
+            await storage.delete()
+            if job.requested_by_user_id != str(user.user_id):
+                raise HTTPException(
+                    status_code=status.HTTP_409_CONFLICT,
+                    detail="An App deployment is already in progress.",
+                )
+        if job.notification_id is None:
+            try:
+                await ensure_platform_job_notification(ctx.db, job)
+            except Exception:
+                logger.warning(
+                    "App deploy queued without a progress notification",
+                    extra={"platform_job_id": str(job.id)},
+                    exc_info=True,
+                )
+        await ctx.db.commit()
+        worker_owns_source = True
+        await ctx.db.refresh(job)
+        await publish_platform_job_update(job)
+        response.headers["Location"] = f"/api/platform-jobs/{job.id}"
+        return PlatformJobAccepted(
+            job_id=job.id,
+            notification_id=job.notification_id,
+            status=job.status,
+            reused=reused,
+        )
+    except Exception:
+        # Once committed the worker owns deletion. Before that, avoid leaving
+        # an unreferenced source object behind.
+        if not worker_owns_source:
+            try:
+                await storage.delete()
+            except Exception:
+                logger.warning("Failed to clean rejected App source upload", exc_info=True)
+        raise
+    finally:
+        tmp_path.unlink(missing_ok=True)
 
 
 @router.post(
@@ -596,6 +728,11 @@ async def publish_application(
     # Publishing a solution-managed app is a deploy-owned action.
     await assert_entity_id_not_solution_managed(ctx.db, Application, app_id)
     application = await get_application_by_id_or_404(ctx, app_id)
+    if application.app_model == "standalone_v2":
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="V2 Apps are deployed, not published. Use `bifrost app deploy`.",
+        )
     job, reused = await enqueue_platform_job(
         ctx.db,
         APPLICATION_PUBLISH_DEFINITION,
@@ -667,6 +804,12 @@ async def replace_application_endpoint(
     """
     # Repointing a solution-managed app's source is a deploy-owned action.
     await assert_entity_id_not_solution_managed(ctx.db, Application, app_id)
+    app = await get_application_by_id_or_404(ctx, app_id)
+    if app.app_model == "standalone_v2":
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="V2 App source is local and cannot be assigned an _repo path.",
+        )
     repo = ApplicationRepository(
         ctx.db,
         ctx.org_id,
@@ -758,6 +901,11 @@ async def validate_application(
     from src.models.orm.workflows import Workflow
 
     app = await get_application_by_id_or_404(ctx, app_id)
+    if app.repo_path is None:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="This App's source is local. Run validation in the local project.",
+        )
     prefix = app.repo_prefix
 
     # Get all app files

--- a/api/src/routers/workflows.py
+++ b/api/src/routers/workflows.py
@@ -254,6 +254,11 @@ async def _get_app_workflow_ids(db: DbSession, app_id: UUID) -> set[UUID]:
     if not app:
         return set()
 
+    # Independently deployed V2 Apps have no server-side source tree. Their
+    # workflow references are resolved dynamically by the live SDK at runtime.
+    if app.repo_path is None:
+        return set()
+
     # Scan file_index for source code
     prefix = app.repo_prefix
     fi_result = await db.execute(
@@ -636,6 +641,15 @@ async def get_workflow_usage_stats(
 
         apps: list[EntityUsage] = []
         for app_row in all_apps:
+            if app_row.repo_path is None:
+                apps.append(
+                    EntityUsage(
+                        id=str(app_row.id),
+                        name=app_row.name,
+                        workflow_count=0,
+                    )
+                )
+                continue
             prefix = app_row.repo_path.rstrip("/") + "/"
             fi_result = await db.execute(
                 select(FileIndex.content).where(

--- a/api/src/services/application_deploy_storage.py
+++ b/api/src/services/application_deploy_storage.py
@@ -1,0 +1,64 @@
+"""Transient object-storage staging for independent App deploy source."""
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import AsyncIterator
+from pathlib import Path
+from uuid import UUID
+
+from src.config import Settings, get_settings
+from src.services.file_storage.s3_client import S3StorageClient
+
+APP_DEPLOY_INPUT_ROOT = "_application_deploy_jobs"
+CHUNK_SIZE = 8 * 1024 * 1024
+
+
+class ApplicationDeployInputIntegrityError(Exception):
+    pass
+
+
+class ApplicationDeployStorage:
+    """Own the source zip for exactly one platform job.
+
+    The job deletes this object in a ``finally`` block. It is build input, not
+    an application source store.
+    """
+
+    def __init__(self, job_id: UUID | str, settings: Settings | None = None):
+        self.job_id = str(job_id)
+        self._settings = settings or get_settings()
+        self._storage = S3StorageClient(self._settings)
+        self._bucket = self._settings.s3_bucket or ""
+        self.key = f"{APP_DEPLOY_INPUT_ROOT}/{self.job_id}/input.zip"
+
+    async def write_path(self, path: Path) -> tuple[str, int]:
+        async def chunks() -> AsyncIterator[bytes]:
+            with path.open("rb") as source:
+                while chunk := source.read(CHUNK_SIZE):
+                    yield chunk
+
+        return await self._storage.put_object_from_chunks(
+            self.key, chunks(), content_type="application/zip"
+        )
+
+    async def copy_to_path(self, path: Path, *, expected_sha256: str) -> int:
+        digest = hashlib.sha256()
+        size = 0
+        with path.open("wb") as destination:
+            async for chunk in self._storage.iter_object_chunks(
+                self.key, chunk_size=CHUNK_SIZE
+            ):
+                destination.write(chunk)
+                digest.update(chunk)
+                size += len(chunk)
+        if digest.hexdigest() != expected_sha256:
+            path.unlink(missing_ok=True)
+            raise ApplicationDeployInputIntegrityError(
+                f"staged App input for job {self.job_id} failed integrity check"
+            )
+        return size
+
+    async def delete(self) -> None:
+        async with self._storage.get_client() as s3:
+            await s3.delete_object(Bucket=self._bucket, Key=self.key)

--- a/api/src/services/manifest_generator.py
+++ b/api/src/services/manifest_generator.py
@@ -637,6 +637,7 @@ async def generate_manifest(
         apps={
             str(app.id): serialize_app(app, app_roles_by_app.get(str(app.id), []))
             for app in apps_list
+            if app.repo_path is not None
         },
         mcp_servers={
             str(server.id): serialize_mcp_server(

--- a/api/src/services/solutions/app_build.py
+++ b/api/src/services/solutions/app_build.py
@@ -43,8 +43,18 @@ class SolutionAppBuilder:
         self._settings = settings or get_settings()
         self._bucket: str = self._settings.s3_bucket or ""
 
-    def _dist_key(self, app_id: UUID | str, rel: str = "") -> str:
-        base = f"{APPS_PREFIX}{app_id}/dist/"
+    def _dist_key(
+        self,
+        app_id: UUID | str,
+        rel: str = "",
+        *,
+        deployment_id: UUID | str | None = None,
+    ) -> str:
+        base = (
+            f"{APPS_PREFIX}{app_id}/deployments/{deployment_id}/dist/"
+            if deployment_id is not None
+            else f"{APPS_PREFIX}{app_id}/dist/"
+        )
         return f"{base}{rel.lstrip('/')}" if rel else base
 
     def _client(self):
@@ -96,6 +106,21 @@ class SolutionAppBuilder:
         """Full-replace upload of an already-compiled dist/ to
         ``_apps/{app_id}/dist/`` (cheap PUTs). Runs AFTER the DB commit."""
         await self._upload_dist(app_id, dist)
+
+    async def upload_deployment(
+        self,
+        app_id: UUID | str,
+        deployment_id: UUID | str,
+        dist: dict[str, bytes],
+    ) -> None:
+        """Upload one immutable deployment without touching the active build."""
+        async with self._client() as c:
+            for rel, data in dist.items():
+                await c.put_object(
+                    Bucket=self._bucket,
+                    Key=self._dist_key(app_id, rel, deployment_id=deployment_id),
+                    Body=data,
+                )
 
     async def build(
         self,
@@ -195,15 +220,29 @@ class SolutionAppBuilder:
             for rel, data in dist.items():
                 await c.put_object(Bucket=self._bucket, Key=self._dist_key(app_id, rel), Body=data)
 
-    async def read_dist(self, app_id: UUID | str, rel: str) -> bytes:
+    async def read_dist(
+        self,
+        app_id: UUID | str,
+        rel: str,
+        *,
+        deployment_id: UUID | str | None = None,
+    ) -> bytes:
         """Read one built dist file back from ``_apps/{app_id}/dist/``."""
         async with self._client() as c:
-            resp = await c.get_object(Bucket=self._bucket, Key=self._dist_key(app_id, rel))
+            resp = await c.get_object(
+                Bucket=self._bucket,
+                Key=self._dist_key(app_id, rel, deployment_id=deployment_id),
+            )
             return await resp["Body"].read()
 
-    async def list_dist(self, app_id: UUID | str) -> list[str]:
+    async def list_dist(
+        self,
+        app_id: UUID | str,
+        *,
+        deployment_id: UUID | str | None = None,
+    ) -> list[str]:
         """List the relative paths of an app's uploaded ``dist/``."""
-        prefix = self._dist_key(app_id)
+        prefix = self._dist_key(app_id, deployment_id=deployment_id)
         strip = len(prefix)
         paths: list[str] = []
         token = None
@@ -227,3 +266,15 @@ class SolutionAppBuilder:
         async with self._client() as c:
             for rel in await self.list_dist(app_id):
                 await c.delete_object(Bucket=self._bucket, Key=self._dist_key(app_id, rel))
+
+    async def delete_deployment(
+        self, app_id: UUID | str, deployment_id: UUID | str
+    ) -> None:
+        """Delete one versioned deployment artifact."""
+        rels = await self.list_dist(app_id, deployment_id=deployment_id)
+        async with self._client() as c:
+            for rel in rels:
+                await c.delete_object(
+                    Bucket=self._bucket,
+                    Key=self._dist_key(app_id, rel, deployment_id=deployment_id),
+                )

--- a/api/tests/e2e/api/test_applications.py
+++ b/api/tests/e2e/api/test_applications.py
@@ -89,6 +89,42 @@ class TestApplicationCRUD:
         # Cleanup
         _delete_app(e2e_client, platform_admin.headers, app["id"])
 
+    def test_create_independent_v2_application_has_no_repo_source(
+        self, e2e_client, platform_admin
+    ):
+        response = e2e_client.post(
+            "/api/applications",
+            headers=platform_admin.headers,
+            json={
+                "name": "Independent V2 App",
+                "slug": "independent-v2-app",
+                "app_model": "standalone_v2",
+            },
+        )
+        assert response.status_code == 201, response.text
+        app = response.json()
+        assert app["repo_path"] is None
+        assert app["solution_id"] is None
+        assert app["is_published"] is False
+        assert app["has_unpublished_changes"] is False
+
+        source_response = e2e_client.get(
+            f"/api/applications/{app['id']}/files",
+            headers=platform_admin.headers,
+        )
+        assert source_response.status_code == 409
+        assert "source is local" in source_response.json()["detail"]
+
+        _delete_app(e2e_client, platform_admin.headers, app["id"])
+
+    def test_non_admin_cannot_deploy_an_application(self, e2e_client, org1_user):
+        response = e2e_client.post(
+            f"/api/applications/{uuid.uuid4()}/deploy",
+            headers=org1_user.headers,
+            files={"source": ("source.zip", b"not-a-zip", "application/zip")},
+        )
+        assert response.status_code == 403
+
     def test_get_application_by_slug(self, e2e_client, platform_admin):
         """Get application by slug."""
         app = _create_app(e2e_client, platform_admin.headers, "get-test-app", name="Get Test App")

--- a/api/tests/unit/jobs/test_application_deploy.py
+++ b/api/tests/unit/jobs/test_application_deploy.py
@@ -1,9 +1,16 @@
 import zipfile
+from contextlib import asynccontextmanager
 from pathlib import Path
+from types import SimpleNamespace
+from uuid import uuid4
 
 import pytest
 
-from src.jobs.platform.application_deploy import _read_source_zip
+from src.jobs.platform.application_deploy import (
+    ApplicationDeployPayload,
+    _read_source_zip,
+    run_application_deploy,
+)
 from src.jobs.platform.base import PlatformJobFailure
 
 
@@ -27,3 +34,148 @@ def test_deploy_source_is_read_without_persisting_a_tree(tmp_path: Path) -> None
     )
     assert _read_source_zip(archive)["src/main.tsx"] == b"x"
     assert not (tmp_path / "src").exists()
+
+
+@pytest.mark.asyncio
+async def test_deploy_atomically_activates_then_removes_old_artifact(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source = _zip(
+        tmp_path / "source.zip",
+        {"package.json": b"{}", "index.html": b"<div id='root'>"},
+    )
+    app_id, old_id, new_id = uuid4(), uuid4(), uuid4()
+    app = SimpleNamespace(
+        id=app_id,
+        solution_id=None,
+        app_model="standalone_v2",
+        active_deployment_id=old_id,
+        deployed_at=None,
+    )
+    events: list[tuple[str, object]] = []
+
+    class Storage:
+        def __init__(self, _job_id):
+            pass
+
+        async def copy_to_path(self, path: Path, *, expected_sha256: str) -> None:
+            events.append(("copy", expected_sha256))
+            path.write_bytes(source.read_bytes())
+
+        async def delete(self) -> None:
+            events.append(("delete_source", None))
+
+    class Builder:
+        def compile_dist(self, application_id, source_files, _dependencies):
+            events.append(("compile", application_id))
+            assert "package.json" in source_files
+            return {"index.html": b"built"}
+
+        async def upload_deployment(self, application_id, deployment_id, dist):
+            events.append(("upload", (application_id, deployment_id, dist)))
+
+        async def delete_deployment(self, application_id, deployment_id):
+            events.append(("delete_artifact", (application_id, deployment_id)))
+
+    class DB:
+        async def get(self, _model, requested_id):
+            assert requested_id == app_id
+            return app
+
+        async def flush(self):
+            events.append(("flush", app.active_deployment_id))
+
+    @asynccontextmanager
+    async def db_context():
+        yield DB()
+
+    class Context:
+        job_id = uuid4()
+
+        async def report(self, message: str, *, percent: int):
+            events.append(("report", (message, percent)))
+
+    monkeypatch.setattr(
+        "src.jobs.platform.application_deploy.ApplicationDeployStorage", Storage
+    )
+    monkeypatch.setattr(
+        "src.jobs.platform.application_deploy.SolutionAppBuilder", Builder
+    )
+    monkeypatch.setattr(
+        "src.jobs.platform.application_deploy.get_db_context", db_context
+    )
+
+    result = await run_application_deploy(
+        Context(),
+        ApplicationDeployPayload(
+            application_id=app_id,
+            deployment_id=new_id,
+            input_sha256="sha",
+        ),
+    )
+
+    assert result["deployment_id"] == str(new_id)
+    assert app.active_deployment_id == new_id
+    assert app.deployed_at is not None
+    assert ("delete_artifact", (app_id, old_id)) in events
+    assert ("delete_artifact", (app_id, new_id)) not in events
+    assert events[-1] == ("delete_source", None)
+
+
+@pytest.mark.asyncio
+async def test_failed_build_keeps_active_artifact_and_cleans_transient_state(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source = _zip(
+        tmp_path / "source.zip",
+        {"package.json": b"{}", "index.html": b"<div id='root'>"},
+    )
+    app_id, old_id, new_id = uuid4(), uuid4(), uuid4()
+    app = SimpleNamespace(active_deployment_id=old_id)
+    deleted: list[tuple[str, object]] = []
+
+    class Storage:
+        def __init__(self, _job_id):
+            pass
+
+        async def copy_to_path(self, path: Path, *, expected_sha256: str) -> None:
+            path.write_bytes(source.read_bytes())
+
+        async def delete(self) -> None:
+            deleted.append(("source", None))
+
+    class Builder:
+        def compile_dist(self, *_args, **_kwargs):
+            raise RuntimeError("broken build")
+
+        async def delete_deployment(self, application_id, deployment_id):
+            deleted.append(("artifact", (application_id, deployment_id)))
+
+    class Context:
+        job_id = uuid4()
+
+        async def report(self, _message: str, *, percent: int):
+            pass
+
+    monkeypatch.setattr(
+        "src.jobs.platform.application_deploy.ApplicationDeployStorage", Storage
+    )
+    monkeypatch.setattr(
+        "src.jobs.platform.application_deploy.SolutionAppBuilder", Builder
+    )
+
+    with pytest.raises(PlatformJobFailure, match="broken build"):
+        await run_application_deploy(
+            Context(),
+            ApplicationDeployPayload(
+                application_id=app_id,
+                deployment_id=new_id,
+                input_sha256="sha",
+            ),
+        )
+
+    assert app.active_deployment_id == old_id
+    assert deleted == [
+        ("source", None),
+        ("artifact", (app_id, new_id)),
+    ]

--- a/api/tests/unit/jobs/test_application_deploy.py
+++ b/api/tests/unit/jobs/test_application_deploy.py
@@ -1,0 +1,29 @@
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from src.jobs.platform.application_deploy import _read_source_zip
+from src.jobs.platform.base import PlatformJobFailure
+
+
+def _zip(path: Path, files: dict[str, bytes]) -> Path:
+    with zipfile.ZipFile(path, "w") as archive:
+        for name, content in files.items():
+            archive.writestr(name, content)
+    return path
+
+
+def test_deploy_source_requires_vite_root(tmp_path: Path) -> None:
+    archive = _zip(tmp_path / "source.zip", {"src/main.tsx": b"export {}"})
+    with pytest.raises(PlatformJobFailure, match="package.json and index.html"):
+        _read_source_zip(archive)
+
+
+def test_deploy_source_is_read_without_persisting_a_tree(tmp_path: Path) -> None:
+    archive = _zip(
+        tmp_path / "source.zip",
+        {"package.json": b"{}", "index.html": b"<div id='root'>", "src/main.tsx": b"x"},
+    )
+    assert _read_source_zip(archive)["src/main.tsx"] == b"x"
+    assert not (tmp_path / "src").exists()

--- a/api/tests/unit/repositories/test_applications_repository.py
+++ b/api/tests/unit/repositories/test_applications_repository.py
@@ -11,6 +11,7 @@ MultipleResultsFound. Mirrors test_deploy_takes_advisory_lock_on_slug.
 from __future__ import annotations
 
 import uuid
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -68,17 +69,18 @@ async def test_create_application_takes_slug_advisory_lock_first(db_session, mon
     ), "duplicate-check SELECT not found after the lock"
 
 
-async def test_create_application_barks_on_v2_default(db_session):
-    """A bare `apps create` defaults to standalone_v2, but a loose (non-solution)
-    v2 app can never render (only a Solution deploy builds its dist). So
-    create_application REFUSES v2 with a message pointing at the Solution flow.
-    Solution apps are created by deploy, not this path."""
+async def test_create_application_creates_v2_without_repo_source(db_session, monkeypatch):
+    """Independent V2 Apps have metadata only; source never enters _repo."""
     repo = ApplicationRepository(db_session, org_id=None, user_id=None, is_superuser=True)
-    with pytest.raises(ValueError, match="Solution"):
-        await repo.create_application(
-            ApplicationCreate(name="V2 loose", slug=f"v2-{uuid.uuid4().hex[:8]}"),
-            created_by="dev@x",
-        )
+    scaffold = AsyncMock()
+    monkeypatch.setattr(repo, "_scaffold_code_files", scaffold)
+    app = await repo.create_application(
+        ApplicationCreate(name="V2 App", slug=f"v2-{uuid.uuid4().hex[:8]}"),
+        created_by="dev@x",
+    )
+    assert app.repo_path is None
+    assert app.solution_id is None
+    scaffold.assert_not_awaited()
 
 
 async def test_create_application_default_is_v2():

--- a/api/tests/unit/routers/test_app_code_files.py
+++ b/api/tests/unit/routers/test_app_code_files.py
@@ -231,7 +231,7 @@ class TestGetV2DistAsset:
         from uuid import uuid4
 
         app_id = uuid4()
-        fake_app = SimpleNamespace(id=app_id)
+        fake_app = SimpleNamespace(id=app_id, active_deployment_id=None)
 
         async def _fake_get_app(ctx, _app_id):
             return fake_app
@@ -241,7 +241,7 @@ class TestGetV2DistAsset:
         )
 
         class _FakeBuilder:
-            async def read_dist(self, _app_id, _rel):
+            async def read_dist(self, _app_id, _rel, *, deployment_id=None):
                 raise read_dist_exc
 
         monkeypatch.setattr(

--- a/api/tests/unit/test_app_binding.py
+++ b/api/tests/unit/test_app_binding.py
@@ -1,0 +1,16 @@
+from pathlib import Path
+
+from bifrost.app_binding import AppBinding, find_app_root, read_app_binding, write_app_binding
+
+
+def test_standard_env_binding_preserves_unrelated_values(tmp_path: Path) -> None:
+    (tmp_path / "package.json").write_text("{}")
+    (tmp_path / ".env").write_text("CUSTOM=value\nBIFROST_APP_ID=old\n")
+
+    write_app_binding(tmp_path, AppBinding("https://example.test/", "new-id"))
+
+    assert read_app_binding(tmp_path) == AppBinding("https://example.test", "new-id")
+    assert "CUSTOM=value" in (tmp_path / ".env").read_text()
+    child = tmp_path / "src" / "nested"
+    child.mkdir(parents=True)
+    assert find_app_root(child) == tmp_path

--- a/api/tests/unit/test_application_v2_publish_state.py
+++ b/api/tests/unit/test_application_v2_publish_state.py
@@ -1,9 +1,8 @@
-"""standalone_v2 apps have NO publish/draft concept — created == published.
+"""V2 Apps have deployment state without a publish/draft concept.
 
-The v1 draft→publish editor flow doesn't apply to v2 (source-built + served), so
-`is_published` is unconditionally True for v2 and `has_unpublished_changes` is
-False. This is what stops the v1 "Not Published"/"Open Editor" screen from
-leaking onto a v2 app reached by slug. Pure ORM-property logic, no DB needed.
+The compatibility ``is_published`` field means launchable for V2 Apps: an
+independent App needs an active artifact, while a Solution App keeps its
+existing unversioned deploy artifact behavior.
 """
 from __future__ import annotations
 
@@ -16,9 +15,14 @@ def _app(app_model: str, snapshot=None) -> Application:
     return a
 
 
-def test_v2_is_always_published_even_without_snapshot():
-    # No published_snapshot, but v2 → still "published" (created == published).
-    assert _app("standalone_v2", snapshot=None).is_published is True
+def test_independent_v2_is_not_launchable_before_deploy():
+    assert _app("standalone_v2", snapshot=None).is_published is False
+
+
+def test_independent_v2_is_launchable_with_active_deployment():
+    app = _app("standalone_v2")
+    app.active_deployment_id = "11111111-1111-1111-1111-111111111111"
+    assert app.is_published is True
 
 
 def test_v2_has_no_unpublished_changes():

--- a/api/tests/unit/test_cli_app.py
+++ b/api/tests/unit/test_cli_app.py
@@ -1,0 +1,38 @@
+import zipfile
+from pathlib import Path
+
+from bifrost.commands.app import _scaffold, _zip_project
+
+
+def test_scaffold_is_a_vite_project_with_standard_ignored_env(tmp_path: Path) -> None:
+    root = tmp_path / "my-app"
+    _scaffold(root, "my-app")
+
+    assert (root / "package.json").is_file()
+    assert (root / "vite.config.ts").is_file()
+    assert ".env" in (root / ".gitignore").read_text().splitlines()
+    readme = (root / "README.md").read_text()
+    assert "bifrost app start" in readme
+    assert "standalone" not in readme.lower()
+    app_source = (root / "src" / "App.tsx").read_text()
+    assert "live Bifrost environment" in app_source
+    assert "install's own workflow" not in app_source
+
+
+def test_deploy_archive_never_contains_env_or_generated_files(tmp_path: Path) -> None:
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "main.tsx").write_text("export {}")
+    (tmp_path / "package.json").write_text("{}")
+    (tmp_path / "index.html").write_text("<div id='root'>")
+    (tmp_path / ".env").write_text("SECRET=do-not-upload")
+    (tmp_path / "node_modules" / "x").mkdir(parents=True)
+    (tmp_path / "node_modules" / "x" / "index.js").write_text("generated")
+    destination = tmp_path.parent / "source.zip"
+
+    _zip_project(tmp_path, destination)
+
+    with zipfile.ZipFile(destination) as archive:
+        names = set(archive.namelist())
+    assert "src/main.tsx" in names
+    assert ".env" not in names
+    assert not any(name.startswith("node_modules/") for name in names)

--- a/api/tests/unit/test_cli_app_migrate.py
+++ b/api/tests/unit/test_cli_app_migrate.py
@@ -1,0 +1,109 @@
+"""Independent App migration and slug-cutover CLI coverage."""
+
+from __future__ import annotations
+
+import pathlib
+from unittest import mock
+
+from click.testing import CliRunner
+
+from bifrost.commands.app import _scaffold, app_group
+
+A_ID = "11111111-1111-1111-1111-111111111111"
+B_ID = "22222222-2222-2222-2222-222222222222"
+
+
+def _response(payload: dict, status: int = 200) -> mock.MagicMock:
+    response = mock.MagicMock()
+    response.status_code = status
+    response.json.return_value = payload
+    response.text = str(payload)
+    response.raise_for_status.return_value = None
+    return response
+
+
+def _v1_app(root: pathlib.Path) -> pathlib.Path:
+    source = root / "legacy"
+    (source / "pages").mkdir(parents=True)
+    (source / "components").mkdir()
+    (source / "pages" / "index.tsx").write_text(
+        'import { Button, useState, useWorkflowQuery } from "bifrost";\n'
+        "export default function Home() { return null; }\n"
+    )
+    (source / "_layout.tsx").write_text(
+        'import { Outlet } from "react-router-dom";\n'
+        "export default function Layout() { return <Outlet/>; }\n"
+    )
+    return source
+
+
+def test_migrate_uses_independent_app_lifecycle(tmp_path: pathlib.Path) -> None:
+    source = _v1_app(tmp_path)
+    destination = tmp_path / "modern"
+
+    def create_project(root: pathlib.Path, **_kwargs):  # type: ignore[no-untyped-def]
+        _scaffold(root, "modern")
+        return {"id": A_ID}, "modern"
+
+    with (
+        mock.patch("bifrost.commands.app._create_project", side_effect=create_project),
+        mock.patch("subprocess.run") as run,
+    ):
+        run.return_value = mock.Mock(returncode=0, stdout=b"", stderr=b"")
+        result = CliRunner().invoke(
+            app_group,
+            ["migrate", str(source), str(destination), "--name", "Modern"],
+        )
+
+    assert result.exit_code == 0, result.output
+    migrated = (destination / "src" / "pages" / "index.tsx").read_text()
+    assert 'from "react"' in migrated
+    assert 'from "@/components/ui/button"' in migrated
+    assert 'useWorkflowQuery } from "bifrost"' in migrated
+    assert (destination / "src" / "_layout.tsx").is_file()
+    assert "bifrost app start" in result.output
+    assert "bifrost app deploy" in result.output
+    assert "bifrost app swap-slugs" in result.output
+    assert "none are captured" in result.output
+    assert "bifrost solution" not in result.output
+
+
+def test_app_swap_slugs_resolves_refs_and_posts_atomic_cutover() -> None:
+    captured: dict[str, object] = {"gets": []}
+
+    async def get(path: str):
+        cast_gets = captured["gets"]
+        assert isinstance(cast_gets, list)
+        cast_gets.append(path)
+        slug = path.rsplit("/", 1)[-1]
+        return _response({"id": A_ID if slug == "legacy" else B_ID})
+
+    async def post(path: str, json: dict | None = None):
+        captured["post"] = (path, json)
+        return _response(
+            {
+                "applications": [
+                    {"name": "Modern", "slug": "legacy"},
+                    {"name": "Legacy", "slug": "modern"},
+                ]
+            }
+        )
+
+    client = mock.MagicMock(api_url="https://example.test")
+    client.get = get
+    client.post = post
+    with mock.patch("bifrost.commands.app._client", return_value=client):
+        result = CliRunner().invoke(
+            app_group, ["swap-slugs", "legacy", "modern"]
+        )
+
+    assert result.exit_code == 0, result.output
+    assert captured["gets"] == [
+        "/api/applications/legacy",
+        "/api/applications/modern",
+    ]
+    assert captured["post"] == (
+        "/api/applications/swap-slugs",
+        {"app_a": A_ID, "app_b": B_ID},
+    )
+    assert "/apps/legacy" in result.output

--- a/api/tests/unit/test_cli_surface_smoke.py
+++ b/api/tests/unit/test_cli_surface_smoke.py
@@ -30,6 +30,7 @@ TOP_LEVEL_COMMANDS = {
     "push",
     "pull",
     "solution",
+    "app",
     "deploy",
     "watch",
     "api",

--- a/api/tests/unit/test_solution_dev_proxy.py
+++ b/api/tests/unit/test_solution_dev_proxy.py
@@ -252,6 +252,38 @@ async def test_local_path_ref_runs_in_function_host():
         await up_runner.cleanup()
 
 
+async def test_app_start_forwards_workflow_to_live_platform_with_separate_scope():
+    record = {}
+    up_port, dev_port = _free_port(), _free_port()
+    up_runner = await _serve(_make_upstream(record), up_port)
+    cfg = DevProxyConfig(
+        upstream_url=f"http://127.0.0.1:{up_port}",
+        token="t",
+        app_id="app-id",
+        org_id="runtime-org",
+        local_workflows=False,
+    )
+    dev_runner = await _serve(
+        build_dev_app(cfg, None, vite_url="http://127.0.0.1:1"), dev_port
+    )
+    try:
+        async with httpx.AsyncClient() as client:
+            response = await client.post(
+                f"http://127.0.0.1:{dev_port}/api/workflows/execute",
+                json={"workflow_id": "loose-live-workflow", "input_data": {"x": 1}},
+            )
+        assert response.status_code == 200
+        assert record["execute_body"] == {
+            "workflow_id": "loose-live-workflow",
+            "input_data": {"x": 1},
+            "app_id": "app-id",
+            "org_id": "runtime-org",
+        }
+    finally:
+        await dev_runner.cleanup()
+        await up_runner.cleanup()
+
+
 class _RaisingHost:
     def resolve(self, ref):
         return ref

--- a/api/tests/unit/test_solution_id_on_public_models.py
+++ b/api/tests/unit/test_solution_id_on_public_models.py
@@ -81,6 +81,7 @@ class _FakeAppRow:
         self.icon = None
         self.organization_id = None
         self.published_at = None
+        self.deployed_at = None
         self.created_at = "2026-06-06T00:00:00+00:00"
         self.updated_at = "2026-06-06T00:00:00+00:00"
         self.created_by = None

--- a/client/src/components/applications/ApplicationListSurface.tsx
+++ b/client/src/components/applications/ApplicationListSurface.tsx
@@ -54,7 +54,7 @@ function isV2App(app: ApplicationListItem): boolean {
 }
 
 function canLaunchApp(app: ApplicationListItem): boolean {
-	return app.is_published || isV2App(app);
+	return app.is_published;
 }
 
 export function ApplicationListSurface({
@@ -134,7 +134,9 @@ export function ApplicationListSurface({
 					<DataTableBody>
 						{apps.map((app) => {
 							const opensPreview =
-								!canLaunchApp(app) && Boolean(onPreview);
+								!isV2App(app) &&
+								!canLaunchApp(app) &&
+								Boolean(onPreview);
 							return (
 								<DataTableRow
 									key={app.id}
@@ -203,7 +205,9 @@ export function ApplicationListSurface({
 													variant="default"
 													className="text-xs"
 												>
-													Published
+													{isV2App(app)
+														? "Deployed"
+														: "Published"}
 												</Badge>
 											)}
 											{app.has_unpublished_changes && (
@@ -221,14 +225,18 @@ export function ApplicationListSurface({
 														className="text-xs"
 													>
 														{isV2App(app)
-															? "V2"
+															? "Not deployed"
 															: "Empty"}
 													</Badge>
 												)}
 										</div>
 									</DataTableCell>
 									<DataTableCell className="w-0 whitespace-nowrap">
-										{app.is_published ? "Published" : "-"}
+										{app.is_published
+											? isV2App(app)
+												? "Deployed"
+												: "Published"
+											: "-"}
 									</DataTableCell>
 									<DataTableCell className="w-0 whitespace-nowrap text-right">
 										<div className="flex gap-1 justify-end">
@@ -238,7 +246,9 @@ export function ApplicationListSurface({
 												disabled={!canLaunchApp(app)}
 												title={
 													!canLaunchApp(app)
-														? "No published version"
+														? isV2App(app)
+															? "Deploy this App first"
+															: "No published version"
 														: `Open ${term(terminology, "app", "formalSingularLower")}`
 												}
 											>
@@ -281,20 +291,21 @@ export function ApplicationListSurface({
 																<Pencil className="h-4 w-4" />
 															</Button>
 														)}
-														{onOpenCode && (
-															<Button
-																variant="ghost"
-																size="sm"
-																onClick={() =>
-																	onOpenCode(
-																		app,
-																	)
-																}
-																title="Code editor"
-															>
-																<Code2 className="h-4 w-4" />
-															</Button>
-														)}
+														{!isV2App(app) &&
+															onOpenCode && (
+																<Button
+																	variant="ghost"
+																	size="sm"
+																	onClick={() =>
+																		onOpenCode(
+																			app,
+																		)
+																	}
+																	title="Code editor"
+																>
+																	<Code2 className="h-4 w-4" />
+																</Button>
+															)}
 														{onDelete && (
 															<Button
 																variant="ghost"
@@ -325,10 +336,11 @@ export function ApplicationListSurface({
 	return (
 		<div className="grid grid-cols-1 gap-4 sm:grid-cols-[repeat(auto-fill,minmax(320px,1fr))]">
 			{apps.map((app) => {
-				const opensPreview = !canLaunchApp(app) && Boolean(onPreview);
+				const opensPreview =
+					!isV2App(app) && !canLaunchApp(app) && Boolean(onPreview);
 				const defaultTarget = canLaunchApp(app)
 					? () => onLaunch(app)
-					: onPreview
+					: !isV2App(app) && onPreview
 						? () => onPreview(app)
 						: undefined;
 				const orgLabel = isPlatformAdmin
@@ -398,7 +410,7 @@ export function ApplicationListSurface({
 												<Pencil className="h-3.5 w-3.5" />
 											</Button>
 										)}
-										{onOpenCode && (
+										{!isV2App(app) && onOpenCode && (
 											<Button
 												type="button"
 												variant="ghost"
@@ -471,7 +483,9 @@ export function ApplicationListSurface({
 										variant="default"
 										className="text-[10px] px-1.5 py-0"
 									>
-										Published
+										{isV2App(app)
+											? "Deployed"
+											: "Published"}
 									</Badge>
 								)}
 								{app.has_unpublished_changes && (
@@ -485,7 +499,9 @@ export function ApplicationListSurface({
 								{!app.is_published &&
 									!app.has_unpublished_changes && (
 										<span className="text-[11px] text-muted-foreground">
-											{isV2App(app) ? "V2" : "Empty"}
+											{isV2App(app)
+												? "Not deployed"
+												: "Empty"}
 										</span>
 									)}
 							</div>

--- a/client/src/components/jsx-app/StandaloneV2App.test.tsx
+++ b/client/src/components/jsx-app/StandaloneV2App.test.tsx
@@ -156,7 +156,7 @@ describe("StandaloneV2App", () => {
 		expect(bootstrap).toMatchObject({
 			token: "tok-1",
 			basename: "/apps/dash",
-			orgScope: "org-42",
+			orgScope: null,
 			appId: "app-1",
 		});
 		expect(window.__BIFROST_APP__).toBeUndefined();
@@ -183,7 +183,7 @@ describe("StandaloneV2App", () => {
 		expect(mount.mock.calls[0][1]).toMatchObject({
 			baseUrl: window.location.origin,
 			token: "local-serving-token",
-			orgScope: "local-install-org",
+			orgScope: "stale-musick-org",
 			appId: "app-1",
 			basename: "/apps/dash",
 		});

--- a/client/src/components/jsx-app/StandaloneV2App.tsx
+++ b/client/src/components/jsx-app/StandaloneV2App.tsx
@@ -244,7 +244,6 @@ export function StandaloneV2App({
 	entry,
 	css,
 	baseUrl,
-	appOrgId,
 	runtimeContract,
 }: StandaloneV2AppProps) {
 	const containerRef = useRef<HTMLDivElement>(null);
@@ -277,8 +276,9 @@ export function StandaloneV2App({
 		const basename = isPreview
 			? `/apps/${appSlug}/preview`
 			: `/apps/${appSlug}`;
-		const orgScope =
-			appOrgId ?? (scope.type === "organization" ? scope.orgId : null);
+		// Visibility/deployment scope is separate from runtime data scope. All
+		// Apps run against the user's currently selected organization.
+		const orgScope = scope.type === "organization" ? scope.orgId : null;
 		const entryUrl = new URL(
 			`${assets.baseUrl}/${assets.entry}`,
 			window.location.origin,
@@ -452,7 +452,6 @@ export function StandaloneV2App({
 		isPreview,
 		assets,
 		sourceKey,
-		appOrgId,
 		scope,
 		token,
 	]);

--- a/client/src/lib/app-sdk/files.test.ts
+++ b/client/src/lib/app-sdk/files.test.ts
@@ -4,12 +4,14 @@ import {
 	FileNotFoundError,
 	FilePolicyError,
 	files,
+	setDefaultFileScope,
 	setBifrostTransport,
 } from "./files";
 
 let restoreTransport: (() => void) | null = null;
 
 afterEach(() => {
+	setDefaultFileScope(null);
 	restoreTransport?.();
 	restoreTransport = null;
 	vi.unstubAllGlobals();
@@ -27,6 +29,15 @@ function okNoContent() {
 }
 
 describe("files web SDK", () => {
+	it("uses the provider's runtime organization when scope is omitted", async () => {
+		const fetchMock = vi.fn().mockResolvedValue(okJson({ content: "hello", binary: false }));
+		vi.stubGlobal("fetch", fetchMock);
+		setDefaultFileScope("runtime-org");
+
+		await files.read("docs/readme.txt");
+
+		expect(JSON.parse(fetchMock.mock.calls[0][1].body).scope).toBe("runtime-org");
+	});
 	it("read posts to /api/files/read with workspace defaults", async () => {
 		const fetchMock = vi
 			.fn()

--- a/client/src/lib/app-sdk/files.test.ts
+++ b/client/src/lib/app-sdk/files.test.ts
@@ -179,6 +179,25 @@ describe("files web SDK", () => {
 		});
 	});
 
+	it("signedUrl combines the provider organization with custom expiration", async () => {
+		const fetchMock = vi.fn().mockResolvedValue(
+			okJson({
+				url: "https://s3/x",
+				path: "_repo/x",
+				expires_in: 3600,
+			}),
+		);
+		vi.stubGlobal("fetch", fetchMock);
+		setDefaultFileScope("runtime-org");
+
+		await files.signedUrl("x.txt", { method: "GET", expiresIn: 3600 });
+
+		expect(JSON.parse(fetchMock.mock.calls[0][1].body)).toMatchObject({
+			scope: "runtime-org",
+			expires_in: 3600,
+		});
+	});
+
 	it("signedUrls uses the batch endpoint without workflow endpoints", async () => {
 		const fetchMock = vi
 			.fn()

--- a/client/src/lib/app-sdk/files.ts
+++ b/client/src/lib/app-sdk/files.ts
@@ -42,6 +42,16 @@ export interface SignedUrlResult {
 
 type FileUploadContent = string | Blob | Uint8Array | ArrayBuffer;
 
+let defaultScope: string | null = null;
+
+export function setDefaultFileScope(scope: string | null): () => void {
+	const previous = defaultScope;
+	defaultScope = scope;
+	return () => {
+		defaultScope = previous;
+	};
+}
+
 function getCsrfToken(): string {
 	const match = document.cookie.match(/(?:^|;\s*)csrf_token=([^;]+)/);
 	return match ? decodeURIComponent(match[1]) : "";
@@ -51,7 +61,7 @@ function requestDefaults(options: FileOptions = {}) {
 	return {
 		location: options.location ?? "workspace",
 		mode: options.mode ?? "cloud",
-		scope: options.scope ?? null,
+		scope: options.scope ?? defaultScope,
 	};
 }
 
@@ -60,7 +70,7 @@ function signedDefaults(options: SignedUrlOptions = {}) {
 		method: options.method ?? "PUT",
 		content_type: options.contentType ?? "application/octet-stream",
 		location: options.location ?? "workspace",
-		scope: options.scope ?? null,
+		scope: options.scope ?? defaultScope,
 	};
 }
 
@@ -68,7 +78,10 @@ async function errorText(response: Response): Promise<string> {
 	const text = await response.text().catch(() => "");
 	if (!text) return response.statusText;
 	try {
-		const body = JSON.parse(text) as { detail?: unknown; message?: unknown };
+		const body = JSON.parse(text) as {
+			detail?: unknown;
+			message?: unknown;
+		};
 		const detail = body.detail ?? body.message;
 		if (typeof detail === "string") return detail;
 		if (detail !== undefined) return JSON.stringify(detail);
@@ -136,7 +149,9 @@ async function http<T>(
 	}
 	if (response.status === 204) return null;
 	if (!response.ok) {
-		throw new Error(`files: ${response.status} ${await errorText(response)}`);
+		throw new Error(
+			`files: ${response.status} ${await errorText(response)}`,
+		);
 	}
 	return (await response.json()) as T;
 }

--- a/client/src/lib/app-sdk/provider.tsx
+++ b/client/src/lib/app-sdk/provider.tsx
@@ -18,7 +18,7 @@
  * deployed. The v1 globalThis path is untouched.
  */
 import {
-  createContext,
+	createContext,
   useCallback,
   useContext,
   useEffect,
@@ -28,6 +28,7 @@ import {
   type ReactNode,
 } from "react";
 
+import { setDefaultFileScope } from "./files";
 import { setBifrostTransport, setDefaultAppScope } from "./tables";
 
 export interface BifrostContextValue {
@@ -222,10 +223,11 @@ export function BifrostProvider({
   const installKey = `${baseUrl}|${token}|${orgScope ?? ""}|${appId ?? ""}`;
   const installedRef = useRef<{
     key: string;
-    fetchImpl: typeof fetch | undefined;
-    restoreTransport: () => void;
-    restoreScope: () => void;
-  } | null>(null);
+		fetchImpl: typeof fetch | undefined;
+		restoreTransport: () => void;
+		restoreScope: () => void;
+		restoreFileScope: () => void;
+	} | null>(null);
   // Restore scheduled by the effect cleanup, pending in a microtask. A
   // re-install (render-time or effect re-run) cancels it by replacing the
   // marker, so StrictMode's synthetic cleanup→re-setup never actually
@@ -246,17 +248,19 @@ export function BifrostProvider({
         // (the table equivalent of the useWorkflow app_id, Codex #15).
         ...(appId ? { "X-Bifrost-App": appId } : {}),
       },
-    });
-    const restoreScope = setDefaultAppScope(orgScope);
-    const prev = installedRef.current;
+		});
+		const restoreScope = setDefaultAppScope(orgScope);
+		const restoreFileScope = setDefaultFileScope(orgScope);
+		const prev = installedRef.current;
     installedRef.current = {
       key: installKey,
       fetchImpl,
       // Keep the FIRST install's restores: unmount must return to the
       // pre-mount transport/scope, not to one of our own intermediates.
-      restoreTransport: prev?.restoreTransport ?? restoreTransport,
-      restoreScope: prev?.restoreScope ?? restoreScope,
-    };
+			restoreTransport: prev?.restoreTransport ?? restoreTransport,
+			restoreScope: prev?.restoreScope ?? restoreScope,
+			restoreFileScope: prev?.restoreFileScope ?? restoreFileScope,
+		};
   };
   const installRef = useRef(install);
   installRef.current = install;
@@ -290,10 +294,11 @@ export function BifrostProvider({
       queueMicrotask(() => {
         if (pendingRestoreRef.current !== pending) return;
         pendingRestoreRef.current = null;
-        installedRef.current = null;
-        installed.restoreTransport();
-        installed.restoreScope();
-      });
+				installedRef.current = null;
+				installed.restoreTransport();
+				installed.restoreScope();
+				installed.restoreFileScope();
+			});
     };
   }, []);
 

--- a/client/src/lib/app-sdk/use-workflow.test.tsx
+++ b/client/src/lib/app-sdk/use-workflow.test.tsx
@@ -103,6 +103,31 @@ describe("useWorkflow", () => {
     expect(calls[0].body.app_id).toBe("app-123");
   });
 
+  it("sends runtime org scope separately from App identity", async () => {
+    const calls: { body: Record<string, unknown> }[] = [];
+    const fakeFetch = (async (_input: RequestInfo | URL, init?: RequestInit) => {
+      calls.push({ body: init?.body ? JSON.parse(String(init.body)) : {} });
+      return new Response(JSON.stringify({ execution_id: "e0", status: "Success", result: {} }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }) as typeof fetch;
+    render(
+      <BifrostProvider
+        baseUrl="https://dev.example"
+        token="tok-x"
+        appId="app-123"
+        orgScope="runtime-org"
+        fetchImpl={fakeFetch}
+      >
+        <Runner onResult={() => {}} />
+      </BifrostProvider>,
+    );
+    screen.getByText("go").click();
+    await waitFor(() => expect(calls.length).toBe(1));
+    expect(calls[0].body).toMatchObject({ app_id: "app-123", org_id: "runtime-org" });
+  });
+
   it("omits app_id when the host supplies none (dev / non-solution app)", async () => {
     const calls: { body: Record<string, unknown> }[] = [];
     const fakeFetch = (async (_input: RequestInfo | URL, init?: RequestInit) => {

--- a/client/src/lib/app-sdk/use-workflow.ts
+++ b/client/src/lib/app-sdk/use-workflow.ts
@@ -98,7 +98,7 @@ class ExecutionFetchError extends Error {
  * `<BifrostProvider>` (throws otherwise — same contract as `useBifrostContext`).
  */
 export function useWorkflow<T = unknown>(workflowRef: string): UseWorkflowState<T> {
-  const { authedFetch, appId } = useBifrostContext();
+  const { authedFetch, appId, orgScope } = useBifrostContext();
   const [data, setData] = useState<T | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<Error | null>(null);
@@ -151,9 +151,10 @@ export function useWorkflow<T = unknown>(workflowRef: string): UseWorkflowState<
             workflow_id: workflowRef,
             input_data: input,
             // Scope a path::function ref to THIS install's own workflow (so it
-            // can't resolve a sibling install's workflow sharing the path).
-            ...(appId ? { app_id: appId } : {}),
-          }),
+						// can't resolve a sibling install's workflow sharing the path).
+						...(appId ? { app_id: appId } : {}),
+						...(orgScope ? { org_id: orgScope } : {}),
+					}),
         });
         if (!resp.ok) {
           throw new Error(`workflow execution failed: ${resp.status} ${resp.statusText}`);
@@ -265,7 +266,7 @@ export function useWorkflow<T = unknown>(workflowRef: string): UseWorkflowState<
         if (seq === seqRef.current) setLoading(false);
       }
     },
-    [authedFetch, workflowRef, appId],
+		[authedFetch, workflowRef, appId, orgScope],
   );
 
   return { data, loading, error, run, logs, status, executionId };

--- a/client/src/lib/v1.d.ts
+++ b/client/src/lib/v1.d.ts
@@ -9164,6 +9164,30 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/applications/{app_id}/deploy": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Deploy an App
+         * @description Build local App source and atomically activate the resulting artifact.
+         *
+         *     Source is staged only for the platform job and is deleted whether the job
+         *     succeeds or fails. The Application row and object storage retain compiled
+         *     ``dist`` files only.
+         */
+        post: operations["deploy_application_api_applications__app_id__deploy_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/applications/{app_id}/publish": {
         parameters: {
             query?: never;
@@ -11951,6 +11975,11 @@ export interface components {
             organization_id: string | null;
             /** Published At */
             published_at: string | null;
+            /**
+             * Deployed At
+             * @description When the currently active app artifact was deployed.
+             */
+            deployed_at?: string | null;
             /** Created At */
             created_at: string | null;
             /** Updated At */
@@ -11987,9 +12016,9 @@ export interface components {
             role_ids?: string[];
             /**
              * Repo Path
-             * @description Workspace-relative path to the app's source directory. Mutated via POST /api/applications/{id}/replace.
+             * @description Workspace source path for legacy or Solution-owned apps. Independent apps have no server-side source path.
              */
-            repo_path: string;
+            repo_path?: string | null;
             /**
              * Logo
              * @description Inline presentation logo as a data URL on single-application responses.
@@ -12566,6 +12595,11 @@ export interface components {
              * @enum {string}
              */
             cost_basis: "history" | "fallback";
+        };
+        /** Body_deploy_application_api_applications__app_id__deploy_post */
+        Body_deploy_application_api_applications__app_id__deploy_post: {
+            /** Source */
+            source: string;
         };
         /** Body_deploy_solution_api_solutions__solution_id__deploy_post */
         Body_deploy_solution_api_solutions__solution_id__deploy_post: {
@@ -43575,6 +43609,41 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["ApplicationDefinition"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    deploy_application_api_applications__app_id__deploy_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                app_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "multipart/form-data": components["schemas"]["Body_deploy_application_api_applications__app_id__deploy_post"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            202: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PlatformJobAccepted"];
                 };
             };
             /** @description Validation Error */

--- a/client/src/pages/AppRouter.tsx
+++ b/client/src/pages/AppRouter.tsx
@@ -42,11 +42,7 @@ export function AppRouter({ preview = false }: AppRouterProps) {
 	const isEmbed = hasRole("EmbedUser");
 
 	// Fetch application metadata
-	const {
-		data: application,
-		isLoading,
-		error,
-	} = useApplication(slugParam);
+	const { data: application, isLoading, error } = useApplication(slugParam);
 
 	// Drive the browser tab title + favicon from the open app. Skipped in embed
 	// mode, where the host page owns its own chrome. Must run before the early
@@ -75,7 +71,8 @@ export function AppRouter({ preview = false }: AppRouterProps) {
 						<div className="flex items-center gap-2 text-destructive">
 							<AlertTriangle className="h-5 w-5" />
 							<CardTitle>
-								{term(terminology, "app", "formalSingular")} Error
+								{term(terminology, "app", "formalSingular")}{" "}
+								Error
 							</CardTitle>
 						</div>
 						<CardDescription>
@@ -107,13 +104,14 @@ export function AppRouter({ preview = false }: AppRouterProps) {
 						<div className="flex items-center gap-2 text-muted-foreground">
 							<AlertTriangle className="h-5 w-5" />
 							<CardTitle>
-								{term(terminology, "app", "formalSingular")} Not Found
+								{term(terminology, "app", "formalSingular")} Not
+								Found
 							</CardTitle>
 						</div>
 						<CardDescription>
 							The requested{" "}
-							{term(terminology, "app", "formalSingularLower")} does
-							not exist or you don't have access to it.
+							{term(terminology, "app", "formalSingularLower")}{" "}
+							does not exist or you don't have access to it.
 						</CardDescription>
 					</CardHeader>
 					<CardContent>
@@ -130,21 +128,23 @@ export function AppRouter({ preview = false }: AppRouterProps) {
 		);
 	}
 
-	// Handle not published (only for non-preview mode). standalone_v2 apps have
-	// NO publish concept (created == published; deploy serves the source) — the
-	// v1 "Not Published"/"Open Editor" screen must never apply to them. The
-	// server already reports is_published=true for v2; this guards the client too.
-	if (!preview && application.app_model !== "standalone_v2" && !application.is_published) {
+	// V1 uses publish/draft. V2 uses deploy and has no in-platform editor.
+	if (!preview && !application.is_published) {
+		const isV2 = application.app_model === "standalone_v2";
 		return (
 			<div className="min-h-screen flex items-center justify-center p-4">
 				<Card className="max-w-md w-full">
 					<CardHeader>
 						<div className="flex items-center gap-2 text-muted-foreground">
 							<AlertTriangle className="h-5 w-5" />
-							<CardTitle>Not Published</CardTitle>
+							<CardTitle>
+								{isV2 ? "Not Deployed" : "Not Published"}
+							</CardTitle>
 						</div>
 						<CardDescription>
-							This application has not been published yet.
+							{isV2
+								? "Deploy this App from its local project with `bifrost app deploy`."
+								: "This application has not been published yet."}
 						</CardDescription>
 					</CardHeader>
 					<CardContent className="flex gap-2">
@@ -155,13 +155,15 @@ export function AppRouter({ preview = false }: AppRouterProps) {
 							<ArrowLeft className="mr-2 h-4 w-4" />
 							Back
 						</Button>
-						<Button
-							onClick={() =>
-								navigate(`/apps/${slugParam}/edit`)
+						{!isV2 && (
+							<Button
+								onClick={() =>
+									navigate(`/apps/${slugParam}/edit`)
 							}
-						>
-							Open Editor
-						</Button>
+							>
+								Open Editor
+							</Button>
+						)}
 					</CardContent>
 				</Card>
 			</div>

--- a/client/src/pages/Applications.test.tsx
+++ b/client/src/pages/Applications.test.tsx
@@ -111,6 +111,26 @@ describe("Applications — app launch behavior", () => {
 		).toBeInTheDocument();
 		expect(screen.queryByText(/open published/i)).not.toBeInTheDocument();
 	});
+
+	it("shows an undeployed v2 App without an in-platform code editor", async () => {
+		mockUseApplications.mockReturnValue({
+			data: {
+				applications: [
+					makeApp({
+						app_model: "standalone_v2",
+						is_published: false,
+					}),
+				],
+			},
+			isLoading: false,
+			refetch: vi.fn(),
+		});
+		await renderPage();
+		expect(screen.getByText("Not deployed")).toBeInTheDocument();
+		expect(
+			screen.queryByRole("button", { name: /code editor/i }),
+		).not.toBeInTheDocument();
+	});
 });
 
 describe("Applications — solution-managed badge (grid view)", () => {

--- a/docs/runbooks/web-sdk.md
+++ b/docs/runbooks/web-sdk.md
@@ -1,7 +1,7 @@
 # Bifrost Web SDK
 
-The v2 web SDK is the installable `bifrost` package used by
-`standalone_v2` Solution apps:
+The V2 web SDK is the installable `bifrost` package used by independent and
+Solution-owned Apps:
 
 ```tsx
 import { BifrostProvider, BifrostHeader, useWorkflowMutation } from "bifrost";
@@ -32,34 +32,34 @@ instance that served it.
 
 ## Local Apps
 
-Scaffolded v2 apps declare the SDK dependency as an instance URL:
-
-```json
-{
-  "dependencies": {
-    "bifrost": "https://your-bifrost.example.com/api/sdk/download"
-  }
-}
-```
-
-That is why local development needs no npm registry publish. `npm install`
-downloads the SDK tarball from the Bifrost instance the app targets.
-
-To update a local app's SDK after upgrading Bifrost, reinstall the dependency
-from the target instance:
+V2 App scaffolds deliberately omit an instance-specific SDK dependency from
+`package.json`. Both connected development commands install the selected
+instance's SDK transiently without rewriting project metadata:
 
 ```bash
-npm install bifrost@https://your-bifrost.example.com/api/sdk/download
+bifrost app start
+bifrost solution start
 ```
 
-Commit the resulting `package-lock.json` change if the app source keeps a lock
-file. If the app should point at a different Bifrost environment, change the URL
-in `package.json` and run the same install command.
+An independent App stores only `BIFROST_API_URL` and `BIFROST_APP_ID` in its
+gitignored `.env`. A Solution stores its install binding in `.env` and its
+portable ownership metadata in the descriptor and manifests.
+
+For an independent App, start again after removing a stale
+`node_modules/bifrost` package. For a Solution App, use the explicit update
+command:
+
+```bash
+bifrost solution sdk update [path] --app <slug>
+```
+
+Do not commit an instance URL or authentication token to `package.json`.
 
 ## Deployed Apps
 
-Server-side Solution builds do not call the public SDK download URL and do not
-need network access to npm for the SDK itself. `SolutionAppBuilder` generates
+Server-side independent-App and Solution builds do not call the public SDK
+download URL and do not need network access to npm for the SDK itself.
+`SolutionAppBuilder` is the shared V2 compiler: it generates
 the same tarball from the running API image, writes it into the temporary build
 directory as `bifrost-sdk.tgz`, and injects:
 
@@ -71,9 +71,10 @@ directory as `bifrost-sdk.tgz`, and injects:
 }
 ```
 
-Then it runs `npm install` and `vite build`. Redeploying or reinstalling a
-Solution after a Bifrost upgrade rebuilds the app against the SDK bundled with
-that upgraded instance.
+Then it runs `npm install` and `vite build`. `bifrost app deploy` uploads source
+only for that durable build, stores an immutable compiled artifact, atomically
+activates it, and deletes the source. `bifrost solution deploy` builds the same
+App shape as part of full Solution reconciliation.
 
 Prebuilt disconnected Solution packages are different: if a bundle ships a
 ready `dist/`, the platform skips the server-side Vite build. In that case the
@@ -81,7 +82,7 @@ SDK version is whatever the bundle was built with.
 
 ## App Mount Lifecycle
 
-Apps v2 keep the module graph exactly as Vite emits it. The host loads the
+V2 Apps keep the module graph exactly as Vite emits it. The host loads the
 content-hashed entry through its canonical URL, without per-mount query
 parameters, then invokes the entry's exported `mount(mountEl, bootstrap)` for
 each visit. `mount` must return a teardown function (normally
@@ -117,18 +118,17 @@ version follows the Bifrost instance version returned by `shared.version`.
 
 Practical consequences:
 
-- App authors should depend on an instance URL, not `bifrost@latest`.
+- App authors should let the CLI/server inject the selected instance's SDK, not depend on `bifrost@latest`.
 - SDK changes ship with the Bifrost deployment that contains them.
-- Local apps update by reinstalling from `/api/sdk/download`.
-- Deployed source-built apps update when the Solution is rebuilt on the target
-  instance.
+- Local Apps update through `app start` or `solution sdk update`.
+- Deployed source-built Apps update when the App or Solution is redeployed on the target instance.
 - Breaking SDK surface changes should be treated as Bifrost release changes and
   documented in release notes, because apps consume the SDK from their host
   instance.
 
 ## Header Ownership
 
-The platform does not wrap `standalone_v2` apps in a shell. Apps own their
+The platform does not wrap V2 Apps in a shell. Apps own their
 layout. `<BifrostHeader>` is an optional SDK component that an app can compose
 when it wants familiar platform chrome.
 

--- a/plugins/bifrost/.codex-plugin/plugin.json
+++ b/plugins/bifrost/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "bifrost",
-  "version": "1.2.2",
-  "description": "Bifrost — MSP automation platform. Skills for building workflows, forms, agents, apps, tables, and files with the Bifrost SDK + CLI, setting up local Bifrost development, and packaging Bifrost agents as Microsoft 365 Copilot Cowork plugins, :migrate (move a legacy v1 inline app + its backing entities into an installable v2 Solution).",
+  "version": "1.2.3",
+  "description": "Bifrost — MSP automation platform. Skills for building workflows, forms, agents, independent Apps, Solutions, tables, and files with the Bifrost SDK + CLI, including v1 migration into either V2 ownership model.",
   "author": {
     "name": "Jack Musick",
     "url": "https://github.com/gobifrost/bifrost"
@@ -13,7 +13,7 @@
   "interface": {
     "displayName": "Bifrost",
     "shortDescription": "Build, set up, and package Bifrost automation artifacts",
-    "longDescription": "Use Bifrost skills to build workflows, forms, agents, apps, tables, and files with the Bifrost SDK and CLI; set up local Bifrost development; and package Bifrost agents as Microsoft 365 Copilot Cowork plugins.",
+    "longDescription": "Use Bifrost skills to build workflows, forms, agents, independent Apps, Solutions, tables, and files with the Bifrost SDK and CLI; migrate legacy Apps; set up local development; and package Bifrost agents as Microsoft 365 Copilot Cowork plugins.",
     "developerName": "Jack Musick",
     "category": "Engineering",
     "capabilities": [
@@ -22,7 +22,7 @@
       "Write"
     ],
     "defaultPrompt": [
-      "Help me build a Bifrost workflow, form, agent, app, table, or file-backed Solution.",
+      "Help me build an independent Bifrost App, Solution, workflow, form, agent, table, or managed-file experience.",
       "Set up this project for local Bifrost development.",
       "Package a Bifrost agent as a Microsoft 365 Copilot Cowork plugin."
     ],

--- a/plugins/bifrost/skills/bifrost-build/SKILL.md
+++ b/plugins/bifrost/skills/bifrost-build/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: build
-description: Build or modify Bifrost apps, workflows, forms, agents, tables, managed files, configs, integrations, events, and related platform resources. Use for Solution-owned v2 projects, loose instance _repo/v1 content, local preview and testing, deployment planning, or MCP-only Bifrost work. Covers instance and install targeting, source ownership, access controls, testing, app design and theming, visual QA, and deployment handoff.
+description: Build or modify Bifrost apps, workflows, forms, agents, tables, managed files, configs, integrations, events, and related platform resources. Use for independent or Solution-owned V2 Apps, loose instance _repo/v1 content, local preview and testing, deployment planning, or MCP-only Bifrost work. Covers instance and install targeting, source ownership, access controls, testing, app design and theming, visual QA, and deployment handoff.
 ---
 
 # Bifrost Build
@@ -13,7 +13,7 @@ Follow the process below for every task. Load only the references routed for the
 
 ## Prerequisites
 
-This Solution workflow requires Bifrost CLI 1.2.2 or newer. The selected
+These App and Solution workflows require Bifrost CLI 1.2.3 or newer. The selected
 instance may enforce a newer minimum through `/api/version`; when the CLI gate
 blocks, install the CLI served by that instance before continuing.
 
@@ -32,37 +32,39 @@ A sandbox may be unable to read the host credential store. If authentication app
 
 ### 1. Choose the working model and target
 
-First choose which of three working models owns the change. `Workspace` here means the selected instance's loose `_repo` source and live loose entities; it does not mean global entity scope.
+First choose which of four working models owns the change. `Workspace` here means the selected instance's loose `_repo` source and live loose entities; it does not mean global entity scope.
 
 | Working model | Use it when | Authoring and lifecycle | Read next |
 |---|---|---|---|
 | **Workspace** | Maintaining a v1 app, building a loose workflow/entity, or intentionally creating source/resources shared at the instance level | Edit `_repo` source with `bifrost files`; create and mutate its scoped entity records directly with dedicated CLI commands. Commands target the selected instance directly; v1 app source remains draft until published. | `references/repository.md` |
+| **App** | Building one normal Vite/React App in its own git repository while workflows, tables, files, configs, and integrations remain live platform resources | Create or bind with `bifrost app create` / `app bind`; develop with `bifrost app start`; deliver only the App bundle with `bifrost app deploy`. Source stays local and never enters `_repo` or a manifest. | `references/apps-independent.md` |
 | **Solution** | Building a cohesive, portable, versioned app or automation package that should own and deploy its definitions together | Edit local source and `.bifrost` manifests; preview with `bifrost solution start`; deliver with `bifrost solution deploy`. Keep `global_repo_access: false`. | `references/solutions.md` |
 | **Solution supported by the Workspace** | A Solution intentionally depends on eligible shared `_repo` modules, registered loose workflows, tables, or files | Author and deploy Solution-owned definitions locally, but manage each shared Workspace dependency separately through its own CLI/file path. Set `global_repo_access: true`; this adds runtime fallback, not ownership or permission. | `references/solutions.md` and `references/solution-resource-access.md` |
 
-Use `bifrost.solution.yaml` at the project root as the ownership marker. If it exists, inspect `global_repo_access` to distinguish the second and third models. If it does not exist, use the Workspace model. If starting inside a nested folder, locate the root with ordinary file discovery; do not use a custom shell loop.
+Use `bifrost.solution.yaml` at the project root as the Solution ownership marker. If it exists, inspect `global_repo_access` to distinguish the two Solution models. Without it, a project-level `.env` containing `BIFROST_APP_ID` identifies an independent App; an ordinary loose checkout without either marker uses the Workspace model. If starting inside a nested folder, locate the root with ordinary file discovery; do not use a custom shell loop.
 
-For net-new work, confirm the model with the user before scaffolding. Prefer a Solution for a new product or package that should be portable and lifecycle-managed. Use the Workspace for deliberately loose, shared, or existing v1 content. Enable Workspace support for a Solution only when the shared dependencies are intentional and understood, never as a default convenience.
+For net-new work, confirm the model with the user before scaffolding. Use an App when one independently deployed frontend should consume live platform resources. Prefer a Solution when the frontend and its workflows, tables, configs, or other definitions must travel and reconcile as one installable package. Use the Workspace for deliberately loose, shared, or existing v1 content. Enable Workspace support for a Solution only when the shared dependencies are intentional and understood, never as a default convenience.
 
 Then establish the exact instance and, for either Solution model, the install that the CLI resolves. Read `.env` in the intended CLI invocation directory, normally the project or Solution root. Parent-directory `.env` files are not selected implicitly. Inspect these optional fields when present:
 
 - `BIFROST_API_URL`
+- `BIFROST_APP_ID`
 - `BIFROST_SOLUTION_ID`
 - `BIFROST_SOLUTION_SLUG`
 - `BIFROST_SOLUTION_ORG_ID`
 - `BIFROST_SOLUTION_SCOPE`
 
-Treat `.env` as optional local instance/install selection, not portable source. Do not commit it. A normal Bifrost project `.env` should not contain access or refresh tokens; report only the selector and binding fields above. Without an explicit install binding, Solution commands resolve a unique install by portable slug and print `--solution <id>` choices when several are available. If deploy finds no install, it requires `--org <ref>` or `--global` before creating one.
+Treat `.env` as local instance/App/install selection, not portable source. Do not commit it. A normal Bifrost project `.env` should not contain access or refresh tokens; report only the selector and binding fields above. An App clone uses `bifrost app bind` to recreate `BIFROST_API_URL` and `BIFROST_APP_ID`. Without an explicit install binding, Solution commands resolve a unique install by portable slug and print `--solution <id>` choices when several are available. If Solution deploy finds no install, it requires `--org <ref>` or `--global` before creating one.
 
 Compare `Current connection` and `Default connection` from `bifrost auth default`:
 
 - If `.env` selects a non-default instance, tell the user which instance and install are selected and offer the saved default before material work.
-- Removing `BIFROST_API_URL` from `.env` returns that directory to the saved default connection. Use `--url` for a one-command override; use `solution bind` only when intentionally remembering one install.
+- Removing `BIFROST_API_URL` from `.env` returns that directory to the saved default connection. Use `--url` for a one-command override; use `app bind` or `solution bind` only when intentionally remembering a target.
 - Never change the user's saved default merely to target one project.
 
 ### 2. Understand and plan the change
 
-If this is a Solution, state its name/slug, selected instance, resolved install, and install scope. Then confirm the requested outcome and intended users.
+If this is an App, state its local project, selected instance, bound App, and intended runtime organizations. If this is a Solution, state its name/slug, selected instance, resolved install, and install scope. Then confirm the requested outcome and intended users.
 
 For every material change, present a concise plan and get confirmation before editing. A small, well-bounded bug fix does not need ceremony. The plan must identify:
 
@@ -77,13 +79,13 @@ Keep the access tuple `(organization, access_level, role_ids)` compatible across
 
 ### 3. Build in the correct ownership model
 
-Load the artifact references routed below and follow the working model selected in step 1. Use curated references for the method and generated appendices or `--help` for exact syntax; never infer a familiar command or flag. Do not mix authoring paths: Workspace entities mutate live; Solution-owned definitions change through local source and deploy. If a Solution supported by the Workspace needs changes on both sides, track them as separate change sets with separate ownership, access, verification, and delivery effects.
+Load the artifact references routed below and follow the working model selected in step 1. Use curated references for the method and generated appendices or `--help` for exact syntax; never infer a familiar command or flag. Do not mix authoring paths: Workspace entities mutate live; independent App source changes locally and only its compiled artifact deploys; Solution-owned definitions change through local source and deploy. If an App or a Solution supported by the Workspace needs changes on both sides, track them as separate change sets with separate ownership, access, verification, and delivery effects.
 
 Use test-driven development for behavior: define the acceptance result, write a focused failing test when useful, implement the change, and make it pass. Do not create contrived tests for visual-only acceptance; verify the rendered result instead.
 
 Before adding workflow logic, search for an existing module that already owns the domain or integration behavior. Keep workflows as thin orchestration; put reusable business and integration logic in modules.
 
-Treat local Solution preview as connected development, not a data sandbox. Table, managed-file, config, and integration writes can affect the selected instance.
+Treat `app start` and `solution start` as connected development, not data sandboxes. Table, managed-file, config, and integration writes can affect the selected instance.
 
 ### 4. Verify the complete experience
 
@@ -107,8 +109,8 @@ Summarize what changed and what was verified. Separate source changes from live 
 
 Keep these layers distinct:
 
-- **Working model and source ownership** determine where definitions are edited: instance `_repo`/live records or local Solution source.
-- **Lifecycle ownership** determines how definitions reach the platform: immediate Workspace mutation or Solution deploy.
+- **Working model and source ownership** determine where definitions are edited: instance `_repo`/live records, one local App repository, or local Solution source.
+- **Lifecycle ownership** determines how definitions reach the platform: immediate Workspace mutation, App artifact deploy, or Solution full-replace deploy.
 - **Dependency resolution** determines where running code may look after its own resources miss. `global_repo_access` changes this layer only.
 - **Authorization** determines whether a resolved entity or row/file operation is allowed. Organization, access level, roles, policies, and external-user rules always apply.
 - **Environment data** such as table rows, runtime files, config values, and integration mappings can be live even while Solution source is running locally.
@@ -118,6 +120,7 @@ Therefore, a Solution supported by the Workspace may call an eligible loose work
 These relationships produce the following hard boundaries:
 
 - Solution-owned apps, workflows, forms, agents, tables, configs, claims, and file-location declarations change through local source plus `bifrost solution deploy`; do not live-mutate their managed records.
+- Independent App source changes only in its local repository. `bifrost app deploy` builds and activates the App artifact; it does not capture, copy, or own the live workflows, tables, files, configs, or integrations the App calls.
 - Instance `_repo` source changes through direct `bifrost files` commands. Writing source does not replace entity creation or workflow registration.
 - `.bifrost/*.yaml` is Solution source inside a Solution. Outside a Solution, discover and mutate live entities with their CLI commands rather than treating an exported manifest as live state.
 - `global_repo_access` is a runtime fallback gate, not install scope, global entity permission, or an authorization bypass.
@@ -128,10 +131,11 @@ These relationships produce the following hard boundaries:
 
 | Need | Load for the task |
 |---|---|
+| Create, bind, start, deploy, or migrate an independent App | `references/apps-independent.md`, `references/apps-v2.md`, `references/app-quality.md`, and `references/web-sdk-v2.md` |
 | Create, bind, start, capture, deploy, export, or install a Solution | `references/solutions.md` |
 | Read or write instance `_repo` source; maintain loose modules, workflows, or v1 apps | `references/repository.md` |
 | Author, register, execute, rename, or expose a Python workflow | `references/workflows.md` and the relevant section of `references/python-sdk.md` |
-| Build or modify a v2 Solution app | `references/apps-v2.md`, `references/app-quality.md`, and `references/web-sdk-v2.md` |
+| Build or modify a V2 App inside a Solution | `references/apps-v2.md`, `references/app-quality.md`, and `references/web-sdk-v2.md` |
 | Maintain an existing inline v1 app | Read `references/apps-v1.md` and `references/app-quality.md`; search `references/platform-api.md` only for the exact v1 export being used |
 | Create or change forms, agents, configs, integrations, events, orgs, roles, or claims | `references/entities.md` |
 | Define a table, write policies, or use table data | `references/tables.md` |

--- a/plugins/bifrost/skills/bifrost-build/generated/cli-reference.md
+++ b/plugins/bifrost/skills/bifrost-build/generated/cli-reference.md
@@ -158,6 +158,107 @@ Options:
   --help                          Show this message and exit.
 ```
 
+## `app`
+
+```
+Usage: app [OPTIONS] COMMAND [ARGS]...
+
+  Create, bind, run, and deploy an App project.
+
+Options:
+  --help  Show this message and exit.
+
+Commands:
+  bind        Bind a cloned Vite project to an existing App.
+  create      Create a Vite project and its remote App record.
+  deploy      Build and atomically deploy the current App project.
+  migrate     Migrate a pulled v1 App directory into an independent V2...
+  start       Run the local Vite App against live Bifrost resources.
+  swap-slugs  Atomically exchange v1 and independent V2 App slugs during...
+```
+
+### `app bind`
+
+```
+Usage: app bind [OPTIONS] REF [PATH]
+
+  Bind a cloned Vite project to an existing App.
+
+Options:
+  --url TEXT  Bifrost instance URL.
+  --help      Show this message and exit.
+```
+
+### `app create`
+
+```
+Usage: app create [OPTIONS] [PATH]
+
+  Create a Vite project and its remote App record.
+
+Options:
+  --name TEXT  App display name (default: directory name).
+  --slug TEXT  URL slug (default: derived from name).
+  --org TEXT   Organization UUID or name.
+  --global     Create a globally visible App.
+  --url TEXT   Bifrost instance URL.
+  --help       Show this message and exit.
+```
+
+### `app deploy`
+
+```
+Usage: app deploy [OPTIONS] [PATH]
+
+  Build and atomically deploy the current App project.
+
+Options:
+  --help  Show this message and exit.
+```
+
+### `app migrate`
+
+```
+Usage: app migrate [OPTIONS] SOURCE PATH
+
+  Migrate a pulled v1 App directory into an independent V2 App project.
+
+Options:
+  --name TEXT  App display name (default: destination name).
+  --slug TEXT  Temporary V2 URL slug (default: derived from name).
+  --org TEXT   Organization UUID or name.
+  --global     Create a globally visible App.
+  --url TEXT   Bifrost instance URL.
+  --help       Show this message and exit.
+```
+
+### `app start`
+
+```
+Usage: app start [OPTIONS] [PATH]
+
+  Run the local Vite App against live Bifrost resources.
+
+Options:
+  --org TEXT         Run against another authorized organization.
+  --port INTEGER     [default: 3000]
+  --host TEXT        [default: 127.0.0.1]
+  --public-url TEXT
+  --help             Show this message and exit.
+```
+
+### `app swap-slugs`
+
+```
+Usage: app swap-slugs [OPTIONS] APP_A APP_B
+
+  Atomically exchange v1 and independent V2 App slugs during cutover.
+
+Options:
+  --url TEXT  Bifrost instance URL.
+  --help      Show this message and exit.
+```
+
 ## `apps`
 
 ```
@@ -1833,7 +1934,7 @@ Commands:
   export        Download a Solution's workspace zip (shareable or full...
   init          Alias for `solution create`: scaffold and create a remote...
   install       Install a Solution from a workspace zip (drag-and-drop...
-  migrate-app   Migrate a v1 inline app dir to a scaffolded standalone_v2...
+  migrate-app   Migrate a v1 inline App directory to a scaffolded V2 App:...
   pull          Pull captured entities into the local .bifrost/ manifest...
   scaffold-app  Scaffold a standalone_v2 React app (package.json, vite,...
   sdk           Manage the app's vendored Bifrost SDK.
@@ -2009,8 +2110,8 @@ Options:
 ```
 Usage: solution migrate-app [OPTIONS] SOURCE V2_SLUG
 
-  Migrate a v1 inline app dir to a scaffolded standalone_v2 app: scaffold +
-  port source + rewrite imports + install shadcn. STOPS before build/wire and
+  Migrate a v1 inline App directory to a scaffolded V2 App: scaffold + port
+  source + rewrite imports + install shadcn. STOPS before build/wire and
   prints a checklist of the judgment steps left to you.
 
 Options:

--- a/plugins/bifrost/skills/bifrost-build/generated/openapi-digest.md
+++ b/plugins/bifrost/skills/bifrost-build/generated/openapi-digest.md
@@ -84,6 +84,7 @@
 | GET | `/api/applications/{app_id}/bundle-manifest` |
 | GET | `/api/applications/{app_id}/dependencies` |
 | PUT | `/api/applications/{app_id}/dependencies` |
+| POST | `/api/applications/{app_id}/deploy` |
 | GET | `/api/applications/{app_id}/dist/{path}` |
 | GET | `/api/applications/{app_id}/draft` |
 | PUT | `/api/applications/{app_id}/draft` |

--- a/plugins/bifrost/skills/bifrost-build/references/apps-independent.md
+++ b/plugins/bifrost/skills/bifrost-build/references/apps-independent.md
@@ -1,0 +1,104 @@
+# Independent Apps
+
+Use this model for one V2 frontend that lives in its own ordinary git repository while its workflows, tables, files, configs, and integrations remain live Bifrost resources. Use a Solution instead when those definitions must be packaged, installed, versioned, and reconciled together.
+
+## Source and binding
+
+Create a project and remote App record together:
+
+```bash
+bifrost app create operations --name "Operations"
+cd operations
+npm install
+```
+
+The directory is a normal Vite project. Its only Bifrost-specific local state is a gitignored `.env`:
+
+```dotenv
+BIFROST_API_URL=https://bifrost.example.com
+BIFROST_APP_ID=<uuid>
+```
+
+There is no Solution descriptor, `.bifrost` manifest, source YAML, `_repo` App directory, draft, preview, or publish step. A clean clone restores its local binding with:
+
+```bash
+bifrost app bind <app-id-or-slug> . --url https://bifrost.example.com
+```
+
+Never commit `.env`, access tokens, or refresh tokens.
+
+## Connected development
+
+Run the local App against the selected instance's live platform resources:
+
+```bash
+bifrost app start
+```
+
+`app start` runs Vite behind an authenticated Bifrost proxy. It does not execute local Python workflows. Workflow refs resolve against the live registered workflows visible to the App and selected organization. Tables, managed files, configs, integrations, and `_repo` modules are live as well; writes are real.
+
+Run `app start` before the first standalone `npm run build` in a clean checkout. Start installs the selected instance's SDK into `node_modules` transiently; it is intentionally absent from the portable `package.json` and git history. Server deploy installs the same instance-matched SDK in its isolated build directory.
+
+App identity and runtime organization scope are separate. The default organization is the current viewer's selected organization. An authorized provider/admin can troubleshoot another organization without rebinding or editing source:
+
+```bash
+bifrost app start --org "Customer Org"
+```
+
+This override does not bypass App, workflow, table, file, role, policy, or external-user authorization.
+
+## Deploy
+
+Deploy from the bound project root:
+
+```bash
+bifrost app deploy
+```
+
+The CLI excludes `.env`, ignored files, dependencies, and build output, then uploads source only for the duration of a durable server-side build. The server stores an immutable compiled artifact, atomically activates it, and discards uploaded source. A failed build leaves the previous deployment active.
+
+Deploy changes only the App artifact. It does not capture or mutate live backing resources. Confirm required workflows and policies exist in every organization where the App will run.
+
+## Global and organization-scoped Apps
+
+Choose visibility when creating the remote record:
+
+```bash
+bifrost app create operations --org "Customer Org"
+bifrost app create shared-portal --global
+```
+
+Both forms use the viewer's active organization as runtime data scope. The App record's organization controls visibility; it is not a hardcoded data-scope override. Verify the complete access tuple across the App and every resource it calls.
+
+## Migrate a v1 App
+
+Pull the legacy `_repo/apps/<slug>` source to a local directory, then create an independent V2 project with the deterministic import rewrite:
+
+```bash
+bifrost app migrate ./legacy-source ./operations-v2 \
+  --name "Operations" --slug operations-v2
+```
+
+The command ports pages/components, rewrites v1 platform imports, installs detected UI and browser dependencies, binds the new App, and prints the remaining route/design/access checklist. It does not move backing entities because independent Apps intentionally continue using live resources.
+
+After browser acceptance and deploy, preserve the live URL with an atomic slug swap:
+
+```bash
+bifrost app deploy ./operations-v2
+bifrost app swap-slugs operations operations-v2
+```
+
+The old v1 App remains parked under the temporary slug for rollback. Do not delete it until the V2 App has been verified with realistic users and organizations.
+
+## Acceptance
+
+Before handoff:
+
+- run tests, type checking, and `npm run build`;
+- inspect every route through the `app start` proxy, including refresh/deep links;
+- verify loading, empty, denied, error, disabled, and success states;
+- exercise live workflow, table, and file behavior in the default organization;
+- exercise `--org` with an authorized operator and confirm an unauthorized viewer cannot override scope;
+- deploy, launch from the Apps UI, and verify the same resource behavior;
+- intentionally fail a build once and confirm the previous deployment remains live;
+- confirm `.env` and App source are absent from permanent platform storage.

--- a/plugins/bifrost/skills/bifrost-build/references/apps-v1.md
+++ b/plugins/bifrost/skills/bifrost-build/references/apps-v1.md
@@ -1,6 +1,6 @@
 # Inline v1 Apps
 
-Use this reference only to maintain an existing `inline_v1` app or when the user explicitly requires a loose instance app. Build new apps as v2 apps inside a Solution.
+Use this reference only to maintain an existing `inline_v1` App. Build new Apps as V2 projects, either independently or inside a Solution according to ownership needs.
 
 ## Ownership
 
@@ -69,4 +69,4 @@ Publication queues the production rebuild. Verify its result and the published r
 
 Apply `app-quality.md` to v1 changes as well. Use semantic platform tokens where the runtime supports them, verify the actual rendered preview, and test all affected states.
 
-When converting to v2, use `bifrost solution migrate-app <source-slug> <v2-slug>` and then complete the judgment work it reports: real package imports, local shadcn components, provider/mount lifecycle, portable workflow refs, state replacement, full theming, and visual QA. Do not perform a mechanical import rewrite and call the migration complete.
+When converting to V2, choose ownership first. Use `bifrost app migrate <source-dir> <destination>` when the frontend should remain backed by live platform resources. Use `bifrost solution migrate-app <source-dir> <v2-slug>` when the App and selected backing definitions should become one installable package. Both commands stop before judgment-heavy route wiring, access review, theming, and visual QA; do not perform a mechanical import rewrite and call the migration complete.

--- a/plugins/bifrost/skills/bifrost-build/references/apps-v2.md
+++ b/plugins/bifrost/skills/bifrost-build/references/apps-v2.md
@@ -1,6 +1,6 @@
-# v2 Solution Apps
+# V2 Apps
 
-Use `standalone_v2` for every new Bifrost app. A v2 app is a normal React/TypeScript/Vite project owned by a Solution and deployed from source.
+A V2 App is a normal React/TypeScript/Vite project. It can be independently deployed from its own repository or owned and deployed as part of a Solution. Choose the ownership model before scaffolding; read `apps-independent.md` for independent App lifecycle and `solutions.md` for Solution lifecycle.
 
 Read `app-quality.md` before designing user-visible UI and `web-sdk-v2.md` when using Bifrost data or workflows.
 
@@ -12,10 +12,16 @@ From a Solution root:
 bifrost solution scaffold-app operations
 ```
 
-Use the scaffolded structure instead of recreating it from memory:
+For an independent App repository:
+
+```bash
+bifrost app create operations --name "Operations"
+```
+
+Both commands create the same App project structure; a Solution nests it under `apps/<slug>/` and adds its descriptor/manifests:
 
 ```text
-apps/operations/
+operations/                    # independent repo root, or apps/operations in a Solution
 ├── package.json
 ├── vite.config.ts
 ├── tsconfig.json
@@ -28,6 +34,8 @@ apps/operations/
     ├── components/
     ├── lib/
     └── pages/
+
+# Solution ownership adds these outside the App directory:
 functions/
 .bifrost/apps.yaml
 bifrost.solution.yaml
@@ -35,7 +43,7 @@ bifrost.solution.yaml
 
 Keep the scaffold's `index.html` and reusable `mount()` lifecycle in `src/main.tsx`. It registers the app module, receives per-mount URL/token/org/app/theme bootstrap data, wraps the app in `BifrostProvider`, and mounts the router at the host-provided basename. Hand-written legacy entrypoints often work locally and fail when the platform mounts the app more than once.
 
-The scaffold creates the app manifest entry. App metadata, source path, logo path, and dependencies deploy from the Solution; do not create or update the managed app record live.
+The Solution scaffold creates an App manifest entry; its metadata and source deploy with the Solution. The independent scaffold creates and binds the remote App record but stores no manifest or remote source. Do not cross these ownership models.
 
 ## Import boundaries
 
@@ -65,7 +73,7 @@ Use `../generated/web-sdk-surface.md` to confirm SDK exports. Do not guess an ex
 
 ## App-to-workflow contract
 
-Reference Solution workflows with portable workspace-root-relative locators:
+Reference workflows with portable path/function locators:
 
 ```tsx
 const query = useWorkflowQuery("functions/list_clients.py::run", { status: "active" });
@@ -74,34 +82,36 @@ const save = useWorkflowMutation("functions/save_client.py::run");
 
 Prefer `useWorkflowQuery` for reads that run on mount and `useWorkflowMutation` for explicit actions. Guard nullable initial data, render the hook's error, and prevent duplicate mutations while loading.
 
-Enforce authorization and integration access in the workflow. Client-side hiding is a convenience, not a security boundary. Keep config secrets and OAuth tokens out of browser code.
+Solution Apps resolve their own deployed workflows first. Independent Apps resolve live registered workflows in the selected organization. Enforce authorization and integration access in the workflow. Client-side hiding is a convenience, not a security boundary. Keep config secrets and OAuth tokens out of browser code.
 
 ## Dependencies and components
 
 Use the app's normal package manifest for browser dependencies. Install shadcn components into the app and import their local source; the platform does not inject the host client's private component tree into v2 apps.
 
-The scaffold intentionally omits an instance-specific `bifrost` dependency. `bifrost solution start` installs the selected instance's SDK transiently without changing `package.json`; deployed builds inject the SDK shipped by the serving instance.
+The scaffold intentionally omits an instance-specific `bifrost` dependency. `bifrost app start` and `bifrost solution start` install the selected instance's SDK transiently without changing `package.json`; deployed builds inject the SDK shipped by the serving instance.
 
 Prefer dependencies that are actively maintained, browser-safe, and compatible with the app's React version. Do not introduce a library for behavior that the platform or browser already provides simply because an old example used it.
 
 ## Local development
 
-Run the Solution's connected development server:
+Run the lifecycle's connected development server:
 
 ```bash
 bifrost solution start operations
+# or, from an independent App root:
+bifrost app start
 ```
 
 Open the proxy origin printed by the command, not Vite's internal port. App and workflow code hot-reload behind the same origin.
 
-The preview uses the bound install and selected live instance. Reads and writes to tables, managed files, configs, integrations, and fallback resources use real instance state. Seed disposable data or obtain permission before exercising production-sensitive mutations.
+Both paths use live instance data. A Solution start can run local Solution workflows; an independent App start never runs local workflows and proxies workflow calls to the live platform. Reads and writes to tables, managed files, configs, integrations, and shared resources use real instance state. Seed disposable data or obtain permission before exercising production-sensitive mutations.
 
 ## Completion checks
 
 Before offering deploy:
 
 - run the app's tests, type check, and production build;
-- exercise local workflows through the app, not only as isolated Python functions;
+- exercise workflow calls through the App; for an independent App those calls must hit the live platform rather than local Python;
 - inspect every changed route and important state using `app-quality.md`;
 - verify `supportsTheme` only after both themes pass;
 - confirm the app and supporting entities share compatible organization/access/roles;

--- a/plugins/bifrost/skills/bifrost-build/references/sources.yaml
+++ b/plugins/bifrost/skills/bifrost-build/references/sources.yaml
@@ -16,15 +16,27 @@ references:
       - api/bifrost/commands/apps.py
       - api/bifrost/platform_names.py
       - client/src/lib/app-code-runtime.ts
-    verified_at_sha: 3b29c703c87059b382aad7c90b41c9054d3c719e
+    verified_at_sha: b70a55c77024659b69536842335b515f629dd45e
 
   - file: references/apps-v2.md
     source_globs:
+      - api/bifrost/commands/app.py
       - api/bifrost/commands/solution.py
       - api/bifrost/manifest.py
       - client/src/lib/app-sdk/*.ts
       - client/src/lib/app-sdk/*.tsx
-    verified_at_sha: 3b29c703c87059b382aad7c90b41c9054d3c719e
+    verified_at_sha: b70a55c77024659b69536842335b515f629dd45e
+
+  - file: references/apps-independent.md
+    source_globs:
+      - api/bifrost/app_binding.py
+      - api/bifrost/app_migration.py
+      - api/bifrost/commands/app.py
+      - api/src/jobs/platform/application_deploy.py
+      - api/src/routers/applications.py
+      - client/src/lib/app-sdk/*.ts
+      - client/src/lib/app-sdk/*.tsx
+    verified_at_sha: b70a55c77024659b69536842335b515f629dd45e
 
   - file: references/entities.md
     source_globs:
@@ -113,7 +125,7 @@ references:
       - client/src/lib/app-sdk/use-files.ts
       - client/src/lib/app-sdk/use-table.ts
       - client/src/lib/app-sdk/use-workflow*.ts
-    verified_at_sha: 3b29c703c87059b382aad7c90b41c9054d3c719e
+    verified_at_sha: b70a55c77024659b69536842335b515f629dd45e
 
   - file: references/workflows.md
     source_globs:

--- a/plugins/bifrost/skills/bifrost-build/references/web-sdk-v2.md
+++ b/plugins/bifrost/skills/bifrost-build/references/web-sdk-v2.md
@@ -1,16 +1,14 @@
 # Web SDK v2
 
-The instance-served `bifrost` package is the runtime SDK for `standalone_v2` Solution apps. Use `../generated/web-sdk-surface.md` for the exact export/type surface. Read `apps-v2.md` for project structure and `app-quality.md` for UI completion.
+The instance-served `bifrost` package is the runtime SDK for V2 Apps, both independent and Solution-owned. Use `../generated/web-sdk-surface.md` for the exact export/type surface. Read `apps-v2.md` for project structure and `app-quality.md` for UI completion.
 
 ## Keeping an existing app current
 
-The web SDK is vendored into each app. A platform deployment does not update an existing app's installed SDK automatically. When a reported behavior is fixed in the web SDK, or an app predates the SDK behavior it now relies on, refresh that app before rebuilding it:
+The CLI installs the selected instance's web SDK into local dependencies for development, and each server-side deploy builds with that instance's SDK. When a reported behavior is fixed in the web SDK, or an App predates the SDK behavior it now relies on, refresh it before rebuilding:
 
-```bash
-bifrost solution sdk update [PATH] --app <app-slug>
-```
+For a Solution App, run `bifrost solution sdk update [PATH] --app <app-slug>`. For an independent App, `bifrost app start` installs the selected instance's current SDK transiently; remove a stale `node_modules/bifrost` only when the CLI reports a contract mismatch, then start again.
 
-Omit `--app` for a single-app Solution. This command downloads the SDK from the connected Bifrost instance and reinstalls the vendored package; do not hand-edit the generated SDK files. After updating, run the app's typecheck, tests, and production build, then redeploy it. API-only execution fixes and host-shell asset fixes do not require an app SDK update.
+Omit `--app` for a single-App Solution. The Solution command downloads the SDK from the connected Bifrost instance and reinstalls the vendored package; do not hand-edit generated SDK files. After updating, run the App's typecheck, tests, and production build, then redeploy it. API-only execution fixes and host-shell asset fixes do not require an App SDK update.
 
 ## Provider and context
 
@@ -55,7 +53,7 @@ await createOrder.mutate({ customerId, lines });
 
 Initial query data is nullable. Render loading and error states before accessing it. Keep query parameter objects stable so ordinary renders do not create accidental refetch loops. For mutations, expose progress, handle rejection, and prevent duplicate action where necessary.
 
-Workflow hooks resolve within the current app/Solution context. A UUID is environment-specific; a bare name can be ambiguous and may proxy to a deployed copy during local work.
+Workflow hooks resolve within the current App context. Solution Apps prefer their install's workflows; independent Apps use live registered workflows in the selected organization. A UUID is environment-specific, so prefer a portable path/function ref.
 
 ## Tables
 
@@ -88,7 +86,7 @@ const reports = useFiles("reports/", {
 await files.write("reports/status.txt", "ready", { location: "documents" });
 ```
 
-Solution locations must be declared. Render denied separately from empty, and use signed upload/download behavior for large binary data. Read `files.md`.
+Solution locations must be declared. Independent Apps use live managed-file locations and policies. Render denied separately from empty, and use signed upload/download behavior for large binary data. Read `files.md`.
 
 ## Errors
 

--- a/plugins/bifrost/skills/bifrost-migrate/SKILL.md
+++ b/plugins/bifrost/skills/bifrost-migrate/SKILL.md
@@ -1,36 +1,38 @@
 ---
 name: migrate
-description: Migrate a legacy Bifrost v1 (inline) app and its backing entities into a clean, installable v2 Solution. Use when the user wants to move an existing _repo app into Solutions, modernize a v1 inline app to standalone_v2, capture loose workflows/tables/configs into a Solution, or standardize/rename a messy workspace. Trigger phrases — "migrate this app to a solution", "move X into a solution", "v1 to v2", "/migrate", "convert my app to standalone v2", "capture these workflows into a solution".
+description: Migrate a legacy Bifrost v1 inline App into either an independent V2 App backed by live platform resources or a clean, installable V2 Solution with captured backing entities. Use for v1-to-v2 modernization, App cutover, Solution capture, or workspace cleanup. Trigger phrases — "migrate this app", "migrate this app to a solution", "move X into a solution", "v1 to v2", "/migrate", "convert my app to v2", "capture these workflows into a solution".
 ---
 
-# Bifrost Migrate (v1 → v2 Solution)
+# Bifrost Migrate (v1 → V2 App or Solution)
 
-Move a legacy inline (`inline_v1`) app and its non-shared backing entities into a clean,
-installable **Solution** (`standalone_v2`), with standardized folders and renamed workflows.
+Move a legacy inline (`inline_v1`) App into one of two explicit ownership models:
+
+- an **independent V2 App** in a normal git repository, continuing to use live workflows, tables, files, configs, and integrations; or
+- an installable **Solution** that owns the V2 App and selected non-shared backing definitions together.
 
 This skill is **judgment-heavy orchestration**, not a one-shot command. It drives existing
-primitives (`bifrost solution migrate-app`, `bifrost solution scaffold-app`, `bifrost solution
-start`, `bifrost solution swap-slugs`, `bifrost solution capture`) and makes the per-app calls a
+primitives (`bifrost app migrate`, `bifrost app start`, `bifrost app deploy`, `bifrost app swap-slugs`, `bifrost solution migrate-app`, `bifrost solution scaffold-app`, `bifrost solution
+start`, `bifrost solution swap-slugs`, `bifrost solution capture`) and makes the per-App calls a
 deterministic command can't: which shadcn components to add, whether layout/theme translate, what
 is safe to capture vs. irreducibly shared.
 
-## The hard rule of why this exists (read first)
+## Choose ownership before migrating
 
-- **A v1 app CANNOT live in a Solution.** Deploy hard-rejects non-`standalone_v2`. Capture refuses
-  inline_v1 apps (it would build an uninstallable bundle). So you do **not** "capture the app" —
-  you **re-author it as v2** and capture its **backing tables/workflows/configs**.
+- Choose an **independent App** when only the frontend should move local and deploy independently while existing platform resources remain live and shared. There is no manifest, capture, or Solution install.
+- Choose a **Solution** when the App and its non-shared backing definitions must be portable, installable, and lifecycle-managed together.
+- **A v1 App cannot be captured into a Solution.** Re-author the frontend as V2, then capture only the selected backing tables/workflows/configs. Independent migration captures nothing by design.
 - **The v1→v2 import surface gap is large.** v1 `import … from "bifrost"` injects ~40 shadcn UI
   components + React + react-router + lucide + `cn`/`format` at runtime. The v2 `bifrost` SDK
   exports only: `BifrostProvider`, `useBifrostContext`, `BifrostHeader`, `useWorkflow`, `useTable`,
   `useInfiniteTable`, `tables`. **No UI components, no React, no router.** Nearly every v1 import
-  line must be rewritten — that's what `bifrost solution migrate-app` does (deterministically).
+  line must be rewritten — both `bifrost app migrate` and `bifrost solution migrate-app` use the same deterministic rewrite.
 
 ## Who runs what
 
 | Action | Who | Why |
 |---|---|---|
-| `bifrost solution migrate-app`, `bifrost solution scaffold-app`, `solution capture --dry-run`/apply, `solution swap-slugs`, `bifrost api GET …`, `npx shadcn add`, file writes under the new app dir | **Agent** | non-interactive, scoped |
-| `bifrost solution start` | **Agent** starts it; **user** drives the browser | long-running dev server; user confirms design |
+| `bifrost app migrate`, `app deploy`, `app swap-slugs`, `bifrost solution migrate-app`, `solution capture --dry-run`/apply, `solution swap-slugs`, `bifrost api GET …`, `npx shadcn add`, file writes under the new App dir | **Agent** | non-interactive, scoped |
+| `bifrost app start` or `bifrost solution start` | **Agent** starts it; **user** drives the browser | long-running dev server; user confirms design |
 | `bifrost watch` / `sync` / `push` / `git push` | **User** | broad blast radius, deploy cadence |
 
 ## Gather org preferences up front (AskUserQuestion)
@@ -41,8 +43,7 @@ Before touching code, collect the conventions — they shape every later step:
    `orders_sync_records`). Renames MUST rewrite every ref (this skill does that — see step 6).
 2. **Folder layout.** Default: flat `workflows/` + flat `modules/` (NOT nested "feature" dirs).
    Standardize whatever mess `_repo` is in.
-3. **Which app(s)** to migrate, and the **target Solution** (existing install id, or create and bind
-   a new one with `bifrost solution create` / `init`).
+3. **Which App(s)** to migrate and the **target ownership model**. For an independent App, choose its destination repo/path, temporary slug, visibility, and org/global App scope. For a Solution, choose the existing install or create/bind one with `bifrost solution create`.
 4. **Confirm-in-browser or skip.** Offer to skip the browser-confirm loop once the user trusts the
    output.
 
@@ -54,7 +55,43 @@ the dev environment"). All `bifrost` calls below use that scratch CLI.
 
 ---
 
-## Per-app migration flow
+## Independent App migration flow
+
+Use this path when backing resources intentionally stay live rather than becoming Solution-owned.
+
+### 1. Read the v1 App and inventory dependencies
+
+- Pull/read the v1 source under `_repo/{repo_path}/`.
+- Inventory every workflow, table, managed-file location, config, and integration the App uses, plus the App/workflow/table/file access tuple in each target organization.
+- Identify UUID workflow refs and rewrite them to portable `path::function` refs. Independent deploy does not remap or capture backing entities.
+
+### 2. Create and port the independent V2 project
+
+```bash
+bifrost app migrate /path/to/pulled/v1-source ./<new-slug> \
+  --name "<Title>" --slug <new-slug> [--org <ref> | --global]
+```
+
+This creates the remote V2 App, writes its gitignored `.env` binding, scaffolds a normal Vite project, ports source, rewrites imports, installs detected dependencies, and prints the remaining judgment checklist. It does not write App source to `_repo`, create YAML, or capture platform resources.
+
+### 3. Wire, build, and browser-confirm
+
+- Complete route/layout wiring, v1-only hook replacement, theming, and error/loading/empty states.
+- Run `bifrost app start` first so the selected instance's SDK is installed transiently. Confirm every route, deep-link refresh, and core interaction in a browser, then run `npm run build`.
+- Exercise live workflow, table, and file behavior in the current org, then use `bifrost app start --org <ref>` as an authorized operator. Confirm an ordinary viewer cannot override scope.
+
+### 4. Deploy and cut over
+
+```bash
+bifrost app deploy
+bifrost app swap-slugs <old-v1-slug> <new-v2-slug>
+```
+
+Deploy before swapping. Launch the deployed App and repeat the browser/resource checks. The swap is atomic and parks the v1 App at the temporary slug for rollback. A failed deploy must leave the prior V2 artifact active. There is no capture step.
+
+---
+
+## Solution migration flow
 
 Do ONE app at a time, fully, before the next. Each step gates the following.
 
@@ -233,7 +270,23 @@ A's Solution would orphan B's reference across the scope boundary. Report it; le
 
 ## Verification before declaring done
 
-- The v2 app builds + runs under `bifrost solution start`, every page works.
+For either ownership model:
+
+- The V2 App builds and every route works in a real browser through the correct `start` command.
+- If theme support is present, every page and overlay is visually verified in both light and dark mode.
+- Workflow refs are portable, and live/deployed calls were exercised through the App rather than only in isolation.
+- The live slug serves the V2 row after the atomic swap, while the v1 row remains available under the parked slug until rollback is no longer needed.
+
+For an independent App:
+
+- `.env` is ignored; no App source or metadata YAML exists in `_repo` or permanent upload storage.
+- Default and authorized alternate-org runtime scopes were verified, including denial for an unauthorized viewer.
+- Live workflows, tables, and files work locally and after deploy; none became Solution-owned.
+- A deliberately broken redeploy leaves the active artifact unchanged.
+
+For a Solution:
+
+- The V2 App builds + runs under `bifrost solution start`, every page works.
 - If `supportsTheme` is present, every page and overlay is visually verified in both light and dark
   mode and uses theme tokens throughout; otherwise the theme toggle is absent.
 - Capture `--dry-run` shows no dangling refs after rename (refs rewritten).


### PR DESCRIPTION
Closes #670

## Summary
- add first-class `bifrost app create`, `bind`, `start`, `deploy`, `migrate`, and `swap-slugs` lifecycle commands using a standard gitignored `.env` binding
- keep independent App source entirely local; deploy stages source transiently, builds durably through a platform job, atomically activates versioned artifacts, and discards source
- separate App identity/deployment visibility from the user-selected runtime organization scope for workflows, tables, and files
- remove publish/editor behavior from independent V2 Apps while preserving Solution-owned and legacy App behavior
- share the v1-to-v2 migration engine with Solutions while giving independent Apps their own live-resource checklist and cutover flow
- update and mirror the Bifrost build/migrate skills, bump plugin manifests to 1.2.3, and add the independent App lifecycle reference

## Documentation
- public documentation ships separately in [website#13](https://github.com/gobifrost/website/pull/13)

## Live acceptance
- migrated real org-scoped and global v1 Apps into clean independent V2 project directories
- browser-witnessed `app start --org` against an alternate organization using live workflow, table, and `_repo` file access
- browser-witnessed launch from the Apps UI and hard refresh of the deployed global App
- deployed successfully through the platform-job build path
- forced a real Vite build failure and verified the previously deployed version remained live
- exercised atomic v1/v2 slug swap and restoration in both directions
- confirmed the project binding is only `.env`, with no App source stored under `_repo`

## Verification
- exact clean-head `./test.sh pre-pr` passed for `bfc518051604`
- production client build, TypeScript, and ESLint passed
- 1,888 Vitest tests passed
- API pyright and ruff passed
- 5,837 backend unit/contract tests passed; 3 skipped, 20 deselected
- 1,786 backend E2E tests passed
- 4 Playwright smoke tests passed, including the Apps preview/publish regression journey
- production API candidate image built and exercised successfully
- docs: manifest lint passed and 121-page production build passed

The full Playwright suite was not run. The four-test pre-PR smoke selection and separate manual Chromium acceptance covered the relevant browser journeys.