### PR TITLE
Fix V2 app token rotation without remounting

### DIFF
--- a/client/src/components/jsx-app/StandaloneV2App.test.tsx
+++ b/client/src/components/jsx-app/StandaloneV2App.test.tsx
@@ -9,7 +9,10 @@ import {
 } from "./StandaloneV2App";
 
 const orgScopeState = vi.hoisted(() => ({
-	scope: { type: "global" as "global" | "organization", orgId: null as string | null },
+	scope: {
+		type: "global" as "global" | "organization",
+		orgId: null as string | null,
+	},
 }));
 
 const { mockAuthFetch } = vi.hoisted(() => ({ mockAuthFetch: vi.fn() }));
@@ -39,8 +42,8 @@ let appendedScripts: HTMLScriptElement[] = [];
 let appendedStylesheets: HTMLLinkElement[] = [];
 
 function moduleScript(entry: string): HTMLScriptElement {
-	const script = appendedScripts.find(
-		(candidate) => candidate.dataset.bifrostAppEntry?.endsWith(`assets/${entry}.js`),
+	const script = appendedScripts.find((candidate) =>
+		candidate.dataset.bifrostAppEntry?.endsWith(`assets/${entry}.js`),
 	);
 	if (!script) throw new Error(`No module script found for ${entry}`);
 	return script;
@@ -93,7 +96,7 @@ beforeEach(() => {
 	vi.spyOn(console, "error").mockImplementation(() => {});
 	const appendChild = document.head.appendChild.bind(document.head);
 	vi.spyOn(document.head, "appendChild").mockImplementation(
-		<T extends Node,>(node: T): T => {
+		<T extends Node>(node: T): T => {
 			// happy-dom tries to fetch module scripts and immediately dispatches an
 			// error. Retain them in-memory so each test controls load completion.
 			if (node instanceof HTMLScriptElement) {
@@ -118,7 +121,9 @@ afterEach(() => {
 describe("StandaloneV2App", () => {
 	it("loads the immutable entry and stylesheet through canonical URLs", async () => {
 		localStorage.setItem("bifrost_access_token", "tok-1");
-		render(<StandaloneV2App {...props("canonical")} css="assets/main.css" />);
+		render(
+			<StandaloneV2App {...props("canonical")} css="assets/main.css" />,
+		);
 
 		let script!: HTMLScriptElement;
 		await waitFor(() => {
@@ -140,12 +145,11 @@ describe("StandaloneV2App", () => {
 	it("passes isolated bootstrap to mount and calls its teardown", async () => {
 		localStorage.setItem("bifrost_access_token", "tok-1");
 		const teardown = vi.fn();
-		const mount = vi.fn((_el: HTMLElement, _boot: BifrostAppBootstrap) => teardown);
+		const mount = vi.fn(
+			(_el: HTMLElement, _boot: BifrostAppBootstrap) => teardown,
+		);
 		const view = render(
-			<StandaloneV2App
-				{...props("bootstrap")}
-				appOrgId="org-42"
-			/>,
+			<StandaloneV2App {...props("bootstrap")} appOrgId="org-42" />,
 		);
 		const root = view.getByTestId("solution-v2-app-root");
 
@@ -165,10 +169,33 @@ describe("StandaloneV2App", () => {
 		expect(teardown).toHaveBeenCalledTimes(1);
 	});
 
+	it("keeps the app mounted across token rotation and tears it down on logout", async () => {
+		localStorage.setItem("bifrost_access_token", "tok-1");
+		const teardown = vi.fn();
+		const mount = vi.fn<StandaloneV2Module["mount"]>(() => teardown);
+		const view = render(<StandaloneV2App {...props("token-rotation")} />);
+
+		await finishModuleLoad("token-rotation", mount);
+		await waitFor(() => expect(mount).toHaveBeenCalledTimes(1));
+		localStorage.setItem("bifrost_access_token", "tok-2");
+		view.rerender(<StandaloneV2App {...props("token-rotation")} />);
+
+		expect(mount).toHaveBeenCalledTimes(1);
+		expect(teardown).not.toHaveBeenCalled();
+
+		localStorage.removeItem("bifrost_access_token");
+		view.rerender(<StandaloneV2App {...props("token-rotation")} />);
+
+		await waitFor(() => expect(teardown).toHaveBeenCalledTimes(1));
+	});
+
 	it("mounts with the serving session and installed scope, not stale realm state", async () => {
 		localStorage.setItem("bifrost_access_token", "stale-musick-token");
 		sessionStorage.setItem("bifrost_embed_token", "local-serving-token");
-		orgScopeState.scope = { type: "organization", orgId: "stale-musick-org" };
+		orgScopeState.scope = {
+			type: "organization",
+			orgId: "stale-musick-org",
+		};
 		const mount = vi.fn<StandaloneV2Module["mount"]>(() => vi.fn());
 
 		render(
@@ -193,8 +220,12 @@ describe("StandaloneV2App", () => {
 		localStorage.setItem("bifrost_access_token", "tok-1");
 		const firstTeardown = vi.fn();
 		const secondTeardown = vi.fn();
-		const firstMount = vi.fn<StandaloneV2Module["mount"]>(() => firstTeardown);
-		const secondMount = vi.fn<StandaloneV2Module["mount"]>(() => secondTeardown);
+		const firstMount = vi.fn<StandaloneV2Module["mount"]>(
+			() => firstTeardown,
+		);
+		const secondMount = vi.fn<StandaloneV2Module["mount"]>(
+			() => secondTeardown,
+		);
 		const { rerender } = render(<StandaloneV2App {...props("first")} />);
 
 		await finishModuleLoad("first", firstMount);
@@ -210,7 +241,9 @@ describe("StandaloneV2App", () => {
 	it("waits for both the module and stylesheet before mounting", async () => {
 		localStorage.setItem("bifrost_access_token", "tok-1");
 		const mount = vi.fn<StandaloneV2Module["mount"]>(() => vi.fn());
-		render(<StandaloneV2App {...props("styled")} css="assets/styled.css" />);
+		render(
+			<StandaloneV2App {...props("styled")} css="assets/styled.css" />,
+		);
 
 		await finishModuleLoad("styled", mount);
 		expect(mount).not.toHaveBeenCalled();
@@ -238,7 +271,9 @@ describe("StandaloneV2App", () => {
 		expect(
 			await screen.findByRole("heading", { name: "Application updated" }),
 		).toBeInTheDocument();
-		expect(screen.getByText("Loading the latest version…")).toBeInTheDocument();
+		expect(
+			screen.getByText("Loading the latest version…"),
+		).toBeInTheDocument();
 
 		await act(async () => resolveManifest(manifest("fresh")));
 		await finishModuleLoad("fresh", mount);
@@ -254,7 +289,12 @@ describe("StandaloneV2App", () => {
 		mockAuthFetch.mockResolvedValueOnce(manifest("fresh-css", "fresh-css"));
 		const oldMount = vi.fn<StandaloneV2Module["mount"]>(() => vi.fn());
 		const freshMount = vi.fn<StandaloneV2Module["mount"]>(() => vi.fn());
-		render(<StandaloneV2App {...props("stale-css")} css="assets/stale-css.css" />);
+		render(
+			<StandaloneV2App
+				{...props("stale-css")}
+				css="assets/stale-css.css"
+			/>,
+		);
 
 		await finishModuleLoad("stale-css", oldMount);
 		act(() => stylesheet("stale-css").dispatchEvent(new Event("error")));
@@ -277,7 +317,9 @@ describe("StandaloneV2App", () => {
 		});
 		act(() => script.dispatchEvent(new Event("error")));
 
-		expect(await screen.findByText(/Failed to load the application entry/i)).toBeInTheDocument();
+		expect(
+			await screen.findByText(/Failed to load the application entry/i),
+		).toBeInTheDocument();
 		expect(mockAuthFetch).toHaveBeenCalledTimes(1);
 	});
 
@@ -292,9 +334,13 @@ describe("StandaloneV2App", () => {
 
 	it("does not load or mount while unauthenticated", async () => {
 		render(<StandaloneV2App {...props("unauthenticated")} />);
-		expect(await screen.findByText(/Not authenticated/i)).toBeInTheDocument();
 		expect(
-			appendedScripts.some((script) => script.src.endsWith("unauthenticated.js")),
+			await screen.findByText(/Not authenticated/i),
+		).toBeInTheDocument();
+		expect(
+			appendedScripts.some((script) =>
+				script.src.endsWith("unauthenticated.js"),
+			),
 		).toBe(false);
 	});
 
@@ -308,7 +354,9 @@ describe("StandaloneV2App", () => {
 		});
 		view.unmount();
 
-		(window.__BIFROST_APP_MODULES__ ??= new Map()).set(script.src, { mount });
+		(window.__BIFROST_APP_MODULES__ ??= new Map()).set(script.src, {
+			mount,
+		});
 		act(() => script.dispatchEvent(new Event("load")));
 		await act(async () => Promise.resolve());
 		expect(mount).not.toHaveBeenCalled();
@@ -319,18 +367,31 @@ describe("StandaloneV2App", () => {
 		const teardown = vi.fn();
 		const mount = vi.fn<StandaloneV2Module["mount"]>(() => teardown);
 		const first = render(
-			<StandaloneV2App {...props("concurrent")} appId="app-A" appSlug="aaa" />,
+			<StandaloneV2App
+				{...props("concurrent")}
+				appId="app-A"
+				appSlug="aaa"
+			/>,
 		);
 		const second = render(
-			<StandaloneV2App {...props("concurrent")} appId="app-B" appSlug="bbb" />,
+			<StandaloneV2App
+				{...props("concurrent")}
+				appId="app-B"
+				appSlug="bbb"
+			/>,
 		);
 
 		await finishModuleLoad("concurrent", mount);
 		await waitFor(() => expect(mount).toHaveBeenCalledTimes(2));
 		expect(mount.mock.calls[0][0]).not.toBe(mount.mock.calls[1][0]);
-		expect(mount.mock.calls.map((call) => call[1].appId)).toEqual(["app-A", "app-B"]);
+		expect(mount.mock.calls.map((call) => call[1].appId)).toEqual([
+			"app-A",
+			"app-B",
+		]);
 		expect(
-			appendedScripts.filter((script) => script.src.endsWith("concurrent.js")),
+			appendedScripts.filter((script) =>
+				script.src.endsWith("concurrent.js"),
+			),
 		).toHaveLength(1);
 
 		first.unmount();
@@ -342,13 +403,18 @@ describe("StandaloneV2App", () => {
 		localStorage.setItem("bifrost_access_token", "tok-1");
 		const teardown = vi.fn();
 		const view = render(
-			<StandaloneV2App {...props("legacy-first")} runtimeContract={null} />,
+			<StandaloneV2App
+				{...props("legacy-first")}
+				runtimeContract={null}
+			/>,
 		);
 
 		let script!: HTMLScriptElement;
 		await waitFor(() => {
 			script = appendedScripts.find((candidate) =>
-				candidate.dataset.bifrostLegacyAppEntry?.endsWith("assets/legacy-first.js"),
+				candidate.dataset.bifrostLegacyAppEntry?.endsWith(
+					"assets/legacy-first.js",
+				),
 			)!;
 			expect(script).toBeTruthy();
 		});
@@ -367,7 +433,10 @@ describe("StandaloneV2App", () => {
 		const teardown = vi.fn();
 		const view = render(
 			<StrictMode>
-				<StandaloneV2App {...props("legacy-strict")} runtimeContract={null} />
+				<StandaloneV2App
+					{...props("legacy-strict")}
+					runtimeContract={null}
+				/>
 			</StrictMode>,
 		);
 
@@ -381,7 +450,9 @@ describe("StandaloneV2App", () => {
 		const script = appendedScripts.find((candidate) =>
 			candidate.src.endsWith("assets/legacy-strict.js"),
 		)!;
-		expect(document.body.contains(window.__BIFROST_APP__?.mountEl ?? null)).toBe(true);
+		expect(
+			document.body.contains(window.__BIFROST_APP__?.mountEl ?? null),
+		).toBe(true);
 		window.__BIFROST_APP__?.registerUnmount(teardown);
 		act(() => script.dispatchEvent(new Event("load")));
 		await act(async () => Promise.resolve());
@@ -393,10 +464,16 @@ describe("StandaloneV2App", () => {
 	it("rejects a concurrent mount of the same legacy side-effect entry", async () => {
 		localStorage.setItem("bifrost_access_token", "tok-1");
 		const first = render(
-			<StandaloneV2App {...props("legacy-concurrent")} runtimeContract={null} />,
+			<StandaloneV2App
+				{...props("legacy-concurrent")}
+				runtimeContract={null}
+			/>,
 		);
 		const second = render(
-			<StandaloneV2App {...props("legacy-concurrent")} runtimeContract={null} />,
+			<StandaloneV2App
+				{...props("legacy-concurrent")}
+				runtimeContract={null}
+			/>,
 		);
 
 		const message = await second.findByText(

--- a/client/src/components/jsx-app/StandaloneV2App.tsx
+++ b/client/src/components/jsx-app/StandaloneV2App.tsx
@@ -266,11 +266,16 @@ export function StandaloneV2App({
 	const { scope } = useOrgScope();
 
 	const token = getActiveToken();
+	const isAuthenticated = Boolean(token);
 	const error = token ? loadError : "Not authenticated — cannot mount the application.";
 
 	useEffect(() => {
 		const mountEl = containerRef.current;
-		if (!mountEl || !token) return;
+		// Read the bootstrap seed only when a mount is actually starting. The
+		// boolean dependency below tears down on logout, but ordinary token
+		// rotation keeps the app's React tree mounted.
+		const bootstrapToken = getActiveToken();
+		if (!mountEl || !bootstrapToken) return;
 
 		setLoadError(null);
 		const basename = isPreview
@@ -311,7 +316,7 @@ export function StandaloneV2App({
 		const bootstrap: BifrostAppBootstrap = {
 			basename,
 			baseUrl: window.location.origin,
-			token,
+			token: bootstrapToken,
 			orgScope,
 			appId,
 			onLogout: () => {
@@ -446,15 +451,7 @@ export function StandaloneV2App({
 			}
 			mountEl.replaceChildren();
 		};
-	}, [
-		appId,
-		appSlug,
-		isPreview,
-		assets,
-		sourceKey,
-		scope,
-		token,
-	]);
+	}, [appId, appSlug, isPreview, assets, sourceKey, scope, isAuthenticated]);
 
 	if (error) {
 		return (

--- a/client/src/lib/api-client.test.ts
+++ b/client/src/lib/api-client.test.ts
@@ -2,6 +2,17 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { apiClient, authFetch } from "./api-client";
 import { ACCESS_TOKEN_KEY } from "./auth-token";
 
+interface TestPlatformAuthBridge {
+	getAccessToken: () => string | null;
+	canRefreshAccessToken: () => boolean;
+	refreshAccessToken: () => Promise<boolean>;
+	handleAuthenticationFailure: () => void;
+}
+
+type TestPlatformAuthGlobal = typeof globalThis & {
+	__BIFROST_PLATFORM_AUTH_V1__?: TestPlatformAuthBridge;
+};
+
 /**
  * Build a mock Response with a given status and an empty body.
  */
@@ -22,6 +33,42 @@ function buildFakeToken(): string {
 	const payload = btoa(JSON.stringify({ exp: farFuture }));
 	return `${header}.${payload}.sig`;
 }
+
+describe("V2 app platform auth bridge", () => {
+	afterEach(() => {
+		vi.unstubAllGlobals();
+		localStorage.clear();
+		sessionStorage.clear();
+	});
+
+	it("shares one refresh request across concurrent SDK recovery calls", async () => {
+		const refreshedToken = buildFakeToken();
+		let releaseRefresh!: () => void;
+		const refreshGate = new Promise<void>((resolve) => {
+			releaseRefresh = resolve;
+		});
+		const fetchMock = vi.fn(async () => {
+			await refreshGate;
+			return mockJsonResponse(200, { access_token: refreshedToken });
+		});
+		vi.stubGlobal("fetch", fetchMock);
+		const bridge = (globalThis as TestPlatformAuthGlobal)
+			.__BIFROST_PLATFORM_AUTH_V1__;
+		expect(bridge).toBeDefined();
+
+		const first = bridge!.refreshAccessToken();
+		const second = bridge!.refreshAccessToken();
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+		releaseRefresh();
+
+		await expect(Promise.all([first, second])).resolves.toEqual([
+			true,
+			true,
+		]);
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+		expect(bridge!.getAccessToken()).toBe(refreshedToken);
+	});
+});
 
 /**
  * Drain the microtask queue + advance fake timers so any pending setTimeout

--- a/client/src/lib/api-client.ts
+++ b/client/src/lib/api-client.ts
@@ -156,6 +156,17 @@ function isTokenExpiringSoon(token: string): boolean {
 // Lock to prevent concurrent refresh attempts
 let refreshPromise: Promise<boolean> | null = null;
 
+interface PlatformAuthBridge {
+	getAccessToken: () => string | null;
+	canRefreshAccessToken: () => boolean;
+	refreshAccessToken: () => Promise<boolean>;
+	handleAuthenticationFailure: () => void;
+}
+
+type PlatformAuthGlobal = typeof globalThis & {
+	__BIFROST_PLATFORM_AUTH_V1__?: PlatformAuthBridge;
+};
+
 /**
  * Refresh the access token using the refresh token cookie
  * Uses HttpOnly cookie for refresh token (more secure than localStorage)
@@ -231,6 +242,19 @@ function handleAuthFailure(): void {
 		window.location.href = `/login?returnTo=${encodeURIComponent(currentPath)}`;
 	}
 }
+
+// Standalone V2 apps execute in the platform document but ship their own copy
+// of the web SDK. This bridge lets that SDK share the host's live token and
+// single-flight refresh path without adding a new bootstrap prop that every
+// Solution entry would have to forward. Embed sessions intentionally remain
+// non-refreshable: their short-lived capability token must re-enter the embed
+// handshake instead of borrowing the signed-in user's refresh cookie.
+(globalThis as PlatformAuthGlobal).__BIFROST_PLATFORM_AUTH_V1__ = {
+	getAccessToken: getActiveToken,
+	canRefreshAccessToken: () => !isEmbedSession(),
+	refreshAccessToken,
+	handleAuthenticationFailure: handleAuthFailure,
+};
 
 /**
  * Ensure we have a valid (non-expiring) access token before making a request

--- a/client/src/lib/app-sdk/provider.test.tsx
+++ b/client/src/lib/app-sdk/provider.test.tsx
@@ -1,9 +1,29 @@
-import { render, screen } from "@testing-library/react";
-import { StrictMode, useEffect } from "react";
-import { describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { createRef, StrictMode, useEffect } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { BifrostProvider, useBifrostContext } from "./provider";
 import { getBifrostTransport } from "./tables";
+
+interface TestPlatformAuthBridge {
+	getAccessToken: () => string | null;
+	canRefreshAccessToken: () => boolean;
+	refreshAccessToken: () => Promise<boolean>;
+	handleAuthenticationFailure: () => void;
+}
+
+type TestPlatformAuthGlobal = typeof globalThis & {
+	__BIFROST_PLATFORM_AUTH_V1__?: TestPlatformAuthBridge;
+};
+
+function setPlatformAuth(bridge: TestPlatformAuthBridge): void {
+	(globalThis as TestPlatformAuthGlobal).__BIFROST_PLATFORM_AUTH_V1__ =
+		bridge;
+}
+
+afterEach(() => {
+	delete (globalThis as TestPlatformAuthGlobal).__BIFROST_PLATFORM_AUTH_V1__;
+});
 
 function Probe() {
   const c = useBifrostContext();
@@ -17,7 +37,11 @@ function Probe() {
 describe("BifrostProvider", () => {
   it("provides baseUrl, token, and orgScope via context", () => {
     render(
-      <BifrostProvider baseUrl="https://dev.example" token="tok-123" orgScope="org-9">
+			<BifrostProvider
+				baseUrl="https://dev.example"
+				token="tok-123"
+				orgScope="org-9"
+			>
         <Probe />
       </BifrostProvider>,
     );
@@ -39,9 +63,15 @@ describe("BifrostProvider", () => {
 
   it("exposes an authed fetch that attaches the bearer token and base url", async () => {
     let captured: { url: string; auth: string | null } | null = null;
-    const fakeFetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+		const fakeFetch = (async (
+			input: RequestInfo | URL,
+			init?: RequestInit,
+		) => {
       const headers = new Headers(init?.headers);
-      captured = { url: String(input), auth: headers.get("Authorization") };
+			captured = {
+				url: String(input),
+				auth: headers.get("Authorization"),
+			};
       return new Response("{}", { status: 200 });
     }) as typeof fetch;
 
@@ -53,7 +83,11 @@ describe("BifrostProvider", () => {
     }
 
     render(
-      <BifrostProvider baseUrl="https://dev.example" token="tok-abc" fetchImpl={fakeFetch}>
+			<BifrostProvider
+				baseUrl="https://dev.example"
+				token="tok-abc"
+				fetchImpl={fakeFetch}
+			>
         <Caller />
       </BifrostProvider>,
     );
@@ -63,6 +97,140 @@ describe("BifrostProvider", () => {
     expect(captured!.url).toBe("https://dev.example/api/workflows/run");
     expect(captured!.auth).toBe("Bearer tok-abc");
   });
+
+	it("uses the host's live token on later requests without remounting", async () => {
+		let liveToken = "tok-1";
+		setPlatformAuth({
+			getAccessToken: () => liveToken,
+			canRefreshAccessToken: () => true,
+			refreshAccessToken: vi.fn().mockResolvedValue(true),
+			handleAuthenticationFailure: vi.fn(),
+		});
+		const seen: string[] = [];
+		const fakeFetch = vi.fn(
+			async (_input: RequestInfo | URL, init?: RequestInit) => {
+				seen.push(
+					new Headers(init?.headers).get("Authorization") ?? "",
+				);
+				return new Response("{}", { status: 200 });
+			},
+		);
+		const callSdkRef = createRef<typeof fetch>();
+
+		function Caller() {
+			const { authedFetch } = useBifrostContext();
+			useEffect(() => {
+				callSdkRef.current = authedFetch;
+			}, [authedFetch]);
+			return null;
+		}
+
+		render(
+			<BifrostProvider
+				baseUrl="/"
+				token="bootstrap-token"
+				fetchImpl={fakeFetch}
+			>
+				<Caller />
+			</BifrostProvider>,
+		);
+		await waitFor(() => expect(callSdkRef.current).toBeDefined());
+		await callSdkRef.current!("/api/first");
+		liveToken = "tok-2";
+		await callSdkRef.current!("/api/second");
+
+		expect(seen).toEqual(["Bearer tok-1", "Bearer tok-2"]);
+		expect(screen.queryByText("Not authenticated")).not.toBeInTheDocument();
+	});
+
+	it("refreshes once after a 401 and retries the request with the rotated token", async () => {
+		let liveToken = "tok-old";
+		const refreshAccessToken = vi.fn(async () => {
+			liveToken = "tok-new";
+			return true;
+		});
+		const handleAuthenticationFailure = vi.fn();
+		setPlatformAuth({
+			getAccessToken: () => liveToken,
+			canRefreshAccessToken: () => true,
+			refreshAccessToken,
+			handleAuthenticationFailure,
+		});
+		const seen: string[] = [];
+		const fakeFetch = vi.fn(
+			async (_input: RequestInfo | URL, init?: RequestInit) => {
+				const authorization =
+					new Headers(init?.headers).get("Authorization") ?? "";
+				seen.push(authorization);
+				return new Response("{}", {
+					status: authorization === "Bearer tok-old" ? 401 : 200,
+				});
+			},
+		);
+		const callSdkRef = createRef<typeof fetch>();
+
+		function Caller() {
+			const { authedFetch } = useBifrostContext();
+			useEffect(() => {
+				callSdkRef.current = authedFetch;
+			}, [authedFetch]);
+			return null;
+		}
+
+		render(
+			<BifrostProvider baseUrl="/" token="tok-old" fetchImpl={fakeFetch}>
+				<Caller />
+			</BifrostProvider>,
+		);
+		await waitFor(() => expect(callSdkRef.current).toBeDefined());
+		const response = await callSdkRef.current!("/api/workflows/execute", {
+			method: "POST",
+			body: JSON.stringify({ input: "preserved" }),
+		});
+
+		expect(response.status).toBe(200);
+		expect(seen).toEqual(["Bearer tok-old", "Bearer tok-new"]);
+		expect(refreshAccessToken).toHaveBeenCalledTimes(1);
+		expect(handleAuthenticationFailure).not.toHaveBeenCalled();
+		expect(fakeFetch.mock.calls.map(([, init]) => init?.body)).toEqual([
+			JSON.stringify({ input: "preserved" }),
+			JSON.stringify({ input: "preserved" }),
+		]);
+	});
+
+	it("hands an unrecoverable 401 back to the platform auth failure handler", async () => {
+		const handleAuthenticationFailure = vi.fn();
+		setPlatformAuth({
+			getAccessToken: () => "tok-old",
+			canRefreshAccessToken: () => true,
+			refreshAccessToken: vi.fn().mockResolvedValue(false),
+			handleAuthenticationFailure,
+		});
+		const fakeFetch = vi
+			.fn()
+			.mockResolvedValue(new Response("{}", { status: 401 }));
+		const callSdkRef = createRef<typeof fetch>();
+
+		function Caller() {
+			const { authedFetch } = useBifrostContext();
+			useEffect(() => {
+				callSdkRef.current = authedFetch;
+			}, [authedFetch]);
+			return null;
+		}
+
+		render(
+			<BifrostProvider baseUrl="/" token="tok-old" fetchImpl={fakeFetch}>
+				<Caller />
+			</BifrostProvider>,
+		);
+		await waitFor(() => expect(callSdkRef.current).toBeDefined());
+		const response = await callSdkRef.current!("/api/private");
+
+		expect(response.status).toBe(401);
+		expect(handleAuthenticationFailure).toHaveBeenCalledTimes(1);
+		expect(fakeFetch).toHaveBeenCalledTimes(1);
+	});
 
   it("treats / as the browser's same-origin transport", async () => {
     let captured: string | null = null;
@@ -78,7 +246,11 @@ describe("BifrostProvider", () => {
     }
 
     render(
-      <BifrostProvider baseUrl="/" token="tok-forwarded" fetchImpl={fakeFetch}>
+			<BifrostProvider
+				baseUrl="/"
+				token="tok-forwarded"
+				fetchImpl={fakeFetch}
+			>
         <Caller />
       </BifrostProvider>,
     );
@@ -94,7 +266,10 @@ describe("BifrostProvider", () => {
     // execution goes through authedFetch. Both must carry the same context
     // signal or the server derives a different install scope per surface.
     let captured: { appHeader: string | null } | null = null;
-    const fakeFetch = (async (_input: RequestInfo | URL, init?: RequestInit) => {
+		const fakeFetch = (async (
+			_input: RequestInfo | URL,
+			init?: RequestInit,
+		) => {
       const headers = new Headers(init?.headers);
       captured = { appHeader: headers.get("X-Bifrost-App") };
       return new Response("{}", { status: 200 });
@@ -123,7 +298,10 @@ describe("BifrostProvider", () => {
 
   it("omits X-Bifrost-App on authedFetch when no appId is bound", async () => {
     let captured: { appHeader: string | null } | null = null;
-    const fakeFetch = (async (_input: RequestInfo | URL, init?: RequestInit) => {
+		const fakeFetch = (async (
+			_input: RequestInfo | URL,
+			init?: RequestInit,
+		) => {
       const headers = new Headers(init?.headers);
       captured = { appHeader: headers.get("X-Bifrost-App") };
       return new Response("{}", { status: 200 });
@@ -136,7 +314,11 @@ describe("BifrostProvider", () => {
     }
 
     render(
-      <BifrostProvider baseUrl="https://dev.example" token="tok-abc" fetchImpl={fakeFetch}>
+			<BifrostProvider
+				baseUrl="https://dev.example"
+				token="tok-abc"
+				fetchImpl={fakeFetch}
+			>
         <Caller />
       </BifrostProvider>,
     );
@@ -147,9 +329,7 @@ describe("BifrostProvider", () => {
 
   it("routes the table SDK through baseUrl + bearer while mounted", async () => {
     const { tables } = await import("./tables");
-    const fetchMock = vi
-      .fn()
-      .mockResolvedValue(
+		const fetchMock = vi.fn().mockResolvedValue(
         new Response(JSON.stringify({ id: "r", data: {} }), {
           status: 200,
           headers: { "content-type": "application/json" },
@@ -174,9 +354,7 @@ describe("BifrostProvider", () => {
     // restore is deferred by a microtask (StrictMode cancellation window).
     unmount();
     await Promise.resolve();
-    const globalFetch = vi
-      .fn()
-      .mockResolvedValue(
+		const globalFetch = vi.fn().mockResolvedValue(
         new Response(JSON.stringify({ id: "r", data: {} }), {
           status: 200,
           headers: { "content-type": "application/json" },
@@ -184,14 +362,14 @@ describe("BifrostProvider", () => {
       );
     vi.stubGlobal("fetch", globalFetch);
     await tables.get("notes", "r");
-    expect(globalFetch.mock.calls[0][0]).toBe("/api/tables/notes/documents/r");
+		expect(globalFetch.mock.calls[0][0]).toBe(
+			"/api/tables/notes/documents/r",
+		);
   });
 
   it("routes the file SDK through the provider app header while mounted", async () => {
     const { files } = await import("./files");
-    const fetchMock = vi
-      .fn()
-      .mockResolvedValue(
+		const fetchMock = vi.fn().mockResolvedValue(
         new Response(JSON.stringify({ exists: true }), {
           status: 200,
           headers: { "content-type": "application/json" },
@@ -209,12 +387,16 @@ describe("BifrostProvider", () => {
       </BifrostProvider>,
     );
 
-    await expect(files.exists("reports/q1.txt", { location: "reports" })).resolves.toBe(true);
+		await expect(
+			files.exists("reports/q1.txt", { location: "reports" }),
+		).resolves.toBe(true);
     const [, init] = fetchMock.mock.calls[0];
-    const requestHeaders = init.headers as Record<string, string>;
-    expect(fetchMock.mock.calls[0][0]).toBe("https://dev.example/api/files/exists");
-    expect(requestHeaders.Authorization).toBe("Bearer tok-file");
-    expect(requestHeaders["X-Bifrost-App"]).toBe("app-123");
+		const requestHeaders = new Headers(init.headers);
+		expect(fetchMock.mock.calls[0][0]).toBe(
+			"https://dev.example/api/files/exists",
+		);
+		expect(requestHeaders.get("Authorization")).toBe("Bearer tok-file");
+		expect(requestHeaders.get("X-Bifrost-App")).toBe("app-123");
   });
 
   it("installs the transport before child mount effects run", () => {
@@ -251,7 +433,10 @@ describe("BifrostProvider", () => {
     }
     const { unmount } = render(
       <StrictMode>
-        <BifrostProvider baseUrl="https://strict.example" token="tok-sm">
+				<BifrostProvider
+					baseUrl="https://strict.example"
+					token="tok-sm"
+				>
           <TransportProbe />
         </BifrostProvider>
       </StrictMode>,

--- a/client/src/lib/app-sdk/provider.tsx
+++ b/client/src/lib/app-sdk/provider.tsx
@@ -34,7 +34,7 @@ import { setBifrostTransport, setDefaultAppScope } from "./tables";
 export interface BifrostContextValue {
   /** Absolute base URL of the Bifrost API (no trailing slash). */
   baseUrl: string;
-  /** Bearer access token for API calls. */
+	/** Current bearer access token for API calls. */
   token: string;
   /** Active organization scope (UUID), or null for the caller's default. */
   orgScope: string | null;
@@ -45,7 +45,7 @@ export interface BifrostContextValue {
    * when the host doesn't supply it.
    */
   appId: string | null;
-  /** `fetch` that joins `baseUrl` and attaches the bearer token. */
+	/** `fetch` that joins `baseUrl`, follows token rotation, and retries one 401. */
   authedFetch: typeof fetch;
   /** Log the user out. No-op if the app did not supply `onLogout`. */
   logout: () => void;
@@ -73,6 +73,21 @@ export type Theme = "light" | "dark";
 const BifrostContext = createContext<BifrostContextValue | null>(null);
 
 const THEME_KEY = "theme";
+
+interface PlatformAuthBridge {
+	getAccessToken: () => string | null;
+	canRefreshAccessToken: () => boolean;
+	refreshAccessToken: () => Promise<boolean>;
+	handleAuthenticationFailure: () => void;
+}
+
+type PlatformAuthGlobal = typeof globalThis & {
+	__BIFROST_PLATFORM_AUTH_V1__?: PlatformAuthBridge;
+};
+
+function platformAuth(): PlatformAuthBridge | undefined {
+	return (globalThis as PlatformAuthGlobal).__BIFROST_PLATFORM_AUTH_V1__;
+}
 
 export interface BifrostProviderProps {
   baseUrl: string;
@@ -144,7 +159,9 @@ export function BifrostProvider({
   // Theme state: seed from the host prop, else the shared localStorage key.
   // Apply the `dark` root class on mount + every change so the app (and the
   // platform) stay visually in sync through one contract.
-  const [theme, setThemeState] = useState<Theme>(() => readStoredTheme(themeProp));
+	const [theme, setThemeState] = useState<Theme>(() =>
+		readStoredTheme(themeProp),
+	);
   useEffect(() => {
     applyThemeClass(theme);
   }, [theme]);
@@ -160,7 +177,8 @@ export function BifrostProvider({
   const setTheme = useCallback(
     (next: Theme) => {
       setThemeState(next);
-      if (typeof localStorage !== "undefined") localStorage.setItem(THEME_KEY, next);
+			if (typeof localStorage !== "undefined")
+				localStorage.setItem(THEME_KEY, next);
       applyThemeClass(next);
       onThemeChange?.(next);
     },
@@ -173,10 +191,17 @@ export function BifrostProvider({
 
   const value = useMemo<BifrostContextValue>(() => {
     const baseFetch = fetchImpl ?? globalThis.fetch;
-    const authedFetch: typeof fetch = (input, init) => {
-      const headers = new Headers(init?.headers);
-      if (!headers.has("Authorization")) {
-        headers.set("Authorization", `Bearer ${token}`);
+		const currentToken = () => {
+			const auth = platformAuth();
+			return auth ? auth.getAccessToken() : token;
+		};
+		const authedFetch: typeof fetch = async (input, init) => {
+			const callerHeaders = new Headers(init?.headers);
+			const managesAuthorization = !callerHeaders.has("Authorization");
+			const requestWithToken = (accessToken: string | null) => {
+				const headers = new Headers(callerHeaders);
+				if (managesAuthorization && accessToken) {
+					headers.set("Authorization", `Bearer ${accessToken}`);
       }
       if (orgScope && !headers.has("X-Bifrost-Org")) {
         headers.set("X-Bifrost-Org", orgScope);
@@ -189,10 +214,41 @@ export function BifrostProvider({
       }
       return baseFetch(joinUrl(baseUrl, input), { ...init, headers });
     };
+
+			const attemptedToken = currentToken();
+			let response = await requestWithToken(attemptedToken);
+			const auth = platformAuth();
+			if (
+				response.status !== 401 ||
+				!managesAuthorization ||
+				!auth?.canRefreshAccessToken()
+			) {
+				return response;
+			}
+
+			// The host may already have rotated the token while this request was
+			// in flight. Prefer that value before asking it to rotate again.
+			let freshToken = auth.getAccessToken();
+			if (!freshToken || freshToken === attemptedToken) {
+				const refreshed = await auth.refreshAccessToken();
+				freshToken = refreshed ? auth.getAccessToken() : null;
+			}
+
+			if (!freshToken) {
+				auth.handleAuthenticationFailure();
+				return response;
+			}
+
+			response = await requestWithToken(freshToken);
+			if (response.status === 401) auth.handleAuthenticationFailure();
+			return response;
+		};
     const logout = () => onLogout?.();
     return {
       baseUrl: baseUrl.replace(/\/$/, ""),
-      token,
+			get token() {
+				return currentToken() ?? "";
+			},
       orgScope,
       appId,
       authedFetch,
@@ -202,7 +258,18 @@ export function BifrostProvider({
       toggleTheme,
       supportsTheme,
     };
-  }, [baseUrl, token, orgScope, appId, fetchImpl, onLogout, theme, setTheme, toggleTheme, supportsTheme]);
+	}, [
+		baseUrl,
+		token,
+		orgScope,
+		appId,
+		fetchImpl,
+		onLogout,
+		theme,
+		setTheme,
+		toggleTheme,
+		supportsTheme,
+	]);
 
   // Route the data SDK (tables.*/useTable) through this provider so a v2 app
   // in `npm run dev` (different origin) reaches the configured Bifrost API with
@@ -240,9 +307,12 @@ export function BifrostProvider({
       // Raw token for the ws client (query-param auth — WebSocket can't send
       // an Authorization header). HTTP calls use the header below.
       token,
-      fetchImpl,
+			getToken: () => {
+				const auth = platformAuth();
+				return auth ? (auth.getAccessToken() ?? undefined) : token;
+			},
+			fetchImpl: value.authedFetch,
       headers: {
-        Authorization: `Bearer ${token}`,
         // Identify the calling app so the server resolves a `useTable("name")`
         // call to THIS install's own deployed table, not a sibling install's
         // (the table equivalent of the useWorkflow app_id, Codex #15).
@@ -303,7 +373,9 @@ export function BifrostProvider({
   }, []);
 
   return (
-    <BifrostContext.Provider value={value}>{children}</BifrostContext.Provider>
+		<BifrostContext.Provider value={value}>
+			{children}
+		</BifrostContext.Provider>
   );
 }
 

--- a/client/src/lib/app-sdk/transport.ts
+++ b/client/src/lib/app-sdk/transport.ts
@@ -11,18 +11,19 @@
  *   same-origin requests with cookie/CSRF auth (the platform serves the app,
  *   so the session cookie is present). Unchanged behavior.
  * - **v2 standalone apps:** `<BifrostProvider>` installs a transport pointing
- *   at the configured `baseUrl` with a bearer token (and optional org header),
- *   so `tables.*`/`useTable` reach the real Bifrost API even when the app is
- *   served by its own dev server (`npm run dev`) on a different origin.
+ *   at the configured `baseUrl` with an authenticated fetch and a lazy token
+ *   reader for WebSocket reconnects, so `tables.*`/`useTable` reach the real
+ *   Bifrost API even when the app is served by its own dev server.
  */
 export interface BifrostTransport {
   baseUrl: string;
   /**
-   * Raw bearer token. HTTP calls carry it via `headers.Authorization`; the
-   * websocket client needs it separately because `WebSocket` cannot send
-   * headers — the server accepts a `token` query param on `/ws/connect`.
+	 * Initial bearer token. Updated providers prefer `getToken`; this remains as
+	 * the local-development and older-provider fallback.
    */
   token?: string;
+	/** Read the current token at connection time (deployed V2 apps rotate it). */
+	getToken?: () => string | undefined;
   fetchImpl?: typeof fetch;
   headers?: Record<string, string>;
 }

--- a/client/src/lib/app-sdk/ws-client.test.ts
+++ b/client/src/lib/app-sdk/ws-client.test.ts
@@ -57,7 +57,10 @@ describe("subscribeToTable", () => {
     const first = MockWebSocket.instances[0];
     first.emit("open", {});
     first.emit("message", {
-      data: JSON.stringify({ type: "subscribed", channel: "table:table-1" }),
+			data: JSON.stringify({
+				type: "subscribed",
+				channel: "table:table-1",
+			}),
     });
     expect(recovered).not.toHaveBeenCalled();
 
@@ -78,7 +81,10 @@ describe("subscribeToTable", () => {
     expect(recovered).not.toHaveBeenCalled();
 
     second.emit("message", {
-      data: JSON.stringify({ type: "subscribed", channel: "table:table-1" }),
+			data: JSON.stringify({
+				type: "subscribed",
+				channel: "table:table-1",
+			}),
     });
     expect(recovered).toHaveBeenCalledTimes(1);
     expect(events).toHaveLength(2);
@@ -97,12 +103,20 @@ describe("subscribeToTable", () => {
 
   it("requests a snapshot refresh when the initial handshake only succeeds after retry", () => {
     const recovered = vi.fn();
-    const unsubscribe = subscribeToTable("table-1", null, () => {}, recovered);
+		const unsubscribe = subscribeToTable(
+			"table-1",
+			null,
+			() => {},
+			recovered,
+		);
     MockWebSocket.instances[0].emit("close", { code: 1006 });
 
     vi.advanceTimersByTime(500);
     MockWebSocket.instances[1].emit("message", {
-      data: JSON.stringify({ type: "subscribed", channel: "table:table-1" }),
+			data: JSON.stringify({
+				type: "subscribed",
+				channel: "table:table-1",
+			}),
     });
 
     expect(recovered).toHaveBeenCalledTimes(1);
@@ -139,7 +153,9 @@ describe("buildWsUrl", () => {
   it("defaults to the window origin with NO token param (v1 inline, cookie auth)", () => {
     const url = new URL(buildWsUrl());
     const origin = new URL(window.location.href);
-    expect(url.protocol).toBe(origin.protocol === "https:" ? "wss:" : "ws:");
+		expect(url.protocol).toBe(
+			origin.protocol === "https:" ? "wss:" : "ws:",
+		);
     expect(url.host).toBe(origin.host);
     expect(url.pathname).toBe("/ws/connect");
     expect(url.searchParams.has("token")).toBe(false);
@@ -152,4 +168,21 @@ describe("buildWsUrl", () => {
     });
     expect(buildWsUrl()).toBe("ws://localhost:8000/ws/connect?token=t2");
   });
+
+	it("reads the live token each time a websocket reconnect URL is built", () => {
+		let token = "t-old";
+		restore = setBifrostTransport({
+			baseUrl: "https://remote.example",
+			token: "bootstrap-token",
+			getToken: () => token,
+		});
+
+		expect(buildWsUrl()).toBe(
+			"wss://remote.example/ws/connect?token=t-old",
+		);
+		token = "t-new";
+		expect(buildWsUrl()).toBe(
+			"wss://remote.example/ws/connect?token=t-new",
+		);
+	});
 });

--- a/client/src/lib/app-sdk/ws-client.ts
+++ b/client/src/lib/app-sdk/ws-client.ts
@@ -39,7 +39,8 @@ export function buildWsUrl(): string {
   const base = t.baseUrl ? new URL(t.baseUrl) : new URL(window.location.href);
   const proto = base.protocol === "https:" ? "wss:" : "ws:";
   const url = new URL("/ws/connect", `${proto}//${base.host}`);
-  if (t.token) url.searchParams.set("token", t.token);
+	const token = t.getToken?.() ?? t.token;
+	if (token) url.searchParams.set("token", token);
   return url.toString();
 }
 
@@ -177,7 +178,8 @@ export function subscribeToTable(
     onMessage: (message) => {
       onEvent(message as TableChangeMessage);
       return !(
-        message.type === "error" || message.type === "subscription_revoked"
+				message.type === "error" ||
+				message.type === "subscription_revoked"
       );
     },
   });
@@ -202,7 +204,8 @@ export function subscribeToFiles(
     onMessage: (message) => {
       onEvent(message as FileChangeMessage);
       return !(
-        message.type === "error" || message.type === "subscription_revoked"
+				message.type === "error" ||
+				message.type === "subscription_revoked"
       );
     },
   });


### PR DESCRIPTION
## Summary
- expose the host authentication lifecycle to bundled V2 SDKs through a versioned same-document bridge
- make SDK HTTP, table, file, workflow, and WebSocket calls read the current access token lazily
- retry one SDK-owned 401 through the host single-flight refresh path while preserving embed-session boundaries
- keep mounted V2 apps alive across token rotation, while still tearing them down on logout

## Verification
- 124 targeted Vitest tests across provider, tables, files, workflows, WebSockets, host auth, SDK contract, and V2 mounting
- 12 backend SDK package and fingerprint tests
- TypeScript typecheck
- ESLint (0 errors; 2 pre-existing warnings outside changed files)

Fixes #688