### PR TITLE
fix(events): allow multi-tenant Teams activities

### DIFF
--- a/api/src/services/webhooks/adapters/microsoft_bot_framework.py
+++ b/api/src/services/webhooks/adapters/microsoft_bot_framework.py
@@ -43,17 +43,12 @@ class MicrosoftBotFrameworkAdapter(WebhookAdapter):
 
     config_schema = {
         "type": "object",
-        "required": ["app_id", "tenant_id"],
+        "required": ["app_id"],
         "properties": {
             "app_id": {
                 "type": "string",
                 "title": "Microsoft App ID",
                 "description": "Application/client ID registered for the Azure Bot.",
-            },
-            "tenant_id": {
-                "type": "string",
-                "title": "Microsoft Tenant ID",
-                "description": "Entra tenant ID allowed to send Teams activities.",
             },
         },
     }
@@ -67,9 +62,6 @@ class MicrosoftBotFrameworkAdapter(WebhookAdapter):
         app_id = str(config.get("app_id") or "").strip()
         if not app_id:
             raise ValueError("Microsoft Bot Framework app_id is required")
-        tenant_id = str(config.get("tenant_id") or "").strip()
-        if not tenant_id:
-            raise ValueError("Microsoft Bot Framework tenant_id is required")
         return SubscribeResult()
 
     async def unsubscribe(
@@ -95,11 +87,6 @@ class MicrosoftBotFrameworkAdapter(WebhookAdapter):
             return Rejected(
                 message="Bot Framework app ID is not configured", status_code=500
             )
-        tenant_id = str(config.get("tenant_id") or "").strip()
-        if not tenant_id:
-            return Rejected(
-                message="Bot Framework tenant ID is not configured", status_code=500
-            )
 
         authorization = request.headers.get("authorization", "")
         scheme, separator, token = authorization.partition(" ")
@@ -109,7 +96,7 @@ class MicrosoftBotFrameworkAdapter(WebhookAdapter):
             )
 
         try:
-            await self._validate_token(token.strip(), app_id, tenant_id, payload)
+            await self._validate_token(token.strip(), app_id, payload)
         except (jwt.PyJWTError, KeyError, TypeError, ValueError) as exc:
             logger.warning(
                 "Bot Framework token validation failed: %s", type(exc).__name__
@@ -153,7 +140,6 @@ class MicrosoftBotFrameworkAdapter(WebhookAdapter):
         self,
         token: str,
         app_id: str,
-        tenant_id: str,
         payload: dict[str, Any],
     ) -> None:
         header = jwt.get_unverified_header(token)
@@ -188,14 +174,6 @@ class MicrosoftBotFrameworkAdapter(WebhookAdapter):
         channel_id = str(payload.get("channelId") or "")
         if channel_id != "msteams":
             raise ValueError("Only Microsoft Teams activities are accepted")
-        channel_data = payload.get("channelData")
-        activity_tenant_id = (
-            (channel_data.get("tenant") or {}).get("id")
-            if isinstance(channel_data, dict)
-            else None
-        )
-        if activity_tenant_id != tenant_id:
-            raise ValueError("Microsoft Teams tenant mismatch")
         endorsements = jwk.get("endorsements") or []
         if channel_id not in endorsements:
             raise ValueError("Signing key is not endorsed for Microsoft Teams")

--- a/api/tests/e2e/api/test_events.py
+++ b/api/tests/e2e/api/test_events.py
@@ -522,7 +522,6 @@ class TestWebhookReceiver:
                     "adapter_name": "microsoft_bot_framework",
                     "config": {
                         "app_id": "11111111-1111-1111-1111-111111111111",
-                        "tenant_id": "22222222-2222-2222-2222-222222222222",
                     },
                 },
             },

