### PR TITLE
feat(events): authorize mapped Teams tenants

### DIFF
--- a/api/src/routers/events.py
+++ b/api/src/routers/events.py
@@ -53,6 +53,7 @@ from src.models.orm.events import (
     ScheduleSource,
     WebhookSource,
 )
+from src.models.orm.integrations import Integration
 from src.repositories.events import (
     EventDeliveryRepository,
     EventRepository,
@@ -477,6 +478,38 @@ async def create_source(
                     status_code=status.HTTP_400_BAD_REQUEST,
                     detail=str(e),
                 ) from e
+
+        uses_integration_mapping = getattr(
+            adapter, "uses_integration_mapping", lambda _config: False
+        )(request.webhook.config)
+        if uses_integration_mapping:
+            mapping_integration_name = getattr(
+                adapter, "mapping_integration_name", None
+            )
+            if not request.webhook.integration_id:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail=(
+                        f"Adapter '{adapter_name}' requires an integration for "
+                        "mapped-tenant admission"
+                    ),
+                )
+            mapping_integration = await db.get(
+                Integration, request.webhook.integration_id
+            )
+            if (
+                mapping_integration is None
+                or mapping_integration.is_deleted
+                or mapping_integration.name != mapping_integration_name
+            ):
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail=(
+                        f"Adapter '{adapter_name}' requires the "
+                        f"'{mapping_integration_name}' integration for "
+                        "mapped-tenant admission"
+                    ),
+                )
 
         # Create webhook source record
         webhook_source = WebhookSource(

--- a/api/src/services/events/processor.py
+++ b/api/src/services/events/processor.py
@@ -33,6 +33,7 @@ from src.models.orm.events import (
     EventSubscription,
     WebhookSource,
 )
+from src.models.orm.integrations import IntegrationMapping
 from src.repositories.events import (
     EventDeliveryRepository,
     EventRepository,
@@ -335,6 +336,16 @@ class EventProcessor:
             return result
 
         if isinstance(result, Deliver):
+            mapping_entity_id = adapter.get_mapping_entity_id(result, config)
+            if mapping_entity_id is not None:
+                mapping_result = await self._authorize_mapped_delivery(
+                    webhook_source=webhook_source,
+                    adapter=adapter,
+                    deliver=result,
+                    entity_id=mapping_entity_id,
+                )
+                if isinstance(mapping_result, Rejected):
+                    return mapping_result
             # Process the event
             return await self._process_delivery(
                 webhook_source=webhook_source,
@@ -349,6 +360,55 @@ class EventProcessor:
             message="Internal error",
             status_code=500,
         )
+
+    async def _authorize_mapped_delivery(
+        self,
+        *,
+        webhook_source: WebhookSource,
+        adapter: Any,
+        deliver: Deliver,
+        entity_id: str,
+    ) -> Deliver | Rejected:
+        """Authorize and scope a delivery through one integration mapping."""
+        integration = webhook_source.integration
+        expected_integration_name = adapter.mapping_integration_name
+        if (
+            integration is None
+            or integration.is_deleted
+            or integration.name != expected_integration_name
+        ):
+            logger.error(
+                "Mapped webhook source is not linked to its required integration",
+                extra={"adapter_name": adapter.name},
+            )
+            return Rejected(
+                message="Webhook mapping integration is not configured",
+                status_code=500,
+            )
+
+        mapping_rows = await self.session.execute(
+            sa.select(IntegrationMapping.organization_id).where(
+                IntegrationMapping.integration_id == integration.id,
+                sa.func.lower(IntegrationMapping.entity_id) == entity_id.lower(),
+                IntegrationMapping.organization_id.is_not(None),
+            )
+        )
+        organization_ids = set(mapping_rows.scalars().all())
+        if len(organization_ids) != 1:
+            logger.warning(
+                "Mapped webhook delivery was rejected",
+                extra={
+                    "adapter_name": adapter.name,
+                    "mapping_match_count": len(organization_ids),
+                },
+            )
+            return Rejected(
+                message="Webhook tenant is not authorized",
+                status_code=403,
+            )
+
+        deliver.organization_id = organization_ids.pop()
+        return deliver
 
     async def emit_topic(
         self,
@@ -473,6 +533,7 @@ class EventProcessor:
             id=uuid.uuid4(),
             event_source_id=event_source.id,
             event_type=deliver.event_type,
+            organization_id=deliver.organization_id,
             received_at=datetime.now(timezone.utc),
             headers=deliver.raw_headers,
             data=deliver.data,

--- a/api/src/services/webhooks/adapters/microsoft_bot_framework.py
+++ b/api/src/services/webhooks/adapters/microsoft_bot_framework.py
@@ -30,6 +30,7 @@ class MicrosoftBotFrameworkAdapter(WebhookAdapter):
     display_name = "Microsoft Bot Framework"
     description = "Authenticated Microsoft Teams bot activities"
     requires_integration = None
+    mapping_integration_name = "Microsoft Teams Bot"
     renewal_interval = None
 
     _OPENID_URL = "https://login.botframework.com/v1/.well-known/openidconfiguration"
@@ -43,7 +44,7 @@ class MicrosoftBotFrameworkAdapter(WebhookAdapter):
 
     config_schema = {
         "type": "object",
-        "required": ["app_id", "tenant_id"],
+        "required": ["app_id"],
         "properties": {
             "app_id": {
                 "type": "string",
@@ -53,7 +54,20 @@ class MicrosoftBotFrameworkAdapter(WebhookAdapter):
             "tenant_id": {
                 "type": "string",
                 "title": "Microsoft Tenant ID",
-                "description": "Entra tenant ID allowed to send Teams activities.",
+                "description": (
+                    "Entra tenant ID allowed to send Teams activities when tenant "
+                    "admission uses one configured tenant."
+                ),
+            },
+            "tenant_admission": {
+                "type": "string",
+                "title": "Tenant Admission",
+                "description": (
+                    "Authorize one configured tenant or resolve the activity tenant "
+                    "through mappings on the linked Microsoft Teams Bot integration."
+                ),
+                "enum": ["configured_tenant", "integration_mappings"],
+                "default": "configured_tenant",
             },
         },
     }
@@ -68,7 +82,7 @@ class MicrosoftBotFrameworkAdapter(WebhookAdapter):
         if not app_id:
             raise ValueError("Microsoft Bot Framework app_id is required")
         tenant_id = str(config.get("tenant_id") or "").strip()
-        if not tenant_id:
+        if not tenant_id and not self.uses_integration_mapping(config):
             raise ValueError("Microsoft Bot Framework tenant_id is required")
         return SubscribeResult()
 
@@ -96,7 +110,7 @@ class MicrosoftBotFrameworkAdapter(WebhookAdapter):
                 message="Bot Framework app ID is not configured", status_code=500
             )
         tenant_id = str(config.get("tenant_id") or "").strip()
-        if not tenant_id:
+        if not tenant_id and not self.uses_integration_mapping(config):
             return Rejected(
                 message="Bot Framework tenant ID is not configured", status_code=500
             )
@@ -109,7 +123,12 @@ class MicrosoftBotFrameworkAdapter(WebhookAdapter):
             )
 
         try:
-            await self._validate_token(token.strip(), app_id, tenant_id, payload)
+            await self._validate_token(
+                token.strip(),
+                app_id,
+                tenant_id or None,
+                payload,
+            )
         except (jwt.PyJWTError, KeyError, TypeError, ValueError) as exc:
             logger.warning(
                 "Bot Framework token validation failed: %s", type(exc).__name__
@@ -149,11 +168,23 @@ class MicrosoftBotFrameworkAdapter(WebhookAdapter):
             },
         )
 
+    def uses_integration_mapping(self, config: dict[str, Any]) -> bool:
+        return config.get("tenant_admission") == "integration_mappings"
+
+    def get_mapping_entity_id(
+        self,
+        deliver: Deliver,
+        config: dict[str, Any],
+    ) -> str | None:
+        if not self.uses_integration_mapping(config):
+            return None
+        return str(deliver.data.get("tenant_id") or "").strip() or None
+
     async def _validate_token(
         self,
         token: str,
         app_id: str,
-        tenant_id: str,
+        tenant_id: str | None,
         payload: dict[str, Any],
     ) -> None:
         header = jwt.get_unverified_header(token)
@@ -194,7 +225,7 @@ class MicrosoftBotFrameworkAdapter(WebhookAdapter):
             if isinstance(channel_data, dict)
             else None
         )
