### PR TITLE
test: clean up external integration OAuth fixtures

### DIFF
--- a/api/tests/e2e/platform/test_cli_integrations_external.py
+++ b/api/tests/e2e/platform/test_cli_integrations_external.py
@@ -152,15 +152,14 @@ async def global_integration(e2e_client, platform_admin, db_session, org1):
     db_session.add(provider)
     await db_session.flush()
 
-    db_session.add(
-        OAuthToken(
-            organization_id=None,
-            provider_id=provider.id,
-            user_id=None,
-            encrypted_access_token=encrypt_secret(GLOBAL_ACCESS_TOKEN).encode(),
-            scopes=["read"],
-        )
+    token = OAuthToken(
+        organization_id=None,
+        provider_id=provider.id,
+        user_id=None,
+        encrypted_access_token=encrypt_secret(GLOBAL_ACCESS_TOKEN).encode(),
+        scopes=["read"],
     )
+    db_session.add(token)
     await db_session.commit()
 
     # Org-scoped mapping in the external user's own org (org1), with a
@@ -184,6 +183,13 @@ async def global_integration(e2e_client, platform_admin, db_session, org1):
         "org_id": org1["id"],
     }
 
+    # Integration deletion is soft, so its provider and client-credentials
+    # token do not cascade away. Remove them explicitly: otherwise each
+    # function-scoped fixture invocation leaves another refreshable token for
+    # the live scheduler to sweep later in the E2E run.
+    await db_session.delete(token)
+    await db_session.delete(provider)
+    await db_session.commit()
     e2e_client.delete(
         f"/api/integrations/{integration_id}", headers=platform_admin.headers
     )
@@ -362,3 +368,20 @@ class TestExternalIntegrationsRefreshToken:
             f"normal org user must reach the global provider (not 404): "
             f"{resp.status_code} {resp.text}"
         )
+
+
+@pytest.mark.asyncio
+async def test_global_integration_fixture_removes_refreshable_oauth_state(db_session):
+    """Repeated fixture use must not pollute the later live scheduler tests."""
+    from sqlalchemy import func, select
+
+    from src.models.orm import OAuthProvider
+    from src.models.orm.oauth import OAuthToken
+
+    leaked_tokens = await db_session.scalar(
+        select(func.count())
+        .select_from(OAuthToken)
+        .join(OAuthProvider)
+        .where(OAuthProvider.provider_name.like("ext_integ_provider_%"))
+    )
+    assert leaked_tokens == 0


### PR DESCRIPTION
Fixes #690.

## Summary

- explicitly delete the function-scoped external integration OAuth token and provider during fixture teardown
- add an end-of-module assertion that repeated fixture use leaves no refreshable OAuth state
- prevent the real 15-minute scheduler sweep from colliding with scheduler diagnostics in full pre-PR runs

## Verification

- `./test.sh tests/e2e/platform/test_cli_integrations_external.py tests/e2e/platform/test_scheduler_diagnostics.py tests/e2e/platform/test_scheduler_fixture_workloads.py -v` — 17 passed
- `./test.sh pre-pr` at `ddf13b5d668e9d83960cb0402e0126cbbefe052a` — passed
  - client: 294 files / 1,898 tests
  - backend unit/contract: 5,838 passed, 3 skipped, 20 deselected
  - backend E2E: 1,786 passed, 1 skipped
  - browser smoke: 4 passed
  - production client/API builds, TypeScript, lint, and API quality passed

The prior full run failed after the 15-minute scheduler interval with exactly 12 leaked tokens; this run passed both scheduler tests in the same full-suite ordering.