--- a/api/tests/unit/services/test_webhook_adapters.py
+++ b/api/tests/unit/services/test_webhook_adapters.py
@@ -551,7 +551,6 @@ class TestMicrosoftBotFrameworkAdapter:
     """Tests Microsoft Bot Framework authentication and normalization."""
 
     app_id = "11111111-1111-1111-1111-111111111111"
-    tenant_id = "tenant-1"
     service_url = "https://smba.trafficmanager.net/amer/"
 
     @pytest.fixture
@@ -618,17 +617,18 @@ class TestMicrosoftBotFrameworkAdapter:
             await adapter.subscribe("https://example.com/hook", {}, None)
 
     @pytest.mark.asyncio
-    async def test_subscribe_requires_tenant_id(self, adapter):
-        with pytest.raises(ValueError, match="tenant_id"):
-            await adapter.subscribe(
-                "https://example.com/hook", {"app_id": self.app_id}, None
-            )
+    async def test_subscribe_only_requires_app_id(self, adapter):
+        result = await adapter.subscribe(
+            "https://example.com/hook", {"app_id": self.app_id}, None
+        )
+
+        assert result.state == {}
 
     @pytest.mark.asyncio
     async def test_missing_bearer_token_is_rejected(self, adapter):
         result = await adapter.handle_request(
             self._request(self._activity()),
-            {"app_id": self.app_id, "tenant_id": self.tenant_id},
+            {"app_id": self.app_id},
             {},
         )
 
@@ -643,7 +643,7 @@ class TestMicrosoftBotFrameworkAdapter:
 
         result = await adapter.handle_request(
             self._request(self._activity(), token),
-            {"app_id": self.app_id, "tenant_id": self.tenant_id},
+            {"app_id": self.app_id},
             {},
         )
 
@@ -678,7 +678,7 @@ class TestMicrosoftBotFrameworkAdapter:
 
         result = await adapter.handle_request(
             self._request(activity, token),
-            {"app_id": self.app_id, "tenant_id": self.tenant_id},
+            {"app_id": self.app_id},
             {},
         )
 
@@ -693,7 +693,7 @@ class TestMicrosoftBotFrameworkAdapter:
 
         result = await adapter.handle_request(
             self._request(self._activity(), self._token(private_key)),
-            {"app_id": self.app_id, "tenant_id": self.tenant_id},
+            {"app_id": self.app_id},
             {},
         )
 
@@ -701,7 +701,7 @@ class TestMicrosoftBotFrameworkAdapter:
         assert result.status_code == 401
 
     @pytest.mark.asyncio
-    async def test_activity_from_another_tenant_is_rejected(
+    async def test_activity_tenant_is_delivered_for_downstream_routing(
         self, adapter, signing_material
     ):
         private_key, jwk = signing_material
@@ -711,9 +711,9 @@ class TestMicrosoftBotFrameworkAdapter:
 
         result = await adapter.handle_request(
             self._request(activity, self._token(private_key)),
-            {"app_id": self.app_id, "tenant_id": self.tenant_id},
+            {"app_id": self.app_id},
             {},
         )
 
-        assert isinstance(result, Rejected)
-        assert result.status_code == 401
+        assert isinstance(result, Deliver)
+        assert result.data["tenant_id"] == "other-tenant"


### PR DESCRIPTION
## Summary
- remove the Microsoft Bot Framework adapter's single-tenant configuration requirement
- preserve Microsoft JWT, audience, issuer, service URL, Teams channel, and signing-key endorsement validation
- deliver the authenticated activity tenant ID for downstream workflow authorization and organization routing

## Why
The central Bifrost Teams bot is multi-tenant. Its workflow already resolves `channelData.tenant.id` through the global Microsoft Teams Bot integration mappings and establishes organization scope. The adapter's configured-tenant equality check rejected valid activities before that workflow could run.

## Verification
- focused webhook adapter suite: 36 passed
- focused live webhook endpoint E2E: passed
- `./test.sh pre-pr`: passed for `4d59e630e892ec82dad25d78bd420f3545509ce5`