### PR TITLE
fix(ci): make dev versions chronologically monotonic

### DIFF
--- a/scripts/compute-dev-version.sh
+++ b/scripts/compute-dev-version.sh
@@ -1,8 +1,14 @@
 #!/usr/bin/env bash
 # Compute a monotonic semver dev version for the current commit.
 #
-# Format: <next-patch>-dev.<commits-since-tag>
-# Example: latest tag v0.8.0, 47 commits ahead -> 0.8.1-dev.47
+# Format: <next-patch>-dev.<HEAD-committer-epoch>
+# Example: latest tag v0.8.0, HEAD committed at epoch 1788062400
+#          -> 0.8.1-dev.1788062400
+#
+# The committer timestamp is part of the commit object, so an exact merge
+# candidate and the same commit on main compute the same version. Unlike a
+# commits-since-tag count, it also cannot move backwards merely because a PR
+# was rebased or squash-merged with fewer commits in its resulting history.
 #
 # Requires: a `v<MAJOR>.<MINOR>.<PATCH>` annotated tag in history.
 # Exits non-zero with a diagnostic on stderr if no usable tag exists.
@@ -24,6 +30,10 @@ minor="${BASH_REMATCH[2]}"
 patch="${BASH_REMATCH[3]}"
 next_patch=$((patch + 1))
 
-commits=$(git rev-list "${last_tag}..HEAD" --count)
+sequence=$(git show -s --format=%ct HEAD 2>/dev/null || true)
+if ! [[ "$sequence" =~ ^[1-9][0-9]*$ ]]; then
+  echo "compute-dev-version: could not read a positive HEAD committer timestamp" >&2
+  exit 1
+fi
 
-printf '%s.%s.%s-dev.%s\n' "$major" "$minor" "$next_patch" "$commits"
+printf '%s.%s.%s-dev.%s\n' "$major" "$minor" "$next_patch" "$sequence"

--- a/scripts/test-compute-dev-version.sh
+++ b/scripts/test-compute-dev-version.sh
@@ -39,24 +39,24 @@ run_test() {
 }
 
 run_test "tag at HEAD, no commits ahead" \
-  'git commit --allow-empty -m init -q && git tag v0.8.0' \
-  '0.8.1-dev.0' 0
+  'GIT_AUTHOR_DATE=@1000000000 GIT_COMMITTER_DATE=@1000000000 git commit --allow-empty -m init -q && git tag v0.8.0' \
+  '0.8.1-dev.1000000000' 0
 
-run_test "tag with 1 commit ahead" \
-  'git commit --allow-empty -m init -q && git tag v0.8.0 && git commit --allow-empty -m c1 -q' \
-  '0.8.1-dev.1' 0
+run_test "version follows HEAD committer timestamp" \
+  'GIT_AUTHOR_DATE=@1000000000 GIT_COMMITTER_DATE=@1000000000 git commit --allow-empty -m init -q && git tag v0.8.0 && GIT_AUTHOR_DATE=@1000000042 GIT_COMMITTER_DATE=@1000000042 git commit --allow-empty -m c1 -q' \
+  '0.8.1-dev.1000000042' 0
 
-run_test "tag with 47 commits ahead" \
-  'git commit --allow-empty -m init -q && git tag v0.8.0 && for i in $(seq 47); do git commit --allow-empty -m "c$i" -q; done' \
-  '0.8.1-dev.47' 0
+run_test "history length does not determine sequence" \
+  'GIT_AUTHOR_DATE=@1000000000 GIT_COMMITTER_DATE=@1000000000 git commit --allow-empty -m init -q && git tag v0.8.0 && for i in $(seq 47); do GIT_AUTHOR_DATE=@1000000047 GIT_COMMITTER_DATE=@1000000047 git commit --allow-empty -m "c$i" -q; done' \
+  '0.8.1-dev.1000000047' 0
 
 run_test "release sets next dev cycle floor" \
-  'git commit --allow-empty -m init -q && git tag v0.8.0 && git commit --allow-empty -m c1 -q && git tag v0.9.0 && git commit --allow-empty -m c2 -q' \
-  '0.9.1-dev.1' 0
+  'GIT_AUTHOR_DATE=@1000000000 GIT_COMMITTER_DATE=@1000000000 git commit --allow-empty -m init -q && git tag v0.8.0 && GIT_AUTHOR_DATE=@1000000001 GIT_COMMITTER_DATE=@1000000001 git commit --allow-empty -m c1 -q && git tag v0.9.0 && GIT_AUTHOR_DATE=@1000000002 GIT_COMMITTER_DATE=@1000000002 git commit --allow-empty -m c2 -q' \
+  '0.9.1-dev.1000000002' 0
 
 run_test "minor with double-digit patch" \
-  'git commit --allow-empty -m init -q && git tag v1.2.10 && git commit --allow-empty -m c1 -q' \
-  '1.2.11-dev.1' 0
+  'GIT_AUTHOR_DATE=@1000000000 GIT_COMMITTER_DATE=@1000000000 git commit --allow-empty -m init -q && git tag v1.2.10 && GIT_AUTHOR_DATE=@1000000001 GIT_COMMITTER_DATE=@1000000001 git commit --allow-empty -m c1 -q' \
+  '1.2.11-dev.1000000001' 0
 
 run_test "no tags fails loudly" \
   'git commit --allow-empty -m init -q' \


### PR DESCRIPTION
## Summary

- derive the dev prerelease sequence from the commit's stable committer timestamp
- keep the merge-queue candidate and main promotion on the same version
- prevent squash/rebase history length from producing an apparent downgrade

## Verification

- `bash scripts/test-compute-dev-version.sh`
- `./scripts/compute-dev-version.sh`
- `git diff --check`

## Incident

A newer merged image computed `1.2.1-dev.63` while the hosted cluster already ran an older-code `1.2.1-dev.64`, so Keel refused the rollout as a downgrade.