-        if activity_tenant_id != tenant_id:
+        if tenant_id is not None and activity_tenant_id != tenant_id:
             raise ValueError("Microsoft Teams tenant mismatch")
         endorsements = jwk.get("endorsements") or []
         if channel_id not in endorsements:

--- a/api/src/services/webhooks/protocol.py
+++ b/api/src/services/webhooks/protocol.py
@@ -145,6 +145,9 @@ class Deliver:
     raw_headers: dict[str, str] | None = None
     """Original request headers (for logging)."""
 
+    organization_id: UUID | None = None
+    """Organization resolved from an authenticated integration mapping."""
+
 
 @dataclass
 class Rejected:
@@ -203,6 +206,9 @@ class WebhookAdapter(ABC):
 
     renewal_interval: timedelta | None = None
     """How often to check for subscription renewal. None = no renewal needed."""
+
+    mapping_integration_name: str | None = None
+    """Integration whose mappings may authorize and scope incoming deliveries."""
 
     # ==================== ABSTRACT METHODS ====================
 
@@ -279,6 +285,18 @@ class WebhookAdapter(ABC):
             - Rejected: Reject the request (invalid signature, etc.)
         """
         pass
+
+    def uses_integration_mapping(self, config: dict[str, Any]) -> bool:
+        """Return whether this source authorizes deliveries through mappings."""
+        return False
+
+    def get_mapping_entity_id(
+        self,
+        deliver: Deliver,
+        config: dict[str, Any],
+    ) -> str | None:
+        """Return the external entity ID to resolve for a mapped delivery."""
+        return None
 
     # ==================== OPTIONAL METHODS ====================
 

--- a/api/tests/e2e/api/test_events.py
+++ b/api/tests/e2e/api/test_events.py
@@ -195,6 +195,67 @@ class TestEventSourceCRUD:
             headers=platform_admin.headers,
         )
 
+    def test_create_mapped_teams_source_requires_teams_integration(
+        self, e2e_client, platform_admin
+    ):
+        """Mapped Teams admission is bound to the Teams integration."""
+        without_integration = e2e_client.post(
+            "/api/events/sources",
+            headers=platform_admin.headers,
+            json={
+                "name": f"E2E Mapped Teams Missing {uuid.uuid4().hex[:8]}",
+                "source_type": "webhook",
+                "webhook": {
+                    "adapter_name": "microsoft_bot_framework",
+                    "config": {
+                        "app_id": "11111111-1111-1111-1111-111111111111",
+                        "tenant_admission": "integration_mappings",
+                    },
+                },
+            },
+        )
+        assert without_integration.status_code == 400, without_integration.text
+
+        integration_response = e2e_client.post(
+            "/api/integrations",
+            headers=platform_admin.headers,
+            json={"name": "Microsoft Teams Bot", "config_schema": []},
+        )
+        assert integration_response.status_code == 201, integration_response.text
+        integration = integration_response.json()
+
+        source = None
+        try:
+            create_response = e2e_client.post(
+                "/api/events/sources",
+                headers=platform_admin.headers,
+                json={
+                    "name": f"E2E Mapped Teams {uuid.uuid4().hex[:8]}",
+                    "source_type": "webhook",
+                    "webhook": {
+                        "adapter_name": "microsoft_bot_framework",
+                        "integration_id": integration["id"],
+                        "config": {
+                            "app_id": "11111111-1111-1111-1111-111111111111",
+                            "tenant_admission": "integration_mappings",
+                        },
+                    },
+                },
+            )
+            assert create_response.status_code == 201, create_response.text
+            source = create_response.json()
+            assert source["webhook"]["integration_id"] == integration["id"]
+        finally:
+            if source is not None:
+                e2e_client.delete(
+                    f"/api/events/sources/{source['id']}",
+                    headers=platform_admin.headers,
+                )
+            e2e_client.delete(
+                f"/api/integrations/{integration['id']}",
+                headers=platform_admin.headers,
+            )
+
     def test_create_webhook_source_returns_callback_url(self, e2e_client, platform_admin):
         """Verify callback URL is /api/hooks/{uuid}."""
         source_name = f"E2E Callback URL Test {uuid.uuid4().hex[:8]}"

--- a/api/tests/unit/services/events/test_mapped_webhook_admission.py
+++ b/api/tests/unit/services/events/test_mapped_webhook_admission.py
@@ -1,0 +1,94 @@
+"""Mapped integration admission for authenticated webhook deliveries."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+
+from src.services.events.processor import EventProcessor
+from src.services.webhooks.protocol import Deliver, Rejected
+
+
+def _adapter(deliver: Deliver) -> SimpleNamespace:
+    return SimpleNamespace(
+        name="mapped_adapter",
+        mapping_integration_name="Microsoft Teams Bot",
+        handle_request=AsyncMock(return_value=deliver),
+        get_mapping_entity_id=lambda _deliver, _config: "customer-tenant",
+    )
+
+
+def _source(integration: SimpleNamespace) -> tuple[SimpleNamespace, SimpleNamespace]:
+    event_source = SimpleNamespace(id=uuid4())
+    webhook_source = SimpleNamespace(
+        adapter_name="mapped_adapter",
+        config={"tenant_admission": "integration_mappings"},
+        state={},
+        integration=integration,
+    )
+    return event_source, webhook_source
+
+
+def _mapping_result(*organization_ids):
+    result = MagicMock()
+    result.scalars.return_value.all.return_value = list(organization_ids)
+    return result
+
+
+@pytest.mark.asyncio
+async def test_mapped_delivery_is_scoped_to_exact_organization(monkeypatch):
+    integration = SimpleNamespace(
+        id=uuid4(), name="Microsoft Teams Bot", is_deleted=False
+    )
+    organization_id = uuid4()
+    session = MagicMock()
+    session.execute = AsyncMock(return_value=_mapping_result(organization_id))
+    processor = EventProcessor(session)
+    deliver = Deliver(data={"tenant_id": "customer-tenant"})
+    adapter = _adapter(deliver)
+    monkeypatch.setattr(
+        "src.services.events.processor.get_adapter", lambda _name: adapter
+    )
+    processor._process_delivery = AsyncMock(return_value=deliver)
+    event_source, webhook_source = _source(integration)
+
+    result = await processor.process_webhook(
+        event_source,
+        webhook_source,
+        SimpleNamespace(),
+    )
+
+    assert result is deliver
+    assert deliver.organization_id == organization_id
+    processor._process_delivery.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("organization_ids", [(), (uuid4(), uuid4())])
+async def test_unknown_or_ambiguous_mapping_is_rejected(
+    monkeypatch, organization_ids
+):
+    integration = SimpleNamespace(
+        id=uuid4(), name="Microsoft Teams Bot", is_deleted=False
+    )
+    session = MagicMock()
+    session.execute = AsyncMock(return_value=_mapping_result(*organization_ids))
+    processor = EventProcessor(session)
+    deliver = Deliver(data={"tenant_id": "customer-tenant"})
+    adapter = _adapter(deliver)
+    monkeypatch.setattr(
+        "src.services.events.processor.get_adapter", lambda _name: adapter
+    )
+    processor._process_delivery = AsyncMock()
+    event_source, webhook_source = _source(integration)
+
+    result = await processor.process_webhook(
+        event_source,
+        webhook_source,
+        SimpleNamespace(),
+    )
+
+    assert isinstance(result, Rejected)
+    assert result.status_code == 403
+    processor._process_delivery.assert_not_awaited()

