### PR TITLE
Fix first-turn chat sequencing

### DIFF
--- a/client/e2e/chat-attachments.admin.spec.ts
+++ b/client/e2e/chat-attachments.admin.spec.ts
@@ -225,7 +225,18 @@ test.describe("Chat attachments and model profiles", () => {
 
 		await page.getByLabel("Chat input").fill("Summarize this file");
 		await page.getByRole("button", { name: "Send message" }).click();
+		const userMessage = page.getByText("Summarize this file", {
+			exact: true,
+		});
+		await expect(userMessage).toBeVisible();
 		await expect(page.getByText("Thinking…")).toBeVisible();
+		const [userBox, activityBox] = await Promise.all([
+			userMessage.boundingBox(),
+			page.getByText("Thinking…").boundingBox(),
+		]);
+		expect(userBox).not.toBeNull();
+		expect(activityBox).not.toBeNull();
+		expect(userBox!.y).toBeLessThan(activityBox!.y);
 		await page.screenshot({
 			path: "playwright-results/screenshots/chat-thinking.png",
 			fullPage: true,
@@ -286,6 +297,12 @@ test.describe("Chat attachments and model profiles", () => {
 			}),
 		).toHaveCount(0);
 		await page.getByRole("button", { name: /Worked for 1s/i }).click();
+		await expect(
+			page.getByText("Routed to", { exact: true }),
+		).toBeVisible();
+		await expect(
+			page.getByText("Document Agent", { exact: true }),
+		).toBeVisible();
 		await page
 			.getByRole("button", { name: /create_text_artifact/i })
 			.click();

--- a/client/src/components/chat/ChatInput.test.tsx
+++ b/client/src/components/chat/ChatInput.test.tsx
@@ -161,6 +161,20 @@ describe("ChatInput — @ mentions", () => {
 });
 
 describe("ChatInput — attachments and model profile", () => {
+	it("matches the conversation column width", () => {
+		const { container } = renderWithProviders(
+			<ChatInput onSend={vi.fn()} />,
+		);
+
+		expect(container.firstElementChild?.firstElementChild).toHaveClass(
+			"max-w-4xl",
+		);
+		expect(screen.getByLabelText("Chat input").parentElement).toHaveClass(
+			"bg-card",
+			"text-card-foreground",
+		);
+	});
+
 	it("keeps primary composer controls touch-sized on phones", () => {
 		const { container } = renderWithProviders(
 			<ChatInput onSend={vi.fn()} />,

--- a/client/src/components/chat/ChatInput.tsx
+++ b/client/src/components/chat/ChatInput.tsx
@@ -306,7 +306,7 @@ export function ChatInput({
 
 	return (
 		<div className="px-3 pb-[max(0.75rem,env(safe-area-inset-bottom))] pt-2 sm:px-4 sm:pb-4">
-			<div className="mx-auto max-w-3xl">
+			<div className="mx-auto max-w-4xl">
 				<div
 					onDrop={handleDrop}
 					onDragOver={(event) => {
@@ -315,7 +315,7 @@ export function ChatInput({
 					}}
 					onDragLeave={() => setIsDragging(false)}
 					className={cn(
-						"relative rounded-2xl border bg-background shadow-sm transition-colors",
+						"relative rounded-2xl border bg-card text-card-foreground shadow-sm transition-colors",
 						"focus-within:border-ring focus-within:ring-2 focus-within:ring-ring/20",
 						isDragging && "border-primary bg-primary/5",
 					)}

--- a/client/src/components/chat/ChatSystemEvent.tsx
+++ b/client/src/components/chat/ChatSystemEvent.tsx
@@ -18,6 +18,8 @@ export interface SystemEvent {
 	id: string;
 	type: SystemEventType;
 	timestamp: string;
+	/** Client message ID for the user turn that caused this event. */
+	turnId?: string;
 	// For agent switches
 	agentName?: string;
 	agentId?: string;

--- a/client/src/components/chat/ChatWindow.test.tsx
+++ b/client/src/components/chat/ChatWindow.test.tsx
@@ -293,6 +293,47 @@ describe("ChatWindow — messages render & send", () => {
 		expect(screen.getByText("pong")).toBeInTheDocument();
 	});
 
+	it("keeps routed activity after its user message despite clock skew", () => {
+		messagesRef.data = [
+			{
+				id: "user-1",
+				role: "user",
+				content: "Route this",
+				created_at: "2026-04-20T00:00:20Z",
+			},
+			{
+				id: "assistant-1",
+				role: "assistant",
+				content: "Done",
+				duration_ms: 1_000,
+				created_at: "2026-04-20T00:00:10Z",
+			},
+		];
+		storeSelectors.systemEventsByConversation = {
+			"c-1": [
+				{
+					id: "route-1",
+					type: "agent_switch",
+					turnId: "user-1",
+					timestamp: "2026-04-20T00:00:05Z",
+				},
+			],
+		};
+
+		const { container } = renderWithProviders(
+			<ChatWindow conversationId="c-1" />,
+		);
+		const renderedItems = Array.from(
+			container.querySelectorAll("[data-marker]"),
+		).map((element) => element.getAttribute("data-marker"));
+
+		expect(renderedItems).toEqual([
+			"chat-message",
+			"sys-event",
+			"chat-message",
+		]);
+	});
+
 	it("uses the persisted run summary duration even when its content is empty", () => {
 		messagesRef.data = [
 			{

--- a/client/src/components/chat/ChatWindow.tsx
+++ b/client/src/components/chat/ChatWindow.tsx
@@ -237,7 +237,9 @@ export function ChatWindow({ conversationId, agentName }: ChatWindowProps) {
 		(profile) => profile.id === selectedModelProfileId,
 	)
 		? selectedModelProfileId
-		: (modelProfileData?.default_profile_id ?? modelProfiles[0]?.id ?? null);
+		: (modelProfileData?.default_profile_id ??
+			modelProfiles[0]?.id ??
+			null);
 
 	// Use WebSocket streaming
 	const {
@@ -277,6 +279,14 @@ export function ChatWindow({ conversationId, agentName }: ChatWindowProps) {
 	const timeline = useMemo<TimelineItem[]>(() => {
 		const items: TimelineItem[] = [];
 		let currentToolGroup: MessagePublic[] = [];
+		const placedEventIds = new Set<string>();
+		const eventsByTurnId = new Map<string, SystemEvent[]>();
+		for (const event of systemEvents) {
+			if (!event.turnId) continue;
+			const turnEvents = eventsByTurnId.get(event.turnId) ?? [];
+			turnEvents.push(event);
+			eventsByTurnId.set(event.turnId, turnEvents);
+		}
 
 		const flushToolGroup = () => {
 			if (currentToolGroup.length > 0) {
@@ -304,25 +314,46 @@ export function ChatWindow({ conversationId, agentName }: ChatWindowProps) {
 					data: msg,
 					timestamp: msg.created_at,
 				});
+
+				if (msg.role === "user") {
+					const unifiedMessage = msg as UnifiedMessage;
+					const turnIds = [msg.id, unifiedMessage.localId].filter(
+						(value): value is string => Boolean(value),
+					);
+					for (const turnId of turnIds) {
+						for (const event of eventsByTurnId.get(turnId) ?? []) {
+							if (placedEventIds.has(event.id)) continue;
+							items.push({
+								type: "event",
+								data: event,
+								timestamp: event.timestamp,
+							});
+							placedEventIds.add(event.id);
+						}
+					}
+				}
 			}
 		}
 		flushToolGroup();
 
-		// Add system events
+		// Events created before turn anchoring was available retain their timestamp
+		// position. Anchored events are already placed immediately after the user
+		// message that caused them, independent of browser/server clock skew.
 		for (const event of systemEvents) {
-			items.push({
+			if (placedEventIds.has(event.id)) continue;
+			const eventItem: TimelineItem = {
 				type: "event",
 				data: event,
 				timestamp: event.timestamp,
-			});
+			};
+			const insertionIndex = items.findIndex(
+				(item) =>
+					new Date(item.timestamp).getTime() >
+					new Date(event.timestamp).getTime(),
+			);
+			if (insertionIndex === -1) items.push(eventItem);
+			else items.splice(insertionIndex, 0, eventItem);
 		}
-
-		// Sort by timestamp
-		items.sort(
-			(a, b) =>
-				new Date(a.timestamp).getTime() -
-				new Date(b.timestamp).getTime(),
-		);
 
 		return items;
 	}, [messages, systemEvents]);

--- a/client/src/hooks/useChatStream.test.tsx
+++ b/client/src/hooks/useChatStream.test.tsx
@@ -74,6 +74,9 @@ import { useChatStream } from "./useChatStream";
 
 beforeEach(() => {
 	vi.clearAllMocks();
+	vi.mocked(webSocketService.isConnected).mockReturnValue(true);
+	vi.mocked(webSocketService.connectToChat).mockResolvedValue(undefined);
+	vi.mocked(webSocketService.sendChatMessage).mockReturnValue(true);
 	mocks.callbacks.chat = undefined;
 	mocks.callbacks.job = undefined;
 	mocks.store.messagesByConversation = {};
@@ -88,7 +91,67 @@ beforeEach(() => {
 	);
 });
 
-describe("useChatStream video jobs", () => {
+describe("useChatStream", () => {
+	it("renders and subscribes the first message before waiting for transport", async () => {
+		const queryClient = new QueryClient();
+		const wrapper = ({ children }: { children: ReactNode }) => (
+			<QueryClientProvider client={queryClient}>
+				{children}
+			</QueryClientProvider>
+		);
+		let resolveConnection: (() => void) | undefined;
+		vi.mocked(webSocketService.isConnected).mockReturnValue(false);
+		vi.mocked(webSocketService.connectToChat).mockImplementation(
+			() =>
+				new Promise<void>((resolve) => {
+					resolveConnection = resolve;
+				}),
+		);
+		const { result } = renderHook(
+			() => useChatStream({ conversationId: undefined }),
+			{ wrapper },
+		);
+
+		let sendPromise: Promise<void> | undefined;
+		act(() => {
+			sendPromise = result.current.sendMessage("hello", "conversation-1");
+		});
+
+		expect(mocks.store.addMessage).toHaveBeenCalledWith(
+			"conversation-1",
+			expect.objectContaining({ content: "hello", isOptimistic: true }),
+		);
+		expect(mocks.store.startStreaming).toHaveBeenCalledOnce();
+		expect(webSocketService.onChatStream).toHaveBeenCalledWith(
+			"conversation-1",
+			expect.any(Function),
+		);
+		expect(webSocketService.sendChatMessage).not.toHaveBeenCalled();
+
+		act(() => {
+			mocks.callbacks.chat?.({
+				type: "agent_switch",
+				conversation_id: "conversation-1",
+				agent_switch: {
+					agent_name: "Router target",
+					agent_id: "agent-1",
+					reason: "routed",
+				},
+			});
+		});
+		expect(mocks.store.addSystemEvent).toHaveBeenCalledWith(
+			"conversation-1",
+			expect.objectContaining({
+				type: "agent_switch",
+				turnId: expect.any(String),
+			}),
+		);
+
+		resolveConnection?.();
+		await sendPromise;
+		expect(webSocketService.sendChatMessage).toHaveBeenCalledOnce();
+	});
+
 	it("does not end an active run when the new conversation subscription mounts", async () => {
 		const queryClient = new QueryClient();
 		const wrapper = ({ children }: { children: ReactNode }) => (

--- a/client/src/hooks/useChatStream.ts
+++ b/client/src/hooks/useChatStream.ts
@@ -65,6 +65,9 @@ export function useChatStream({
 	const handleChunkRef = useRef<((chunk: ChatStreamChunk) => void) | null>(
 		null,
 	);
+	const chatUnsubscribeRef = useRef<(() => void) | null>(null);
+	const subscribedConversationIdRef = useRef<string | null>(null);
+	const activeUserMessageIdRef = useRef<string | null>(null);
 	const artifactJobUnsubscribersRef = useRef(new Map<string, () => void>());
 	const runAssistantMessageIdRef = useRef<string | null>(null);
 
@@ -97,10 +100,7 @@ export function useChatStream({
 	// Handle incoming chat stream chunks
 	const handleChunk = useCallback(
 		(chunk: ChatStreamChunk) => {
-			const observeArtifactJob = (
-				result: unknown,
-				messageId: string,
-			) => {
+			const observeArtifactJob = (result: unknown, messageId: string) => {
 				if (!result || typeof result !== "object") return;
 				const job = result as {
 					type?: string;
@@ -154,24 +154,30 @@ export function useChatStream({
 									"Open the notification for details.",
 							});
 						}
-						artifactJobUnsubscribersRef.current
-							.get(job.job_id!)?.();
+						artifactJobUnsubscribersRef.current.get(
+							job.job_id!,
+						)?.();
 						artifactJobUnsubscribersRef.current.delete(job.job_id!);
 						if (convId) {
-							useChatStore.getState().updateMessage(convId, messageId, {
-								tool_state:
-									update.status === "succeeded"
-										? "completed"
-										: "error",
-								tool_result: {
-									...job,
-									status: update.status,
-								},
-							});
+							useChatStore
+								.getState()
+								.updateMessage(convId, messageId, {
+									tool_state:
+										update.status === "succeeded"
+											? "completed"
+											: "error",
+									tool_result: {
+										...job,
+										status: update.status,
+									},
+								});
 						}
 					},
 				);
-				artifactJobUnsubscribersRef.current.set(job.job_id, unsubscribe);
+				artifactJobUnsubscribersRef.current.set(
+					job.job_id,
+					unsubscribe,
+				);
 			};
 
 			// Handle title update - refresh conversations to show new title
@@ -256,7 +262,8 @@ export function useChatStream({
 
 					// Create assistant message (with server-provided ID and current timestamp)
 					if (chunk.assistant_message_id) {
-						runAssistantMessageIdRef.current = chunk.assistant_message_id;
+						runAssistantMessageIdRef.current =
+							chunk.assistant_message_id;
 						const assistantMessage: UnifiedMessage = {
 							id: chunk.assistant_message_id,
 							conversation_id: convId,
@@ -367,8 +374,7 @@ export function useChatStream({
 				case "artifact_ready": {
 					const convId = currentConversationIdRef.current;
 					const artifact = chunk.artifact;
-					if (!convId || !chunk.message_id || !artifact?.id)
-						break;
+					if (!convId || !chunk.message_id || !artifact?.id) break;
 					const messages =
 						useChatStore.getState().messagesByConversation[
 							convId
@@ -377,9 +383,7 @@ export function useChatStream({
 						(item) => item.id === chunk.message_id,
 					);
 					const attachments = message?.attachments ?? [];
-					if (
-						!attachments.some((item) => item.id === artifact.id)
-					) {
+					if (!attachments.some((item) => item.id === artifact.id)) {
 						useChatStore
 							.getState()
 							.updateMessage(convId, chunk.message_id, {
@@ -484,7 +488,9 @@ export function useChatStream({
 						: null;
 
 					const summaryMessageId =
-						chunk.message_id || runAssistantMessageIdRef.current || streamingId;
+						chunk.message_id ||
+						runAssistantMessageIdRef.current ||
+						streamingId;
 
 					// The final segment may have a temporary client ID when it starts
 					// after tool execution. Replace that ID with the persisted summary
@@ -494,7 +500,8 @@ export function useChatStream({
 						useChatStore
 							.getState()
 							.updateMessage(convId, messageToFinalize, {
-								...(summaryMessageId && messageToFinalize !== summaryMessageId
+								...(summaryMessageId &&
+								messageToFinalize !== summaryMessageId
 									? { id: summaryMessageId }
 									: {}),
 								isStreaming: false,
@@ -512,6 +519,7 @@ export function useChatStream({
 							.setStreamingMessageIdForConversation(convId, null);
 					}
 					runAssistantMessageIdRef.current = null;
+					activeUserMessageIdRef.current = null;
 
 					completeStream();
 
@@ -544,6 +552,8 @@ export function useChatStream({
 								id: `event-${Date.now()}`,
 								type: "agent_switch",
 								timestamp: new Date().toISOString(),
+								turnId:
+									activeUserMessageIdRef.current ?? undefined,
 								agentName: chunk.agent_switch.agent_name,
 								agentId: chunk.agent_switch.agent_id,
 								reason:
@@ -586,12 +596,14 @@ export function useChatStream({
 							id: `error-${Date.now()}`,
 							type: "error",
 							timestamp: new Date().toISOString(),
+							turnId: activeUserMessageIdRef.current ?? undefined,
 							error: errorMsg,
 						});
 					}
 
 					// Clear any pending question on error
 					setPendingQuestion(null);
+					activeUserMessageIdRef.current = null;
 					resetStream();
 					break;
 				}
@@ -615,6 +627,35 @@ export function useChatStream({
 		handleChunkRef.current = handleChunk;
 	}, [handleChunk]);
 
+	const subscribeToConversation = useCallback(
+		(targetConversationId: string) => {
+			currentConversationIdRef.current = targetConversationId;
+			if (
+				subscribedConversationIdRef.current === targetConversationId &&
+				chatUnsubscribeRef.current
+			) {
+				return;
+			}
+
+			chatUnsubscribeRef.current?.();
+			chatUnsubscribeRef.current = webSocketService.onChatStream(
+				targetConversationId,
+				(chunk) => handleChunkRef.current?.(chunk),
+			);
+			subscribedConversationIdRef.current = targetConversationId;
+		},
+		[],
+	);
+
+	useEffect(
+		() => () => {
+			chatUnsubscribeRef.current?.();
+			chatUnsubscribeRef.current = null;
+			subscribedConversationIdRef.current = null;
+		},
+		[],
+	);
+
 	// Send message via WebSocket
 	const sendMessage = useCallback(
 		async (
@@ -628,11 +669,6 @@ export function useChatStream({
 			if (!targetConversationId) {
 				toast.error("No conversation selected");
 				return;
-			}
-
-			// Ensure connected
-			if (!webSocketService.isConnected()) {
-				await webSocketService.connectToChat(targetConversationId);
 			}
 
 			// Generate stable ID for user message
@@ -651,39 +687,45 @@ export function useChatStream({
 				isOptimistic: true,
 				localId: userMessageId, // Use same ID as localId for dedup
 			};
+			activeUserMessageIdRef.current = userMessageId;
 			addMessage(targetConversationId, userMessage);
 
-			// Start streaming state (no assistant placeholder yet - created on message_start)
+			// Show the sent message and run state before transport setup. This is
+			// especially important for the first turn, when the conversation channel
+			// does not exist until after the conversation-creation request completes.
 			startStreaming();
+			subscribeToConversation(targetConversationId);
 
-			// Send the chat message with localId for deduplication
-			const sent = webSocketService.sendChatMessage(
-				targetConversationId,
-				message,
-				userMessageId,
-				attachments.map((attachment) => attachment.id),
-				modelProfileId,
-			);
-			if (!sent) {
-				try {
+			try {
+				// Install the local callback before joining the server channel so no
+				// routing or tool chunks can arrive in the gap between connect and subscribe.
+				await webSocketService.connectToChat(targetConversationId);
+
+				// Send the chat message with localId for deduplication
+				let sent = webSocketService.sendChatMessage(
+					targetConversationId,
+					message,
+					userMessageId,
+					attachments.map((attachment) => attachment.id),
+					modelProfileId,
+				);
+				if (!sent) {
 					await webSocketService.connectToChat(targetConversationId);
-					const retried = webSocketService.sendChatMessage(
+					sent = webSocketService.sendChatMessage(
 						targetConversationId,
 						message,
 						userMessageId,
 						attachments.map((attachment) => attachment.id),
 						modelProfileId,
 					);
-					if (!retried) throw new Error("WebSocket is not connected");
-				} catch (error) {
-					console.error(
-						"[useChatStream] Failed to send message:",
-						error,
-					);
-					setStreamError("Failed to send message");
-					resetStream();
-					throw error;
 				}
+				if (!sent) throw new Error("WebSocket is not connected");
+			} catch (error) {
+				console.error("[useChatStream] Failed to send message:", error);
+				setStreamError("Failed to send message");
+				activeUserMessageIdRef.current = null;
+				resetStream();
+				throw error;
 			}
 		},
 		[
@@ -692,6 +734,7 @@ export function useChatStream({
 			startStreaming,
 			setStreamError,
 			resetStream,
+			subscribeToConversation,
 		],
 	);
 
@@ -699,17 +742,13 @@ export function useChatStream({
 	useEffect(() => {
 		if (!conversationId) return;
 
-		let unsubscribe: (() => void) | null = null;
+		// Subscribe locally before joining the channel. The first message may be
+		// sent by the pre-navigation render with a conversation ID override.
+		subscribeToConversation(conversationId);
 
-		// Connect and subscribe
 		const setup = async () => {
 			try {
 				await webSocketService.connectToChat(conversationId);
-				// Subscribe to chat stream (replaces any existing callback)
-				unsubscribe = webSocketService.onChatStream(
-					conversationId,
-					(chunk) => handleChunkRef.current?.(chunk),
-				);
 				setIsConnected(true);
 			} catch (error) {
 				console.error("[useChatStream] Failed to connect:", error);
@@ -717,11 +756,7 @@ export function useChatStream({
 			}
 		};
 		setup();
-
-		return () => {
-			unsubscribe?.();
-		};
-	}, [conversationId]);
+	}, [conversationId, subscribeToConversation]);
 
 	// Track connection status from service via event subscription
 	useEffect(() => {

--- a/client/src/lib/chat-utils.test.ts
+++ b/client/src/lib/chat-utils.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it, vi, afterEach } from "vitest";
-import { generateLocalId, generateMessageId } from "./chat-utils";
+import {
+	generateLocalId,
+	generateMessageId,
+	integrateMessages,
+} from "./chat-utils";
 
 const originalRandomUUID = crypto.randomUUID;
 const originalGetRandomValues = crypto.getRandomValues.bind(crypto);
@@ -28,8 +32,12 @@ describe("chat-utils ids", () => {
 			value: vi.fn(() => "11111111-1111-4111-8111-111111111111"),
 		});
 
-		expect(generateMessageId()).toBe("11111111-1111-4111-8111-111111111111");
-		expect(generateLocalId()).toBe("local-11111111-1111-4111-8111-111111111111");
+		expect(generateMessageId()).toBe(
+			"11111111-1111-4111-8111-111111111111",
+		);
+		expect(generateLocalId()).toBe(
+			"local-11111111-1111-4111-8111-111111111111",
+		);
 	});
 
 	it("falls back to getRandomValues when randomUUID is unavailable", () => {
@@ -41,14 +49,16 @@ describe("chat-utils ids", () => {
 			configurable: true,
 			value: vi.fn((array: Uint8Array) => {
 				array.set([
-					0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc, 0xde, 0xf0,
-					0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc, 0xde, 0xf0,
+					0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc, 0xde, 0xf0, 0x12, 0x34,
+					0x56, 0x78, 0x9a, 0xbc, 0xde, 0xf0,
 				]);
 				return array;
 			}),
 		});
 
-		expect(generateMessageId()).toBe("12345678-9abc-4ef0-9234-56789abcdef0");
+		expect(generateMessageId()).toBe(
+			"12345678-9abc-4ef0-9234-56789abcdef0",
+		);
 	});
 
 	it("uses a timestamp fallback only when no browser crypto API exists", () => {
@@ -60,5 +70,44 @@ describe("chat-utils ids", () => {
 		vi.spyOn(Math, "random").mockReturnValue(0.5);
 
 		expect(generateMessageId()).toBe("fallback-mubbs7i8-i");
+	});
+});
+
+describe("integrateMessages", () => {
+	it("preserves server sequence and local arrival order across clock skew", () => {
+		const serverMessages = [
+			{
+				id: "user-1",
+				conversation_id: "conversation-1",
+				role: "user",
+				content: "Hello",
+				sequence: 1,
+				created_at: "2026-01-01T00:00:20Z",
+			},
+			{
+				id: "assistant-1",
+				conversation_id: "conversation-1",
+				role: "assistant",
+				content: "Hi",
+				sequence: 2,
+				created_at: "2026-01-01T00:00:10Z",
+			},
+		] as Parameters<typeof integrateMessages>[0];
+		const localMessages = [
+			{
+				id: "tool-1",
+				conversation_id: "conversation-1",
+				role: "tool_call",
+				content: null,
+				sequence: Date.now(),
+				created_at: "2026-01-01T00:00:05Z",
+			},
+		] as Parameters<typeof integrateMessages>[1];
+
+		expect(
+			integrateMessages(serverMessages, localMessages).map(
+				(message) => message.id,
+			),
+		).toEqual(["user-1", "assistant-1", "tool-1"]);
 	});
 });

--- a/client/src/lib/chat-utils.ts
+++ b/client/src/lib/chat-utils.ts
@@ -114,33 +114,34 @@ export function mergeMessages(
 /**
  * Integrate incoming messages into existing array
  * - Deduplication is now handled by the chat store's dedupStateByConversation
- * - This function just merges and sorts for consistency
+ * - API order is authoritative; local-only messages retain arrival order
  */
 export function integrateMessages(
   existing: UnifiedMessage[],
   incoming: UnifiedMessage[]
 ): UnifiedMessage[] {
-  const byId = new Map<string, UnifiedMessage>();
+  // The API already returns messages in authoritative sequence order, while
+  // the local store records streamed messages in arrival order. Preserve both
+  // orders instead of comparing browser and server clocks: clock skew can put
+  // a response before the user message that caused it.
+  const integrated = existing.map((message) => ({ ...message }));
+  const indexById = new Map(
+    integrated.map((message, index) => [message.id, index])
+  );
 
-  // Index existing messages
-  existing.forEach((m) => {
-    byId.set(m.id, m);
-  });
-
-  // Merge incoming (updates existing, adds new)
-  incoming.forEach((m) => {
-    const existingMsg = byId.get(m.id);
-    if (existingMsg) {
-      byId.set(m.id, mergeMessages(existingMsg, m));
-    } else {
-      byId.set(m.id, m);
+  incoming.forEach((message) => {
+    const existingIndex = indexById.get(message.id);
+    if (existingIndex === undefined) {
+      indexById.set(message.id, integrated.length);
+      integrated.push(message);
+      return;
     }
+
+    integrated[existingIndex] = mergeMessages(
+      integrated[existingIndex],
+      message
+    );
   });
 
-  // Sort by createdAt + ID for stability
-  return Array.from(byId.values()).sort((a, b) => {
-    const timeDiff =
-      new Date(a.created_at).getTime() - new Date(b.created_at).getTime();
-    return timeDiff !== 0 ? timeDiff : a.id.localeCompare(b.id);
-  });
+  return integrated;
 }


### PR DESCRIPTION
## Summary

- render the optimistic first user message before waiting for WebSocket setup
- register the conversation callback before subscribing so routing and tool events cannot be missed
- preserve causal message order across browser/server clock skew and anchor routing events to their user turn
- extend component and Playwright coverage for first-turn ordering, routed activity, and tool results

## Verification

- `./test.sh client unit src/lib/chat-utils.test.ts src/hooks/useChatStream.test.tsx src/components/chat/ChatWindow.test.tsx`
- `./test.sh client e2e e2e/chat-attachments.admin.spec.ts`
- `(cd client && npm run tsc && npm run lint)`
- live disposable-stack browser run with an OpenRouter-backed routing agent and tool: 32 ms optimistic paint; user → activity → answer ordering; routed event and tool result visible

Fixes #684
