### PR TITLE
feat(files): support configurable signed URL expiration

### DIFF
--- a/.claude/skills/bifrost-build/generated/python-sdk-signatures.md
+++ b/.claude/skills/bifrost-build/generated/python-sdk-signatures.md
@@ -98,7 +98,7 @@ Event publishing operations (async).
 
 **`files.exists(path: str, location: str = 'workspace', mode: Mode = 'cloud', scope: str | None = None) -> bool`**
 
-**`files.get_signed_url(path: str, method: Literal['PUT', 'GET'] = 'PUT', content_type: str = 'application/octet-stream', location: str = 'uploads', scope: str | None = None) -> dict`**
+**`files.get_signed_url(path: str, method: Literal['PUT', 'GET'] = 'PUT', content_type: str = 'application/octet-stream', location: str = 'uploads', scope: str | None = None, expires_in: int = 600) -> dict`**
 
 **`files.list(directory: str = '', location: str = 'workspace', mode: Mode = 'cloud', scope: str | None = None) -> list[str]`**
 

--- a/api/bifrost/files.py
+++ b/api/bifrost/files.py
@@ -333,6 +333,7 @@ class files:
         content_type: str = "application/octet-stream",
         location: str = "uploads",
         scope: str | None = None,
+        expires_in: int = 600,
     ) -> dict:
         """
         Generate a presigned S3 URL for direct file upload or download.
@@ -345,6 +346,7 @@ class files:
                 compatibility with form upload flows. Use "workspace" to sign
                 URLs for files written via `files.write_bytes(..., location="workspace")`.
             scope: Org scope; provider-org override allowed.
+            expires_in: URL lifetime in seconds, from 1 second through 7 days.
 
         Returns:
             dict with keys: url, path, expires_in
@@ -367,6 +369,7 @@ class files:
                 "content_type": content_type,
                 "location": location,
                 "scope": effective_scope,
+                "expires_in": expires_in,
             }
         )
         raise_for_status_with_detail(response)

--- a/api/src/routers/files.py
+++ b/api/src/routers/files.py
@@ -169,6 +169,12 @@ class SignedUrlRequest(BaseModel):
     content_type: str = Field(default="application/octet-stream", description="MIME type (only used for PUT)")
     location: str = Field(default="uploads", description="Storage location. Defaults to 'uploads' for backwards compatibility with form upload flows.")
     scope: str | None = Field(default=None, description="Org scope. Required for non-workspace, non-uploads locations.")
+    expires_in: int = Field(
+        default=600,
+        ge=1,
+        le=604800,
+        description="URL expiration in seconds (maximum 7 days)",
+    )
 
 
 class SignedUrlResponse(BaseModel):
@@ -1009,15 +1015,18 @@ async def _build_signed_url(
         url = await file_storage.generate_presigned_upload_url(
             path=s3_path,
             content_type=request.content_type,
+            expires_in=request.expires_in,
         )
     else:
         url = await file_storage.generate_presigned_download_url(
             path=s3_path,
+            expires_in=request.expires_in,
         )
 
     return SignedUrlResponse(
         url=url,
         path=s3_path,
+        expires_in=request.expires_in,
     )
 
 

--- a/api/tests/e2e/api/test_files_signed_url_roundtrip.py
+++ b/api/tests/e2e/api/test_files_signed_url_roundtrip.py
@@ -32,13 +32,22 @@ class TestSignedUrlRoundTrip:
         }
         return e2e_client.post("/api/files/write", headers=headers, json=body)
 
-    def _sign(self, e2e_client, headers, path: str, location: str, scope: str | None = None):
+    def _sign(
+        self,
+        e2e_client,
+        headers,
+        path: str,
+        location: str,
+        scope: str | None = None,
+        expires_in: int = 600,
+    ):
         body = {
             "path": path,
             "method": "GET",
             "location": location,
             "content_type": "application/octet-stream",
             "scope": scope,
+            "expires_in": expires_in,
         }
         return e2e_client.post("/api/files/signed-url", headers=headers, json=body)
 
@@ -50,9 +59,16 @@ class TestSignedUrlRoundTrip:
         write = self._write(e2e_client, platform_admin.headers, path, "workspace", content)
         assert write.status_code == 204, f"write failed: {write.text}"
 
-        sign = self._sign(e2e_client, platform_admin.headers, path, "workspace")
+        sign = self._sign(
+            e2e_client,
+            platform_admin.headers,
+            path,
+            "workspace",
+            expires_in=604800,
+        )
         assert sign.status_code == 200, f"sign failed: {sign.text}"
         signed = sign.json()
+        assert signed["expires_in"] == 604800
         assert signed["path"] == f"_repo/{path}", (
             f"workspace sign should target _repo/, got {signed['path']}"
         )

--- a/api/tests/unit/routers/test_files_signed_url.py
+++ b/api/tests/unit/routers/test_files_signed_url.py
@@ -5,10 +5,11 @@ Tests path validation, location/scope handling, and presigned URL generation.
 Path resolution is delegated to `shared.file_paths.resolve_s3_key`.
 """
 
