### PR TITLE
Auto-detect OpenAI transport for Azure Foundry models

### DIFF
--- a/api/alembic/versions/20260902_openai_transport_detection.py
+++ b/api/alembic/versions/20260902_openai_transport_detection.py
@@ -1,0 +1,36 @@
+"""Store the detected OpenAI-compatible transport per model profile.
+
+Revision ID: 20260902_openai_transport
+Revises: 20260829_app_deployments
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "20260902_openai_transport"
+down_revision: str | None = "20260829_app_deployments"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "ai_model_profiles",
+        sa.Column("openai_transport", sa.String(length=32), nullable=True),
+    )
+    op.create_check_constraint(
+        "ck_ai_model_profiles_openai_transport",
+        "ai_model_profiles",
+        "openai_transport IS NULL OR openai_transport IN ('responses', 'chat_completions')",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        "ck_ai_model_profiles_openai_transport",
+        "ai_model_profiles",
+        type_="check",
+    )
+    op.drop_column("ai_model_profiles", "openai_transport")

--- a/api/src/models/orm/ai_models.py
+++ b/api/src/models/orm/ai_models.py
@@ -64,6 +64,7 @@ class AIModelProfile(Base):
         nullable=False,
     )
     model: Mapped[str] = mapped_column(String(200), nullable=False)
+    openai_transport: Mapped[str | None] = mapped_column(String(32), nullable=True)
     capabilities: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
     enabled_for_chat: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False, server_default="false")
     created_at: Mapped[datetime] = mapped_column(
@@ -83,6 +84,10 @@ class AIModelProfile(Base):
     agents: Mapped[list["Agent"]] = relationship(back_populates="llm_profile", lazy="selectin")
 
     __table_args__ = (
+        CheckConstraint(
+            "openai_transport IS NULL OR openai_transport IN ('responses', 'chat_completions')",
+            name="ck_ai_model_profiles_openai_transport",
+        ),
         Index("uq_ai_model_profiles_name_ci", text("lower(name)"), unique=True),
         Index("ix_ai_model_profiles_connection_id", "connection_id"),
         Index("ix_ai_model_profiles_enabled_for_chat", "enabled_for_chat"),

--- a/api/src/services/agent_runtime/model_factory.py
+++ b/api/src/services/agent_runtime/model_factory.py
@@ -6,7 +6,7 @@ scheduler import boundary while giving every agent surface one model abstraction
 
 from decimal import Decimal, InvalidOperation
 
-from pydantic_ai.models import Model
+from pydantic_ai.models import Model, infer_model
 from pydantic_ai.usage import RequestUsage
 
 from src.services.agent_runtime.retry_transport import get_ai_retry_http_client
@@ -34,6 +34,8 @@ def agent_model_settings(
         settings["max_tokens"] = resolved_max_tokens
     if is_openrouter_endpoint(config.endpoint):
         settings["extra_body"] = {"session_id": session_id[:256]}
+    elif config.provider == "openai":
+        settings["openai_store"] = False
     return settings
 
 
@@ -141,7 +143,6 @@ def create_agent_model(config: LLMConfig, *, model: str | None = None) -> Model:
             )
 
         from openai import AsyncOpenAI
-        from pydantic_ai.models.openai import OpenAIChatModel
         from pydantic_ai.providers.openai import OpenAIProvider
 
         client = AsyncOpenAI(
@@ -151,7 +152,10 @@ def create_agent_model(config: LLMConfig, *, model: str | None = None) -> Model:
             max_retries=0,
         )
         provider = OpenAIProvider(openai_client=client)
-        return OpenAIChatModel(model_name, provider=provider)
+        return infer_model(
+            f"openai:{model_name}",
+            provider_factory=lambda _provider_name: provider,
+        )
 
     if config.provider == "anthropic":
         from anthropic import AsyncAnthropic

--- a/api/src/services/agent_runtime/model_factory.py
+++ b/api/src/services/agent_runtime/model_factory.py
@@ -143,6 +143,7 @@ def create_agent_model(config: LLMConfig, *, model: str | None = None) -> Model:
             )
 
         from openai import AsyncOpenAI
+        from pydantic_ai.models.openai import OpenAIChatModel
         from pydantic_ai.providers.openai import OpenAIProvider
 
         client = AsyncOpenAI(
@@ -152,6 +153,8 @@ def create_agent_model(config: LLMConfig, *, model: str | None = None) -> Model:
             max_retries=0,
         )
         provider = OpenAIProvider(openai_client=client)
+        if config.openai_transport == "chat_completions":
+            return OpenAIChatModel(model_name, provider=provider)
         return infer_model(
             f"openai:{model_name}",
             provider_factory=lambda _provider_name: provider,

--- a/api/src/services/ai_model_service.py
+++ b/api/src/services/ai_model_service.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING
 from uuid import UUID
 
 from cryptography.fernet import Fernet
-from sqlalchemy import delete, func, select
+from sqlalchemy import delete, func, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import joinedload, selectinload
 
@@ -212,11 +212,27 @@ class AIModelService:
                 "Please configure the API key in System Settings > AI Configuration."
             )
 
+        openai_transport = profile.openai_transport
+        if connection.provider == "openai_compatible" and openai_transport is None:
+            from src.services.openai_transport_detection import (
+                detect_openai_transport,
+            )
+
+            openai_transport = await detect_openai_transport(
+                api_key=api_key,
+                endpoint=connection.endpoint,
+                model=profile.model,
+            )
+            profile.openai_transport = openai_transport
+            profile.updated_at = datetime.now(timezone.utc)
+            await self.session.flush()
+
         return LLMConfig(
             provider=provider,
             model=profile.model,
             api_key=api_key,
             endpoint=connection.endpoint,
+            openai_transport=openai_transport,
         )
 
     async def list_chat_profiles(self) -> tuple[list[AIModelProfile], UUID | None]:
@@ -379,12 +395,21 @@ class AIModelService:
                 trimmed_name, exclude_id=connection.id
             )
             connection.name = trimmed_name
+        transport_may_change = (
+            provider is not None or endpoint_provided or api_key is not None
+        )
         if provider is not None:
             connection.provider = provider
         if provider is not None or endpoint_provided:
             connection.endpoint = self.normalize_endpoint(connection.provider, endpoint)
         if api_key is not None:
             connection.encrypted_api_key = self.encrypt_api_key(api_key)
+        if transport_may_change:
+            await self.session.execute(
+                update(AIModelProfile)
+                .where(AIModelProfile.connection_id == connection.id)
+                .values(openai_transport=None)
+            )
         connection.updated_at = datetime.now(timezone.utc)
         await self.session.flush()
         return connection
@@ -517,11 +542,13 @@ class AIModelService:
         if connection_id is not None:
             await self.get_connection(connection_id)
             profile.connection_id = connection_id
+            profile.openai_transport = None
         if model is not None:
             trimmed_model = model.strip()
             if not trimmed_model:
                 raise ValueError("Model id is required")
             profile.model = trimmed_model
+            profile.openai_transport = None
         if capabilities_provided:
             profile.capabilities = (
                 capabilities.model_dump(mode="json") if capabilities else None

--- a/api/src/services/llm/base.py
+++ b/api/src/services/llm/base.py
@@ -112,6 +112,7 @@ class LLMConfig:
     model: str
     api_key: str
     endpoint: str | None = None
+    openai_transport: Literal["responses", "chat_completions"] | None = None
     # Optional parameters
     extra_params: dict[str, Any] = field(default_factory=dict)
 

--- a/api/src/services/llm/pydantic_client.py
+++ b/api/src/services/llm/pydantic_client.py
@@ -26,7 +26,7 @@ from pydantic_ai.messages import (
     UserContent,
 )
 from pydantic_ai.models import ModelRequestParameters
-from pydantic_ai.settings import ModelSettings
+from pydantic_ai.models.openai import OpenAIResponsesModelSettings
 from pydantic_ai.tools import ToolDefinition as PydanticToolDefinition
 
 from src.services.agent_runtime.model_factory import (
@@ -139,9 +139,9 @@ class PydanticAIClient(BaseLLMClient):
             logger.error("Pydantic AI streaming error: %s", exc)
             yield LLMStreamChunk(type="error", error=str(exc))
 
-    def _model_settings(self, max_tokens: int | None) -> ModelSettings:
+    def _model_settings(self, max_tokens: int | None) -> OpenAIResponsesModelSettings:
         resolved_max_tokens = request_max_tokens(self.config, max_tokens)
-        settings = ModelSettings()
+        settings = OpenAIResponsesModelSettings()
         if resolved_max_tokens is not None:
             settings["max_tokens"] = resolved_max_tokens
         if self.provider_name == "openai":

--- a/api/src/services/llm/pydantic_client.py
+++ b/api/src/services/llm/pydantic_client.py
@@ -141,9 +141,12 @@ class PydanticAIClient(BaseLLMClient):
 
     def _model_settings(self, max_tokens: int | None) -> ModelSettings:
         resolved_max_tokens = request_max_tokens(self.config, max_tokens)
-        if resolved_max_tokens is None:
-            return ModelSettings()
-        return ModelSettings(max_tokens=resolved_max_tokens)
+        settings = ModelSettings()
+        if resolved_max_tokens is not None:
+            settings["max_tokens"] = resolved_max_tokens
+        if self.provider_name == "openai":
+            settings["openai_store"] = False
+        return settings
 
     @staticmethod
     def _request_parameters(

--- a/api/src/services/openai_transport_detection.py
+++ b/api/src/services/openai_transport_detection.py
@@ -1,0 +1,67 @@
+"""Detect the usable OpenAI-compatible inference transport once per profile."""
+
+from typing import Literal
+
+from openai import APIStatusError, AsyncOpenAI
+
+from src.services.agent_runtime.retry_transport import get_ai_retry_http_client
+
+OpenAITransport = Literal["responses", "chat_completions"]
+
+
+def _responses_are_unsupported(error: APIStatusError) -> bool:
+    if error.status_code in (404, 405, 501):
+        return True
+    if error.status_code != 400:
+        return False
+    message = str(error).casefold()
+    return any(
+        marker in message
+        for marker in (
+            "model not supported",
+            "does not support the responses api",
+            "responses api is not supported",
+            "unsupported endpoint",
+            "unknown endpoint",
+        )
+    )
+
+
+async def detect_openai_transport(
+    *, api_key: str, endpoint: str | None, model: str
+) -> OpenAITransport:
+    """Probe Responses first and use Chat only for a definite unsupported error."""
+
+    client = AsyncOpenAI(
+        api_key=api_key,
+        base_url=endpoint,
+        http_client=get_ai_retry_http_client(),
+        max_retries=0,
+    )
+    try:
+        await client.responses.create(
+            model=model,
+            input="Reply with OK.",
+            max_output_tokens=64,
+            store=False,
+        )
+        return "responses"
+    except APIStatusError as error:
+        if not _responses_are_unsupported(error):
+            raise ValueError(
+                f"Could not verify model '{model}' through the Responses API "
+                f"(HTTP {error.status_code}); transport was not changed."
+            ) from error
+
+    try:
+        await client.chat.completions.create(
+            model=model,
+            messages=[{"role": "user", "content": "Reply with OK."}],
+            max_completion_tokens=64,
+        )
+    except APIStatusError as error:
+        raise ValueError(
+            f"Model '{model}' is unavailable through both Responses and Chat "
+            f"Completions (Chat HTTP {error.status_code})."
+        ) from error
+    return "chat_completions"

--- a/api/src/services/provider_catalog_service.py
+++ b/api/src/services/provider_catalog_service.py
@@ -137,6 +137,16 @@ class ProviderCatalogService:
                     ProviderModelInfo(m.id, m.id, _model_output_modalities(m))
                     for m in sorted(response.data, key=lambda item: item.id)
                 ]
+                hostname = (urlparse(endpoint).hostname or "") if endpoint else ""
+                if hostname.endswith((".openai.azure.com", ".services.ai.azure.com")):
+                    return ProviderTestResult(
+                        True,
+                        (
+                            f"Connected to {endpoint_label}. Microsoft Foundry's model "
+                            "catalog does not identify deployment names; enter the "
+                            "deployment name manually."
+                        ),
+                    )
                 if _is_openrouter_endpoint(endpoint):
                     try:
                         models = await list_openrouter_models(api_key)

--- a/api/tests/unit/services/test_agent_runtime.py
+++ b/api/tests/unit/services/test_agent_runtime.py
@@ -190,6 +190,20 @@ def test_openai_uses_pydantic_default_model() -> None:
     ) is False
 
 
+def test_openai_uses_detected_chat_completions_transport() -> None:
+    from pydantic_ai.models.openai import OpenAIChatModel
+
+    config = LLMConfig(
+        provider="openai",
+        model="chat-only-model",
+        api_key="test-key",
+        endpoint="https://models.example.test/v1",
+        openai_transport="chat_completions",
+    )
+
+    assert isinstance(create_agent_model(config), OpenAIChatModel)
+
+
 def test_create_agent_model_uses_native_openrouter_adapter() -> None:
     from pydantic_ai.models.openrouter import OpenRouterModel, OpenRouterModelSettings
 

--- a/api/tests/unit/services/test_agent_runtime.py
+++ b/api/tests/unit/services/test_agent_runtime.py
@@ -593,6 +593,57 @@ async def test_legacy_complete_uses_stream_transport_for_large_output_limits() -
 
 
 @pytest.mark.asyncio
+async def test_direct_openai_complete_and_stream_disable_storage() -> None:
+    response = ModelResponse(
+        parts=[TextPart("hello")],
+        usage=RequestUsage(input_tokens=12, output_tokens=3),
+        model_name="test-model",
+        provider_name="openai",
+        finish_reason="stop",
+    )
+
+    class FakeStream:
+        def __aiter__(self):
+            async def events():
+                if False:
+                    yield None
+
+            return events()
+
+        def get(self):
+            return response
+
+    class FakeStreamContext:
+        async def __aenter__(self):
+            return FakeStream()
+
+        async def __aexit__(self, *args):
+            return False
+
+    client = PydanticAIClient(
+        LLMConfig(provider="openai", model="test-model", api_key="test-key")
+    )
+    with patch(
+        "src.services.llm.pydantic_client.create_agent_model",
+        return_value=MagicMock(),
+    ), patch(
+        "src.services.llm.pydantic_client.model_request_stream",
+        side_effect=[FakeStreamContext(), FakeStreamContext()],
+    ) as request_stream:
+        await client.complete([LLMMessage(role="user", content="hello")])
+        _ = [
+            chunk
+            async for chunk in client.stream(
+                [LLMMessage(role="user", content="hello")]
+            )
+        ]
+
+    assert request_stream.call_count == 2
+    for call in request_stream.call_args_list:
+        assert call.kwargs["model_settings"]["openai_store"] is False
+
+
+@pytest.mark.asyncio
 async def test_toolset_preserves_stored_json_schema_and_emits_lifecycle_events() -> None:
     calls: list[tuple[str, dict]] = []
     events = []

--- a/api/tests/unit/services/test_agent_runtime.py
+++ b/api/tests/unit/services/test_agent_runtime.py
@@ -172,6 +172,24 @@ def test_create_agent_model_supports_every_configured_provider(
         assert provider_client.max_retries == 0
 
 
+def test_openai_uses_pydantic_default_model() -> None:
+    from pydantic_ai.models.openai import OpenAIResponsesModel
+
+    config = LLMConfig(
+        provider="openai",
+        model="gpt-5.6-luna",
+        api_key="test-key",
+        endpoint="https://foundry.example.test/openai/v1",
+    )
+
+    model = create_agent_model(config)
+
+    assert isinstance(model, OpenAIResponsesModel)
+    assert agent_model_settings(config, max_tokens=None, session_id="run-1").get(
+        "openai_store"
+    ) is False
+
+
 def test_create_agent_model_uses_native_openrouter_adapter() -> None:
     from pydantic_ai.models.openrouter import OpenRouterModel, OpenRouterModelSettings
 
@@ -215,7 +233,9 @@ def test_runtime_uses_provider_output_defaults_except_when_api_requires_limit() 
     openai = LLMConfig(provider="openai", model="gpt-5", api_key="test-key")
     anthropic = LLMConfig(provider="anthropic", model="claude-sonnet", api_key="test-key")
 
-    assert agent_model_settings(openai, max_tokens=None, session_id="run-123") == {}
+    assert agent_model_settings(openai, max_tokens=None, session_id="run-123") == {
+        "openai_store": False,
+    }
     assert agent_model_settings(anthropic, max_tokens=None, session_id="run-123") == {
         "max_tokens": 16_384,
     }

--- a/api/tests/unit/services/test_openai_transport_detection.py
+++ b/api/tests/unit/services/test_openai_transport_detection.py
@@ -1,0 +1,117 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+from openai import BadRequestError, RateLimitError
+
+from src.services.openai_transport_detection import detect_openai_transport
+
+
+def _status_error(error_type, status: int, message: str):
+    response = httpx.Response(
+        status,
+        request=httpx.Request("POST", "https://models.example.test/v1/responses"),
+    )
+    return error_type(message, response=response, body={"message": message})
+
+
+def _client(*, responses_result=None, responses_error=None, chat_error=None):
+    return SimpleNamespace(
+        responses=SimpleNamespace(
+            create=AsyncMock(
+                return_value=responses_result,
+                side_effect=responses_error,
+            )
+        ),
+        chat=SimpleNamespace(
+            completions=SimpleNamespace(
+                create=AsyncMock(return_value=MagicMock(), side_effect=chat_error)
+            )
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_detect_openai_transport_prefers_responses() -> None:
+    client = _client(responses_result=MagicMock())
+
+    with patch(
+        "src.services.openai_transport_detection.AsyncOpenAI", return_value=client
+    ):
+        transport = await detect_openai_transport(
+            api_key="test-key",
+            endpoint="https://models.example.test/v1",
+            model="test-model",
+        )
+
+    assert transport == "responses"
+    client.chat.completions.create.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_detect_openai_transport_falls_back_for_unsupported_model() -> None:
+    client = _client(
+        responses_error=_status_error(
+            BadRequestError, 400, "Model not supported for the Responses API"
+        )
+    )
+
+    with patch(
+        "src.services.openai_transport_detection.AsyncOpenAI", return_value=client
+    ):
+        transport = await detect_openai_transport(
+            api_key="test-key",
+            endpoint="https://models.example.test/v1",
+            model="test-model",
+        )
+
+    assert transport == "chat_completions"
+    client.chat.completions.create.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_detect_openai_transport_fails_when_both_transports_are_unavailable() -> (
+    None
+):
+    client = _client(
+        responses_error=_status_error(
+            BadRequestError, 400, "Model not supported for the Responses API"
+        ),
+        chat_error=_status_error(BadRequestError, 400, "Unknown deployment"),
+    )
+
+    with (
+        patch(
+            "src.services.openai_transport_detection.AsyncOpenAI", return_value=client
+        ),
+        pytest.raises(ValueError, match="unavailable through both"),
+    ):
+        await detect_openai_transport(
+            api_key="test-key",
+            endpoint="https://models.example.test/v1",
+            model="test-model",
+        )
+
+    client.chat.completions.create.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_detect_openai_transport_does_not_fallback_for_rate_limits() -> None:
+    client = _client(
+        responses_error=_status_error(RateLimitError, 429, "Rate limit exceeded")
+    )
+
+    with (
+        patch(
+            "src.services.openai_transport_detection.AsyncOpenAI", return_value=client
+        ),
+        pytest.raises(ValueError, match="transport was not changed"),
+    ):
+        await detect_openai_transport(
+            api_key="test-key",
+            endpoint="https://models.example.test/v1",
+            model="test-model",
+        )
+
+    client.chat.completions.create.assert_not_awaited()

--- a/api/tests/unit/services/test_provider_catalog_service.py
+++ b/api/tests/unit/services/test_provider_catalog_service.py
@@ -1,7 +1,35 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
 import httpx
 import pytest
 
-from src.services.provider_catalog_service import list_openrouter_models
+from src.services.provider_catalog_service import (
+    ProviderCatalogService,
+    list_openrouter_models,
+)
+
+
+@pytest.mark.asyncio
+async def test_foundry_catalog_is_not_presented_as_deployment_names():
+    client = SimpleNamespace(
+        models=SimpleNamespace(
+            list=AsyncMock(
+                return_value=SimpleNamespace(
+                    data=[SimpleNamespace(id="gpt-5.6-luna-2026-07-09")]
+                )
+            )
+        )
+    )
+    with patch("openai.AsyncOpenAI", return_value=client):
+        result = await ProviderCatalogService().list_openai(
+            "sk-test",
+            "https://example.openai.azure.com/openai/v1",
+        )
+
+    assert result.success is True
+    assert result.models is None
+    assert "deployment name manually" in result.message
 
 
 @pytest.mark.asyncio

--- a/api/tests/unit/test_ai_model_service.py
+++ b/api/tests/unit/test_ai_model_service.py
@@ -1,3 +1,4 @@
+from unittest.mock import AsyncMock, patch
 from uuid import uuid4
 
 import pytest
@@ -119,6 +120,67 @@ async def test_openai_compatible_connection_requires_endpoint(db_session):
             api_key="sk-test",
             endpoint=None,
         )
+
+
+@pytest.mark.asyncio
+async def test_openai_compatible_profile_detects_and_remembers_transport(db_session):
+    service = AIModelService(db_session)
+    connection = await service.create_connection(
+        name="Foundry",
+        provider="openai_compatible",
+        api_key="sk-test",
+        endpoint="https://foundry.example.test/openai/v1",
+    )
+    profile = await service.create_profile(
+        name="Foundry Luna",
+        connection_id=connection.id,
+        model="gpt-5.6-luna",
+        capabilities=None,
+        enabled_for_chat=True,
+    )
+    detector = AsyncMock(return_value="responses")
+
+    with patch(
+        "src.services.openai_transport_detection.detect_openai_transport", detector
+    ):
+        first = await service.resolve_config(profile_id=profile.id)
+        second = await service.resolve_config(profile_id=profile.id)
+
+    assert first.openai_transport == "responses"
+    assert second.openai_transport == "responses"
+    detector.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_profile_and_connection_changes_clear_detected_transport(db_session):
+    service = AIModelService(db_session)
+    connection = await service.create_connection(
+        name="Compatible",
+        provider="openai_compatible",
+        api_key="sk-test",
+        endpoint="https://one.example.test/v1",
+    )
+    profile = await service.create_profile(
+        name="Compatible Model",
+        connection_id=connection.id,
+        model="model-one",
+        capabilities=None,
+        enabled_for_chat=True,
+    )
+    profile.openai_transport = "responses"
+    await db_session.flush()
+
+    updated = await service.update_profile(profile.id, model="model-two")
+    assert updated.openai_transport is None
+
+    updated.openai_transport = "chat_completions"
+    await db_session.flush()
+    await service.update_connection(
+        connection.id,
+        endpoint="https://two.example.test/v1",
+        endpoint_provided=True,
+    )
+    assert updated.openai_transport is None
 
 
 @pytest.mark.asyncio
@@ -262,12 +324,17 @@ async def test_resolve_config_defaults_to_platform_default_assignment(db_session
     )
     await service.set_assignment("primary", profile.id)
 
-    config = await service.resolve_config()
+    with patch(
+        "src.services.openai_transport_detection.detect_openai_transport",
+        AsyncMock(return_value="responses"),
+    ):
+        config = await service.resolve_config()
 
     assert config.provider == "openai"
     assert config.endpoint == "https://llm.example.test/v1"
     assert config.api_key == "compatible-key"
     assert config.model == "custom/model"
+    assert config.openai_transport == "responses"
 
 
 @pytest.mark.asyncio

--- a/client/e2e/ai-model-settings.admin.spec.ts
+++ b/client/e2e/ai-model-settings.admin.spec.ts
@@ -307,6 +307,11 @@ test.describe("AI model settings", () => {
 		await profileDialog.getByLabel("Profile Name").fill("Support Chat");
 		await profileDialog.getByLabel("Provider Connection").click();
 		await page.getByRole("option", { name: /Default/ }).click();
+		await expect(
+			profileDialog.getByText(
+				"This list is supplied by the provider and may include models your account cannot access. Choose a model available to your account.",
+			),
+		).toBeVisible();
 		await profileDialog.getByLabel("Model", { exact: true }).click();
 		await page
 			.getByRole("option", { name: "GPT-5.1 mini gpt-5.1-mini" })

--- a/client/src/components/ai/ProviderModelField.test.tsx
+++ b/client/src/components/ai/ProviderModelField.test.tsx
@@ -89,6 +89,11 @@ describe("ProviderModelField", () => {
 				screen.getByRole("option", { name: "Text Embedding 3 Large" }),
 			).toBeInTheDocument(),
 		);
+		expect(
+			screen.getByText(
+				"This list is supplied by the provider and may include models your account cannot access. Choose a model available to your account.",
+			),
+		).toBeInTheDocument();
 		fireEvent.change(screen.getByLabelText("Model"), {
 			target: { value: "text-embedding-3-large" },
 		});

--- a/client/src/components/ai/ProviderModelField.tsx
+++ b/client/src/components/ai/ProviderModelField.tsx
@@ -37,21 +37,30 @@ export function ProviderModelField({
 			<Label htmlFor={id}>Model</Label>
 			{!modelsQuery.isError &&
 			(!connectionId || modelsQuery.isLoading || options.length > 0) ? (
-				<Combobox
-					id={id}
-					value={value}
-					onValueChange={onValueChange}
-					options={options}
-					placeholder={
-						connectionId
-							? "Select a model"
-							: "Select a provider first"
-					}
-					searchPlaceholder="Search models..."
-					emptyText="No models reported by this provider."
-					disabled={!connectionId}
-					isLoading={modelsQuery.isLoading}
-				/>
+				<>
+					<Combobox
+						id={id}
+						value={value}
+						onValueChange={onValueChange}
+						options={options}
+						placeholder={
+							connectionId
+								? "Select a model"
+								: "Select a provider first"
+						}
+						searchPlaceholder="Search models..."
+						emptyText="No models reported by this provider."
+						disabled={!connectionId}
+						isLoading={modelsQuery.isLoading}
+					/>
+					{Boolean(modelsQuery.data?.models.length) && (
+						<p className="text-xs text-muted-foreground">
+							This list is supplied by the provider and may
+							include models your account cannot access. Choose a
+							model available to your account.
+						</p>
+					)}
+				</>
 			) : (
 				<>
 					<Input


### PR DESCRIPTION
## Summary

- try the OpenAI Responses API on first use of an OpenAI-compatible model profile
- fall back to Chat Completions only when Responses is definitively unsupported
- persist the successful transport and reset detection when connection-critical settings change
- disable Responses server-side storage
- avoid presenting the misleading Azure Foundry model catalog as deployment names
- clarify that provider model catalogs may include models unavailable to the connected account

This supersedes #667 because GitHub rejected maintainer pushes to its organization-owned fork branch. It incorporates and credits the original transport work from #667, then applies the reviewed automatic-detection design and live Azure validation.

Closes #666.

## Verification

- live Microsoft Foundry deployment: gpt-5.6-luna (2026-07-09)
- Responses detection succeeded through the normal Bifrost client path
- the detected transport persisted and was reused from a second database session without probing again
- targeted backend unit tests passed (56 tests)
- transport-specific live checks passed
- API Pyright and Ruff passed
- migration applied cleanly with one Alembic head
- ProviderModelField Vitest passed (2 tests)
- AI model settings Playwright passed (3 tests, including setup)
- client TypeScript check passed
- client lint passed with two pre-existing warnings outside changed files

## Original work

- #667
- https://github.com/MTG-Thomas/bifrost/issues/618
- https://github.com/MTG-Thomas/bifrost/pull/620