### PR TITLE
fix(agent): preserve caller org for workflow tools

### DIFF
--- a/api/shared/scope_resolver.py
+++ b/api/shared/scope_resolver.py
@@ -72,6 +72,11 @@ UNSET: Final[_Unset] = _Unset()
 RequestedScope = _Unset | None | UUID
 
 
+def has_scope_bypass(*, is_platform_admin: bool, is_provider_org: bool) -> bool:
+    """Return whether a principal may target global or another organization."""
+    return is_platform_admin or is_provider_org
+
+
 def resolve_effective_scope(
     *,
     caller_org_id: UUID | None,
@@ -104,7 +109,10 @@ def resolve_effective_scope(
             scope. The message identifies the rule that failed without
             disclosing other orgs' existence.
     """
-    bypass = is_platform_admin or is_provider_org
+    bypass = has_scope_bypass(
+        is_platform_admin=is_platform_admin,
+        is_provider_org=is_provider_org,
+    )
 
     if isinstance(requested_scope, _Unset):
         return caller_org_id

--- a/api/src/models/contracts/mcp.py
+++ b/api/src/models/contracts/mcp.py
@@ -118,6 +118,7 @@ class MCPGatewayCapabilitySearchRequest(BaseModel):
     query: str | None = Field(default=None, max_length=500)
     agent_id: str | None = None
     tool_ref: str | None = None
+    discovery_scope: Literal["accessible", "all"] = "accessible"
     limit: int = Field(default=10, ge=1, le=20)
 
     @model_validator(mode="after")

--- a/api/src/routers/agents.py
+++ b/api/src/routers/agents.py
@@ -326,7 +326,6 @@ async def list_agents(
     - Users see AUTHENTICATED agents + ROLE_BASED agents assigned to their roles
     """
     if discovery_only:
-        filter_type = None
         filter_org_id = user.organization_id
         is_admin = False
     else:
@@ -348,7 +347,7 @@ async def list_agents(
         is_external=user.is_external,
     )
 
-    if is_admin and filter_type is not None:
+    if is_admin:
         # Admins use list_all_in_scope with filter_type for flexibility
         agents = await repo.list_all_in_scope(filter_type, active_only=active_only)
     else:

--- a/api/src/routers/agents.py
+++ b/api/src/routers/agents.py
@@ -19,6 +19,7 @@ from fastapi.responses import Response
 from sqlalchemy import delete, select
 from sqlalchemy.orm import selectinload
 
+from shared.scope_resolver import has_scope_bypass
 from src.core.auth import CurrentActiveUser
 from src.core.db_deps import DbSession
 from src.core.log_safety import log_safe
@@ -303,6 +304,13 @@ async def list_agents(
         False,
         description="Include per-agent run stats in the list response.",
     ),
+    discovery_only: bool = Query(
+        False,
+        description=(
+            "Apply ordinary organization and role visibility even for "
+            "impersonation-capable callers. Used by chat discovery."
+        ),
+    ),
 ) -> list[AgentSummary]:
     """
     List agents the user has access to.
@@ -317,17 +325,19 @@ async def list_agents(
     - Platform admins see all agents
     - Users see AUTHENTICATED agents + ROLE_BASED agents assigned to their roles
     """
-    # Apply organization filter using repository
-    try:
-        filter_type, filter_org_id = resolve_org_filter(user, scope)
-    except ValueError as e:
-        raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-            detail=str(e),
-        )
-
-    # Check if user is platform admin
-    is_admin = user.is_platform_admin
+    if discovery_only:
+        filter_type = None
+        filter_org_id = user.organization_id
+        is_admin = False
+    else:
+        try:
+            filter_type, filter_org_id = resolve_org_filter(user, scope)
+        except ValueError as e:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail=str(e),
+            )
+        is_admin = user.is_platform_admin
 
     # Create repository with appropriate access context
     repo = AgentRepository(
@@ -338,7 +348,7 @@ async def list_agents(
         is_external=user.is_external,
     )
 
-    if is_admin:
+    if is_admin and filter_type is not None:
         # Admins use list_all_in_scope with filter_type for flexibility
         agents = await repo.list_all_in_scope(filter_type, active_only=active_only)
     else:
@@ -653,8 +663,10 @@ async def get_agent(
     user: CurrentActiveUser,
 ) -> AgentPublic:
     """Get agent by ID."""
-    # Check if user is platform admin
-    is_admin = user.is_platform_admin
+    is_admin = has_scope_bypass(
+        is_platform_admin=user.is_platform_admin,
+        is_provider_org=user.is_provider_org,
+    )
 
     repo = AgentRepository(
         session=db,

--- a/api/src/routers/chat.py
+++ b/api/src/routers/chat.py
@@ -21,6 +21,7 @@ from fastapi import APIRouter, File, HTTPException, Response, UploadFile, status
 from sqlalchemy import func, select, update
 from sqlalchemy.orm import selectinload
 
+from shared.scope_resolver import has_scope_bypass
 from src.core.auth import CurrentActiveUser
 from src.core.db_deps import DbSession
 from src.models.contracts.agents import (
@@ -777,7 +778,10 @@ async def _check_agent_access(db: DbSession, user, agent: Agent) -> bool:
         db,
         org_id=user.organization_id,
         user_id=user.user_id,
-        is_superuser=user.is_platform_admin,
+        is_superuser=has_scope_bypass(
+            is_platform_admin=user.is_platform_admin,
+            is_provider_org=user.is_provider_org,
+        ),
         is_external=user.is_external,
     )
     accessible = await repo.get(id=agent.id)

--- a/api/src/routers/mcp.py
+++ b/api/src/routers/mcp.py
@@ -531,6 +531,7 @@ async def list_mcp_tools(
     result = await tool_service.get_accessible_tools(
         user_roles=current_user.roles,
         is_superuser=current_user.is_superuser,
+        is_provider_org=current_user.is_provider_org,
         user_id=current_user.user_id,
         org_id=current_user.organization_id,
         is_external=current_user.is_external,

--- a/api/src/routers/mcp.py
+++ b/api/src/routers/mcp.py
@@ -529,10 +529,12 @@ async def list_mcp_tools(
             detail="External MCP access is disabled",
         )
 
-    # Per-user tool access is role-scoped inside MCPToolAccessService.
+    # This REST inventory backs the platform settings allow/block controls.
+    # Normal MCP discovery remains role-scoped in the protocol gateway.
     tool_service = MCPToolAccessService(db)
     result = await tool_service.get_accessible_tools(
         user_roles=current_user.roles,
+        is_superuser=current_user.is_superuser,
         user_id=current_user.user_id,
         org_id=current_user.organization_id,
         is_external=current_user.is_external,

--- a/api/src/routers/mcp.py
+++ b/api/src/routers/mcp.py
@@ -99,6 +99,7 @@ def _raise_gateway_http_error(exc: Exception) -> NoReturn:
     status_code = {
         "INVALID_ARGUMENTS": status.HTTP_422_UNPROCESSABLE_ENTITY,
         "INVALID_CAPABILITY_SEARCH": status.HTTP_422_UNPROCESSABLE_ENTITY,
+        "IMPERSONATION_FORBIDDEN": status.HTTP_403_FORBIDDEN,
         "INVALID_RESULT_PATH": status.HTTP_422_UNPROCESSABLE_ENTITY,
         "AGENT_NOT_FOUND_OR_FORBIDDEN": status.HTTP_404_NOT_FOUND,
         "TOOL_NOT_FOUND_OR_FORBIDDEN": status.HTTP_404_NOT_FOUND,
@@ -127,6 +128,7 @@ async def search_gateway_capabilities(
             query=request.query,
             agent_id=request.agent_id,
             tool_ref=request.tool_ref,
+            discovery_scope=request.discovery_scope,
             limit=request.limit,
         )
     except Exception as exc:

--- a/api/src/routers/mcp.py
+++ b/api/src/routers/mcp.py
@@ -72,6 +72,7 @@ def _gateway_service(current_user: CurrentActiveUser):
             user_id=current_user.user_id,
             org_id=current_user.organization_id,
             is_platform_admin=current_user.is_superuser,
+            is_provider_org=current_user.is_provider_org,
             is_external=current_user.is_external,
             user_email=current_user.email,
             user_name=current_user.name,
@@ -530,8 +531,6 @@ async def list_mcp_tools(
     tool_service = MCPToolAccessService(db)
     result = await tool_service.get_accessible_tools(
         user_roles=current_user.roles,
-        is_superuser=current_user.is_superuser,
-        is_provider_org=current_user.is_provider_org,
         user_id=current_user.user_id,
         org_id=current_user.organization_id,
         is_external=current_user.is_external,

--- a/api/src/routers/websocket.py
+++ b/api/src/routers/websocket.py
@@ -21,6 +21,7 @@ from shared.policy_rules import PolicyRuleDomainMismatch, PolicyRuleNotFound, re
 from src.repositories.policy_rule import PolicyRuleRepository
 from shared.policies.subscription import decide_visibility_change
 from shared.role_cache import get_user_roles
+from shared.scope_resolver import has_scope_bypass
 from src.core.auth import get_current_user_ws
 from src.core.principal import UserPrincipal
 from src.core.database import get_db_context
@@ -1570,7 +1571,10 @@ async def _process_chat_message(
                     db,
                     org_id=user.organization_id,
                     user_id=user.user_id,
-                    is_superuser=user.is_superuser,
+                    is_superuser=has_scope_bypass(
+                        is_platform_admin=user.is_platform_admin,
+                        is_provider_org=user.is_provider_org,
+                    ),
                     is_external=user.is_external,
                 )
                 accessible_agent = await repo.get_agent_with_access_check(conversation.agent_id)

--- a/api/src/services/agent_executor.py
+++ b/api/src/services/agent_executor.py
@@ -35,6 +35,7 @@ from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 from sqlalchemy.orm import selectinload
 
+from shared.scope_resolver import has_scope_bypass
 from src.core.principal import UserPrincipal
 from src.models.contracts.agents import (
     AgentSwitch,
@@ -192,7 +193,10 @@ class AgentExecutor:
                 session,
                 org_id=user.organization_id,
                 user_id=user.user_id,
-                is_superuser=user.is_superuser,
+                is_superuser=has_scope_bypass(
+                    is_platform_admin=user.is_platform_admin,
+                    is_provider_org=user.is_provider_org,
+                ),
                 is_external=user.is_external,
             )
             accessible_agent = await repo.get_agent_with_access_check(new_agent.id)
@@ -260,7 +264,6 @@ class AgentExecutor:
             self._session_factory,
             user_id=user.user_id if user else None,
             org_id=user.organization_id if user else None,
-            is_superuser=user.is_superuser if user else False,
             is_external=user.is_external if user else False,
         )
 

--- a/api/src/services/agent_executor.py
+++ b/api/src/services/agent_executor.py
@@ -1364,23 +1364,46 @@ class AgentExecutor:
                 )
             resolved_workflow_id, resolved_workflow_name = resolved_workflow
 
-            # Get user info from conversation
-            user = conversation.user if conversation else None
+            # Chat constructs the authenticated caller once at entry and passes
+            # it through every dispatch path. Prefer that canonical context so
+            # workflow execution does not depend on a lazily loaded ORM user.
+            # The conversation fallback preserves direct/internal callers that
+            # predate the shared caller context.
+            user = conversation.user if conversation and not caller else None
+            caller_has_scope = caller is not None and "organization_id" in caller
 
             execution_response = await execute_agent_workflow_tool(
                 workflow_id=resolved_workflow_id,
                 workflow_name=resolved_workflow_name,
                 parameters=tool_call.arguments or {},
                 caller=AgentWorkflowCaller(
-                    user_id=str(user.id) if user else "system",
-                    email=user.email if user else "system@internal.gobifrost.com",
-                    name=user.name if user else "System",
+                    user_id=(
+                        str(caller.get("user_id"))
+                        if caller and caller.get("user_id")
+                        else str(user.id) if user else "system"
+                    ),
+                    email=(
+                        str(caller.get("email"))
+                        if caller and caller.get("email")
+                        else user.email if user else "system@internal.gobifrost.com"
+                    ),
+                    name=(
+                        str(caller.get("name"))
+                        if caller and caller.get("name")
+                        else user.name if user else "System"
+                    ),
                     organization_id=(
-                        user.organization_id
-                        if user
+                        caller.get("organization_id")
+                        if caller_has_scope and caller
+                        else user.organization_id
+                        if user is not None
                         else agent.organization_id if agent else None
                     ),
-                    is_platform_admin=user.is_superuser if user else False,
+                    is_platform_admin=(
+                        bool(caller.get("is_platform_admin", False))
+                        if caller
+                        else user.is_superuser if user else False
+                    ),
                 ),
                 execution_id=execution_id,
                 artifact_workspace_id=str(conversation.id) if conversation else None,

--- a/api/src/services/agent_executor.py
+++ b/api/src/services/agent_executor.py
@@ -1364,9 +1364,6 @@ class AgentExecutor:
             # Get user info from conversation
             user = conversation.user if conversation else None
 
-            # Get org_id from agent (workflows are not org-scoped)
-            org_id = str(agent.organization_id) if agent and agent.organization_id else None
-
             execution_response = await execute_agent_workflow_tool(
                 workflow_id=resolved_workflow_id,
                 workflow_name=resolved_workflow_name,
@@ -1375,9 +1372,13 @@ class AgentExecutor:
                     user_id=str(user.id) if user else "system",
                     email=user.email if user else "system@internal.gobifrost.com",
                     name=user.name if user else "System",
+                    organization_id=(
+                        user.organization_id
+                        if user
+                        else agent.organization_id if agent else None
+                    ),
                     is_platform_admin=user.is_superuser if user else False,
                 ),
-                organization_id=org_id,
                 execution_id=execution_id,
                 artifact_workspace_id=str(conversation.id) if conversation else None,
             )
@@ -1823,7 +1824,13 @@ class AgentExecutor:
             # via get_tool_db() fallback, avoiding long-lived connection holds
             context = MCPContext(
                 user_id=str(user.id) if user else "",
-                org_id=str(agent.organization_id) if agent.organization_id else None,
+                org_id=(
+                    str(user.organization_id)
+                    if user and user.organization_id
+                    else str(agent.organization_id)
+                    if not user and agent.organization_id
+                    else None
+                ),
                 is_platform_admin=user.is_superuser if user else False,
                 user_email=user.email if user else "",
                 user_name=user.name if user else "",

--- a/api/src/services/agent_router.py
+++ b/api/src/services/agent_router.py
@@ -14,7 +14,6 @@ from uuid import UUID
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from src.core.log_safety import log_safe
-from src.core.org_filter import OrgFilterType
 from src.models.orm import Agent
 from src.repositories.agents import AgentRepository
 from src.services.llm import get_llm_client, LLMMessage
@@ -43,13 +42,11 @@ class AgentRouter:
         *,
         user_id: UUID | None = None,
         org_id: UUID | None = None,
-        is_superuser: bool = False,
         is_external: bool = False,
     ):
         self._session_factory = session_factory
         self._user_id = user_id
         self._org_id = org_id
-        self._is_superuser = is_superuser
         self._is_external = is_external
 
     @asynccontextmanager
@@ -213,14 +210,9 @@ Your response (agent name or DIRECT):"""
                 session=session,
                 org_id=self._org_id,
                 user_id=self._user_id,
-                is_superuser=self._is_superuser,
+                is_superuser=False,
                 is_external=self._is_external,
             )
-            if self._is_superuser:
-                return await repo.list_all_in_scope(
-                    filter_type=OrgFilterType.ALL,
-                    active_only=True,
-                )
             return await repo.list_agents(active_only=True)
 
     def strip_mention(self, message: str) -> str:

--- a/api/src/services/execution/agent_workflow_tools.py
+++ b/api/src/services/execution/agent_workflow_tools.py
@@ -14,6 +14,7 @@ class AgentWorkflowCaller:
     user_id: str
     email: str
     name: str
+    organization_id: UUID | str | None
     is_platform_admin: bool = False
 
 
@@ -23,7 +24,6 @@ async def execute_agent_workflow_tool(
     workflow_name: str,
     parameters: dict[str, Any],
     caller: AgentWorkflowCaller,
-    organization_id: UUID | str | None,
     execution_id: str | None = None,
     artifact_workspace_id: str | None = None,
     sync: bool = True,
@@ -38,7 +38,7 @@ async def execute_agent_workflow_tool(
         user_id=caller.user_id,
         user_email=caller.email,
         user_name=caller.name,
-        org_id=str(organization_id) if organization_id else None,
+        org_id=str(caller.organization_id) if caller.organization_id else None,
         is_platform_admin=caller.is_platform_admin,
         is_agent=True,
         execution_id=execution_id,

--- a/api/src/services/execution/autonomous_agent_executor.py
+++ b/api/src/services/execution/autonomous_agent_executor.py
@@ -510,6 +510,15 @@ class AutonomousAgentExecutor:
     # Tool dispatch
     # ------------------------------------------------------------------
 
+    def _execution_org_id(self, agent: Agent) -> UUID | None:
+        """Use authenticated caller scope, or agent scope for autonomous runs."""
+        if self._caller_user_id is not None:
+            raw_org_id = self._caller.get("organization_id") if self._caller else None
+            if raw_org_id is None:
+                return None
+            return UUID(str(raw_org_id))
+        return agent.organization_id
+
     async def _execute_tool(self, tool_call: ToolCallRequest, agent: Agent) -> str:
         """Execute a tool call, mirroring AgentExecutor's dispatch logic."""
         # Knowledge search
@@ -569,13 +578,13 @@ class AutonomousAgentExecutor:
                     and self._caller.get("name")
                     else agent.name
                 ),
+                organization_id=self._execution_org_id(agent),
                 is_platform_admin=(
                     bool(self._caller.get("is_platform_admin", False))
                     if self._caller_user_id and self._caller
                     else False
                 ),
             ),
-            organization_id=agent.organization_id,
             artifact_workspace_id=(
                 self._ancestor_run_ids[0]
                 if self._ancestor_run_ids
@@ -1067,7 +1076,11 @@ class AutonomousAgentExecutor:
                         if self._caller_user_id
                         else SYSTEM_USER_ID
                     ),
-                    org_id=str(agent.organization_id) if agent.organization_id else None,
+                    org_id=(
+                        str(execution_org_id)
+                        if (execution_org_id := self._execution_org_id(agent))
+                        else None
+                    ),
                     is_platform_admin=(
                         bool(self._caller.get("is_platform_admin", False))
                         if self._caller_user_id and self._caller

--- a/api/src/services/mcp_server/auth.py
+++ b/api/src/services/mcp_server/auth.py
@@ -630,6 +630,7 @@ class BifrostAuthProvider:
                 "email": payload.get("email"),
                 "name": payload.get("name"),
                 "is_superuser": payload.get("is_superuser", False),
+                "is_provider_org": payload.get("is_provider_org", False),
                 "is_external": payload.get("is_external", False),
                 "org_id": payload.get("org_id"),
                 "roles": role_names,  # Role names for MCP tool filtering

--- a/api/src/services/mcp_server/gateway.py
+++ b/api/src/services/mcp_server/gateway.py
@@ -18,7 +18,6 @@ from sqlalchemy import select
 from sqlalchemy.orm import selectinload
 
 from shared.scope_resolver import has_scope_bypass
-from src.core.org_filter import OrgFilterType
 from src.models.orm.agents import Agent
 from src.models.orm.agent_runs import AgentRun
 from src.models.orm.executions import Execution
@@ -260,12 +259,13 @@ class MCPAgentGatewayService:
         from src.core.database import get_db_context
 
         async with get_db_context() as db:
-            repo = self._agent_repo(db)
-            if self._has_scope_bypass:
-                return await repo.list_all_in_scope(
-                    OrgFilterType.ALL,
-                    active_only=True,
-                )
+            repo = AgentRepository(
+                db,
+                org_id=self.context.org_id,
+                user_id=self.context.user_id,
+                is_superuser=False,
+                is_external=self.context.is_external,
+            )
             return await repo.list_agents(active_only=True)
 
     async def accessible_agent_count(self) -> int:

--- a/api/src/services/mcp_server/gateway.py
+++ b/api/src/services/mcp_server/gateway.py
@@ -17,6 +17,7 @@ from jsonschema.validators import validator_for
 from sqlalchemy import select
 from sqlalchemy.orm import selectinload
 
+from shared.scope_resolver import has_scope_bypass
 from src.core.org_filter import OrgFilterType
 from src.models.orm.agents import Agent
 from src.models.orm.agent_runs import AgentRun
@@ -241,7 +242,10 @@ class MCPAgentGatewayService:
 
     @property
     def _has_scope_bypass(self) -> bool:
-        return self.context.is_platform_admin or self.context.is_provider_org
+        return has_scope_bypass(
+            is_platform_admin=self.context.is_platform_admin,
+            is_provider_org=self.context.is_provider_org,
+        )
 
     def _agent_repo(self, session: Any) -> AgentRepository:
         return AgentRepository(

--- a/api/src/services/mcp_server/gateway.py
+++ b/api/src/services/mcp_server/gateway.py
@@ -18,6 +18,7 @@ from sqlalchemy import select
 from sqlalchemy.orm import selectinload
 
 from shared.scope_resolver import has_scope_bypass
+from src.core.org_filter import OrgFilterType
 from src.models.orm.agents import Agent
 from src.models.orm.agent_runs import AgentRun
 from src.models.orm.executions import Execution
@@ -58,6 +59,7 @@ GatewayToolSource = Literal[
     "delegation",
     "external_mcp",
 ]
+DiscoveryScope = Literal["accessible", "all"]
 
 
 class GatewayError(Exception):
@@ -255,6 +257,13 @@ class MCPAgentGatewayService:
             is_external=self.context.is_external,
         )
 
+    def _authorize_discovery_scope(self, discovery_scope: DiscoveryScope) -> None:
+        if discovery_scope == "all" and not self._has_scope_bypass:
+            raise GatewayError(
+                "IMPERSONATION_FORBIDDEN",
+                "Cross-organization discovery requires platform/provider impersonation authority.",
+            )
+
     async def _list_accessible_agents(self) -> list[Agent]:
         from src.core.database import get_db_context
 
@@ -268,6 +277,21 @@ class MCPAgentGatewayService:
             )
             return await repo.list_agents(active_only=True)
 
+    async def _list_discovery_agents(
+        self, discovery_scope: DiscoveryScope
+    ) -> list[Agent]:
+        self._authorize_discovery_scope(discovery_scope)
+        if discovery_scope == "accessible":
+            return await self._list_accessible_agents()
+
+        from src.core.database import get_db_context
+
+        async with get_db_context() as db:
+            return await self._agent_repo(db).list_all_in_scope(
+                OrgFilterType.ALL,
+                active_only=True,
+            )
+
     async def accessible_agent_count(self) -> int:
         """Return the caller's live accessible-agent count."""
         return len(await self._list_accessible_agents())
@@ -278,9 +302,11 @@ class MCPAgentGatewayService:
         query: str | None = None,
         agent_id: str | None = None,
         tool_ref: str | None = None,
+        discovery_scope: DiscoveryScope = "accessible",
         limit: int = 10,
     ) -> dict[str, Any]:
         """Search agents and tools, then progressively hydrate one selection."""
+        self._authorize_discovery_scope(discovery_scope)
         bounded_limit = min(max(limit, 1), MAX_CAPABILITY_RESULTS)
         if agent_id is not None:
             snapshot = await self.get_agent_snapshot(agent_id)
@@ -300,7 +326,7 @@ class MCPAgentGatewayService:
             )
 
         snapshots: list[AgentToolSnapshot] = []
-        for agent in await self._list_accessible_agents():
+        for agent in await self._list_discovery_agents(discovery_scope):
             snapshots.append(await self.get_agent_snapshot(str(agent.id)))
 
         candidates: list[tuple[int, str, AgentToolSnapshot, ResolvedGatewayTool | None]] = []

--- a/api/src/services/mcp_server/gateway.py
+++ b/api/src/services/mcp_server/gateway.py
@@ -239,12 +239,16 @@ class MCPAgentGatewayService:
     def __init__(self, context: MCPContext):
         self.context = context
 
+    @property
+    def _has_scope_bypass(self) -> bool:
+        return self.context.is_platform_admin or self.context.is_provider_org
+
     def _agent_repo(self, session: Any) -> AgentRepository:
         return AgentRepository(
             session,
             org_id=self.context.org_id,
             user_id=self.context.user_id,
-            is_superuser=self.context.is_platform_admin,
+            is_superuser=self._has_scope_bypass,
             is_external=self.context.is_external,
         )
 
@@ -253,7 +257,7 @@ class MCPAgentGatewayService:
 
         async with get_db_context() as db:
             repo = self._agent_repo(db)
-            if self.context.is_platform_admin:
+            if self._has_scope_bypass:
                 return await repo.list_all_in_scope(
                     OrgFilterType.ALL,
                     active_only=True,
@@ -1174,6 +1178,7 @@ class MCPAgentGatewayService:
             user_id=self.context.user_id,
             org_id=self.context.org_id,
             is_platform_admin=self.context.is_platform_admin,
+            is_provider_org=self.context.is_provider_org,
             is_external=self.context.is_external,
             user_email=self.context.user_email,
             user_name=self.context.user_name,
@@ -1215,9 +1220,9 @@ class MCPAgentGatewayService:
                 user_id=str(self.context.user_id),
                 email=self.context.user_email,
                 name=self.context.user_name or "MCP User",
+                organization_id=self.context.org_id,
                 is_platform_admin=self.context.is_platform_admin,
             ),
-            organization_id=self.context.org_id,
             sync=not async_execution,
         )
         data = {

--- a/api/src/services/mcp_server/middleware.py
+++ b/api/src/services/mcp_server/middleware.py
@@ -80,6 +80,7 @@ class ToolFilterMiddleware(Middleware):
 
         user_roles = token.claims.get("roles", [])
         is_superuser = token.claims.get("is_superuser", False)
+        is_provider_org = token.claims.get("is_provider_org", False)
         is_external = token.claims.get("is_external", False)
         user_id = token.claims.get("user_id")
         org_id = token.claims.get("org_id")
@@ -100,6 +101,7 @@ class ToolFilterMiddleware(Middleware):
                     agent_id=agent_id,
                     user_roles=user_roles,
                     is_superuser=is_superuser,
+                    is_provider_org=is_provider_org,
                     user_id=user_id,
                     org_id=org_id,
                     is_external=is_external,
@@ -180,6 +182,7 @@ class ToolFilterMiddleware(Middleware):
 
         user_roles = token.claims.get("roles", [])
         is_superuser = token.claims.get("is_superuser", False)
+        is_provider_org = token.claims.get("is_provider_org", False)
         is_external = token.claims.get("is_external", False)
         user_id = token.claims.get("user_id")
         org_id = token.claims.get("org_id")
@@ -196,6 +199,7 @@ class ToolFilterMiddleware(Middleware):
                     agent_id=agent_id,
                     user_roles=user_roles,
                     is_superuser=is_superuser,
+                    is_provider_org=is_provider_org,
                     user_id=user_id,
                     org_id=org_id,
                     is_external=is_external,

--- a/api/src/services/mcp_server/server.py
+++ b/api/src/services/mcp_server/server.py
@@ -133,6 +133,7 @@ class MCPContext:
     user_id: UUID | str
     org_id: UUID | str | None = None
     is_platform_admin: bool = False
+    is_provider_org: bool = False
     # External (portal/guest) principal — no global tier, no authenticated-
     # tier entitlement. Mirrors UserPrincipal.is_external (the claim is
     # already bypass-neutralized at token mint).
@@ -186,6 +187,7 @@ def _get_context_from_token() -> MCPContext:
         user_id=token.claims.get("user_id", ""),
         org_id=token.claims.get("org_id"),
         is_platform_admin=token.claims.get("is_superuser", False),
+        is_provider_org=token.claims.get("is_provider_org", False),
         is_external=token.claims.get("is_external", False),
         user_email=token.claims.get("email", ""),
         user_name=token.claims.get("name", ""),
@@ -216,6 +218,7 @@ async def _get_runtime_context() -> MCPContext:
 
     user_roles = token.claims.get("roles", [])
     is_superuser = token.claims.get("is_superuser", False)
+    is_provider_org = token.claims.get("is_provider_org", False)
     is_external = token.claims.get("is_external", False)
     user_id = token.claims.get("user_id")
     org_id = token.claims.get("org_id")
@@ -230,6 +233,7 @@ async def _get_runtime_context() -> MCPContext:
                     agent_id=agent_id,
                     user_roles=user_roles,
                     is_superuser=is_superuser,
+                    is_provider_org=is_provider_org,
                     user_id=user_id,
                     org_id=org_id,
                     is_external=is_external,
@@ -243,6 +247,7 @@ async def _get_runtime_context() -> MCPContext:
         user_id=token.claims.get("user_id", ""),
         org_id=token.claims.get("org_id"),
         is_platform_admin=is_superuser,
+        is_provider_org=is_provider_org,
         is_external=is_external,
         user_email=token.claims.get("email", ""),
         user_name=token.claims.get("name", ""),

--- a/api/src/services/mcp_server/server.py
+++ b/api/src/services/mcp_server/server.py
@@ -23,6 +23,8 @@ from uuid import UUID
 
 from fastmcp.tools import ToolResult
 
+from shared.scope_resolver import has_scope_bypass
+
 if TYPE_CHECKING:
     from fastmcp import FastMCP
 
@@ -155,6 +157,14 @@ class MCPContext:
             self.user_id = UUID(self.user_id)
         if isinstance(self.org_id, str) and self.org_id:
             self.org_id = UUID(self.org_id)
+
+    @property
+    def has_scope_bypass(self) -> bool:
+        """Whether this caller may cross organization scope boundaries."""
+        return has_scope_bypass(
+            is_platform_admin=self.is_platform_admin,
+            is_provider_org=self.is_provider_org,
+        )
 
 
 # =============================================================================
@@ -706,7 +716,7 @@ async def _execute_workflow_tool_impl(
                 db,
                 org_id=context.org_id,
                 user_id=context.user_id,
-                is_superuser=context.is_platform_admin,
+                is_superuser=context.has_scope_bypass,
                 is_external=context.is_external,
             )
             workflow = await repo.get(id=workflow_id)

--- a/api/src/services/mcp_server/tool_access.py
+++ b/api/src/services/mcp_server/tool_access.py
@@ -62,8 +62,6 @@ class MCPToolAccessService:
     async def get_accessible_tools(
         self,
         user_roles: list[str],
-        is_superuser: bool,
-        is_provider_org: bool = False,
         user_id: UUID | str | None = None,
         org_id: UUID | str | None = None,
         is_external: bool = False,
@@ -78,28 +76,21 @@ class MCPToolAccessService:
 
         Args:
             user_roles: List of role names the user has (from JWT claims)
-            is_superuser: Whether user is platform admin
-            is_provider_org: Whether the caller belongs to the platform/provider org
             user_id: User UUID for per-workflow role check (from JWT claims).
-                Required for non-superusers — without it, role-based workflows
+                Required — without it, role-based workflows
                 fall back to "deny" because role membership cannot be checked.
             org_id: User's organization UUID for per-workflow org scope check
-                (from JWT claims). Required for non-superusers — without it,
+                (from JWT claims). Without it,
                 org-scoped workflows fall back to "deny" because the in-scope
                 check cannot evaluate.
 
         Returns:
             MCPToolAccessResult containing the filtered tool inventory
         """
-        scope_bypass = has_scope_bypass(
-            is_platform_admin=is_superuser,
-            is_provider_org=is_provider_org,
-        )
-
         # Step 1: Get accessible agents
         accessible_agents = await self._get_accessible_agents(
             user_roles=user_roles,
-            is_superuser=scope_bypass,
+            is_superuser=False,
             is_external=is_external,
             org_id=org_id,
         )
@@ -109,7 +100,7 @@ class MCPToolAccessService:
         tools: list[ToolInfo] = []
         seen_tool_ids: set[str] = set()  # Deduplicate across agents
         workflow_repo = self._build_workflow_repo(
-            user_id=user_id, org_id=org_id, is_superuser=scope_bypass,
+            user_id=user_id, org_id=org_id, is_superuser=False,
             is_external=is_external,
         )
 

--- a/api/src/services/mcp_server/tool_access.py
+++ b/api/src/services/mcp_server/tool_access.py
@@ -62,6 +62,7 @@ class MCPToolAccessService:
     async def get_accessible_tools(
         self,
         user_roles: list[str],
+        is_superuser: bool = False,
         user_id: UUID | str | None = None,
         org_id: UUID | str | None = None,
         is_external: bool = False,
@@ -76,11 +77,15 @@ class MCPToolAccessService:
 
         Args:
             user_roles: List of role names the user has (from JWT claims)
+            is_superuser: Whether the caller is a platform administrator. This
+                is used by the REST settings inventory, not ordinary MCP
+                discovery, so administrators can configure the global MCP
+                allow/block lists without changing their normal tool surface.
             user_id: User UUID for per-workflow role check (from JWT claims).
-                Required — without it, role-based workflows
+                Required for non-superusers — without it, role-based workflows
                 fall back to "deny" because role membership cannot be checked.
             org_id: User's organization UUID for per-workflow org scope check
-                (from JWT claims). Without it,
+                (from JWT claims). Required for non-superusers — without it,
                 org-scoped workflows fall back to "deny" because the in-scope
                 check cannot evaluate.
 
@@ -90,7 +95,7 @@ class MCPToolAccessService:
         # Step 1: Get accessible agents
         accessible_agents = await self._get_accessible_agents(
             user_roles=user_roles,
-            is_superuser=False,
+            is_superuser=is_superuser,
             is_external=is_external,
             org_id=org_id,
         )
@@ -100,7 +105,7 @@ class MCPToolAccessService:
         tools: list[ToolInfo] = []
         seen_tool_ids: set[str] = set()  # Deduplicate across agents
         workflow_repo = self._build_workflow_repo(
-            user_id=user_id, org_id=org_id, is_superuser=False,
+            user_id=user_id, org_id=org_id, is_superuser=is_superuser,
             is_external=is_external,
         )
 

--- a/api/src/services/mcp_server/tool_access.py
+++ b/api/src/services/mcp_server/tool_access.py
@@ -13,6 +13,7 @@ from sqlalchemy import or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
+from shared.scope_resolver import has_scope_bypass
 from src.models.contracts.agents import ToolInfo
 from src.models.enums import AgentAccessLevel
 from src.models.orm.agents import Agent
@@ -90,12 +91,15 @@ class MCPToolAccessService:
         Returns:
             MCPToolAccessResult containing the filtered tool inventory
         """
-        has_scope_bypass = is_superuser or is_provider_org
+        scope_bypass = has_scope_bypass(
+            is_platform_admin=is_superuser,
+            is_provider_org=is_provider_org,
+        )
 
         # Step 1: Get accessible agents
         accessible_agents = await self._get_accessible_agents(
             user_roles=user_roles,
-            is_superuser=has_scope_bypass,
+            is_superuser=scope_bypass,
             is_external=is_external,
             org_id=org_id,
         )
@@ -105,7 +109,7 @@ class MCPToolAccessService:
         tools: list[ToolInfo] = []
         seen_tool_ids: set[str] = set()  # Deduplicate across agents
         workflow_repo = self._build_workflow_repo(
-            user_id=user_id, org_id=org_id, is_superuser=has_scope_bypass,
+            user_id=user_id, org_id=org_id, is_superuser=scope_bypass,
             is_external=is_external,
         )
 
@@ -175,7 +179,10 @@ class MCPToolAccessService:
         Returns:
             AgentScopedToolResult if agent exists and user has access, None otherwise
         """
-        has_scope_bypass = is_superuser or is_provider_org
+        scope_bypass = has_scope_bypass(
+            is_platform_admin=is_superuser,
+            is_provider_org=is_provider_org,
+        )
 
         # Query the specific agent with tools and roles eagerly loaded.
         # Org-scope IN THE DATABASE (LEAK #2): a by-id fetch must not reach an
@@ -191,7 +198,7 @@ class MCPToolAccessService:
             .where(Agent.is_active.is_(True))
         )
 
-        if not has_scope_bypass:
+        if not scope_bypass:
             scope_org = UUID(org_id) if isinstance(org_id, str) and org_id else org_id
             if scope_org is not None:
                 query = query.where(
@@ -212,7 +219,7 @@ class MCPToolAccessService:
 
         # Check access using same rules as _get_accessible_agents
         if not self._check_agent_access(
-            agent, user_roles, has_scope_bypass, is_external
+            agent, user_roles, scope_bypass, is_external
         ):
             logger.warning(f"User denied access to agent {agent_id}")
             return None
@@ -238,7 +245,7 @@ class MCPToolAccessService:
         # the executor). seen_tool_ids is fresh because this is an
         # agent-scoped call: no cross-agent dedup needed.
         workflow_repo = self._build_workflow_repo(
-            user_id=user_id, org_id=org_id, is_superuser=has_scope_bypass,
+            user_id=user_id, org_id=org_id, is_superuser=scope_bypass,
             is_external=is_external,
         )
         for workflow_info in await self._visible_workflows_for_agent(

--- a/api/src/services/mcp_server/tool_access.py
+++ b/api/src/services/mcp_server/tool_access.py
@@ -62,6 +62,7 @@ class MCPToolAccessService:
         self,
         user_roles: list[str],
         is_superuser: bool,
+        is_provider_org: bool = False,
         user_id: UUID | str | None = None,
         org_id: UUID | str | None = None,
         is_external: bool = False,
@@ -77,6 +78,7 @@ class MCPToolAccessService:
         Args:
             user_roles: List of role names the user has (from JWT claims)
             is_superuser: Whether user is platform admin
+            is_provider_org: Whether the caller belongs to the platform/provider org
             user_id: User UUID for per-workflow role check (from JWT claims).
                 Required for non-superusers — without it, role-based workflows
                 fall back to "deny" because role membership cannot be checked.
@@ -88,10 +90,12 @@ class MCPToolAccessService:
         Returns:
             MCPToolAccessResult containing the filtered tool inventory
         """
+        has_scope_bypass = is_superuser or is_provider_org
+
         # Step 1: Get accessible agents
         accessible_agents = await self._get_accessible_agents(
             user_roles=user_roles,
-            is_superuser=is_superuser,
+            is_superuser=has_scope_bypass,
             is_external=is_external,
             org_id=org_id,
         )
@@ -101,7 +105,7 @@ class MCPToolAccessService:
         tools: list[ToolInfo] = []
         seen_tool_ids: set[str] = set()  # Deduplicate across agents
         workflow_repo = self._build_workflow_repo(
-            user_id=user_id, org_id=org_id, is_superuser=is_superuser,
+            user_id=user_id, org_id=org_id, is_superuser=has_scope_bypass,
             is_external=is_external,
         )
 
@@ -148,6 +152,7 @@ class MCPToolAccessService:
         agent_id: UUID | str,
         user_roles: list[str],
         is_superuser: bool,
+        is_provider_org: bool = False,
         user_id: UUID | str | None = None,
         org_id: UUID | str | None = None,
         is_external: bool = False,
@@ -163,12 +168,15 @@ class MCPToolAccessService:
             agent_id: The agent UUID to scope to
             user_roles: List of role names the user has (from JWT claims)
             is_superuser: Whether user is platform admin
+            is_provider_org: Whether the caller belongs to the platform/provider org
             user_id: User UUID for per-workflow role check (from JWT claims).
             org_id: User's org UUID for per-workflow org scope check (from claims).
 
         Returns:
             AgentScopedToolResult if agent exists and user has access, None otherwise
         """
+        has_scope_bypass = is_superuser or is_provider_org
+
         # Query the specific agent with tools and roles eagerly loaded.
         # Org-scope IN THE DATABASE (LEAK #2): a by-id fetch must not reach an
         # agent outside the caller's org cascade — otherwise a role_based agent
@@ -183,7 +191,7 @@ class MCPToolAccessService:
             .where(Agent.is_active.is_(True))
         )
 
-        if not is_superuser:
+        if not has_scope_bypass:
             scope_org = UUID(org_id) if isinstance(org_id, str) and org_id else org_id
             if scope_org is not None:
                 query = query.where(
@@ -203,7 +211,9 @@ class MCPToolAccessService:
             return None
 
         # Check access using same rules as _get_accessible_agents
-        if not self._check_agent_access(agent, user_roles, is_superuser, is_external):
+        if not self._check_agent_access(
+            agent, user_roles, has_scope_bypass, is_external
+        ):
             logger.warning(f"User denied access to agent {agent_id}")
             return None
 
@@ -228,7 +238,7 @@ class MCPToolAccessService:
         # the executor). seen_tool_ids is fresh because this is an
         # agent-scoped call: no cross-agent dedup needed.
         workflow_repo = self._build_workflow_repo(
-            user_id=user_id, org_id=org_id, is_superuser=is_superuser,
+            user_id=user_id, org_id=org_id, is_superuser=has_scope_bypass,
             is_external=is_external,
         )
         for workflow_info in await self._visible_workflows_for_agent(

--- a/api/src/services/mcp_server/tools/_http_bridge.py
+++ b/api/src/services/mcp_server/tools/_http_bridge.py
@@ -77,6 +77,7 @@ def _token_from_context(context: "MCPContext") -> str:
         "email": context.user_email or "",
         "name": context.user_name or "",
         "is_superuser": bool(context.is_platform_admin),
+        "is_provider_org": bool(getattr(context, "is_provider_org", False)),
         # OPEN-F: carry is_external from the MCP context. The real user-token
         # mints (mcp_server/auth.py) stamp this via resolve_external_claim;
         # this fallback mint (executor / test contexts) is the one site that

--- a/api/src/services/mcp_server/tools/_org_scope.py
+++ b/api/src/services/mcp_server/tools/_org_scope.py
@@ -16,6 +16,8 @@ from uuid import UUID
 
 from sqlalchemy import Select, or_
 
+from shared.scope_resolver import has_scope_bypass
+
 
 def apply_mcp_org_scope(
     query: Select[Any],
@@ -26,16 +28,19 @@ def apply_mcp_org_scope(
 
     Rules (mirrors ``OrgScopedRepository`` / ``resolve_org_filter``):
 
-    - Platform admin (``context.is_platform_admin``): no filter — full visibility.
+    - Platform admin or provider-org caller: no filter — full visibility.
     - Org user: cascade — own org OR global.
     - Non-admin with no org: global only (legacy behavior).
 
     Args:
         query: The SELECT to scope.
         model: The ORM model being filtered (must have ``organization_id``).
-        context: The MCP context carrying ``is_platform_admin`` and ``org_id``.
+        context: The MCP context carrying principal flags and ``org_id``.
     """
-    if getattr(context, "is_platform_admin", False):
+    if has_scope_bypass(
+        is_platform_admin=getattr(context, "is_platform_admin", False),
+        is_provider_org=getattr(context, "is_provider_org", False),
+    ):
         return query
 
     org_id = getattr(context, "org_id", None)

--- a/api/src/services/mcp_server/tools/agents.py
+++ b/api/src/services/mcp_server/tools/agents.py
@@ -72,15 +72,12 @@ async def get_agent_schema(context: Any) -> ToolResult:  # noqa: ARG001
 
 async def list_agents(context: Any) -> ToolResult:
     """List all agents."""
-    from src.core.org_filter import OrgFilterType
     from src.repositories.agents import AgentRepository
 
     logger.info("MCP list_agents called")
 
     try:
         async with get_tool_db(context) as db:
-            # Determine org_id and admin status based on context
-            is_admin = context.is_platform_admin
             if context.org_id:
                 org_id = UUID(str(context.org_id)) if isinstance(context.org_id, str) else context.org_id
             else:
@@ -95,16 +92,10 @@ async def list_agents(context: Any) -> ToolResult:
                 session=db,
                 org_id=org_id,
                 user_id=user_id,
-                is_superuser=is_admin,
+                is_superuser=False,
                 is_external=context.is_external,
             )
-
-            if is_admin:
-                # Platform admins see all agents using list_all_in_scope
-                agents = await repo.list_all_in_scope(OrgFilterType.ALL, active_only=True)
-            else:
-                # Regular users use list_agents with built-in cascade + role-based access
-                agents = await repo.list_agents(active_only=True)
+            agents = await repo.list_agents(active_only=True)
 
             agents_data = [
                 {

--- a/api/src/services/mcp_server/tools/gateway.py
+++ b/api/src/services/mcp_server/tools/gateway.py
@@ -1,6 +1,6 @@
 """Stable progressive-discovery tools exposed by the unscoped MCP endpoint."""
 
-from typing import Annotated, Any
+from typing import Annotated, Any, Literal
 
 from fastmcp.tools import ToolResult
 from pydantic import Field
@@ -26,6 +26,10 @@ catalog. Read total_tools, returned_tools, complete, and has_more_matches. When
 complete is false—or when no matching tool is returned—assume more tools may
 exist and search again with the same agent_id plus a different or narrower
 query. Do not conclude that a capability is absent from a partial result.
+Use discovery_scope='all' only when the user explicitly requests discovery
+across organizations or otherwise inaccessible agents. This requires
+platform/provider impersonation authority; never select it merely because the
+caller may be an administrator.
 
 After selecting an agent, call bifrost_search_capabilities again with agent_id
 to load its live instructions. Follow those instructions as task-specific
@@ -58,6 +62,16 @@ async def bifrost_search_capabilities(
     query: str | None = None,
     agent_id: str | None = None,
     tool_ref: str | None = None,
+    discovery_scope: Annotated[
+        Literal["accessible", "all"],
+        Field(
+            description=(
+                "Use 'accessible' for normal organization and role discovery. "
+                "Use 'all' only when the user explicitly requests cross-organization "
+                "discovery; it requires platform/provider impersonation authority."
+            )
+        ),
+    ] = "accessible",
     limit: int = 10,
 ) -> ToolResult:
     """Search live agents and tools, or hydrate one selected capability."""
@@ -69,6 +83,7 @@ async def bifrost_search_capabilities(
             "query": query,
             "agent_id": agent_id,
             "tool_ref": tool_ref,
+            "discovery_scope": discovery_scope,
             "limit": limit,
         },
     )
@@ -216,7 +231,9 @@ TOOLS = [
         "Search Bifrost Capabilities",
         "Search accessible agents and tools through one bounded, progressive "
         "surface. Results explicitly disclose omitted tools. Reuse this tool with "
-        "agent_id to load instructions and tool_ref to load one exact schema.",
+        "agent_id to load instructions and tool_ref to load one exact schema. "
+        "Impersonation-capable callers may explicitly set discovery_scope='all' "
+        "to search across organizations.",
     ),
     (
         "bifrost_execute_tool",

--- a/api/src/services/mcp_server/tools/workflow.py
+++ b/api/src/services/mcp_server/tools/workflow.py
@@ -60,7 +60,7 @@ async def execute_workflow(
                 db,
                 org_id=ctx_org_id,
                 user_id=ctx_user_id,
-                is_superuser=context.is_platform_admin,
+                is_superuser=context.has_scope_bypass,
                 is_external=context.is_external,
             )
             workflow = await repo.resolve(workflow_id)
@@ -122,7 +122,7 @@ async def list_workflows(
                 db,
                 org_id=ctx_org_id,
                 user_id=ctx_user_id,
-                is_superuser=context.is_platform_admin,
+                is_superuser=context.has_scope_bypass,
                 is_external=context.is_external,
             )
             workflows = await repo.search(query=query, category=category, limit=100)
@@ -270,7 +270,7 @@ async def get_workflow(
                 db,
                 org_id=ctx_org_id,
                 user_id=ctx_user_id,
-                is_superuser=context.is_platform_admin,
+                is_superuser=context.has_scope_bypass,
                 is_external=context.is_external,
             )
 

--- a/api/tests/e2e/api-integration/test_mcp_gateway.py
+++ b/api/tests/e2e/api-integration/test_mcp_gateway.py
@@ -326,7 +326,7 @@ class TestMCPAgentGateway:
         found = _call_gateway(
             self.token,
             "bifrost_search_capabilities",
-            {"query": self.agent_name},
+            {"query": self.agent_name, "discovery_scope": "all"},
         )
         found_agent = next(
             agent for agent in found["agents"] if agent["id"] == self.agent_id

--- a/api/tests/e2e/api/test_agent_workflow_tool_execution.py
+++ b/api/tests/e2e/api/test_agent_workflow_tool_execution.py
@@ -16,11 +16,14 @@ from pydantic_ai.messages import (
 from pydantic_ai.models import ModelRequestParameters
 from pydantic_ai.models.test import TestModel
 from pydantic_ai.settings import ModelSettings
-from sqlalchemy import select
+from sqlalchemy import select, update
 from sqlalchemy.orm import selectinload
 
 from src.core.principal import UserPrincipal
+from src.models.enums import AgentAccessLevel
 from src.models.orm.agents import Agent, Conversation
+from src.models.orm.executions import Execution
+from src.models.orm.workflows import Workflow
 from src.services.agent_executor import AgentExecutor
 from src.services.llm.base import LLMConfig
 from src.services.llm.pydantic_client import PydanticAIClient
@@ -76,12 +79,26 @@ def _session_factory_for(session):
 
 async def test_chat_executes_workflow_tool_through_live_worker(
     e2e_client,
-    platform_admin,
+    org1_user,
     db_session,
     test_agent_with_tools,
 ):
     agent_data = test_agent_with_tools["agent"]
     workflow = test_agent_with_tools["workflow"]
+    await db_session.execute(
+        update(Agent)
+        .where(Agent.id == UUID(agent_data["id"]))
+        .values(
+            access_level=AgentAccessLevel.EVERYONE,
+            organization_id=None,
+        )
+    )
+    await db_session.execute(
+        update(Workflow)
+        .where(Workflow.id == UUID(workflow["id"]))
+        .values(organization_id=None)
+    )
+    await db_session.commit()
     conversation_response = e2e_client.post(
         "/api/chat/conversations",
         json={
@@ -89,7 +106,7 @@ async def test_chat_executes_workflow_tool_through_live_worker(
             "channel": "chat",
             "title": "Workflow tool session boundary",
         },
-        headers=platform_admin.headers,
+        headers=org1_user.headers,
     )
     assert conversation_response.status_code == 201, conversation_response.text
     conversation_id = UUID(conversation_response.json()["id"])
@@ -145,13 +162,13 @@ async def test_chat_executes_workflow_tool_through_live_worker(
                 .where(Conversation.id == conversation_id)
             )
             conversation = result.scalar_one()
-            assert platform_admin.user_id is not None
+            assert org1_user.user_id is not None
             principal = UserPrincipal(
-                user_id=platform_admin.user_id,
-                email=platform_admin.email,
-                name=platform_admin.name,
-                organization_id=platform_admin.organization_id,
-                is_superuser=platform_admin.is_superuser,
+                user_id=org1_user.user_id,
+                email=org1_user.email,
+                name=org1_user.name,
+                organization_id=org1_user.organization_id,
+                is_superuser=org1_user.is_superuser,
             )
             executor = AgentExecutor(_session_factory_for(db_session))
             final_content = ""
@@ -169,7 +186,7 @@ async def test_chat_executes_workflow_tool_through_live_worker(
         assert final_content == "Workflow tool completed."
         messages_response = e2e_client.get(
             f"/api/chat/conversations/{conversation_id}/messages",
-            headers=platform_admin.headers,
+            headers=org1_user.headers,
         )
         assert messages_response.status_code == 200, messages_response.text
         tool_calls = [
@@ -180,8 +197,13 @@ async def test_chat_executes_workflow_tool_through_live_worker(
         assert len(tool_calls) == 1
         assert tool_calls[0]["tool_state"] == "completed"
         assert tool_calls[0]["tool_result"] == "result: session boundary"
+        execution_id = tool_calls[0]["execution_id"]
+        assert execution_id is not None
+        execution = await db_session.get(Execution, UUID(execution_id))
+        assert execution is not None
+        assert execution.organization_id == org1_user.organization_id
     finally:
         e2e_client.delete(
             f"/api/chat/conversations/{conversation_id}",
-            headers=platform_admin.headers,
+            headers=org1_user.headers,
         )

--- a/api/tests/e2e/api/test_agent_workflow_tool_execution.py
+++ b/api/tests/e2e/api/test_agent_workflow_tool_execution.py
@@ -1,6 +1,5 @@
-"""Live chat boundary coverage for workflow-backed agent tools."""
+"""Chat handler coverage for workflow-backed agent tools."""
 
-from contextlib import asynccontextmanager
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import UUID, uuid4
 
@@ -16,15 +15,15 @@ from pydantic_ai.messages import (
 from pydantic_ai.models import ModelRequestParameters
 from pydantic_ai.models.test import TestModel
 from pydantic_ai.settings import ModelSettings
-from sqlalchemy import select, update
-from sqlalchemy.orm import selectinload
+from sqlalchemy import delete, update
 
 from src.core.principal import UserPrincipal
+from src.models.contracts.agents import ChatRequest
 from src.models.enums import AgentAccessLevel
-from src.models.orm.agents import Agent, Conversation
+from src.models.orm.agents import Agent
 from src.models.orm.executions import Execution
 from src.models.orm.workflows import Workflow
-from src.services.agent_executor import AgentExecutor
+from src.routers.chat import send_message
 from src.services.llm.base import LLMConfig
 from src.services.llm.pydantic_client import PydanticAIClient
 from src.services.model_capabilities import manual_capabilities
@@ -69,15 +68,7 @@ class WorkflowToolTestModel(TestModel):
         )
 
 
-def _session_factory_for(session):
-    @asynccontextmanager
-    async def session_factory():
-        yield session
-
-    return session_factory
-
-
-async def test_chat_executes_workflow_tool_through_live_worker(
+async def test_chat_handler_executes_global_agent_workflow_in_caller_org(
     e2e_client,
     org1_user,
     db_session,
@@ -124,6 +115,7 @@ async def test_chat_executes_workflow_tool_through_live_worker(
         tool_calling=True,
     )
 
+    execution_id: str | None = None
     try:
         with (
             patch(
@@ -150,18 +142,6 @@ async def test_chat_executes_workflow_tool_through_live_worker(
                 return_value=WorkflowToolTestModel(f"wf_{workflow['name']}"),
             ),
         ):
-            result = await db_session.execute(
-                select(Conversation)
-                .options(
-                    selectinload(Conversation.agent).selectinload(Agent.tools),
-                    selectinload(Conversation.agent).selectinload(
-                        Agent.delegated_agents
-                    ),
-                    selectinload(Conversation.user),
-                )
-                .where(Conversation.id == conversation_id)
-            )
-            conversation = result.scalar_one()
             assert org1_user.user_id is not None
             principal = UserPrincipal(
                 user_id=org1_user.user_id,
@@ -170,20 +150,14 @@ async def test_chat_executes_workflow_tool_through_live_worker(
                 organization_id=org1_user.organization_id,
                 is_superuser=org1_user.is_superuser,
             )
-            executor = AgentExecutor(_session_factory_for(db_session))
-            final_content = ""
-            async for chunk in executor.chat(
-                agent=conversation.agent,
-                conversation=conversation,
-                user_message="Run the workflow tool.",
-                stream=False,
-                enable_routing=False,
+            response = await send_message(
+                conversation_id=conversation_id,
+                request=ChatRequest(message="Run the workflow tool."),
+                db=db_session,
                 user=principal,
-            ):
-                if chunk.type == "done":
-                    final_content = chunk.content or ""
+            )
 
-        assert final_content == "Workflow tool completed."
+        assert response.content == "Workflow tool completed."
         messages_response = e2e_client.get(
             f"/api/chat/conversations/{conversation_id}/messages",
             headers=org1_user.headers,
@@ -203,6 +177,11 @@ async def test_chat_executes_workflow_tool_through_live_worker(
         assert execution is not None
         assert execution.organization_id == org1_user.organization_id
     finally:
+        if execution_id is not None:
+            await db_session.execute(
+                delete(Execution).where(Execution.id == UUID(execution_id))
+            )
+            await db_session.commit()
         e2e_client.delete(
             f"/api/chat/conversations/{conversation_id}",
             headers=org1_user.headers,

--- a/api/tests/e2e/api/test_agents.py
+++ b/api/tests/e2e/api/test_agents.py
@@ -358,6 +358,38 @@ class TestAgentScopeFiltering:
         assert scoped_agents["org1"]["id"] in agent_ids, "Should see org1 agent"
         assert scoped_agents["org2"]["id"] in agent_ids, "Should see org2 agent"
 
+    def test_platform_admin_chat_discovery_does_not_expand_for_admin_status(
+        self, e2e_client, platform_admin, scoped_agents
+    ):
+        """Chat discovery uses normal scope even for a platform admin."""
+        response = e2e_client.get(
+            "/api/agents",
+            params={"discovery_only": True},
+            headers=platform_admin.headers,
+        )
+        assert response.status_code == 200
+        agent_ids = {agent["id"] for agent in response.json()}
+
+        assert scoped_agents["global"]["id"] in agent_ids
+        assert scoped_agents["org1"]["id"] not in agent_ids
+        assert scoped_agents["org2"]["id"] not in agent_ids
+
+    def test_provider_chat_discovery_does_not_expand_for_impersonation(
+        self, e2e_client, provider_org_user, scoped_agents
+    ):
+        """Provider impersonation is explicit, not a discovery entitlement."""
+        response = e2e_client.get(
+            "/api/agents",
+            params={"discovery_only": True},
+            headers=provider_org_user.headers,
+        )
+        assert response.status_code == 200
+        agent_ids = {agent["id"] for agent in response.json()}
+
+        assert scoped_agents["global"]["id"] in agent_ids
+        assert scoped_agents["org1"]["id"] not in agent_ids
+        assert scoped_agents["org2"]["id"] not in agent_ids
+
     def test_platform_admin_scope_global_sees_only_global(
         self, e2e_client, platform_admin, scoped_agents
     ):
@@ -431,6 +463,18 @@ class TestAgentScopeFiltering:
         # historically returned (tools, delegated agents, roles, owner).
         assert "tools" in data or "tool_ids" in data
         assert "roles" in data or "role_ids" in data
+
+    def test_provider_user_can_explicitly_get_cross_org_agent(
+        self, e2e_client, provider_org_user, scoped_agents
+    ):
+        """An exact agent ID activates the provider caller's scope bypass."""
+        org2_agent_id = scoped_agents["org2"]["id"]
+        response = e2e_client.get(
+            f"/api/agents/{org2_agent_id}",
+            headers=provider_org_user.headers,
+        )
+        assert response.status_code == 200, response.text
+        assert response.json()["id"] == org2_agent_id
 
     def test_org_user_cannot_get_cross_org_agent(
         self, e2e_client, org1_user, scoped_agents

--- a/api/tests/e2e/api/test_chat.py
+++ b/api/tests/e2e/api/test_chat.py
@@ -483,6 +483,46 @@ class TestConversationsAccessControl:
             except Exception as cleanup_exc:
                 logger.debug(f"agent cleanup skipped: {cleanup_exc}")
 
+    def test_provider_user_can_explicitly_chat_with_cross_org_agent(
+        self,
+        e2e_client,
+        platform_admin,
+        provider_org_user,
+        org1,
+    ):
+        """An explicit chat agent selection activates provider impersonation."""
+        agent_resp = e2e_client.post(
+            "/api/agents",
+            json={
+                "name": f"Provider Explicit Target {uuid4().hex[:8]}",
+                "system_prompt": "Test only.",
+                "channels": ["chat"],
+                "access_level": "role_based",
+                "organization_id": org1["id"],
+            },
+            headers=platform_admin.headers,
+        )
+        assert agent_resp.status_code == 201, agent_resp.text
+        agent = agent_resp.json()
+
+        try:
+            response = e2e_client.post(
+                "/api/chat/conversations",
+                json={
+                    "agent_id": agent["id"],
+                    "channel": "chat",
+                    "title": "Explicit provider test",
+                },
+                headers=provider_org_user.headers,
+            )
+            assert response.status_code == 201, response.text
+            assert response.json()["agent_id"] == agent["id"]
+        finally:
+            e2e_client.delete(
+                f"/api/agents/{agent['id']}",
+                headers=platform_admin.headers,
+            )
+
 
 # =============================================================================
 # Message Tests

--- a/api/tests/e2e/mcp/test_mcp_tool_access_matrix.py
+++ b/api/tests/e2e/mcp/test_mcp_tool_access_matrix.py
@@ -291,6 +291,48 @@ def org_a_user_with_role_x(e2e_client, platform_admin, org1_user, role_x) -> Ite
 
 
 @pytest.fixture
+def customer_org_platform_admin(
+    e2e_client,
+    platform_admin,
+    org1_user,
+    refresh_user_tokens,
+) -> Iterator:
+    """Customer-org user with the named Platform Admin role, but no scope bypass.
+
+    Agent-management routes intentionally recognize this role as an admin grant.
+    Organization impersonation does not: only token superusers and provider-org
+    callers receive the canonical scope bypass.
+    """
+    role_resp = e2e_client.post(
+        "/api/roles",
+        headers=platform_admin.headers,
+        json={"name": "Platform Admin", "permissions": {}},
+    )
+    assert role_resp.status_code == 201, role_resp.text
+    role = role_resp.json()
+    grant_resp = e2e_client.post(
+        f"/api/roles/{role['id']}/users",
+        headers=platform_admin.headers,
+        json={"user_ids": [str(org1_user.user_id)]},
+    )
+    assert grant_resp.status_code in (200, 201, 204), grant_resp.text
+    refreshed_user = refresh_user_tokens(org1_user)
+
+    try:
+        yield refreshed_user
+    finally:
+        e2e_client.delete(
+            f"/api/roles/{role['id']}/users/{org1_user.user_id}",
+            headers=platform_admin.headers,
+        )
+        e2e_client.delete(
+            f"/api/roles/{role['id']}",
+            headers=platform_admin.headers,
+        )
+        refresh_user_tokens(org1_user)
+
+
+@pytest.fixture
 def org_a(org1) -> dict:
     """'Org A' in the matrix is ``org1`` — the agent's home org.
 
@@ -980,3 +1022,133 @@ class TestMcpToolAccessMatrix:
             f"workflow_org_id={workflow.get('organization_id')!r}. "
             f"Content: {content_text[:300]}"
         )
+
+    async def test_provider_org_user_can_list_and_call_cross_org_role_tool(
+        self,
+        seeded_agent_with_tools: dict[str, Any],
+        e2e_client,
+        provider_org_user,
+    ) -> None:
+        """A provider-org non-superuser receives the canonical scope bypass."""
+        agent = seeded_agent_with_tools["agent"]
+        workflow = seeded_agent_with_tools["workflows_by_key"]["org_b_role_gated"]
+        headers = {
+            "Authorization": f"Bearer {provider_org_user.access_token}",
+            "Content-Type": "application/json",
+            "Accept": "application/json, text/event-stream",
+        }
+
+        list_resp = e2e_client.post(
+            f"/mcp/{agent['id']}",
+            headers=headers,
+            json={"jsonrpc": "2.0", "id": 1, "method": "tools/list", "params": {}},
+        )
+        assert list_resp.status_code == 200, list_resp.text
+        list_payload = _parse_mcp_response(list_resp)
+        candidate_names = _candidate_tool_names_for_workflow(workflow)
+        registered_name = next(
+            (
+                tool.get("name")
+                for tool in list_payload["result"].get("tools", [])
+                if tool.get("name") in candidate_names
+            ),
+            None,
+        )
+        assert registered_name is not None, (
+            "provider-org caller did not receive cross-org role-gated tool; "
+            f"candidates={candidate_names}"
+        )
+
+        call_resp = e2e_client.post(
+            f"/mcp/{agent['id']}",
+            headers=headers,
+            json={
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "tools/call",
+                "params": {"name": registered_name, "arguments": {}},
+            },
+        )
+        assert call_resp.status_code == 200, call_resp.text
+        call_payload = _parse_mcp_response(call_resp)
+        assert "error" not in call_payload, call_payload
+        result = call_payload.get("result")
+        assert result is not None and not result.get("isError", False), call_payload
+        content_text = " ".join(
+            block.get("text", "")
+            for block in result.get("content", [])
+            if isinstance(block, dict)
+        )
+        assert "ok" in content_text, content_text
+
+    async def test_customer_org_platform_admin_cannot_list_or_call_cross_org_tool(
+        self,
+        seeded_agent_with_tools: dict[str, Any],
+        e2e_client,
+        platform_admin,
+        customer_org_platform_admin,
+    ) -> None:
+        """A named admin role outside the provider org never grants impersonation."""
+        agent = seeded_agent_with_tools["agent"]
+        workflow = seeded_agent_with_tools["workflows_by_key"]["org_b_role_gated"]
+        admin_headers = {
+            "Authorization": f"Bearer {platform_admin.access_token}",
+            "Content-Type": "application/json",
+            "Accept": "application/json, text/event-stream",
+        }
+        admin_list = e2e_client.post(
+            f"/mcp/{agent['id']}",
+            headers=admin_headers,
+            json={"jsonrpc": "2.0", "id": 1, "method": "tools/list", "params": {}},
+        )
+        assert admin_list.status_code == 200, admin_list.text
+        candidates = _candidate_tool_names_for_workflow(workflow)
+        registered_name = next(
+            (
+                tool.get("name")
+                for tool in _parse_mcp_response(admin_list)["result"].get("tools", [])
+                if tool.get("name") in candidates
+            ),
+            None,
+        )
+        assert registered_name is not None, "fixture admin could not resolve tool name"
+
+        customer_headers = {
+            "Authorization": f"Bearer {customer_org_platform_admin.access_token}",
+            "Content-Type": "application/json",
+            "Accept": "application/json, text/event-stream",
+        }
+        customer_list = e2e_client.post(
+            f"/mcp/{agent['id']}",
+            headers=customer_headers,
+            json={"jsonrpc": "2.0", "id": 1, "method": "tools/list", "params": {}},
+        )
+        assert customer_list.status_code == 200, customer_list.text
+        visible_names = {
+            tool.get("name")
+            for tool in _parse_mcp_response(customer_list)["result"].get("tools", [])
+        }
+        assert registered_name not in visible_names, (
+            "customer-org Platform Admin role leaked cross-org tool metadata"
+        )
+
+        call_resp = e2e_client.post(
+            f"/mcp/{agent['id']}",
+            headers=customer_headers,
+            json={
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "tools/call",
+                "params": {"name": registered_name, "arguments": {}},
+            },
+        )
+        assert call_resp.status_code == 200, call_resp.text
+        payload = _parse_mcp_response(call_resp)
+        if "error" in payload:
+            return
+        result = payload.get("result")
+        assert result is None or result.get("isError", False) or not any(
+            "ok" in block.get("text", "")
+            for block in result.get("content", [])
+            if isinstance(block, dict)
+        ), "customer-org Platform Admin role executed a cross-org tool"

--- a/api/tests/e2e/mcp/test_mcp_tool_access_matrix.py
+++ b/api/tests/e2e/mcp/test_mcp_tool_access_matrix.py
@@ -1081,6 +1081,65 @@ class TestMcpToolAccessMatrix:
         )
         assert "ok" in content_text, content_text
 
+    async def test_provider_gateway_discovery_requires_explicit_agent_target(
+        self,
+        seeded_agent_with_tools: dict[str, Any],
+        e2e_client,
+        provider_org_user,
+    ) -> None:
+        """Provider bypass applies to exact targets, not unscoped discovery."""
+        agent = seeded_agent_with_tools["agent"]
+        headers = {
+            "Authorization": f"Bearer {provider_org_user.access_token}",
+            "Content-Type": "application/json",
+            "Accept": "application/json, text/event-stream",
+        }
+
+        search_response = e2e_client.post(
+            "/mcp",
+            headers=headers,
+            json={
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "tools/call",
+                "params": {
+                    "name": "bifrost_search_capabilities",
+                    "arguments": {"query": agent["name"]},
+                },
+            },
+        )
+        assert search_response.status_code == 200, search_response.text
+        search_payload = _parse_mcp_response(search_response)
+        search_result = search_payload["result"]
+        assert not search_result.get("isError", False), search_payload
+        search_data = search_result.get("structuredContent")
+        assert isinstance(search_data, dict), search_payload
+        assert agent["id"] not in {
+            item["id"] for item in search_data.get("agents", [])
+        }
+
+        explicit_response = e2e_client.post(
+            "/mcp",
+            headers=headers,
+            json={
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "tools/call",
+                "params": {
+                    "name": "bifrost_search_capabilities",
+                    "arguments": {"agent_id": agent["id"]},
+                },
+            },
+        )
+        assert explicit_response.status_code == 200, explicit_response.text
+        explicit_payload = _parse_mcp_response(explicit_response)
+        explicit_result = explicit_payload["result"]
+        assert not explicit_result.get("isError", False), explicit_payload
+        explicit_data = explicit_result.get("structuredContent")
+        assert isinstance(explicit_data, dict), explicit_payload
+        assert "agents" in explicit_data, explicit_data
+        assert explicit_data["agents"][0]["id"] == agent["id"]
+
     async def test_customer_org_platform_admin_cannot_list_or_call_cross_org_tool(
         self,
         seeded_agent_with_tools: dict[str, Any],

--- a/api/tests/e2e/mcp/test_mcp_tool_access_matrix.py
+++ b/api/tests/e2e/mcp/test_mcp_tool_access_matrix.py
@@ -1081,7 +1081,7 @@ class TestMcpToolAccessMatrix:
         )
         assert "ok" in content_text, content_text
 
-    async def test_provider_gateway_discovery_requires_explicit_agent_target(
+    async def test_provider_gateway_discovery_requires_explicit_scope_or_target(
         self,
         seeded_agent_with_tools: dict[str, Any],
         e2e_client,
@@ -1094,6 +1094,27 @@ class TestMcpToolAccessMatrix:
             "Content-Type": "application/json",
             "Accept": "application/json, text/event-stream",
         }
+
+        tools_response = e2e_client.post(
+            "/mcp",
+            headers=headers,
+            json={
+                "jsonrpc": "2.0",
+                "id": 0,
+                "method": "tools/list",
+                "params": {},
+            },
+        )
+        assert tools_response.status_code == 200, tools_response.text
+        tools_payload = _parse_mcp_response(tools_response)
+        search_tool = next(
+            tool
+            for tool in tools_payload["result"]["tools"]
+            if tool["name"] == "bifrost_search_capabilities"
+        )
+        assert search_tool["inputSchema"]["properties"]["discovery_scope"][
+            "enum"
+        ] == ["accessible", "all"]
 
         search_response = e2e_client.post(
             "/mcp",
@@ -1118,12 +1139,35 @@ class TestMcpToolAccessMatrix:
             item["id"] for item in search_data.get("agents", [])
         }
 
-        explicit_response = e2e_client.post(
+        all_response = e2e_client.post(
             "/mcp",
             headers=headers,
             json={
                 "jsonrpc": "2.0",
                 "id": 2,
+                "method": "tools/call",
+                "params": {
+                    "name": "bifrost_search_capabilities",
+                    "arguments": {
+                        "query": agent["name"],
+                        "discovery_scope": "all",
+                    },
+                },
+            },
+        )
+        assert all_response.status_code == 200, all_response.text
+        all_payload = _parse_mcp_response(all_response)
+        all_result = all_payload["result"]
+        all_data = all_result.get("structuredContent")
+        assert isinstance(all_data, dict), all_payload
+        assert agent["id"] in {item["id"] for item in all_data.get("agents", [])}
+
+        explicit_response = e2e_client.post(
+            "/mcp",
+            headers=headers,
+            json={
+                "jsonrpc": "2.0",
+                "id": 3,
                 "method": "tools/call",
                 "params": {
                     "name": "bifrost_search_capabilities",
@@ -1177,6 +1221,28 @@ class TestMcpToolAccessMatrix:
             "Content-Type": "application/json",
             "Accept": "application/json, text/event-stream",
         }
+        all_search = e2e_client.post(
+            "/mcp",
+            headers=customer_headers,
+            json={
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "tools/call",
+                "params": {
+                    "name": "bifrost_search_capabilities",
+                    "arguments": {
+                        "query": agent["name"],
+                        "discovery_scope": "all",
+                    },
+                },
+            },
+        )
+        assert all_search.status_code == 200, all_search.text
+        all_search_payload = _parse_mcp_response(all_search)
+        all_search_data = all_search_payload["result"].get("structuredContent")
+        assert isinstance(all_search_data, dict), all_search_payload
+        assert all_search_data["code"] == "IMPERSONATION_FORBIDDEN"
+
         customer_list = e2e_client.post(
             f"/mcp/{agent['id']}",
             headers=customer_headers,

--- a/api/tests/unit/services/execution/test_agent_workflow_tools.py
+++ b/api/tests/unit/services/execution/test_agent_workflow_tools.py
@@ -20,6 +20,7 @@ async def test_execute_agent_workflow_tool_builds_canonical_agent_context():
         user_id=str(uuid4()),
         email="person@example.com",
         name="Person",
+        organization_id=organization_id,
         is_platform_admin=True,
     )
 
@@ -33,7 +34,6 @@ async def test_execute_agent_workflow_tool_builds_canonical_agent_context():
             workflow_name="ticket_lookup",
             parameters={"ticket_id": 42},
             caller=caller,
-            organization_id=organization_id,
             execution_id="execution-1",
             artifact_workspace_id="workspace-1",
             sync=False,

--- a/api/tests/unit/services/mcp_server/test_auth_provider_claims.py
+++ b/api/tests/unit/services/mcp_server/test_auth_provider_claims.py
@@ -6,6 +6,8 @@ from uuid import uuid4
 import pytest
 
 from src.services.mcp_server.auth import BifrostAuthProvider
+from src.services.mcp_server.server import MCPContext
+from src.services.mcp_server.tools._http_bridge import _token_from_context
 
 
 @pytest.mark.asyncio
@@ -34,3 +36,19 @@ async def test_verify_token_preserves_canonical_scope_bypass_claims():
     assert token is not None
     assert token.claims["is_superuser"] is False
     assert token.claims["is_provider_org"] is True
+
+
+def test_http_bridge_fallback_preserves_provider_org_claim():
+    from src.core.security import decode_token
+
+    context = MCPContext(
+        user_id=uuid4(),
+        org_id=uuid4(),
+        is_provider_org=True,
+        user_email="provider@example.com",
+    )
+
+    payload = decode_token(_token_from_context(context), expected_type="access")
+
+    assert payload is not None
+    assert payload["is_provider_org"] is True

--- a/api/tests/unit/services/mcp_server/test_auth_provider_claims.py
+++ b/api/tests/unit/services/mcp_server/test_auth_provider_claims.py
@@ -1,0 +1,36 @@
+"""Tests for claims preserved at the FastMCP authentication boundary."""
+
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+import pytest
+
+from src.services.mcp_server.auth import BifrostAuthProvider
+
+
+@pytest.mark.asyncio
+async def test_verify_token_preserves_canonical_scope_bypass_claims():
+    user_id = uuid4()
+    org_id = uuid4()
+    payload = {
+        "sub": str(user_id),
+        "email": "provider@example.com",
+        "name": "Provider User",
+        "is_superuser": False,
+        "is_provider_org": True,
+        "is_external": False,
+        "org_id": str(org_id),
+        "exp": 1234567890,
+    }
+    provider = BifrostAuthProvider(base_url="http://test")
+
+    with (
+        patch("src.core.security.decode_token", return_value=payload),
+        patch.object(provider, "_check_mcp_access", new=AsyncMock(return_value=True)),
+        patch.object(provider, "_get_user_roles", new=AsyncMock(return_value=[])),
+    ):
+        token = await provider.verify_token("encoded.jwt")
+
+    assert token is not None
+    assert token.claims["is_superuser"] is False
+    assert token.claims["is_provider_org"] is True

--- a/api/tests/unit/services/mcp_server/test_gateway.py
+++ b/api/tests/unit/services/mcp_server/test_gateway.py
@@ -701,7 +701,8 @@ async def test_delegation_allows_explicit_synchronous_execution():
 
 @pytest.mark.asyncio
 async def test_workflow_dispatch_returns_only_the_workflow_result():
-    service = MCPAgentGatewayService(_context())
+    context = _context()
+    service = MCPAgentGatewayService(context)
     tool = _resolved_tool()
     response = MagicMock()
     response.execution_id = str(uuid4())
@@ -714,10 +715,11 @@ async def test_workflow_dispatch_returns_only_the_workflow_result():
     with patch(
         "src.services.execution.service.execute_tool",
         new=AsyncMock(return_value=response),
-    ):
+    ) as execute:
         result = await service._dispatch_workflow(tool, {"ticket_id": 42})
 
     assert result == [{"ticket": 42}]
+    assert execute.await_args.kwargs["org_id"] == str(context.org_id)
 
 
 @pytest.mark.asyncio

--- a/api/tests/unit/services/mcp_server/test_gateway.py
+++ b/api/tests/unit/services/mcp_server/test_gateway.py
@@ -1,5 +1,6 @@
 """Unit tests for the unscoped MCP agent gateway."""
 
+from contextlib import asynccontextmanager
 from dataclasses import replace
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
@@ -63,6 +64,45 @@ def _resolved_tool(
         source_identity=f"workflow:{uuid4()}",
         source_id=uuid4(),
     )
+
+
+@pytest.mark.asyncio
+async def test_provider_discovery_does_not_use_scope_bypass():
+    context = _context()
+    context.is_provider_org = True
+    service = MCPAgentGatewayService(context)
+    db = MagicMock()
+    repo = MagicMock()
+    repo.list_agents = AsyncMock(return_value=[])
+
+    @asynccontextmanager
+    async def db_context():
+        yield db
+
+    with (
+        patch("src.core.database.get_db_context", return_value=db_context()),
+        patch(
+            "src.services.mcp_server.gateway.AgentRepository",
+            return_value=repo,
+        ) as repo_cls,
+    ):
+        assert await service._list_accessible_agents() == []
+
+    assert repo_cls.call_args.kwargs["is_superuser"] is False
+    repo.list_agents.assert_awaited_once_with(active_only=True)
+
+
+def test_provider_explicit_target_uses_scope_bypass():
+    context = _context()
+    context.is_provider_org = True
+    service = MCPAgentGatewayService(context)
+
+    with patch(
+        "src.services.mcp_server.gateway.AgentRepository",
+    ) as repo_cls:
+        service._agent_repo(MagicMock())
+
+    assert repo_cls.call_args.kwargs["is_superuser"] is True
 
 
 def test_workflow_reference_is_stable_across_display_name_change():

--- a/api/tests/unit/services/mcp_server/test_gateway.py
+++ b/api/tests/unit/services/mcp_server/test_gateway.py
@@ -105,6 +105,59 @@ def test_provider_explicit_target_uses_scope_bypass():
     assert repo_cls.call_args.kwargs["is_superuser"] is True
 
 
+@pytest.mark.asyncio
+async def test_provider_can_explicitly_discover_all_agents():
+    context = _context()
+    context.is_provider_org = True
+    service = MCPAgentGatewayService(context)
+    db = MagicMock()
+    repo = MagicMock()
+    repo.list_all_in_scope = AsyncMock(return_value=[])
+
+    @asynccontextmanager
+    async def db_context():
+        yield db
+
+    with (
+        patch("src.core.database.get_db_context", return_value=db_context()),
+        patch(
+            "src.services.mcp_server.gateway.AgentRepository",
+            return_value=repo,
+        ) as repo_cls,
+    ):
+        assert await service._list_discovery_agents("all") == []
+
+    assert repo_cls.call_args.kwargs["is_superuser"] is True
+    repo.list_all_in_scope.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_ordinary_caller_cannot_discover_all_agents():
+    service = MCPAgentGatewayService(_context())
+
+    with pytest.raises(GatewayError) as exc_info:
+        await service._list_discovery_agents("all")
+
+    assert exc_info.value.code == "IMPERSONATION_FORBIDDEN"
+
+
+@pytest.mark.asyncio
+async def test_ordinary_caller_cannot_combine_all_scope_with_exact_agent():
+    service = MCPAgentGatewayService(_context())
+
+    with (
+        patch.object(service, "get_agent_snapshot", new_callable=AsyncMock) as snapshot,
+        pytest.raises(GatewayError) as exc_info,
+    ):
+        await service.search_capabilities(
+            agent_id=str(uuid4()),
+            discovery_scope="all",
+        )
+
+    assert exc_info.value.code == "IMPERSONATION_FORBIDDEN"
+    snapshot.assert_not_awaited()
+
+
 def test_workflow_reference_is_stable_across_display_name_change():
     service = MCPAgentGatewayService(_context())
     agent = _agent()

--- a/api/tests/unit/services/mcp_server/test_tool_access.py
+++ b/api/tests/unit/services/mcp_server/test_tool_access.py
@@ -308,6 +308,42 @@ class TestGetAccessibleTools:
     """Tests for get_accessible_tools()."""
 
     @pytest.mark.asyncio
+    async def test_platform_settings_inventory_preserves_admin_access(
+        self, service
+    ):
+        """The REST settings inventory can enumerate without changing /mcp discovery."""
+        accessible_agents = AsyncMock(return_value=[])
+        workflow_repo = MagicMock()
+
+        with (
+            patch.object(
+                service,
+                "_get_accessible_agents",
+                accessible_agents,
+            ),
+            patch.object(
+                service,
+                "_build_workflow_repo",
+                return_value=workflow_repo,
+            ) as build_workflow_repo,
+            patch.object(service, "_apply_config_filters", return_value=[]),
+            patch(
+                "src.services.mcp_server.tool_access.MCPConfigService"
+            ) as config_service,
+        ):
+            config_service.return_value.get_config = AsyncMock(
+                return_value=MagicMock()
+            )
+            result = await service.get_accessible_tools(
+                user_roles=[],
+                is_superuser=True,
+            )
+
+        assert result.tools == []
+        assert accessible_agents.await_args.kwargs["is_superuser"] is True
+        assert build_workflow_repo.call_args.kwargs["is_superuser"] is True
+
+    @pytest.mark.asyncio
     async def test_collects_system_tools_from_agents(self, service, mock_session, mock_agent):
         """Should collect system tools from accessible agents."""
         agent = mock_agent(

--- a/api/tests/unit/services/mcp_server/test_tool_access.py
+++ b/api/tests/unit/services/mcp_server/test_tool_access.py
@@ -326,7 +326,6 @@ class TestGetAccessibleTools:
 
                 result = await service.get_accessible_tools(
                     user_roles=[],
-                    is_superuser=True,
                 )
 
         system_tools = [t for t in result.tools if t.type == "system"]
@@ -354,7 +353,6 @@ class TestGetAccessibleTools:
 
             result = await service.get_accessible_tools(
                 user_roles=[],
-                is_superuser=False,
             )
 
         workflow_tools = [t for t in result.tools if t.type == "workflow"]
@@ -385,7 +383,6 @@ class TestGetAccessibleTools:
 
             result = await service.get_accessible_tools(
                 user_roles=[],
-                is_superuser=True,
             )
 
         # Should have 2 unique system tools, not 3
@@ -420,7 +417,6 @@ class TestGetAccessibleTools:
 
             result = await service.get_accessible_tools(
                 user_roles=[],
-                is_superuser=False,
             )
 
         workflow_tools = [t for t in result.tools if t.type == "workflow"]
@@ -583,7 +579,6 @@ class TestSystemToolMetadata:
 
             result = await service.get_accessible_tools(
                 user_roles=[],
-                is_superuser=False,
             )
 
         assert len(result.tools) == 1
@@ -618,7 +613,6 @@ class TestEdgeCases:
 
             result = await service.get_accessible_tools(
                 user_roles=["Other Role"],
-                is_superuser=False,
             )
 
         assert len(result.tools) == 0
@@ -642,7 +636,6 @@ class TestEdgeCases:
 
             result = await service.get_accessible_tools(
                 user_roles=[],
-                is_superuser=False,
             )
 
         assert len(result.tools) == 0
@@ -668,7 +661,6 @@ class TestEdgeCases:
 
             result = await service.get_accessible_tools(
                 user_roles=[],
-                is_superuser=False,
             )
 
         workflow_tool = [t for t in result.tools if t.type == "workflow"][0]
@@ -707,7 +699,6 @@ class TestSearchKnowledgeAutoInjection:
 
             result = await service.get_accessible_tools(
                 user_roles=[],
-                is_superuser=True,
             )
 
         tool_ids = {t.id for t in result.tools}
@@ -734,7 +725,6 @@ class TestSearchKnowledgeAutoInjection:
 
             result = await service.get_accessible_tools(
                 user_roles=[],
-                is_superuser=True,
             )
 
         tool_ids = {t.id for t in result.tools}
@@ -762,7 +752,6 @@ class TestSearchKnowledgeAutoInjection:
 
             result = await service.get_accessible_tools(
                 user_roles=[],
-                is_superuser=True,
             )
 
         sk_tools = [t for t in result.tools if t.id == "search_knowledge"]

--- a/api/tests/unit/services/mcp_server/test_tool_access.py
+++ b/api/tests/unit/services/mcp_server/test_tool_access.py
@@ -794,6 +794,38 @@ class TestSearchKnowledgeAutoInjection:
         assert "search_knowledge" in tool_ids
 
     @pytest.mark.asyncio
+    async def test_provider_org_caller_bypasses_agent_role_requirement(
+        self, service, mock_session, mock_agent
+    ):
+        """Platform-org impersonation has the same scope bypass as superuser."""
+        agent = mock_agent(
+            access_level=AgentAccessLevel.ROLE_BASED,
+            system_tools=["list_workflows"],
+            roles=["Customer Operator"],
+        )
+        mock_result = MagicMock()
+        mock_result.scalars.return_value.unique.return_value.first.return_value = agent
+        mock_session.execute = AsyncMock(return_value=mock_result)
+
+        with patch("src.services.mcp_server.tool_access.MCPConfigService") as mock_config_cls:
+            mock_config = MagicMock(allowed_tool_ids=None, blocked_tool_ids=None)
+            mock_config_cls.return_value.get_config = AsyncMock(
+                return_value=mock_config
+            )
+
+            result = await service.get_tools_for_agent(
+                agent_id=agent.id,
+                user_roles=[],
+                is_superuser=False,
+                is_provider_org=True,
+                user_id=uuid4(),
+                org_id=uuid4(),
+            )
+
+        assert result is not None
+        assert {tool.id for tool in result.tools} == {"list_workflows"}
+
+    @pytest.mark.asyncio
     async def test_get_tools_for_agent_no_inject_without_namespaces(
         self, service, mock_session, mock_agent
     ):

--- a/api/tests/unit/services/mcp_server/test_tool_access.py
+++ b/api/tests/unit/services/mcp_server/test_tool_access.py
@@ -11,10 +11,19 @@ from uuid import uuid4
 import pytest
 
 from src.models.enums import AgentAccessLevel
+from src.services.mcp_server.server import MCPContext
 from src.services.mcp_server.tool_access import MCPToolAccessService
 
 
 # ==================== Fixtures ====================
+
+
+def test_mcp_scope_bypass_requires_superuser_or_provider_org():
+    user_id = uuid4()
+
+    assert MCPContext(user_id=user_id).has_scope_bypass is False
+    assert MCPContext(user_id=user_id, is_platform_admin=True).has_scope_bypass is True
+    assert MCPContext(user_id=user_id, is_provider_org=True).has_scope_bypass is True
 
 
 @pytest.fixture

--- a/api/tests/unit/services/test_agent_executor_tools.py
+++ b/api/tests/unit/services/test_agent_executor_tools.py
@@ -464,9 +464,13 @@ class TestWorkflowToolIdResolution:
             mock_conversation.user = MagicMock()
             mock_conversation.user.id = uuid4()
             mock_conversation.user.name = "Test User"
+            mock_conversation.user.email = "test@example.com"
+            caller_org_id = uuid4()
+            mock_conversation.user.organization_id = caller_org_id
+            mock_conversation.user.is_superuser = False
 
             mock_agent = MagicMock()
-            mock_agent.organization_id = uuid4()
+            mock_agent.organization_id = None
 
             await executor._execute_tool(
                 tool_call, agent=mock_agent, conversation=mock_conversation
@@ -477,6 +481,7 @@ class TestWorkflowToolIdResolution:
         assert execution_kwargs["workflow_id"] == str(workflow_id)
         assert execution_kwargs["workflow_name"] == "Execute HaloPSA SQL"
         assert execution_kwargs["is_agent"] is True
+        assert execution_kwargs["org_id"] == str(caller_org_id)
 
         # Verify the DB query used Workflow.id, not Workflow.name
         call_args = mock_session.execute.call_args

--- a/api/tests/unit/services/test_agent_router_access.py
+++ b/api/tests/unit/services/test_agent_router_access.py
@@ -36,13 +36,11 @@ class SessionBoundAgentRouter(AgentRouter):
         *,
         user_id: UUID,
         org_id: UUID | None,
-        is_superuser: bool = False,
     ):
         super().__init__(
             lambda: None,  # type: ignore[arg-type]
             user_id=user_id,
             org_id=org_id,
-            is_superuser=is_superuser,
         )
         self._session = session
 
@@ -192,6 +190,33 @@ async def test_available_agents_are_limited_to_user_access(db_session: AsyncSess
     names = {agent.name for agent in await router.get_available_agents()}
 
     assert names == {"Global Role Agent", "Org B Auth Agent", "Own Private Agent"}
+
+
+@pytest.mark.asyncio
+async def test_admin_status_does_not_expand_automatic_agent_discovery(
+    db_session: AsyncSession,
+):
+    org_a = await _make_org(db_session, "Admin Discovery Org A")
+    org_b = await _make_org(db_session, "Admin Discovery Org B")
+    admin = await _make_user(
+        db_session,
+        org_id=org_b.id,
+        email_prefix="scoped-admin",
+        is_superuser=True,
+    )
+
+    await _make_agent(db_session, "Admin Own Org Agent", org_id=org_b.id)
+    await _make_agent(db_session, "Admin Cross Org Agent", org_id=org_a.id)
+
+    router = SessionBoundAgentRouter(
+        db_session,
+        user_id=admin.id,
+        org_id=org_b.id,
+    )
+    names = {agent.name for agent in await router.get_available_agents()}
+
+    assert "Admin Own Org Agent" in names
+    assert "Admin Cross Org Agent" not in names
 
 
 @pytest.mark.asyncio

--- a/api/tests/unit/services/test_autonomous_agent_executor.py
+++ b/api/tests/unit/services/test_autonomous_agent_executor.py
@@ -294,6 +294,7 @@ class TestAutonomousAgentExecutor:
     ):
         workflow_id = uuid4()
         caller_user_id = uuid4()
+        caller_org_id = uuid4()
         executor = AutonomousAgentExecutor(mock_session)
         executor._tool_workflow_id_map = {"specialist_tool": workflow_id}
         executor._caller_user_id = caller_user_id
@@ -301,6 +302,7 @@ class TestAutonomousAgentExecutor:
             "user_id": str(caller_user_id),
             "email": "person@example.com",
             "name": "Person",
+            "organization_id": str(caller_org_id),
             "is_platform_admin": True,
         }
 
@@ -330,7 +332,7 @@ class TestAutonomousAgentExecutor:
             user_id=str(caller_user_id),
             user_email="person@example.com",
             user_name="Person",
-            org_id=str(mock_agent.organization_id),
+            org_id=str(caller_org_id),
             is_platform_admin=True,
             is_agent=True,
             execution_id=None,
@@ -382,6 +384,22 @@ class TestAutonomousAgentExecutor:
             sync=True,
         )
 
+    def test_global_caller_scope_does_not_fall_back_to_agent_org(
+        self, mock_session, mock_agent
+    ):
+        executor = AutonomousAgentExecutor(mock_session)
+        executor._caller_user_id = uuid4()
+        executor._caller = {"organization_id": None}
+
+        assert executor._execution_org_id(mock_agent) is None
+
+    def test_run_without_caller_uses_agent_org(self, mock_session, mock_agent):
+        executor = AutonomousAgentExecutor(mock_session)
+        executor._caller_user_id = None
+        executor._caller = None
+
+        assert executor._execution_org_id(mock_agent) == mock_agent.organization_id
+
     @pytest.mark.asyncio
     async def test_delegated_system_tool_inherits_caller_identity(
         self,
@@ -389,6 +407,7 @@ class TestAutonomousAgentExecutor:
         mock_agent,
     ):
         caller_user_id = uuid4()
+        caller_org_id = uuid4()
         captured_context = None
 
         async def system_tool(context, **_arguments):
@@ -402,6 +421,7 @@ class TestAutonomousAgentExecutor:
             "user_id": str(caller_user_id),
             "email": "person@example.com",
             "name": "Person",
+            "organization_id": str(caller_org_id),
             "is_platform_admin": True,
         }
 
@@ -422,6 +442,7 @@ class TestAutonomousAgentExecutor:
         assert captured_context.user_id == caller_user_id
         assert captured_context.user_email == "person@example.com"
         assert captured_context.user_name == "Person"
+        assert captured_context.org_id == caller_org_id
         assert captured_context.is_platform_admin is True
 
     @pytest.mark.asyncio

--- a/api/tests/unit/test_mcp_org_scope_helper.py
+++ b/api/tests/unit/test_mcp_org_scope_helper.py
@@ -19,9 +19,10 @@ def _sql(query) -> str:
     return where
 
 
-def _ctx(*, is_platform_admin=False, org_id=...):
+def _ctx(*, is_platform_admin=False, is_provider_org=False, org_id=...):
     return SimpleNamespace(
         is_platform_admin=is_platform_admin,
+        is_provider_org=is_provider_org,
         org_id=uuid4() if org_id is ... else org_id,
     )
 
@@ -29,6 +30,17 @@ def _ctx(*, is_platform_admin=False, org_id=...):
 def test_platform_admin_no_filter():
     # No WHERE clause at all -> no org filter applied.
     sql = _sql(apply_mcp_org_scope(select(Application), Application, _ctx(is_platform_admin=True)))
+    assert sql.strip() == ""
+
+
+def test_provider_org_user_no_filter():
+    sql = _sql(
+        apply_mcp_org_scope(
+            select(Application),
+            Application,
+            _ctx(is_provider_org=True),
+        )
+    )
     assert sql.strip() == ""
 
 

--- a/client/src/components/chat/MentionPicker.test.tsx
+++ b/client/src/components/chat/MentionPicker.test.tsx
@@ -14,15 +14,22 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { renderWithProviders, screen, fireEvent } from "@/test-utils";
 
-const agentsRef: { data: Array<Record<string, unknown>> } = { data: [] };
+const { agentsRef, useAgentsMock } = vi.hoisted(() => {
+	const agents = { data: [] as Array<Record<string, unknown>> };
+	return {
+		agentsRef: agents,
+		useAgentsMock: vi.fn(() => ({ data: agents.data })),
+	};
+});
 
 vi.mock("@/hooks/useAgents", () => ({
-	useAgents: () => ({ data: agentsRef.data }),
+	useAgents: useAgentsMock,
 }));
 
 import { MentionPicker } from "./MentionPicker";
 
 beforeEach(() => {
+	useAgentsMock.mockClear();
 	agentsRef.data = [
 		{
 			id: "a-1",
@@ -59,6 +66,9 @@ describe("MentionPicker — visibility", () => {
 		expect(screen.getByText("SupportBot")).toBeInTheDocument();
 		expect(screen.getByText("DevBot")).toBeInTheDocument();
 		expect(screen.getByText("DataBot")).toBeInTheDocument();
+		expect(useAgentsMock).toHaveBeenCalledWith(undefined, {
+			discoveryOnly: true,
+		});
 	});
 });
 

--- a/client/src/components/chat/MentionPicker.tsx
+++ b/client/src/components/chat/MentionPicker.tsx
@@ -43,7 +43,7 @@ export function MentionPicker({
 	position,
 }: MentionPickerProps) {
 	const terminology = useTerminology();
-	const { data: agents } = useAgents();
+	const { data: agents } = useAgents(undefined, { discoveryOnly: true });
 	const selectionKey = `${open ? "open" : "closed"}:${searchTerm}`;
 	const [selection, setSelection] = useState({ key: selectionKey, index: 0 });
 	const listRef = useRef<HTMLDivElement>(null);

--- a/client/src/hooks/useAgents.test.ts
+++ b/client/src/hooks/useAgents.test.ts
@@ -1,0 +1,35 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+	useQuery: vi.fn(),
+}));
+
+vi.mock("@/lib/api-client", () => ({
+	$api: {
+		useQuery: mocks.useQuery,
+	},
+}));
+
+import { useAgents } from "./useAgents";
+
+describe("useAgents", () => {
+	beforeEach(() => {
+		mocks.useQuery.mockReset();
+	});
+
+	it("requests ordinary visibility for chat discovery", () => {
+		useAgents(undefined, { discoveryOnly: true });
+
+		expect(mocks.useQuery).toHaveBeenCalledWith("get", "/api/agents", {
+			params: { query: { discovery_only: true } },
+		});
+	});
+
+	it("does not narrow administrative inventory by default", () => {
+		useAgents();
+
+		expect(mocks.useQuery).toHaveBeenCalledWith("get", "/api/agents", {
+			params: { query: undefined },
+		});
+	});
+});

--- a/client/src/hooks/useAgents.ts
+++ b/client/src/hooks/useAgents.ts
@@ -40,10 +40,15 @@ function getErrorMessage(error: unknown, fallback: string): string {
  * - Omitted (undefined): show all agents (superusers) / user's org + global (org users)
  * - "global": show only global agents (org_id IS NULL)
  * - UUID string: show that org's agents + global agents
+ * - discoveryOnly: apply ordinary org/role visibility even for administrators
  */
 export function useAgents(
 	filterScope?: string | null,
-	options?: { includeInactive?: boolean; includeStats?: boolean },
+	options?: {
+		includeInactive?: boolean;
+		includeStats?: boolean;
+		discoveryOnly?: boolean;
+	},
 ) {
 	// Build query params - scope is the new filter parameter
 	const queryParams: Record<string, string | boolean | undefined> = {};
@@ -62,10 +67,13 @@ export function useAgents(
 	if (options?.includeStats) {
 		queryParams.include_stats = true;
 	}
+	if (options?.discoveryOnly) {
+		queryParams.discovery_only = true;
+	}
 
 	return $api.useQuery("get", "/api/agents", {
 		params: {
-			// Type assertion needed until types are regenerated
+			// Narrow the dynamically assembled map to this endpoint's query shape.
 			query:
 				Object.keys(queryParams).length > 0 ? queryParams : undefined,
 		} as {
@@ -73,6 +81,7 @@ export function useAgents(
 				category?: string | null;
 				active_only?: boolean;
 				include_stats?: boolean;
+				discovery_only?: boolean;
 				scope?: string;
 			};
 		},

--- a/client/src/lib/v1.d.ts
+++ b/client/src/lib/v1.d.ts
@@ -19469,6 +19469,12 @@ export interface components {
             /** Tool Ref */
             tool_ref?: string | null;
             /**
+             * Discovery Scope
+             * @default accessible
+             * @enum {string}
+             */
+            discovery_scope: "accessible" | "all";
+            /**
              * Limit
              * @default 10
              */

--- a/client/src/lib/v1.d.ts
+++ b/client/src/lib/v1.d.ts
@@ -36334,6 +36334,8 @@ export interface operations {
                 active_only?: boolean;
                 /** @description Include per-agent run stats in the list response. */
                 include_stats?: boolean;
+                /** @description Apply ordinary organization and role visibility even for impersonation-capable callers. Used by chat discovery. */
+                discovery_only?: boolean;
             };
             header?: never;
             path?: never;


### PR DESCRIPTION
## Summary

- make invocation organization part of the shared agent workflow caller context so identity and scope cannot drift
- use authenticated caller scope for interactive and claim-bearing runs, with agent scope only for autonomous runs without a caller
- keep unscoped chat and MCP discovery constrained to the caller's organization and normal role access, even for impersonation-capable callers
- activate platform/provider impersonation only when an agent is explicitly targeted
- add an opt-in `discovery_scope="all"` MCP search mode for authorized cross-organization discovery without cluttering the default tool surface
- preserve management inventory behavior and provider-org claims across the MCP HTTP bridge
- add chat, REST, automatic-routing, and wire-level MCP regressions

## Scope behavior

- org-scoped workflow: workflow org still wins in the worker
- global workflow with interactive caller: caller org, including explicit global
- global workflow without caller: agent org, including global
- unscoped chat/MCP discovery: ordinary caller org and role access
- MCP `discovery_scope="all"`: all active agents, only for platform-admin/provider-org callers and only when explicitly requested
- exact agent target: canonical platform-admin or provider-org impersonation bypass
- ordinary org users and customer-org users with an admin-named role: no cross-org enumeration or execution bypass
- agent management inventory: unchanged

## Verification

- `./test.sh tests/unit/services/execution/test_agent_workflow_tools.py tests/unit/services/test_agent_executor_tools.py tests/unit/services/test_autonomous_agent_executor.py tests/unit/services/mcp_server/test_gateway.py tests/unit/services/mcp_server/test_tool_access.py tests/unit/services/test_mcp_agent_scope.py -q` (155 passed)
- `./test.sh tests/e2e/api/test_agent_workflow_tool_execution.py -q` (1 passed)
- `./test.sh tests/unit/test_scope_resolver.py tests/unit/test_mcp_org_scope_helper.py tests/unit/services/mcp_server/test_auth_provider_claims.py tests/unit/services/mcp_server/test_tool_access.py tests/unit/services/mcp_server/test_gateway.py -q` (95 passed)
- `./test.sh tests/unit/services/mcp_server/test_tool_implementations.py tests/unit/services/test_mcp_tools.py -q` (55 passed)
- `./test.sh tests/e2e/mcp/test_mcp_tool_access_matrix.py -q` (38 passed, including default/all/unauthorized discovery)
- `./test.sh tests/e2e/api/test_agents.py::TestAgentScopeFiltering tests/e2e/api/test_chat.py::TestConversationsAccessControl -q` (14 passed)
- `./test.sh tests/unit/services/mcp_server/test_auth_provider_claims.py tests/unit/services/test_agent_router_access.py tests/unit/services/mcp_server/test_gateway.py tests/unit/services/mcp_server/test_tool_access.py tests/unit/services/test_mcp_agent_scope.py -q` (92 passed)
- `./test.sh tests/unit/services/mcp_server/test_gateway.py -q` (41 passed after adding discovery scope)
- `./test.sh tests/unit/test_contract_version.py -q` (2 passed)
- `./test.sh tests/unit/test_skill_appendix_fresh.py -q` (1 passed)
- `./test.sh client unit src/hooks/useAgents.test.ts src/components/chat/MentionPicker.test.tsx` (14 passed)
- `./test.sh quality api` (pyright and ruff passed)
- `npm run tsc && npm run lint` (passed; two pre-existing warnings)

The full backend, full Vitest, and browser suites were not run locally. CI runs the broader unit, E2E, client, lint/type, and CodeQL gates.

Fixes #685