+from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import UUID
 
 import pytest
-from unittest.mock import AsyncMock, patch, MagicMock
+from pydantic import ValidationError
 
 from src.core.principal import UserPrincipal
 from src.routers.files import (
@@ -59,6 +60,7 @@ class TestSignedUrlRequestModel:
         assert req.content_type == "application/octet-stream"
         assert req.location == "uploads"  # backwards-compat default
         assert req.scope is None
+        assert req.expires_in == 600
 
     def test_explicit_get(self):
         req = SignedUrlRequest(path="data.csv", method="GET")
@@ -71,6 +73,15 @@ class TestSignedUrlRequestModel:
     def test_explicit_scope(self):
         req = SignedUrlRequest(path="file.txt", location="temp", scope="org-123")
         assert req.scope == "org-123"
+
+    def test_explicit_expiration(self):
+        req = SignedUrlRequest(path="file.txt", expires_in=604800)
+        assert req.expires_in == 604800
+
+    @pytest.mark.parametrize("expires_in", [0, 604801])
+    def test_rejects_expiration_outside_s3_bounds(self, expires_in):
+        with pytest.raises(ValidationError):
+            SignedUrlRequest(path="file.txt", expires_in=expires_in)
 
 
 class TestSignedUrlResponseModel:
@@ -213,9 +224,11 @@ class TestPresignedUrlGeneration:
         req = SignedUrlRequest(path="file.pdf", method="PUT", content_type="application/pdf", scope=str(ORG_A))
         result = await get_signed_url(req, _ctx(), MagicMock(), AsyncMock())
         assert result.url == "https://s3/put-url"
+        assert result.expires_in == 600
         mock_fss.generate_presigned_upload_url.assert_awaited_once_with(
             path=f"uploads/{ORG_A}/file.pdf",
             content_type="application/pdf",
+            expires_in=600,
         )
 
     @pytest.mark.asyncio
@@ -225,9 +238,16 @@ class TestPresignedUrlGeneration:
         mock_fss.generate_presigned_download_url = AsyncMock(return_value="https://s3/get-url")
         mock_fss_class.return_value = mock_fss
 
-        req = SignedUrlRequest(path="file.pdf", method="GET", scope=str(ORG_A))
+        req = SignedUrlRequest(
+            path="file.pdf",
+            method="GET",
+            scope=str(ORG_A),
+            expires_in=604800,
+        )
         result = await get_signed_url(req, _ctx(), MagicMock(), AsyncMock())
         assert result.url == "https://s3/get-url"
+        assert result.expires_in == 604800
         mock_fss.generate_presigned_download_url.assert_awaited_once_with(
             path=f"uploads/{ORG_A}/file.pdf",
+            expires_in=604800,
         )

--- a/api/tests/unit/test_files_sdk_solution_scope.py
+++ b/api/tests/unit/test_files_sdk_solution_scope.py
@@ -116,3 +116,37 @@ async def test_file_sdk_omits_solution_query_without_solution_context(
 
     assert capture_file_sdk_urls
     assert all("solution=" not in url for url in capture_file_sdk_urls)
+
+
+@pytest.mark.asyncio
+async def test_file_sdk_forwards_signed_url_expiration(monkeypatch):
+    captured_json: dict = {}
+
+    class FakeResponse:
+        status_code = 200
+        is_success = True
+
+        def json(self):
+            return {
+                "url": "https://example.invalid/signed",
+                "path": "finance/abc/x.txt",
+                "expires_in": 604800,
+            }
+
+    class FakeClient:
+        async def post(self, url, json=None):
+            captured_json.update(json or {})
+            return FakeResponse()
+
+    monkeypatch.setattr(files_sdk, "get_client", lambda: FakeClient())
+    set_execution_context(_make_context(solution_id=None))
+
+    result = await files_sdk.files.get_signed_url(
+        "x.txt",
+        location="finance",
+        method="GET",
+        expires_in=604800,
+    )
+
+    assert captured_json["expires_in"] == 604800
+    assert result["expires_in"] == 604800

--- a/client/src/lib/app-sdk/files.test.ts
+++ b/client/src/lib/app-sdk/files.test.ts
@@ -147,6 +147,24 @@ describe("files web SDK", () => {
 			content_type: "application/octet-stream",
 			location: "workspace",
 			scope: null,
+			expires_in: 600,
+		});
+	});
+
+	it("signedUrl forwards a custom expiration", async () => {
+		const fetchMock = vi
+			.fn()
+			.mockResolvedValue(okJson({ url: "https://s3/x", path: "_repo/x", expires_in: 604800 }));
+		vi.stubGlobal("fetch", fetchMock);
+
+		const result = await files.signedUrl("x.txt", {
+			method: "GET",
+			expiresIn: 604800,
+		});
+
+		expect(result.expiresIn).toBe(604800);
+		expect(JSON.parse(fetchMock.mock.calls[0][1].body)).toMatchObject({
+			expires_in: 604800,
 		});
 	});
 