--- a/api/tests/unit/services/test_webhook_adapters.py
+++ b/api/tests/unit/services/test_webhook_adapters.py
@@ -27,6 +27,7 @@ from src.services.webhooks import registry as webhook_registry
 from src.services.webhooks.protocol import (
     Deliver,
     Rejected,
+    SubscribeResult,
     WebhookAdapter,
     WebhookIntegrationAuth,
     WebhookRequest,
@@ -625,6 +626,19 @@ class TestMicrosoftBotFrameworkAdapter:
             )
 
     @pytest.mark.asyncio
+    async def test_subscribe_allows_integration_mapping_admission(self, adapter):
+        result = await adapter.subscribe(
+            "https://example.com/hook",
+            {
+                "app_id": self.app_id,
+                "tenant_admission": "integration_mappings",
+            },
+            None,
+        )
+
+        assert isinstance(result, SubscribeResult)
+
+    @pytest.mark.asyncio
     async def test_missing_bearer_token_is_rejected(self, adapter):
         result = await adapter.handle_request(
             self._request(self._activity()),
@@ -717,3 +731,29 @@ class TestMicrosoftBotFrameworkAdapter:
 
         assert isinstance(result, Rejected)
         assert result.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_mapping_admission_defers_tenant_authorization_to_processor(
+        self, adapter, signing_material
+    ):
+        private_key, jwk = signing_material
+        adapter._get_signing_jwk = AsyncMock(return_value=jwk)
+        activity = self._activity()
+        activity["channelData"]["tenant"]["id"] = "customer-tenant"
+
+        result = await adapter.handle_request(
+            self._request(activity, self._token(private_key)),
+            {
+                "app_id": self.app_id,
+                "tenant_admission": "integration_mappings",
+            },
+            {},
+        )
+
+        assert isinstance(result, Deliver)
+        assert (
+            adapter.get_mapping_entity_id(
+                result, {"tenant_admission": "integration_mappings"}
+            )
+            == "customer-tenant"
+        )


### PR DESCRIPTION
## Summary
- add an integration-mappings tenant admission mode to the Microsoft Bot Framework webhook adapter
- require a linked, active Microsoft Teams Bot integration for mapped event sources
- authorize each inbound activity only when its Microsoft tenant ID maps to exactly one Bifrost organization
- stamp the resolved organization onto the event before subscriptions and workflows run
- preserve the existing configured-tenant mode for single-tenant sources

## Why
A central multi-tenant Teams bot must authenticate Microsoft independently from deciding which Bifrost organization owns an activity. This change makes the platform mapping the admission boundary, so unknown and ambiguous tenants are rejected before workflow execution. The existing workflow mapping check remains defense in depth and establishes runtime scope.

## Verification
- focused webhook adapter, processor, and router suite: 43 passed
- focused live API E2E source-creation test: passed
- API quality gate: pyright 0 errors and warnings; ruff passed
- client suite: 294 files, 1,884 tests passed
- backend unit and contract suite: 5,831 passed, 3 pre-existing skips, 20 deselected
- full E2E suite: 1,784 passed, 1 environment-gated skip
- Playwright production smoke: 4 passed
- production API candidate build and exercise: passed
- complete local pre-PR gate passed for 906ae809744c7695f3b30bc6aedde2da5e675a1a