--- a/client/src/lib/app-sdk/files.ts
+++ b/client/src/lib/app-sdk/files.ts
@@ -32,6 +32,7 @@ export interface SignedUrlOptions {
 	contentType?: string;
 	location?: string;
 	scope?: string | null;
+	expiresIn?: number;
 }
 
 export interface SignedUrlResult {
@@ -61,6 +62,7 @@ function signedDefaults(options: SignedUrlOptions = {}) {
 		content_type: options.contentType ?? "application/octet-stream",
 		location: options.location ?? "workspace",
 		scope: options.scope ?? null,
+		expires_in: options.expiresIn ?? 600,
 	};
 }
 

--- a/client/src/lib/v1.d.ts
+++ b/client/src/lib/v1.d.ts
@@ -23936,6 +23936,12 @@ export interface components {
              * @description Org scope. Required for non-workspace, non-uploads locations.
              */
             scope?: string | null;
+            /**
+             * Expires In
+             * @description URL expiration in seconds (maximum 7 days)
+             * @default 600
+             */
+            expires_in: number;
         };
         /**
          * SignedUrlResponse

--- a/plugins/bifrost/skills/bifrost-build/generated/python-sdk-signatures.md
+++ b/plugins/bifrost/skills/bifrost-build/generated/python-sdk-signatures.md
@@ -98,7 +98,7 @@ Event publishing operations (async).
 
 **`files.exists(path: str, location: str = 'workspace', mode: Mode = 'cloud', scope: str | None = None) -> bool`**
 
-**`files.get_signed_url(path: str, method: Literal['PUT', 'GET'] = 'PUT', content_type: str = 'application/octet-stream', location: str = 'uploads', scope: str | None = None) -> dict`**
+**`files.get_signed_url(path: str, method: Literal['PUT', 'GET'] = 'PUT', content_type: str = 'application/octet-stream', location: str = 'uploads', scope: str | None = None, expires_in: int = 600) -> dict`**
 
 **`files.list(directory: str = '', location: str = 'workspace', mode: Mode = 'cloud', scope: str | None = None) -> list[str]`**
 


### PR DESCRIPTION
## Summary
- add a bounded `expires_in` request option to Files signed URLs (1 second to S3 maximum of 7 days)
- expose the option as `expires_in` in the Python SDK and `expiresIn` in the web SDK
- preserve the existing 10-minute default and regenerate public contracts/references

## Verification
- 37 focused backend unit tests passed
- signed download round trip passed with `expires_in=604800`
- API pyright and ruff passed
- client TypeScript, lint, production build, and 1,884 Vitest tests passed
- contract fingerprint tripwire passed
- full pre-PR gate is still running locally