### PR TITLE
fix: paginate users and roles listings

### DIFF
--- a/api/src/models/contracts/__init__.py
+++ b/api/src/models/contracts/__init__.py
@@ -59,6 +59,7 @@ from src.models.contracts.users import (
     RoleKnowledgeResponse,
     RolePublic,
     RoleUpdate,
+    RoleUserSummary,
     RoleUsersResponse,
     RoleWorkflowsResponse,
     UnassignAgentsFromRoleRequest,
@@ -665,6 +666,7 @@ __all__ = [
     "RoleCreate",
     "RoleUpdate",
     "RolePublic",
+    "RoleUserSummary",
     # User/Role assignments
     "UserPermission",
     "PermissionsData",

--- a/api/src/models/contracts/users.py
+++ b/api/src/models/contracts/users.py
@@ -347,6 +347,10 @@ class RoleUsersResponse(BaseModel):
         default_factory=list,
         description="Display-ready summaries for users assigned to the role",
     )
+    total: int = Field(
+        default=0,
+        description="Total users assigned to the role after filtering",
+    )
 
 
 class RoleFormsResponse(BaseModel):

--- a/api/src/models/contracts/users.py
+++ b/api/src/models/contracts/users.py
@@ -329,9 +329,24 @@ class UnassignWorkflowsFromRoleRequest(BaseModel):
     workflow_ids: list[str] = Field(..., min_length=1, max_length=500)
 
 
+class RoleUserSummary(BaseModel):
+    """Display-ready user identity returned by the role detail endpoint."""
+
+    id: UUID
+    name: str | None
+    email: str
+    organization_id: UUID | None
+    organization_name: str | None
+    organization_is_provider: bool = False
+
+
 class RoleUsersResponse(BaseModel):
     """Response model for getting users assigned to a role"""
     user_ids: list[str] = Field(..., description="List of user IDs assigned to the role")
+    users: list[RoleUserSummary] = Field(
+        default_factory=list,
+        description="Display-ready summaries for users assigned to the role",
+    )
 
 
 class RoleFormsResponse(BaseModel):

--- a/api/src/routers/roles.py
+++ b/api/src/routers/roles.py
@@ -8,9 +8,10 @@ Manage roles for organization users.
 
 import logging
 from datetime import datetime, timezone
+from typing import Literal
 from uuid import UUID
 
-from fastapi import APIRouter, HTTPException, status
+from fastapi import APIRouter, HTTPException, Query, Response, status
 from sqlalchemy import func, select, delete
 
 from src.core.auth import CurrentSuperuser
@@ -28,6 +29,7 @@ from src.models import (
     AgentRole as AgentRoleORM,
     Form as FormORM,
     User as UserORM,
+    Organization as OrganizationORM,
     Agent as AgentORM,
 )
 from src.models.orm.applications import Application as ApplicationORM
@@ -40,6 +42,7 @@ from src.models import (
     RolePublic,
     RoleUpdate,
     RoleUsersResponse,
+    RoleUserSummary,
     RoleFormsResponse,
     RoleAgentsResponse,
     RoleAppsResponse,
@@ -90,28 +93,13 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/api/roles", tags=["Roles"])
 
 
-@router.get(
-    "",
-    response_model=list[RolePublic],
-    summary="List all roles",
-    description="Get all roles (Platform admin only)",
-)
-async def list_roles(
-    user: CurrentSuperuser,
-    db: DbSession,
-) -> list[RolePublic]:
-    """List all roles with inline consumer counts (users/forms/agents/apps/workflows/knowledge)."""
-    query = select(RoleORM).order_by(RoleORM.name)
-    result = await db.execute(query)
-    roles = result.scalars().all()
+async def _get_consumer_counts(
+    db: DbSession, role_ids: list[UUID]
+) -> dict[UUID, RoleConsumerCounts]:
+    counts_by_role = {role_id: RoleConsumerCounts() for role_id in role_ids}
+    if not counts_by_role:
+        return counts_by_role
 
-    counts_by_role: dict[UUID, RoleConsumerCounts] = {
-        r.id: RoleConsumerCounts() for r in roles
-    }
-
-    # Six grouped COUNT queries — one per consumer type. Cheap on small/medium
-    # workspaces; if the role count ever explodes, replace with a single UNION
-    # ALL query.
     aggregates: list[tuple[str, "object"]] = [
         ("users", UserRoleORM),
         ("forms", FormRoleORM),
@@ -121,14 +109,64 @@ async def list_roles(
         ("knowledge", KnowledgeNamespaceRoleORM),
     ]
     for field, orm in aggregates:
-        agg = await db.execute(
-            select(orm.role_id, func.count()).group_by(orm.role_id)  # type: ignore[attr-defined]
+        aggregate = await db.execute(
+            select(orm.role_id, func.count())  # type: ignore[attr-defined]
+            .where(orm.role_id.in_(counts_by_role))  # type: ignore[attr-defined]
+            .group_by(orm.role_id)  # type: ignore[attr-defined]
         )
-        for role_id, count in agg.all():
+        for role_id, count in aggregate.all():
             entry = counts_by_role.get(role_id)
-            if entry is None:
-                continue
-            setattr(entry, field, int(count))
+            if entry is not None:
+                setattr(entry, field, int(count))
+    return counts_by_role
+
+
+@router.get(
+    "",
+    response_model=list[RolePublic],
+    summary="List all roles",
+    description="Get all roles (Platform admin only)",
+)
+async def list_roles(
+    user: CurrentSuperuser,
+    db: DbSession,
+    response: Response,
+    search: str | None = Query(None, description="Search role name or description"),
+    sort_by: Literal["name", "created"] = Query("name"),
+    sort_direction: Literal["asc", "desc"] = Query("asc"),
+    limit: int | None = Query(
+        None,
+        ge=1,
+        le=100,
+        description="Maximum rows to return; omit for the legacy unbounded response",
+    ),
+    offset: int = Query(0, ge=0, description="Rows to skip when limit is set"),
+) -> list[RolePublic]:
+    """List all roles with inline consumer counts (users/forms/agents/apps/workflows/knowledge)."""
+    query = select(RoleORM)
+    if search and (term := search.strip()):
+        pattern = f"%{term}%"
+        query = query.where(
+            RoleORM.name.ilike(pattern) | RoleORM.description.ilike(pattern)
+        )
+
+    total = await db.scalar(
+        select(func.count()).select_from(query.order_by(None).subquery())
+    )
+    response.headers["X-Total-Count"] = str(total or 0)
+
+    sort_expression = RoleORM.name if sort_by == "name" else RoleORM.created_at
+    if sort_direction == "desc":
+        sort_expression = sort_expression.desc()
+    else:
+        sort_expression = sort_expression.asc()
+    query = query.order_by(sort_expression, RoleORM.id.asc())
+    if limit is not None:
+        query = query.offset(offset).limit(limit)
+    result = await db.execute(query)
+    roles = result.scalars().all()
+
+    counts_by_role = await _get_consumer_counts(db, [role.id for role in roles])
 
     out: list[RolePublic] = []
     for r in roles:
@@ -178,7 +216,9 @@ async def create_role(
         resource_id=role.id,
         details={"name": role.name},
     )
-    return RolePublic.model_validate(role)
+    public = RolePublic.model_validate(role)
+    public.consumer_counts = (await _get_consumer_counts(db, [role.id]))[role.id]
+    return public
 
 
 @router.get(
@@ -202,7 +242,9 @@ async def get_role(
             detail="Role not found",
         )
 
-    return RolePublic.model_validate(role)
+    public = RolePublic.model_validate(role)
+    public.consumer_counts = (await _get_consumer_counts(db, [role.id]))[role.id]
+    return public
 
 
 @router.patch(
@@ -343,10 +385,34 @@ async def get_role_users(
 ) -> RoleUsersResponse:
     """Get all users assigned to a role."""
     result = await db.execute(
-        select(UserRoleORM.user_id).where(UserRoleORM.role_id == role_id)
+        select(
+            UserORM,
+            OrganizationORM.name,
+            OrganizationORM.is_provider,
+        )
+        .join(UserRoleORM, UserRoleORM.user_id == UserORM.id)
+        .outerjoin(OrganizationORM, OrganizationORM.id == UserORM.organization_id)
+        .where(
+            UserRoleORM.role_id == role_id,
+            UserORM.is_system.is_(False),
+        )
+        .order_by(func.coalesce(UserORM.name, UserORM.email), UserORM.email)
     )
-    user_ids = [str(uid) for uid in result.scalars().all()]
-    return RoleUsersResponse(user_ids=user_ids)
+    users = [
+        RoleUserSummary(
+            id=assigned_user.id,
+            name=assigned_user.name,
+            email=assigned_user.email,
+            organization_id=assigned_user.organization_id,
+            organization_name=organization_name,
+            organization_is_provider=bool(organization_is_provider),
+        )
+        for assigned_user, organization_name, organization_is_provider in result.all()
+    ]
+    return RoleUsersResponse(
+        user_ids=[str(assigned_user.id) for assigned_user in users],
+        users=users,
+    )
 
 
 @router.post(

--- a/api/src/routers/roles.py
+++ b/api/src/routers/roles.py
@@ -382,9 +382,17 @@ async def get_role_users(
     role_id: UUID,
     user: CurrentSuperuser,
     db: DbSession,
+    search: str | None = Query(None, description="Search assigned user name or email"),
+    limit: int | None = Query(
+        None,
+        ge=1,
+        le=100,
+        description="Maximum rows to return; omit for the legacy unbounded response",
+    ),
+    offset: int = Query(0, ge=0, description="Rows to skip when limit is set"),
 ) -> RoleUsersResponse:
-    """Get all users assigned to a role."""
-    result = await db.execute(
+    """Get users assigned to a role."""
+    query = (
         select(
             UserORM,
             OrganizationORM.name,
@@ -396,7 +404,24 @@ async def get_role_users(
             UserRoleORM.role_id == role_id,
             UserORM.is_system.is_(False),
         )
-        .order_by(func.coalesce(UserORM.name, UserORM.email), UserORM.email)
+    )
+    if search and (term := search.strip()):
+        pattern = f"%{term}%"
+        query = query.where(
+            UserORM.name.ilike(pattern) | UserORM.email.ilike(pattern)
+        )
+
+    total = await db.scalar(
+        select(func.count()).select_from(query.order_by(None).subquery())
+    )
+    query = query.order_by(
+        func.coalesce(UserORM.name, UserORM.email), UserORM.email
+    )
+    if limit is not None:
+        query = query.offset(offset).limit(limit)
+
+    result = await db.execute(
+        query
     )
     users = [
         RoleUserSummary(
@@ -412,6 +437,7 @@ async def get_role_users(
     return RoleUsersResponse(
         user_ids=[str(assigned_user.id) for assigned_user in users],
         users=users,
+        total=total or 0,
     )
 
 

--- a/api/src/routers/users.py
+++ b/api/src/routers/users.py
@@ -6,11 +6,12 @@ List and manage users, view user roles and forms.
 
 import logging
 from datetime import datetime, timezone
+from typing import Literal
 from urllib.parse import parse_qs, urlparse
 from uuid import UUID
 
-from fastapi import APIRouter, HTTPException, Query, status
-from sqlalchemy import select
+from fastapi import APIRouter, HTTPException, Query, Response, status
+from sqlalchemy import case, exists, func, or_, select
 
 from src.config import get_settings
 from src.core.auth import CurrentSuperuser
@@ -36,6 +37,7 @@ from src.models.contracts.user_invites import (
     InviteStatus,
     SendInviteRequest,
 )
+from src.models.orm import UserInvite, UserOAuthAccount
 from src.core.constants import PROVIDER_ORG_ID
 
 logger = logging.getLogger(__name__)
@@ -52,6 +54,7 @@ router = APIRouter(prefix="/api/users", tags=["Users"])
 async def list_users(
     user: CurrentSuperuser,
     db: DbSession,
+    response: Response,
     type: str | None = Query(None, description="Filter by user type: 'platform' or 'org'"),
     scope: str | None = Query(
         None,
@@ -59,6 +62,18 @@ async def list_users(
         "or org UUID for specific org."
     ),
     include_inactive: bool = Query(False, description="Include inactive (disabled) users"),
+    search: str | None = Query(None, description="Search user name or email"),
+    sort_by: Literal["name", "email", "status", "created", "last_login"] | None = Query(
+        None, description="Sort field; omit to preserve the legacy email order"
+    ),
+    sort_direction: Literal["asc", "desc"] = Query("asc"),
+    limit: int | None = Query(
+        None,
+        ge=1,
+        le=100,
+        description="Maximum rows to return; omit for the legacy unbounded response",
+    ),
+    offset: int = Query(0, ge=0, description="Rows to skip when limit is set"),
 ) -> list[UserPublic]:
     """List users with optional filtering.
 
@@ -102,16 +117,67 @@ async def list_users(
         query = query.where(UserORM.organization_id == filter_org)
     # ALL: no filter applied
 
-    query = query.order_by(UserORM.email)
+    if search and (term := search.strip()):
+        pattern = f"%{term}%"
+        query = query.where(
+            or_(UserORM.name.ilike(pattern), UserORM.email.ilike(pattern))
+        )
+
+    total = await db.scalar(
+        select(func.count()).select_from(query.order_by(None).subquery())
+    )
+    response.headers["X-Total-Count"] = str(total or 0)
+
+    active_account = or_(
+        UserORM.is_registered.is_(True),
+        exists(
+            select(UserOAuthAccount.id).where(UserOAuthAccount.user_id == UserORM.id)
+        ),
+    )
+    pending_invite = exists(
+        select(UserInvite.id).where(
+            UserInvite.user_id == UserORM.id,
+            UserInvite.revoked_at.is_(None),
+            UserInvite.expires_at >= datetime.now(timezone.utc),
+        )
+    )
+    expired_invite = exists(
+        select(UserInvite.id).where(
+            UserInvite.user_id == UserORM.id,
+            UserInvite.revoked_at.is_(None),
+            UserInvite.expires_at < datetime.now(timezone.utc),
+        )
+    )
+    status_order = case(
+        (active_account, 0),
+        (expired_invite, 1),
+        (pending_invite, 3),
+        else_=2,
+    )
+    sort_expression = {
+        "name": func.coalesce(UserORM.name, UserORM.email),
+        "email": UserORM.email,
+        "status": status_order,
+        "created": UserORM.created_at,
+        "last_login": UserORM.last_login,
+    }.get(sort_by or "email", UserORM.email)
+    if sort_direction == "desc":
+        sort_expression = sort_expression.desc()
+    else:
+        sort_expression = sort_expression.asc()
+    query = query.order_by(sort_expression, UserORM.id.asc())
+    if limit is not None:
+        query = query.offset(offset).limit(limit)
 
     result = await db.execute(query)
     users = result.scalars().all()
 
     invite_svc = UserInviteService(db)
+    statuses = await invite_svc.statuses_for(list(users))
     out: list[UserPublic] = []
     for u in users:
         public = UserPublic.model_validate(u)
-        public.invite_status = await invite_svc.status_for(u)
+        public.invite_status = statuses[u.id]
         out.append(public)
     return out
 

--- a/api/src/services/user_invite_service.py
+++ b/api/src/services/user_invite_service.py
@@ -109,6 +109,49 @@ class UserInviteService:
             return InviteStatus.EXPIRED
         return InviteStatus.PENDING
 
+    async def statuses_for(self, users: list[User]) -> dict[UUID, str]:
+        """Resolve invite status for a user collection with two bounded queries."""
+        if not users:
+            return {}
+
+        user_ids = [user.id for user in users]
+        oauth_user_ids = set(
+            (
+                await self.session.execute(
+                    select(UserOAuthAccount.user_id).where(
+                        UserOAuthAccount.user_id.in_(user_ids)
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        invites = (
+            (
+                await self.session.execute(
+                    select(UserInvite).where(UserInvite.user_id.in_(user_ids))
+                )
+            )
+            .scalars()
+            .all()
+        )
+        invites_by_user = {invite.user_id: invite for invite in invites}
+        now = datetime.now(timezone.utc)
+
+        statuses: dict[UUID, str] = {}
+        for user in users:
+            if user.is_registered or user.id in oauth_user_ids:
+                statuses[user.id] = InviteStatus.ACTIVE
+                continue
+            invite = invites_by_user.get(user.id)
+            if invite is None or invite.revoked_at is not None:
+                statuses[user.id] = InviteStatus.NEVER_INVITED
+            elif invite.expires_at < now:
+                statuses[user.id] = InviteStatus.EXPIRED
+            else:
+                statuses[user.id] = InviteStatus.PENDING
+        return statuses
+
     async def _get_for_user(self, user_id: UUID) -> UserInvite | None:
         return (
             await self.session.execute(

--- a/api/tests/e2e/api/test_roles.py
+++ b/api/tests/e2e/api/test_roles.py
@@ -114,12 +114,19 @@ class TestRoleCRUD:
                     f"/api/roles/{role_id}", headers=platform_admin.headers
                 )
 
-    def test_assign_role_to_user(self, e2e_client, platform_admin, org1_user, test_role):
+    def test_assign_role_to_user(
+        self, e2e_client, platform_admin, org1_user, org2_user, test_role
+    ):
         """Platform admin can assign role to user."""
         response = e2e_client.post(
             f"/api/roles/{test_role['id']}/users",
             headers=platform_admin.headers,
-            json={"user_ids": [str(org1_user.user_id)]},
+            json={
+                "user_ids": [
+                    str(org1_user.user_id),
+                    str(org2_user.user_id),
+                ]
+            },
         )
         # Accept 200, 201, or 204
         assert response.status_code in [200, 201, 204], \
@@ -128,18 +135,33 @@ class TestRoleCRUD:
         assigned = e2e_client.get(
             f"/api/roles/{test_role['id']}/users",
             headers=platform_admin.headers,
+            params={"limit": 1, "offset": 0},
         )
         assert assigned.status_code == 200, assigned.text
-        assert assigned.json()["users"] == [
-            {
-                "id": str(org1_user.user_id),
-                "name": org1_user.name,
-                "email": org1_user.email,
-                "organization_id": str(org1_user.organization_id),
-                "organization_name": "Bifrost Dev Org",
-                "organization_is_provider": False,
-            }
-        ]
+        first_page = assigned.json()
+        assert first_page["total"] == 2
+        assert len(first_page["users"]) == 1
+        assert first_page["user_ids"] == [first_page["users"][0]["id"]]
+        assert first_page["users"][0]["name"] == org1_user.name
+        assert first_page["users"][0]["organization_name"] == "Bifrost Dev Org"
+
+        second = e2e_client.get(
+            f"/api/roles/{test_role['id']}/users",
+            headers=platform_admin.headers,
+            params={"limit": 1, "offset": 1},
+        )
+        assert second.status_code == 200, second.text
+        assert second.json()["total"] == 2
+        assert second.json()["users"][0]["name"] == org2_user.name
+
+        searched = e2e_client.get(
+            f"/api/roles/{test_role['id']}/users",
+            headers=platform_admin.headers,
+            params={"search": org2_user.email, "limit": 25, "offset": 0},
+        )
+        assert searched.status_code == 200, searched.text
+        assert searched.json()["total"] == 1
+        assert searched.json()["users"][0]["email"] == org2_user.email
 
 
 @pytest.mark.e2e

--- a/api/tests/e2e/api/test_roles.py
+++ b/api/tests/e2e/api/test_roles.py
@@ -66,6 +66,54 @@ class TestRoleCRUD:
         role_names = [r["name"] for r in roles]
         assert "E2E Test Role" in role_names
 
+    def test_role_listing_supports_server_pagination_search_and_sort(
+        self, e2e_client, platform_admin
+    ):
+        created = []
+        try:
+            for name in ["Paged role Alpha", "Paged role Bravo"]:
+                response = e2e_client.post(
+                    "/api/roles",
+                    headers=platform_admin.headers,
+                    json={"name": name, "description": "pagination boundary"},
+                )
+                assert response.status_code == 201, response.text
+                created.append(response.json()["id"])
+
+            first = e2e_client.get(
+                "/api/roles",
+                headers=platform_admin.headers,
+                params={
+                    "search": "Paged role",
+                    "sort_by": "name",
+                    "sort_direction": "asc",
+                    "limit": 1,
+                    "offset": 0,
+                },
+            )
+            assert first.status_code == 200, first.text
+            assert first.headers["X-Total-Count"] == "2"
+            assert [role["name"] for role in first.json()] == ["Paged role Alpha"]
+            assert first.json()[0]["consumer_counts"]["users"] == 0
+
+            second = e2e_client.get(
+                "/api/roles",
+                headers=platform_admin.headers,
+                params={
+                    "search": "Paged role",
+                    "sort_by": "name",
+                    "sort_direction": "asc",
+                    "limit": 1,
+                    "offset": 1,
+                },
+            )
+            assert [role["name"] for role in second.json()] == ["Paged role Bravo"]
+        finally:
+            for role_id in created:
+                e2e_client.delete(
+                    f"/api/roles/{role_id}", headers=platform_admin.headers
+                )
+
     def test_assign_role_to_user(self, e2e_client, platform_admin, org1_user, test_role):
         """Platform admin can assign role to user."""
         response = e2e_client.post(
@@ -76,6 +124,22 @@ class TestRoleCRUD:
         # Accept 200, 201, or 204
         assert response.status_code in [200, 201, 204], \
             f"Assign role failed: {response.status_code} - {response.text}"
+
+        assigned = e2e_client.get(
+            f"/api/roles/{test_role['id']}/users",
+            headers=platform_admin.headers,
+        )
+        assert assigned.status_code == 200, assigned.text
+        assert assigned.json()["users"] == [
+            {
+                "id": str(org1_user.user_id),
+                "name": org1_user.name,
+                "email": org1_user.email,
+                "organization_id": str(org1_user.organization_id),
+                "organization_name": "Bifrost Dev Org",
+                "organization_is_provider": False,
+            }
+        ]
 
 
 @pytest.mark.e2e

--- a/api/tests/e2e/api/test_users.py
+++ b/api/tests/e2e/api/test_users.py
@@ -49,6 +49,63 @@ class TestUserListing:
         assert org1_user.email in emails
         assert org2_user.email in emails
 
+    def test_user_listing_supports_server_pagination_search_and_sort(
+        self, e2e_client, platform_admin, org1
+    ):
+        marker = "User page boundary"
+        created_ids = []
+        try:
+            for name, email in [
+                (f"{marker} Alpha", "user-page-alpha@gobifrost.dev"),
+                (f"{marker} Bravo", "user-page-bravo@gobifrost.dev"),
+            ]:
+                create = e2e_client.post(
+                    "/api/users",
+                    headers=platform_admin.headers,
+                    json={
+                        "name": name,
+                        "email": email,
+                        "organization_id": org1["id"],
+                        "is_superuser": False,
+                        "invite": False,
+                    },
+                )
+                assert create.status_code == 201, create.text
+                created_ids.append(create.json()["id"])
+
+            first = e2e_client.get(
+                "/api/users",
+                headers=platform_admin.headers,
+                params={
+                    "search": marker,
+                    "sort_by": "name",
+                    "sort_direction": "asc",
+                    "limit": 1,
+                    "offset": 0,
+                },
+            )
+            assert first.status_code == 200, first.text
+            assert first.headers["X-Total-Count"] == "2"
+            assert [user["name"] for user in first.json()] == [f"{marker} Alpha"]
+
+            second = e2e_client.get(
+                "/api/users",
+                headers=platform_admin.headers,
+                params={
+                    "search": marker,
+                    "sort_by": "name",
+                    "sort_direction": "asc",
+                    "limit": 1,
+                    "offset": 1,
+                },
+            )
+            assert [user["name"] for user in second.json()] == [f"{marker} Bravo"]
+        finally:
+            for user_id in created_ids:
+                e2e_client.delete(
+                    f"/api/users/{user_id}", headers=platform_admin.headers
+                )
+
     def test_system_user_hidden_from_listing(self, e2e_client, platform_admin):
         """System user should never appear in user listings."""
         response = e2e_client.get(

--- a/api/tests/unit/services/test_user_invite_service.py
+++ b/api/tests/unit/services/test_user_invite_service.py
@@ -1,0 +1,60 @@
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from typing import cast
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.models.contracts.user_invites import InviteStatus
+from src.models.orm import User
+from src.services.user_invite_service import UserInviteService
+
+
+@pytest.mark.asyncio
+async def test_statuses_for_resolves_a_page_with_two_queries() -> None:
+    registered_id = uuid4()
+    oauth_id = uuid4()
+    pending_id = uuid4()
+    expired_id = uuid4()
+    never_invited_id = uuid4()
+    users = cast(
+        list[User],
+        [
+            SimpleNamespace(id=registered_id, is_registered=True),
+            SimpleNamespace(id=oauth_id, is_registered=False),
+            SimpleNamespace(id=pending_id, is_registered=False),
+            SimpleNamespace(id=expired_id, is_registered=False),
+            SimpleNamespace(id=never_invited_id, is_registered=False),
+        ],
+    )
+
+    oauth_result = MagicMock()
+    oauth_result.scalars.return_value.all.return_value = [oauth_id]
+    invite_result = MagicMock()
+    invite_result.scalars.return_value.all.return_value = [
+        SimpleNamespace(
+            user_id=pending_id,
+            revoked_at=None,
+            expires_at=datetime.now(timezone.utc) + timedelta(hours=1),
+        ),
+        SimpleNamespace(
+            user_id=expired_id,
+            revoked_at=None,
+            expires_at=datetime.now(timezone.utc) - timedelta(hours=1),
+        ),
+    ]
+    session = AsyncMock(spec=AsyncSession)
+    session.execute.side_effect = [oauth_result, invite_result]
+
+    statuses = await UserInviteService(session).statuses_for(users)
+
+    assert statuses == {
+        registered_id: InviteStatus.ACTIVE,
+        oauth_id: InviteStatus.ACTIVE,
+        pending_id: InviteStatus.PENDING,
+        expired_id: InviteStatus.EXPIRED,
+        never_invited_id: InviteStatus.NEVER_INVITED,
+    }
+    assert session.execute.await_count == 2

--- a/client/e2e/roles.detail.admin.spec.ts
+++ b/client/e2e/roles.detail.admin.spec.ts
@@ -127,6 +127,15 @@ test.describe("Roles detail", () => {
 			page.getByText(new RegExp(`RoleDetail User ${SUFFIX}`)),
 		).toBeVisible();
 
+		// Assigned users open the same detail route as rows on the Users page.
+		await page.getByText(new RegExp(`RoleDetail User ${SUFFIX}`)).click();
+		await expect(page).toHaveURL(new RegExp(`/users/${userId}$`));
+		await page.goBack();
+		await expect(page).toHaveURL(new RegExp(`/roles/${roleId}/users$`));
+		await expect(
+			page.getByRole("heading", { name: ROLE_NAME }),
+		).toBeVisible();
+
 		// Tick + unassign.
 		await page
 			.getByLabel(new RegExp(`Select RoleDetail User ${SUFFIX}`))

--- a/client/e2e/roles.detail.admin.spec.ts
+++ b/client/e2e/roles.detail.admin.spec.ts
@@ -82,6 +82,7 @@ test.describe("Roles detail", () => {
 			page.getByText(new RegExp(`RoleDetail User ${SUFFIX}`)),
 		).toBeVisible();
 		await expect(page.getByText(userId, { exact: true })).toHaveCount(0);
+		await expect(page.getByText("1–1 of 1", { exact: true })).toBeVisible();
 
 		// Remove the seeded assignment so the rest of the test exercises the
 		// empty → assign → assigned lifecycle.

--- a/client/e2e/roles.detail.admin.spec.ts
+++ b/client/e2e/roles.detail.admin.spec.ts
@@ -44,6 +44,11 @@ test.describe("Roles detail", () => {
 		});
 		expect(u.ok(), await u.text()).toBe(true);
 		userId = (await u.json()).id;
+
+		const assign = await api.post(`/api/roles/${roleId}/users`, {
+			data: { user_ids: [userId] },
+		});
+		expect(assign.ok(), await assign.text()).toBe(true);
 	});
 
 	test.afterAll(async ({ api }) => {
@@ -51,11 +56,15 @@ test.describe("Roles detail", () => {
 		if (roleId) await api.delete(`/api/roles/${roleId}`);
 	});
 
-	test("card → users chip → drawer → assigned → unassign", async ({ page }) => {
+	test("card → users chip → drawer → assigned → unassign", async ({
+		page,
+	}) => {
 		await page.goto("/roles");
 
 		// The card for our role is rendered with name visible.
-		await expect(page.getByText(ROLE_NAME).first()).toBeVisible({ timeout: 10000 });
+		await expect(page.getByText(ROLE_NAME).first()).toBeVisible({
+			timeout: 10000,
+		});
 
 		// Navigate directly via the URL — the click-the-chip path is exercised
 		// in the vitest. This spec focuses on the assignment lifecycle, not on
@@ -67,7 +76,19 @@ test.describe("Roles detail", () => {
 			page.getByRole("heading", { name: ROLE_NAME }),
 		).toBeVisible();
 
-		// No users assigned yet.
+		// The role endpoint returns complete user display data. The page never
+		// exposes an assignment UUID while waiting for the user directory.
+		await expect(
+			page.getByText(new RegExp(`RoleDetail User ${SUFFIX}`)),
+		).toBeVisible();
+		await expect(page.getByText(userId, { exact: true })).toHaveCount(0);
+
+		// Remove the seeded assignment so the rest of the test exercises the
+		// empty → assign → assigned lifecycle.
+		await page
+			.getByLabel(new RegExp(`Select RoleDetail User ${SUFFIX}`))
+			.click();
+		await page.getByRole("button", { name: /unassign from role/i }).click();
 		await expect(
 			page.getByText(/no users assigned to this role yet/i),
 		).toBeVisible();
@@ -94,7 +115,11 @@ test.describe("Roles detail", () => {
 		// Use the SheetClose icon-button (the dialog's primary close), not our
 		// outline footer Close button — there are two "Close" buttons in the
 		// drawer DOM.
-		await page.getByRole("dialog").getByRole("button", { name: /^close$/i }).last().click();
+		await page
+			.getByRole("dialog")
+			.getByRole("button", { name: /^close$/i })
+			.last()
+			.click();
 
 		// User is now in the assigned list.
 		await expect(
@@ -102,10 +127,16 @@ test.describe("Roles detail", () => {
 		).toBeVisible();
 
 		// Tick + unassign.
-		await page.getByLabel(new RegExp(`Select RoleDetail User ${SUFFIX}`)).click();
+		await page
+			.getByLabel(new RegExp(`Select RoleDetail User ${SUFFIX}`))
+			.click();
 		await page.getByRole("button", { name: /unassign from role/i }).click();
 
-		await expect(page.getByText(/removed 1 users/i)).toBeVisible({
+		// This flow removes the user twice; target the newest toast so the earlier
+		// notification still fading out does not make the locator ambiguous.
+		await expect(
+			page.locator('[data-sonner-toast][data-front="true"]'),
+		).toContainText(/removed 1 users/i, {
 			timeout: 10000,
 		});
 		await expect(

--- a/client/e2e/users.admin.spec.ts
+++ b/client/e2e/users.admin.spec.ts
@@ -93,7 +93,10 @@ test.describe("User Details", () => {
 			}).observe(document.body, { childList: true, subtree: true });
 		});
 
-		await userRow.locator("td").nth(2).click();
+		const emailCell = userRow.locator("td").nth(3);
+		const email = (await emailCell.textContent())?.trim();
+		expect(email).toBeTruthy();
+		await emailCell.getByText(email!, { exact: true }).click();
 		await expect(page).toHaveURL(/\/users\/[0-9a-f-]+$/);
 		await expect(
 			page.getByRole("dialog", { name: /edit user/i }),

--- a/client/e2e/users.admin.spec.ts
+++ b/client/e2e/users.admin.spec.ts
@@ -53,24 +53,63 @@ test.describe("User Listing", () => {
 });
 
 test.describe("User Details", () => {
-	test("should show user details when clicked", async ({ page }) => {
+	test("opens user details once without remounting the dialog", async ({
+		page,
+	}) => {
 		await page.goto("/users");
 
 		await expect(
 			page.getByRole("heading", { name: /users/i }).first(),
 		).toBeVisible({ timeout: 10000 });
 
-		// Find a user row
 		const userRow = page.locator("table tbody tr").first();
-		const emptyState = page.getByText(/no users/i);
-		await expect(userRow.or(emptyState)).toBeVisible({ timeout: 10000 });
-		const hasUserRow = await userRow.isVisible().catch(() => false);
+		await expect(userRow).toBeVisible({ timeout: 10000 });
+		await page.evaluate(() => {
+			const observedWindow = window as unknown as {
+				__dialogTransitions: string[];
+			};
+			observedWindow.__dialogTransitions = [];
+			new MutationObserver((mutations) => {
+				for (const mutation of mutations) {
+					for (const node of mutation.addedNodes) {
+						if (
+							node instanceof HTMLElement &&
+							(node.matches('[role="dialog"]') ||
+								node.querySelector('[role="dialog"]'))
+						) {
+							observedWindow.__dialogTransitions.push("added");
+						}
+					}
+					for (const node of mutation.removedNodes) {
+						if (
+							node instanceof HTMLElement &&
+							(node.matches('[role="dialog"]') ||
+								node.querySelector('[role="dialog"]'))
+						) {
+							observedWindow.__dialogTransitions.push("removed");
+						}
+					}
+				}
+			}).observe(document.body, { childList: true, subtree: true });
+		});
 
-		if (hasUserRow) {
-			await userRow.click();
-			// Just verify the page responds to the click
-		}
-		// Test passes if either we clicked a user or there were no users
+		await userRow.locator("td").nth(2).click();
+		await expect(page).toHaveURL(/\/users\/[0-9a-f-]+$/);
+		await expect(
+			page.getByRole("dialog", { name: /edit user/i }),
+		).toBeVisible();
+		await page.evaluate(
+			() =>
+				new Promise((resolve) =>
+					requestAnimationFrame(() => requestAnimationFrame(resolve)),
+				),
+		);
+		const transitions = await page.evaluate(
+			() =>
+				(window as unknown as { __dialogTransitions: string[] })
+					.__dialogTransitions,
+		);
+		expect(transitions).toEqual(["added"]);
 	});
 
 	test("should show user organization membership", async ({ page }) => {

--- a/client/src/components/pagination/ListPagination.test.tsx
+++ b/client/src/components/pagination/ListPagination.test.tsx
@@ -1,0 +1,49 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { ListPagination } from "./ListPagination";
+
+describe("ListPagination", () => {
+	it("reports the visible range and navigates by offset", async () => {
+		const user = userEvent.setup();
+		const onPageChange = vi.fn();
+		render(
+			<ListPagination
+				offset={25}
+				limit={25}
+				total={72}
+				onPageChange={onPageChange}
+			/>,
+		);
+
+		expect(screen.getByText("26–50 of 72")).toBeInTheDocument();
+		expect(screen.getByText("Page 2 of 3")).toBeInTheDocument();
+		await user.click(screen.getByRole("link", { name: /previous/i }));
+		await user.click(screen.getByRole("link", { name: /next/i }));
+		expect(onPageChange).toHaveBeenNthCalledWith(1, 0);
+		expect(onPageChange).toHaveBeenNthCalledWith(2, 50);
+	});
+
+	it("disables navigation while fetching", () => {
+		render(
+			<ListPagination
+				offset={0}
+				limit={25}
+				total={50}
+				isFetching
+				onPageChange={vi.fn()}
+			/>,
+		);
+
+		expect(screen.getByLabelText("Loading page")).toBeInTheDocument();
+		expect(screen.getByRole("link", { name: /previous/i })).toHaveAttribute(
+			"aria-disabled",
+			"true",
+		);
+		expect(screen.getByRole("link", { name: /next/i })).toHaveAttribute(
+			"aria-disabled",
+			"true",
+		);
+	});
+});

--- a/client/src/components/pagination/ListPagination.tsx
+++ b/client/src/components/pagination/ListPagination.tsx
@@ -1,0 +1,85 @@
+import { Loader2 } from "lucide-react";
+
+import {
+	Pagination,
+	PaginationContent,
+	PaginationItem,
+	PaginationNext,
+	PaginationPrevious,
+} from "@/components/ui/pagination";
+
+interface ListPaginationProps {
+	offset: number;
+	limit: number;
+	total: number;
+	isFetching?: boolean;
+	onPageChange: (offset: number) => void;
+}
+
+export function ListPagination({
+	offset,
+	limit,
+	total,
+	isFetching = false,
+	onPageChange,
+}: ListPaginationProps) {
+	const page = Math.floor(offset / limit);
+	const totalPages = Math.max(1, Math.ceil(total / limit));
+	const previousDisabled = page === 0 || isFetching;
+	const nextDisabled = page + 1 >= totalPages || isFetching;
+	const first = total === 0 ? 0 : offset + 1;
+	const last = Math.min(offset + limit, total);
+
+	return (
+		<div className="flex flex-wrap items-center justify-between gap-3 border-t px-2 py-3 text-sm text-muted-foreground">
+			<span aria-live="polite">
+				{first}–{last} of {total}
+			</span>
+			<Pagination className="mx-0 w-auto justify-end">
+				<PaginationContent>
+					<PaginationItem>
+						<PaginationPrevious
+							href="#"
+							onClick={(event) => {
+								event.preventDefault();
+								if (!previousDisabled) {
+									onPageChange(Math.max(0, offset - limit));
+								}
+							}}
+							className={
+								previousDisabled
+									? "pointer-events-none opacity-50"
+									: "cursor-pointer"
+							}
+							aria-disabled={previousDisabled}
+						/>
+					</PaginationItem>
+					<li className="flex min-w-28 items-center justify-center gap-1.5 px-2 tabular-nums">
+						{isFetching ? (
+							<Loader2
+								className="h-3.5 w-3.5 animate-spin"
+								aria-label="Loading page"
+							/>
+						) : null}
+						Page {page + 1} of {totalPages}
+					</li>
+					<PaginationItem>
+						<PaginationNext
+							href="#"
+							onClick={(event) => {
+								event.preventDefault();
+								if (!nextDisabled) onPageChange(offset + limit);
+							}}
+							className={
+								nextDisabled
+									? "pointer-events-none opacity-50"
+									: "cursor-pointer"
+							}
+							aria-disabled={nextDisabled}
+						/>
+					</PaginationItem>
+				</PaginationContent>
+			</Pagination>
+		</div>
+	);
+}

--- a/client/src/components/pagination/ListPagination.tsx
+++ b/client/src/components/pagination/ListPagination.tsx
@@ -31,7 +31,7 @@ export function ListPagination({
 	const last = Math.min(offset + limit, total);
 
 	return (
-		<div className="flex flex-wrap items-center justify-between gap-3 border-t px-2 py-3 text-sm text-muted-foreground">
+		<div className="flex flex-wrap items-center justify-between gap-3 px-6 py-4 text-sm text-muted-foreground">
 			<span aria-live="polite">
 				{first}–{last} of {total}
 			</span>

--- a/client/src/components/roles/ConsumerTab.test.tsx
+++ b/client/src/components/roles/ConsumerTab.test.tsx
@@ -52,7 +52,11 @@ describe("ConsumerTab", () => {
 			<ConsumerTab
 				{...defaults}
 				items={[
-					{ id: "a", primary: "Alice", secondary: "alice@example.com" },
+					{
+						id: "a",
+						primary: "Alice",
+						secondary: "alice@example.com",
+					},
 					{ id: "b", primary: "Bob", secondary: "bob@example.com" },
 				]}
 			/>,
@@ -107,9 +111,7 @@ describe("ConsumerTab", () => {
 			/>,
 		);
 
-		await user.click(
-			screen.getByRole("button", { name: /assign users/i }),
-		);
+		await user.click(screen.getByRole("button", { name: /assign users/i }));
 
 		// Candidate is rendered inside the drawer once it opens
 		await waitFor(() => {
@@ -120,5 +122,33 @@ describe("ConsumerTab", () => {
 			screen.getByText(/pick the users you want to add/i),
 		).toBeInTheDocument();
 		expect(onRequestCandidates).toHaveBeenCalledOnce();
+	});
+
+	it("keeps pagination in the pinned table footer", async () => {
+		const user = userEvent.setup();
+		const onPageChange = vi.fn();
+		renderWithProviders(
+			<ConsumerTab
+				{...defaults}
+				items={[{ id: "a", primary: "Alice" }]}
+				pagination={{
+					offset: 0,
+					limit: 25,
+					total: 30,
+					onPageChange,
+				}}
+			/>,
+		);
+
+		const pagination = screen.getByRole("navigation", {
+			name: /pagination/i,
+		});
+		expect(pagination.closest("tfoot")).not.toBeNull();
+		expect(
+			screen.getAllByRole("table")[0].parentElement?.parentElement,
+		).toHaveClass("max-h-full");
+
+		await user.click(screen.getByRole("link", { name: /next page/i }));
+		expect(onPageChange).toHaveBeenCalledWith(25);
 	});
 });

--- a/client/src/components/roles/ConsumerTab.test.tsx
+++ b/client/src/components/roles/ConsumerTab.test.tsx
@@ -98,10 +98,12 @@ describe("ConsumerTab", () => {
 
 	it("opens the AssignDrawer when the Assign button is clicked", async () => {
 		const user = userEvent.setup();
+		const onRequestCandidates = vi.fn();
 		renderWithProviders(
 			<ConsumerTab
 				{...defaults}
 				candidates={[{ id: "c", primary: "Carol" }]}
+				onRequestCandidates={onRequestCandidates}
 			/>,
 		);
 
@@ -117,5 +119,6 @@ describe("ConsumerTab", () => {
 		expect(
 			screen.getByText(/pick the users you want to add/i),
 		).toBeInTheDocument();
+		expect(onRequestCandidates).toHaveBeenCalledOnce();
 	});
 });

--- a/client/src/components/roles/ConsumerTab.test.tsx
+++ b/client/src/components/roles/ConsumerTab.test.tsx
@@ -46,6 +46,28 @@ describe("ConsumerTab", () => {
 		expect(screen.getByText("bob@example.com")).toBeInTheDocument();
 	});
 
+	it("opens an assigned item without treating checkbox selection as navigation", async () => {
+		const user = userEvent.setup();
+		const onItemClick = vi.fn();
+		renderWithProviders(
+			<ConsumerTab
+				{...defaults}
+				items={[{ id: "a", primary: "Alice" }]}
+				onItemClick={onItemClick}
+				getItemHref={(item) => `/users/${item.id}`}
+			/>,
+		);
+
+		await user.click(screen.getByText("Alice"));
+		expect(onItemClick).toHaveBeenCalledWith(
+			expect.objectContaining({ id: "a" }),
+		);
+
+		onItemClick.mockClear();
+		await user.click(screen.getByLabelText("Select Alice"));
+		expect(onItemClick).not.toHaveBeenCalled();
+	});
+
 	it("filters items by search across primary and secondary", async () => {
 		const user = userEvent.setup();
 		renderWithProviders(

--- a/client/src/components/roles/ConsumerTab.tsx
+++ b/client/src/components/roles/ConsumerTab.tsx
@@ -8,6 +8,7 @@ import {
 	DataTable,
 	DataTableBody,
 	DataTableCell,
+	DataTableFooter,
 	DataTableHead,
 	DataTableHeader,
 	DataTableRow,
@@ -27,6 +28,7 @@ import {
 	TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { SearchBox } from "@/components/search/SearchBox";
+import { ListPagination } from "@/components/pagination/ListPagination";
 
 export interface OrgInfo {
 	id: string | null;
@@ -57,6 +59,15 @@ export interface ConsumerTabProps {
 	hideSecondary?: boolean;
 	/** Show an Organization column. Items must populate `org`. */
 	showOrgColumn?: boolean;
+	searchValue?: string;
+	onSearchChange?: (value: string) => void;
+	pagination?: {
+		offset: number;
+		limit: number;
+		total: number;
+		isFetching?: boolean;
+		onPageChange: (offset: number) => void;
+	};
 	onRequestCandidates?: () => void;
 	onAssign: (ids: string[]) => Promise<void>;
 	onUnassign: (ids: string[]) => Promise<void>;
@@ -81,11 +92,15 @@ export function ConsumerTab({
 	secondaryColumnLabel = "Description",
 	hideSecondary = false,
 	showOrgColumn = false,
+	searchValue,
+	onSearchChange,
+	pagination,
 	onRequestCandidates,
 	onAssign,
 	onUnassign,
 }: ConsumerTabProps) {
-	const [search, setSearch] = useState("");
+	const [internalSearch, setInternalSearch] = useState("");
+	const search = searchValue ?? internalSearch;
 	const [selected, setSelected] = useState<Set<string>>(new Set());
 	const [drawerOpen, setDrawerOpen] = useState(false);
 	const [submitting, setSubmitting] = useState(false);
@@ -159,11 +174,11 @@ export function ConsumerTab({
 	};
 
 	return (
-		<div className="flex flex-col gap-3">
+		<div className="flex h-full min-h-0 flex-col gap-3">
 			<div className="flex items-center gap-3">
 				<SearchBox
 					value={search}
-					onChange={setSearch}
+					onChange={onSearchChange ?? setInternalSearch}
 					placeholder={`Search ${consumerLabel}...`}
 					className="flex-1"
 				/>
@@ -189,81 +204,104 @@ export function ConsumerTab({
 					{emptyHint}
 				</div>
 			) : (
-				<DataTable>
-					<DataTableHeader>
-						<DataTableRow>
-							<DataTableHead className="w-0 whitespace-nowrap">
-								<Checkbox
-									checked={
-										allVisibleSelected
-											? true
-											: someVisibleSelected
-												? "indeterminate"
-												: false
-									}
-									onCheckedChange={toggleAll}
-									aria-label={`Select all visible ${consumerLabel}`}
-								/>
-							</DataTableHead>
-							{showOrgColumn && (
+				<div className="flex-1 min-h-0">
+					<DataTable className="max-h-full">
+						<DataTableHeader>
+							<DataTableRow>
 								<DataTableHead className="w-0 whitespace-nowrap">
-									Organization
-								</DataTableHead>
-							)}
-							<DataTableHead className="w-0 whitespace-nowrap">
-								{primaryColumnLabel}
-							</DataTableHead>
-							{!hideSecondary && (
-								<DataTableHead>
-									{secondaryColumnLabel}
-								</DataTableHead>
-							)}
-						</DataTableRow>
-					</DataTableHeader>
-					<DataTableBody>
-						{visibleItems.map((item) => (
-							<DataTableRow key={item.id} className="group/row">
-								<DataTableCell className="w-0 whitespace-nowrap">
 									<Checkbox
-										checked={effectiveSelected.has(item.id)}
-										onCheckedChange={() =>
-											toggleOne(item.id)
+										checked={
+											allVisibleSelected
+												? true
+												: someVisibleSelected
+													? "indeterminate"
+													: false
 										}
-										aria-label={`Select ${item.primary}`}
+										onCheckedChange={toggleAll}
+										aria-label={`Select all visible ${consumerLabel}`}
 									/>
-								</DataTableCell>
+								</DataTableHead>
 								{showOrgColumn && (
-									<DataTableCell className="w-0 whitespace-nowrap text-sm">
-										<OrgBadge org={item.org ?? null} />
-									</DataTableCell>
+									<DataTableHead className="w-0 whitespace-nowrap">
+										Organization
+									</DataTableHead>
 								)}
-								<DataTableCell className="w-0 whitespace-nowrap font-medium">
-									{item.primary}
-								</DataTableCell>
+								<DataTableHead className="w-0 whitespace-nowrap">
+									{primaryColumnLabel}
+								</DataTableHead>
 								{!hideSecondary && (
-									<DataTableCell className="max-w-xs truncate text-muted-foreground">
-										{item.secondary ? (
-											<Tooltip>
-												<TooltipTrigger asChild>
-													<span className="block truncate">
-														{item.secondary}
-													</span>
-												</TooltipTrigger>
-												<TooltipContent>
-													{item.secondary}
-												</TooltipContent>
-											</Tooltip>
-										) : (
-											<span className="text-muted-foreground/60">
-												-
-											</span>
-										)}
-									</DataTableCell>
+									<DataTableHead>
+										{secondaryColumnLabel}
+									</DataTableHead>
 								)}
 							</DataTableRow>
-						))}
-					</DataTableBody>
-				</DataTable>
+						</DataTableHeader>
+						<DataTableBody>
+							{visibleItems.map((item) => (
+								<DataTableRow
+									key={item.id}
+									className="group/row"
+								>
+									<DataTableCell className="w-0 whitespace-nowrap">
+										<Checkbox
+											checked={effectiveSelected.has(
+												item.id,
+											)}
+											onCheckedChange={() =>
+												toggleOne(item.id)
+											}
+											aria-label={`Select ${item.primary}`}
+										/>
+									</DataTableCell>
+									{showOrgColumn && (
+										<DataTableCell className="w-0 whitespace-nowrap text-sm">
+											<OrgBadge org={item.org ?? null} />
+										</DataTableCell>
+									)}
+									<DataTableCell className="w-0 whitespace-nowrap font-medium">
+										{item.primary}
+									</DataTableCell>
+									{!hideSecondary && (
+										<DataTableCell className="max-w-xs truncate text-muted-foreground">
+											{item.secondary ? (
+												<Tooltip>
+													<TooltipTrigger asChild>
+														<span className="block truncate">
+															{item.secondary}
+														</span>
+													</TooltipTrigger>
+													<TooltipContent>
+														{item.secondary}
+													</TooltipContent>
+												</Tooltip>
+											) : (
+												<span className="text-muted-foreground/60">
+													-
+												</span>
+											)}
+										</DataTableCell>
+									)}
+								</DataTableRow>
+							))}
+						</DataTableBody>
+						{pagination && (
+							<DataTableFooter>
+								<DataTableRow>
+									<DataTableCell
+										colSpan={
+											2 +
+											(showOrgColumn ? 1 : 0) +
+											(hideSecondary ? 0 : 1)
+										}
+										className="p-0"
+									>
+										<ListPagination {...pagination} />
+									</DataTableCell>
+								</DataTableRow>
+							</DataTableFooter>
+						)}
+					</DataTable>
+				</div>
 			)}
 
 			{effectiveSelected.size > 0 && (

--- a/client/src/components/roles/ConsumerTab.tsx
+++ b/client/src/components/roles/ConsumerTab.tsx
@@ -68,6 +68,8 @@ export interface ConsumerTabProps {
 		isFetching?: boolean;
 		onPageChange: (offset: number) => void;
 	};
+	onItemClick?: (item: ConsumerTabItem) => void;
+	getItemHref?: (item: ConsumerTabItem) => string;
 	onRequestCandidates?: () => void;
 	onAssign: (ids: string[]) => Promise<void>;
 	onUnassign: (ids: string[]) => Promise<void>;
@@ -95,6 +97,8 @@ export function ConsumerTab({
 	searchValue,
 	onSearchChange,
 	pagination,
+	onItemClick,
+	getItemHref,
 	onRequestCandidates,
 	onAssign,
 	onUnassign,
@@ -241,8 +245,16 @@ export function ConsumerTab({
 								<DataTableRow
 									key={item.id}
 									className="group/row"
+									clickable={Boolean(onItemClick)}
+									href={getItemHref?.(item)}
+									onClick={() => onItemClick?.(item)}
 								>
-									<DataTableCell className="w-0 whitespace-nowrap">
+									<DataTableCell
+										className="w-0 whitespace-nowrap"
+										onClick={(event) =>
+											event.stopPropagation()
+										}
+									>
 										<Checkbox
 											checked={effectiveSelected.has(
 												item.id,

--- a/client/src/components/roles/ConsumerTab.tsx
+++ b/client/src/components/roles/ConsumerTab.tsx
@@ -57,6 +57,7 @@ export interface ConsumerTabProps {
 	hideSecondary?: boolean;
 	/** Show an Organization column. Items must populate `org`. */
 	showOrgColumn?: boolean;
+	onRequestCandidates?: () => void;
 	onAssign: (ids: string[]) => Promise<void>;
 	onUnassign: (ids: string[]) => Promise<void>;
 }
@@ -80,6 +81,7 @@ export function ConsumerTab({
 	secondaryColumnLabel = "Description",
 	hideSecondary = false,
 	showOrgColumn = false,
+	onRequestCandidates,
 	onAssign,
 	onUnassign,
 }: ConsumerTabProps) {
@@ -147,7 +149,9 @@ export function ConsumerTab({
 			setSelected(new Set());
 		} catch (e) {
 			toast.error(
-				e instanceof Error ? e.message : `Failed to remove ${consumerLabel}`,
+				e instanceof Error
+					? e.message
+					: `Failed to remove ${consumerLabel}`,
 			);
 		} finally {
 			setSubmitting(false);
@@ -163,7 +167,12 @@ export function ConsumerTab({
 					placeholder={`Search ${consumerLabel}...`}
 					className="flex-1"
 				/>
-				<Button onClick={() => setDrawerOpen(true)}>
+				<Button
+					onClick={() => {
+						onRequestCandidates?.();
+						setDrawerOpen(true);
+					}}
+				>
 					<Plus className="h-4 w-4 mr-1.5" />
 					Assign {consumerLabel}
 				</Button>
@@ -205,7 +214,9 @@ export function ConsumerTab({
 								{primaryColumnLabel}
 							</DataTableHead>
 							{!hideSecondary && (
-								<DataTableHead>{secondaryColumnLabel}</DataTableHead>
+								<DataTableHead>
+									{secondaryColumnLabel}
+								</DataTableHead>
 							)}
 						</DataTableRow>
 					</DataTableHeader>
@@ -215,7 +226,9 @@ export function ConsumerTab({
 								<DataTableCell className="w-0 whitespace-nowrap">
 									<Checkbox
 										checked={effectiveSelected.has(item.id)}
-										onCheckedChange={() => toggleOne(item.id)}
+										onCheckedChange={() =>
+											toggleOne(item.id)
+										}
 										aria-label={`Select ${item.primary}`}
 									/>
 								</DataTableCell>
@@ -236,10 +249,14 @@ export function ConsumerTab({
 														{item.secondary}
 													</span>
 												</TooltipTrigger>
-												<TooltipContent>{item.secondary}</TooltipContent>
+												<TooltipContent>
+													{item.secondary}
+												</TooltipContent>
 											</Tooltip>
 										) : (
-											<span className="text-muted-foreground/60">-</span>
+											<span className="text-muted-foreground/60">
+												-
+											</span>
 										)}
 									</DataTableCell>
 								)}
@@ -377,7 +394,9 @@ function AssignDrawer({
 			setPicked(new Set());
 		} catch (e) {
 			toast.error(
-				e instanceof Error ? e.message : `Failed to assign ${consumerLabel}`,
+				e instanceof Error
+					? e.message
+					: `Failed to assign ${consumerLabel}`,
 			);
 		} finally {
 			setSubmitting(false);
@@ -394,8 +413,8 @@ function AssignDrawer({
 					<SheetTitle>Assign {consumerLabel}</SheetTitle>
 					<SheetDescription>
 						Pick the {consumerLabel} you want to add to this role.
-						Already-assigned entries are hidden by default — toggle the switch
-						below to see them.
+						Already-assigned entries are hidden by default — toggle
+						the switch below to see them.
 					</SheetDescription>
 				</SheetHeader>
 

--- a/client/src/components/users/UserActionsMenu.test.tsx
+++ b/client/src/components/users/UserActionsMenu.test.tsx
@@ -4,7 +4,9 @@ import { describe, expect, it, vi } from "vitest";
 
 import { UserActionsMenu } from "./UserActionsMenu";
 
-function makeProps(overrides: Partial<React.ComponentProps<typeof UserActionsMenu>> = {}) {
+function makeProps(
+	overrides: Partial<React.ComponentProps<typeof UserActionsMenu>> = {},
+) {
 	return {
 		status: "active",
 		isActive: true,
@@ -24,8 +26,16 @@ describe("UserActionsMenu", () => {
 		const user = userEvent.setup();
 		render(<UserActionsMenu {...makeProps()} />);
 		await user.click(screen.getByRole("button", { name: /user actions/i }));
-		expect(screen.getByText(/disable user/i)).toBeInTheDocument();
-		expect(screen.getByText(/delete permanently/i)).toBeInTheDocument();
+		expect(screen.getByRole("menu")).toHaveClass(
+			"w-max",
+			"whitespace-nowrap",
+		);
+		expect(
+			screen.getByRole("menuitem", { name: "Disable" }),
+		).toBeInTheDocument();
+		expect(
+			screen.getByRole("menuitem", { name: "Delete" }),
+		).toBeInTheDocument();
 		expect(screen.queryByText(/resend invite/i)).not.toBeInTheDocument();
 		expect(screen.queryByText(/send invite/i)).not.toBeInTheDocument();
 		expect(screen.queryByText(/revoke invite/i)).not.toBeInTheDocument();
@@ -44,7 +54,9 @@ describe("UserActionsMenu", () => {
 		render(<UserActionsMenu {...makeProps({ status: "pending" })} />);
 		await user.click(screen.getByRole("button", { name: /user actions/i }));
 		expect(screen.getByText(/resend invite/i)).toBeInTheDocument();
-		expect(screen.getByText(/generate registration link/i)).toBeInTheDocument();
+		expect(
+			screen.getByText(/generate registration link/i),
+		).toBeInTheDocument();
 		expect(screen.getByText(/copy registration link/i)).toBeInTheDocument();
 		expect(screen.getByText(/revoke invite/i)).toBeInTheDocument();
 	});
@@ -53,20 +65,24 @@ describe("UserActionsMenu", () => {
 		const user = userEvent.setup();
 		render(<UserActionsMenu {...makeProps({ isActive: false })} />);
 		await user.click(screen.getByRole("button", { name: /user actions/i }));
-		expect(screen.getByText(/enable user/i)).toBeInTheDocument();
-		expect(screen.queryByText(/disable user/i)).not.toBeInTheDocument();
+		expect(
+			screen.getByRole("menuitem", { name: "Enable" }),
+		).toBeInTheDocument();
+		expect(
+			screen.queryByRole("menuitem", { name: "Disable" }),
+		).not.toBeInTheDocument();
 	});
 
 	it("isSelf marks Disable and Delete as disabled", async () => {
 		const user = userEvent.setup();
 		render(<UserActionsMenu {...makeProps({ isSelf: true })} />);
 		await user.click(screen.getByRole("button", { name: /user actions/i }));
-		expect(screen.getByText(/disable user/i).closest('[role="menuitem"]')).toHaveAttribute(
-			"data-disabled",
-		);
-		expect(screen.getByText(/delete permanently/i).closest('[role="menuitem"]')).toHaveAttribute(
-			"data-disabled",
-		);
+		expect(
+			screen.getByText(/^disable$/i).closest('[role="menuitem"]'),
+		).toHaveAttribute("data-disabled");
+		expect(
+			screen.getByText(/^delete$/i).closest('[role="menuitem"]'),
+		).toHaveAttribute("data-disabled");
 	});
 
 	it("fires onResend / onRegenerate / onCopyLink / onRevoke from menu items", async () => {
@@ -77,7 +93,11 @@ describe("UserActionsMenu", () => {
 			onCopyLink: vi.fn(),
 			onRevoke: vi.fn(),
 		};
-		render(<UserActionsMenu {...makeProps({ status: "pending", ...handlers })} />);
+		render(
+			<UserActionsMenu
+				{...makeProps({ status: "pending", ...handlers })}
+			/>,
+		);
 		await user.click(screen.getByRole("button", { name: /user actions/i }));
 		await user.click(screen.getByText(/resend invite/i));
 		expect(handlers.onResend).toHaveBeenCalledTimes(1);

--- a/client/src/components/users/UserActionsMenu.tsx
+++ b/client/src/components/users/UserActionsMenu.tsx
@@ -52,6 +52,7 @@ export function UserActionsMenu({
 			</DropdownMenuTrigger>
 			<DropdownMenuContent
 				align="end"
+				className="w-max min-w-40 whitespace-nowrap"
 				onClick={(e) => e.stopPropagation()}
 			>
 				{showInviteActions && (
@@ -82,7 +83,7 @@ export function UserActionsMenu({
 				)}
 				<DropdownMenuItem onClick={onToggleActive} disabled={isSelf}>
 					<Power className="mr-2 h-4 w-4" />
-					{isActive ? "Disable user" : "Enable user"}
+					{isActive ? "Disable" : "Enable"}
 				</DropdownMenuItem>
 				<DropdownMenuItem
 					onClick={onDelete}
@@ -90,7 +91,7 @@ export function UserActionsMenu({
 					className="text-destructive"
 				>
 					<Trash2 className="mr-2 h-4 w-4" />
-					Delete permanently
+					Delete
 				</DropdownMenuItem>
 			</DropdownMenuContent>
 		</DropdownMenu>

--- a/client/src/components/users/UserEmailCell.test.tsx
+++ b/client/src/components/users/UserEmailCell.test.tsx
@@ -26,6 +26,19 @@ describe("UserEmailCell", () => {
 		).toBeInTheDocument();
 	});
 
+	it("lets clicks on the email text bubble to the user row", () => {
+		const rowClick = vi.fn();
+		renderWithProviders(
+			<div onClick={rowClick}>
+				<UserEmailCell email="alice@example.com" />
+			</div>,
+		);
+
+		fireEvent.click(screen.getByText("alice@example.com"));
+
+		expect(rowClick).toHaveBeenCalledOnce();
+	});
+
 	it("does not bubble copy clicks up to the row (would otherwise open edit dialog)", () => {
 		const rowClick = vi.fn();
 		renderWithProviders(

--- a/client/src/hooks/useRoles.test.tsx
+++ b/client/src/hooks/useRoles.test.tsx
@@ -1,0 +1,78 @@
+import type { ReactNode } from "react";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockGet, mockUseMutation } = vi.hoisted(() => ({
+	mockGet: vi.fn(),
+	mockUseMutation: vi.fn(),
+}));
+
+vi.mock("@/lib/api-client", () => ({
+	apiClient: { GET: (...args: unknown[]) => mockGet(...args) },
+	$api: { useQuery: vi.fn(), useMutation: mockUseMutation },
+}));
+
+import { useAssignUsersToRole, useRoleUsersPage } from "./useRoles";
+
+let queryClient: QueryClient;
+
+function wrapper({ children }: { children: ReactNode }) {
+	return (
+		<QueryClientProvider client={queryClient}>
+			{children}
+		</QueryClientProvider>
+	);
+}
+
+describe("useRoleUsersPage", () => {
+	beforeEach(() => {
+		mockGet.mockReset();
+		mockUseMutation.mockReset();
+		queryClient = new QueryClient({
+			defaultOptions: { queries: { retry: false } },
+		});
+	});
+
+	it("requests a bounded, searchable assigned-user page", async () => {
+		mockGet.mockResolvedValue({
+			data: { user_ids: ["user-1"], users: [], total: 31 },
+			error: undefined,
+		});
+
+		const { result } = renderHook(
+			() =>
+				useRoleUsersPage("role-1", {
+					search: "  alice  ",
+					limit: 25,
+					offset: 25,
+				}),
+			{ wrapper },
+		);
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(result.current.data?.total).toBe(31);
+		expect(mockGet).toHaveBeenCalledWith("/api/roles/{role_id}/users", {
+			params: {
+				path: { role_id: "role-1" },
+				query: { search: "alice", limit: 25, offset: 25 },
+			},
+		});
+	});
+
+	it("invalidates every assigned-user page after assignment", () => {
+		const invalidate = vi.spyOn(queryClient, "invalidateQueries");
+		mockUseMutation.mockReturnValue({ mutate: vi.fn() });
+
+		renderHook(() => useAssignUsersToRole(), { wrapper });
+		const options = mockUseMutation.mock.calls[0][2];
+		options.onSuccess(undefined, {
+			params: { path: { role_id: "role-1" } },
+			body: { user_ids: ["user-1"] },
+		});
+
+		expect(invalidate).toHaveBeenCalledWith({
+			queryKey: ["get", "/api/roles/{role_id}/users"],
+		});
+	});
+});

--- a/client/src/hooks/useRoles.ts
+++ b/client/src/hooks/useRoles.ts
@@ -2,7 +2,11 @@
  * React Query hooks for roles management using openapi-react-query pattern
  */
 
-import { useQueryClient } from "@tanstack/react-query";
+import {
+	keepPreviousData,
+	useQuery,
+	useQueryClient,
+} from "@tanstack/react-query";
 import { $api, apiClient } from "@/lib/api-client";
 import type { components } from "@/lib/v1";
 import { toast } from "sonner";
@@ -14,6 +18,53 @@ type AssignFormsToRoleRequest =
 
 export function useRoles() {
 	return $api.useQuery("get", "/api/roles", {});
+}
+
+export interface RolesPageParams {
+	search?: string;
+	sortBy: "name" | "created";
+	sortDirection: "asc" | "desc";
+	limit: number;
+	offset: number;
+}
+
+export function useRolesPage(params: RolesPageParams) {
+	return useQuery({
+		queryKey: ["get", "/api/roles", { page: params }],
+		queryFn: async () => {
+			const { data, error, response } = await apiClient.GET(
+				"/api/roles",
+				{
+					params: {
+						query: {
+							search: params.search?.trim() || undefined,
+							sort_by: params.sortBy,
+							sort_direction: params.sortDirection,
+							limit: params.limit,
+							offset: params.offset,
+						},
+					},
+				},
+			);
+			if (error) throw error;
+			return {
+				items: data ?? [],
+				total: Number(
+					response.headers.get("X-Total-Count") ?? data?.length ?? 0,
+				),
+			};
+		},
+		placeholderData: keepPreviousData,
+	});
+}
+
+export function useRole(roleId: string | undefined) {
+	return $api.useQuery(
+		"get",
+		"/api/roles/{role_id}",
+		{ params: { path: { role_id: roleId ?? "" } } },
+		{ enabled: !!roleId },
+	);
 }
 
 export function useCreateRole() {
@@ -231,7 +282,9 @@ export function useAssignAgentsToRole() {
 	const qc = useQueryClient();
 	return $api.useMutation("post", "/api/roles/{role_id}/agents", {
 		onSuccess: () => {
-			qc.invalidateQueries({ queryKey: ["get", "/api/roles/{role_id}/agents"] });
+			qc.invalidateQueries({
+				queryKey: ["get", "/api/roles/{role_id}/agents"],
+			});
 			invalidateRoleList(qc);
 		},
 	});
@@ -241,7 +294,9 @@ export function useBulkUnassignAgents() {
 	const qc = useQueryClient();
 	return $api.useMutation("delete", "/api/roles/{role_id}/agents", {
 		onSuccess: () => {
-			qc.invalidateQueries({ queryKey: ["get", "/api/roles/{role_id}/agents"] });
+			qc.invalidateQueries({
+				queryKey: ["get", "/api/roles/{role_id}/agents"],
+			});
 			invalidateRoleList(qc);
 		},
 	});
@@ -251,7 +306,9 @@ export function useBulkUnassignUsers() {
 	const qc = useQueryClient();
 	return $api.useMutation("delete", "/api/roles/{role_id}/users", {
 		onSuccess: () => {
-			qc.invalidateQueries({ queryKey: ["get", "/api/roles/{role_id}/users"] });
+			qc.invalidateQueries({
+				queryKey: ["get", "/api/roles/{role_id}/users"],
+			});
 			invalidateRoleList(qc);
 		},
 	});
@@ -261,7 +318,9 @@ export function useBulkUnassignForms() {
 	const qc = useQueryClient();
 	return $api.useMutation("delete", "/api/roles/{role_id}/forms", {
 		onSuccess: () => {
-			qc.invalidateQueries({ queryKey: ["get", "/api/roles/{role_id}/forms"] });
+			qc.invalidateQueries({
+				queryKey: ["get", "/api/roles/{role_id}/forms"],
+			});
 			invalidateRoleList(qc);
 		},
 	});
@@ -280,7 +339,9 @@ export function useAssignAppsToRole() {
 	const qc = useQueryClient();
 	return $api.useMutation("post", "/api/roles/{role_id}/apps", {
 		onSuccess: () => {
-			qc.invalidateQueries({ queryKey: ["get", "/api/roles/{role_id}/apps"] });
+			qc.invalidateQueries({
+				queryKey: ["get", "/api/roles/{role_id}/apps"],
+			});
 			invalidateRoleList(qc);
 		},
 	});
@@ -290,7 +351,9 @@ export function useBulkUnassignApps() {
 	const qc = useQueryClient();
 	return $api.useMutation("delete", "/api/roles/{role_id}/apps", {
 		onSuccess: () => {
-			qc.invalidateQueries({ queryKey: ["get", "/api/roles/{role_id}/apps"] });
+			qc.invalidateQueries({
+				queryKey: ["get", "/api/roles/{role_id}/apps"],
+			});
 			invalidateRoleList(qc);
 		},
 	});
@@ -309,7 +372,9 @@ export function useAssignWorkflowsToRole() {
 	const qc = useQueryClient();
 	return $api.useMutation("post", "/api/roles/{role_id}/workflows", {
 		onSuccess: () => {
-			qc.invalidateQueries({ queryKey: ["get", "/api/roles/{role_id}/workflows"] });
+			qc.invalidateQueries({
+				queryKey: ["get", "/api/roles/{role_id}/workflows"],
+			});
 			invalidateRoleList(qc);
 		},
 	});
@@ -319,7 +384,9 @@ export function useBulkUnassignWorkflows() {
 	const qc = useQueryClient();
 	return $api.useMutation("delete", "/api/roles/{role_id}/workflows", {
 		onSuccess: () => {
-			qc.invalidateQueries({ queryKey: ["get", "/api/roles/{role_id}/workflows"] });
+			qc.invalidateQueries({
+				queryKey: ["get", "/api/roles/{role_id}/workflows"],
+			});
 			invalidateRoleList(qc);
 		},
 	});
@@ -338,7 +405,9 @@ export function useAssignKnowledgeToRole() {
 	const qc = useQueryClient();
 	return $api.useMutation("post", "/api/roles/{role_id}/knowledge", {
 		onSuccess: () => {
-			qc.invalidateQueries({ queryKey: ["get", "/api/roles/{role_id}/knowledge"] });
+			qc.invalidateQueries({
+				queryKey: ["get", "/api/roles/{role_id}/knowledge"],
+			});
 			invalidateRoleList(qc);
 		},
 	});
@@ -348,7 +417,9 @@ export function useBulkUnassignKnowledge() {
 	const qc = useQueryClient();
 	return $api.useMutation("delete", "/api/roles/{role_id}/knowledge", {
 		onSuccess: () => {
-			qc.invalidateQueries({ queryKey: ["get", "/api/roles/{role_id}/knowledge"] });
+			qc.invalidateQueries({
+				queryKey: ["get", "/api/roles/{role_id}/knowledge"],
+			});
 			invalidateRoleList(qc);
 		},
 	});

--- a/client/src/hooks/useRoles.ts
+++ b/client/src/hooks/useRoles.ts
@@ -134,13 +134,42 @@ export function useDeleteRole() {
 	});
 }
 
-export function useRoleUsers(roleId: string | undefined) {
-	return $api.useQuery(
-		"get",
-		"/api/roles/{role_id}/users",
-		{ params: { path: { role_id: roleId ?? "" } } },
-		{ enabled: !!roleId },
-	);
+export interface RoleUsersPageParams {
+	search?: string;
+	limit: number;
+	offset: number;
+}
+
+export function useRoleUsersPage(
+	roleId: string | undefined,
+	params: RoleUsersPageParams,
+) {
+	return useQuery({
+		queryKey: [
+			"get",
+			"/api/roles/{role_id}/users",
+			{ roleId, page: params },
+		],
+		enabled: !!roleId,
+		queryFn: async () => {
+			const { data, error } = await apiClient.GET(
+				"/api/roles/{role_id}/users",
+				{
+					params: {
+						path: { role_id: roleId ?? "" },
+						query: {
+							search: params.search?.trim() || undefined,
+							limit: params.limit,
+							offset: params.offset,
+						},
+					},
+				},
+			);
+			if (error) throw error;
+			return data;
+		},
+		placeholderData: keepPreviousData,
+	});
 }
 
 export function useAssignUsersToRole() {
@@ -148,16 +177,12 @@ export function useAssignUsersToRole() {
 
 	return $api.useMutation("post", "/api/roles/{role_id}/users", {
 		onSuccess: (_, variables) => {
-			const roleId = variables.params?.path?.role_id;
 			const userIds =
 				(variables.body as AssignUsersToRoleRequest)?.user_ids || [];
 			queryClient.invalidateQueries({
-				queryKey: [
-					"get",
-					"/api/roles/{role_id}/users",
-					{ params: { path: { role_id: roleId } } },
-				],
+				queryKey: ["get", "/api/roles/{role_id}/users"],
 			});
+			invalidateRoleList(queryClient);
 			toast.success("Users assigned", {
 				description: `${userIds.length} user(s) assigned to role`,
 			});

--- a/client/src/hooks/useUsers.test.tsx
+++ b/client/src/hooks/useUsers.test.tsx
@@ -1,0 +1,72 @@
+import type { ReactNode } from "react";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockGet = vi.fn();
+
+vi.mock("@/lib/api-client", () => ({
+	apiClient: { GET: (...args: unknown[]) => mockGet(...args) },
+	$api: { useQuery: vi.fn(), useMutation: vi.fn() },
+}));
+
+import { useUsersPage } from "./useUsers";
+
+function wrapper({ children }: { children: ReactNode }) {
+	return (
+		<QueryClientProvider
+			client={
+				new QueryClient({
+					defaultOptions: { queries: { retry: false } },
+				})
+			}
+		>
+			{children}
+		</QueryClientProvider>
+	);
+}
+
+describe("useUsersPage", () => {
+	beforeEach(() => mockGet.mockReset());
+
+	it("returns the server total for a bounded user page", async () => {
+		mockGet.mockResolvedValue({
+			data: [{ id: "user-1" }],
+			error: undefined,
+			response: new Response(null, {
+				headers: { "X-Total-Count": "10000" },
+			}),
+		});
+
+		const { result } = renderHook(
+			() =>
+				useUsersPage({
+					search: "  alice  ",
+					sortBy: "name",
+					sortDirection: "asc",
+					limit: 25,
+					offset: 50,
+				}),
+			{ wrapper },
+		);
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(result.current.data).toEqual({
+			items: [{ id: "user-1" }],
+			total: 10000,
+		});
+		expect(mockGet).toHaveBeenCalledWith("/api/users", {
+			params: {
+				query: {
+					scope: undefined,
+					include_inactive: undefined,
+					search: "alice",
+					sort_by: "name",
+					sort_direction: "asc",
+					limit: 25,
+					offset: 50,
+				},
+			},
+		});
+	});
+});

--- a/client/src/hooks/useUsers.ts
+++ b/client/src/hooks/useUsers.ts
@@ -3,8 +3,53 @@
  * Uses openapi-react-query for type-safe API calls
  */
 
-import { useQueryClient } from "@tanstack/react-query";
-import { $api } from "@/lib/api-client";
+import {
+	keepPreviousData,
+	useQuery,
+	useQueryClient,
+} from "@tanstack/react-query";
+import { $api, apiClient } from "@/lib/api-client";
+
+export interface UsersPageParams {
+	scope?: string | null;
+	includeInactive?: boolean;
+	search?: string;
+	sortBy: "name" | "email" | "status" | "created" | "last_login";
+	sortDirection: "asc" | "desc";
+	limit: number;
+	offset: number;
+}
+
+export function useUsersPage(params: UsersPageParams) {
+	return useQuery({
+		queryKey: ["get", "/api/users", { page: params }],
+		queryFn: async () => {
+			const query = {
+				scope: params.scope === null ? "global" : params.scope,
+				include_inactive: params.includeInactive || undefined,
+				search: params.search?.trim() || undefined,
+				sort_by: params.sortBy,
+				sort_direction: params.sortDirection,
+				limit: params.limit,
+				offset: params.offset,
+			};
+			const { data, error, response } = await apiClient.GET(
+				"/api/users",
+				{
+					params: { query },
+				},
+			);
+			if (error) throw error;
+			return {
+				items: data ?? [],
+				total: Number(
+					response.headers.get("X-Total-Count") ?? data?.length ?? 0,
+				),
+			};
+		},
+		placeholderData: keepPreviousData,
+	});
+}
 
 /**
  * Fetch all users filtered by current scope.
@@ -24,6 +69,7 @@ export function useUsers() {
 export function useUsersFiltered(
 	scope?: string | null,
 	includeInactive?: boolean,
+	enabled = true,
 ) {
 	// Build query params - convert null to "global" for the API
 	const queryParams: { scope?: string; include_inactive?: boolean } = {};
@@ -36,11 +82,16 @@ export function useUsersFiltered(
 		queryParams.include_inactive = true;
 	}
 
-	return $api.useQuery("get", "/api/users", {
-		params: {
-			query: queryParams,
+	return $api.useQuery(
+		"get",
+		"/api/users",
+		{
+			params: {
+				query: queryParams,
+			},
 		},
-	});
+		{ enabled },
+	);
 }
 
 /**

--- a/client/src/lib/v1.d.ts
+++ b/client/src/lib/v1.d.ts
@@ -23026,6 +23026,12 @@ export interface components {
              * @description Display-ready summaries for users assigned to the role
              */
             users?: components["schemas"]["RoleUserSummary"][];
+            /**
+             * Total
+             * @description Total users assigned to the role after filtering
+             * @default 0
+             */
+            total: number;
         };
         /**
          * RoleWorkflowsResponse
@@ -29298,7 +29304,14 @@ export interface operations {
     };
     get_role_users_api_roles__role_id__users_get: {
         parameters: {
-            query?: never;
+            query?: {
+                /** @description Search assigned user name or email */
+                search?: string | null;
+                /** @description Maximum rows to return; omit for the legacy unbounded response */
+                limit?: number | null;
+                /** @description Rows to skip when limit is set */
+                offset?: number;
+            };
             header?: never;
             path: {
                 role_id: string;

--- a/client/src/lib/v1.d.ts
+++ b/client/src/lib/v1.d.ts
@@ -22988,6 +22988,30 @@ export interface components {
             } | null;
         };
         /**
+         * RoleUserSummary
+         * @description Display-ready user identity returned by the role detail endpoint.
+         */
+        RoleUserSummary: {
+            /**
+             * Id
+             * Format: uuid
+             */
+            id: string;
+            /** Name */
+            name: string | null;
+            /** Email */
+            email: string;
+            /** Organization Id */
+            organization_id: string | null;
+            /** Organization Name */
+            organization_name: string | null;
+            /**
+             * Organization Is Provider
+             * @default false
+             */
+            organization_is_provider: boolean;
+        };
+        /**
          * RoleUsersResponse
          * @description Response model for getting users assigned to a role
          */
@@ -22997,6 +23021,11 @@ export interface components {
              * @description List of user IDs assigned to the role
              */
             user_ids: string[];
+            /**
+             * Users
+             * @description Display-ready summaries for users assigned to the role
+             */
+            users?: components["schemas"]["RoleUserSummary"][];
         };
         /**
          * RoleWorkflowsResponse
@@ -28716,6 +28745,15 @@ export interface operations {
                 scope?: string | null;
                 /** @description Include inactive (disabled) users */
                 include_inactive?: boolean;
+                /** @description Search user name or email */
+                search?: string | null;
+                /** @description Sort field; omit to preserve the legacy email order */
+                sort_by?: ("name" | "email" | "status" | "created" | "last_login") | null;
+                sort_direction?: "asc" | "desc";
+                /** @description Maximum rows to return; omit for the legacy unbounded response */
+                limit?: number | null;
+                /** @description Rows to skip when limit is set */
+                offset?: number;
             };
             header?: never;
             path?: never;
@@ -29094,7 +29132,16 @@ export interface operations {
     };
     list_roles_api_roles_get: {
         parameters: {
-            query?: never;
+            query?: {
+                /** @description Search role name or description */
+                search?: string | null;
+                sort_by?: "name" | "created";
+                sort_direction?: "asc" | "desc";
+                /** @description Maximum rows to return; omit for the legacy unbounded response */
+                limit?: number | null;
+                /** @description Rows to skip when limit is set */
+                offset?: number;
+            };
             header?: never;
             path?: never;
             cookie?: never;
@@ -29108,6 +29155,15 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["RolePublic"][];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
                 };
             };
         };

--- a/client/src/pages/RoleDetail.tsx
+++ b/client/src/pages/RoleDetail.tsx
@@ -312,6 +312,7 @@ function useOrgLookup() {
 }
 
 function UsersTab({ roleId }: { roleId: string }) {
+	const navigate = useNavigate();
 	const [search, setSearch] = useState("");
 	const [offset, setOffset] = useState(0);
 	const pageSize = 25;
@@ -387,6 +388,8 @@ function UsersTab({ roleId }: { roleId: string }) {
 				isFetching,
 				onPageChange: setOffset,
 			}}
+			onItemClick={(item) => navigate(`/users/${item.id}`)}
+			getItemHref={(item) => `/users/${item.id}`}
 			onRequestCandidates={() => setCandidatesRequested(true)}
 			onAssign={async (ids) => {
 				await assignMut.mutateAsync({

--- a/client/src/pages/RoleDetail.tsx
+++ b/client/src/pages/RoleDetail.tsx
@@ -49,7 +49,7 @@ import {
 import {
 	useRole,
 	useDeleteRole,
-	useRoleUsers,
+	useRoleUsersPage,
 	useRoleForms,
 	useRoleAgents,
 	useRoleApps,
@@ -312,7 +312,18 @@ function useOrgLookup() {
 }
 
 function UsersTab({ roleId }: { roleId: string }) {
-	const { data: assigned, isLoading } = useRoleUsers(roleId);
+	const [search, setSearch] = useState("");
+	const [offset, setOffset] = useState(0);
+	const pageSize = 25;
+	const {
+		data: assigned,
+		isLoading,
+		isFetching,
+	} = useRoleUsersPage(roleId, {
+		search,
+		limit: pageSize,
+		offset,
+	});
 	const [candidatesRequested, setCandidatesRequested] = useState(false);
 	const { data: allUsers, isLoading: loadingAll } = useUsersFiltered(
 		undefined,
@@ -356,10 +367,26 @@ function UsersTab({ roleId }: { roleId: string }) {
 			candidates={candidates}
 			candidatesLoading={loadingAll}
 			consumerLabel="users"
-			emptyHint="No users assigned to this role yet."
+			emptyHint={
+				search
+					? "No assigned users match your search."
+					: "No users assigned to this role yet."
+			}
 			primaryColumnLabel="Name"
 			secondaryColumnLabel="Email"
 			showOrgColumn
+			searchValue={search}
+			onSearchChange={(value) => {
+				setSearch(value);
+				setOffset(0);
+			}}
+			pagination={{
+				offset,
+				limit: pageSize,
+				total: assigned?.total ?? 0,
+				isFetching,
+				onPageChange: setOffset,
+			}}
 			onRequestCandidates={() => setCandidatesRequested(true)}
 			onAssign={async (ids) => {
 				await assignMut.mutateAsync({

--- a/client/src/pages/RoleDetail.tsx
+++ b/client/src/pages/RoleDetail.tsx
@@ -47,7 +47,7 @@ import {
 	SheetTitle,
 } from "@/components/ui/sheet";
 import {
-	useRoles,
+	useRole,
 	useDeleteRole,
 	useRoleUsers,
 	useRoleForms,
@@ -83,14 +83,13 @@ import {
 import type { components } from "@/lib/v1";
 
 type ConsumerKey =
-	| "users"
-	| "forms"
-	| "agents"
-	| "apps"
-	| "workflows"
-	| "knowledge";
+	"users" | "forms" | "agents" | "apps" | "workflows" | "knowledge";
 
-const TABS: { key: ConsumerKey; label: string; Icon: React.ComponentType<{ className?: string }> }[] = [
+const TABS: {
+	key: ConsumerKey;
+	label: string;
+	Icon: React.ComponentType<{ className?: string }>;
+}[] = [
 	{ key: "users", label: "Users", Icon: Users },
 	{ key: "forms", label: "Forms", Icon: FileText },
 	{ key: "agents", label: "Agents", Icon: Bot },
@@ -106,11 +105,7 @@ export function RoleDetail() {
 	const [editOpen, setEditOpen] = useState(false);
 	const [deleteOpen, setDeleteOpen] = useState(false);
 
-	const { data: roles, isLoading: rolesLoading } = useRoles();
-	const role = useMemo(
-		() => roles?.find((r) => r.id === roleId),
-		[roles, roleId],
-	);
+	const { data: role, isLoading: rolesLoading } = useRole(roleId);
 	const deleteRole = useDeleteRole();
 
 	const currentTab: ConsumerKey =
@@ -184,11 +179,13 @@ export function RoleDetail() {
 						{role.name}
 					</h1>
 					{role.description && (
-						<p className="mt-1 text-muted-foreground">{role.description}</p>
+						<p className="mt-1 text-muted-foreground">
+							{role.description}
+						</p>
 					)}
 					<p className="mt-2 text-xs text-muted-foreground">
-						A role grants access to every user, form, agent, app, workflow, and
-						knowledge namespace you assign below.
+						A role grants access to every user, form, agent, app,
+						workflow, and knowledge namespace you assign below.
 					</p>
 				</div>
 				<div className="flex gap-2">
@@ -217,7 +214,11 @@ export function RoleDetail() {
 					{TABS.map(({ key, label, Icon }) => {
 						const count = role.consumer_counts?.[key] ?? 0;
 						return (
-							<TabsTrigger key={key} value={key} className="gap-1.5">
+							<TabsTrigger
+								key={key}
+								value={key}
+								className="gap-1.5"
+							>
 								<Icon className="h-4 w-4" />
 								{label}
 								<span className="ml-1 text-xs text-muted-foreground">
@@ -259,9 +260,10 @@ export function RoleDetail() {
 					<AlertDialogHeader>
 						<AlertDialogTitle>Delete role</AlertDialogTitle>
 						<AlertDialogDescription>
-							Are you sure you want to delete "{role.name}"? This action cannot
-							be undone and removes the role from every user, form, and other
-							consumer it's assigned to.
+							Are you sure you want to delete "{role.name}"? This
+							action cannot be undone and removes the role from
+							every user, form, and other consumer it's assigned
+							to.
 						</AlertDialogDescription>
 					</AlertDialogHeader>
 					<AlertDialogFooter>
@@ -291,10 +293,14 @@ export function RoleDetail() {
 function useOrgLookup() {
 	const { data: orgs } = useOrganizations();
 	return useMemo(() => {
-		const byId = new Map<string, components["schemas"]["OrganizationPublic"]>();
+		const byId = new Map<
+			string,
+			components["schemas"]["OrganizationPublic"]
+		>();
 		for (const o of orgs ?? []) byId.set(o.id, o);
 		return (orgId: string | null | undefined) => {
-			if (!orgId) return { id: null, name: "Platform", isProvider: false };
+			if (!orgId)
+				return { id: null, name: "Platform", isProvider: false };
 			const o = byId.get(orgId);
 			return {
 				id: orgId,
@@ -307,33 +313,29 @@ function useOrgLookup() {
 
 function UsersTab({ roleId }: { roleId: string }) {
 	const { data: assigned, isLoading } = useRoleUsers(roleId);
-	const { data: allUsers, isLoading: loadingAll } = useUsersFiltered();
+	const [candidatesRequested, setCandidatesRequested] = useState(false);
+	const { data: allUsers, isLoading: loadingAll } = useUsersFiltered(
+		undefined,
+		false,
+		candidatesRequested,
+	);
 	const assignMut = useAssignUsersToRole();
 	const unassignMut = useBulkUnassignUsers();
 	const orgFor = useOrgLookup();
 
-	const assignedIds = useMemo(
-		() => new Set(assigned?.user_ids ?? []),
-		[assigned],
-	);
-	const userById = useMemo(() => {
-		const m = new Map<string, components["schemas"]["UserPublic"]>();
-		for (const u of allUsers ?? []) m.set(u.id, u);
-		return m;
-	}, [allUsers]);
-
 	const items: ConsumerTabItem[] = useMemo(
 		() =>
-			Array.from(assignedIds).map((id) => {
-				const u = userById.get(id);
-				return {
-					id,
-					primary: u?.name || u?.email || id,
-					secondary: u?.email && u?.name !== u?.email ? u.email : null,
-					org: orgFor(u?.organization_id),
-				};
-			}),
-		[assignedIds, userById, orgFor],
+			(assigned?.users ?? []).map((u) => ({
+				id: u.id,
+				primary: u.name || u.email,
+				secondary: u.name && u.name !== u.email ? u.email : null,
+				org: {
+					id: u.organization_id ?? null,
+					name: u.organization_name ?? "Platform",
+					isProvider: u.organization_is_provider,
+				},
+			})),
+		[assigned],
 	);
 
 	const candidates: ConsumerTabItem[] = useMemo(
@@ -358,6 +360,7 @@ function UsersTab({ roleId }: { roleId: string }) {
 			primaryColumnLabel="Name"
 			secondaryColumnLabel="Email"
 			showOrgColumn
+			onRequestCandidates={() => setCandidatesRequested(true)}
 			onAssign={async (ids) => {
 				await assignMut.mutateAsync({
 					params: { path: { role_id: roleId } },
@@ -516,7 +519,15 @@ function AppsTab({ roleId }: { roleId: string }) {
 
 	const allApps = useMemo(() => {
 		if (Array.isArray(allAppsResp)) return allAppsResp;
-		return (allAppsResp as { applications?: components["schemas"]["ApplicationPublic"][] } | undefined)?.applications ?? [];
+		return (
+			(
+				allAppsResp as
+					| {
+							applications?: components["schemas"]["ApplicationPublic"][];
+					  }
+					| undefined
+			)?.applications ?? []
+		);
 	}, [allAppsResp]);
 
 	const appById = useMemo(() => {
@@ -663,25 +674,28 @@ function KnowledgeTab({ roleId }: { roleId: string }) {
 	const entries = useMemo(() => data?.entries ?? [], [data]);
 
 	const orgName = useMemo(
-		() =>
-			(orgId?: string | null) => {
-				if (!orgId) return "All organizations";
-				const o = orgs?.find((x) => x.id === orgId);
-				return o?.name || orgId;
-			},
+		() => (orgId?: string | null) => {
+			if (!orgId) return "All organizations";
+			const o = orgs?.find((x) => x.id === orgId);
+			return o?.name || orgId;
+		},
 		[orgs],
 	);
 
 	const visible = useMemo(() => {
 		const q = search.trim().toLowerCase();
 		if (!q) return entries;
-		return entries.filter((e) =>
-			e.namespace.toLowerCase().includes(q) ||
-			orgName(e.organization_id).toLowerCase().includes(q),
+		return entries.filter(
+			(e) =>
+				e.namespace.toLowerCase().includes(q) ||
+				orgName(e.organization_id).toLowerCase().includes(q),
 		);
 	}, [entries, search, orgName]);
 
-	const visibleIds = useMemo(() => new Set(visible.map((e) => e.id)), [visible]);
+	const visibleIds = useMemo(
+		() => new Set(visible.map((e) => e.id)),
+		[visible],
+	);
 	const effective = useMemo(() => {
 		const out = new Set<string>();
 		for (const id of selected) if (visibleIds.has(id)) out.add(id);
@@ -887,18 +901,24 @@ function KnowledgeAssignDrawer({
 
 	return (
 		<Sheet open onOpenChange={(o) => !o && onClose()}>
-			<SheetContent side="right" className="w-[480px] sm:max-w-[480px] flex flex-col">
+			<SheetContent
+				side="right"
+				className="w-[480px] sm:max-w-[480px] flex flex-col"
+			>
 				<SheetHeader>
 					<SheetTitle>Assign knowledge namespace</SheetTitle>
 					<SheetDescription>
-						Grant this role access to a knowledge namespace. Namespaces are
-						free-form strings — pick the one used in your knowledge store.
+						Grant this role access to a knowledge namespace.
+						Namespaces are free-form strings — pick the one used in
+						your knowledge store.
 					</SheetDescription>
 				</SheetHeader>
 
 				<div className="px-6 space-y-3">
 					<label className="block text-sm">
-						<span className="block mb-1 text-muted-foreground">Namespace</span>
+						<span className="block mb-1 text-muted-foreground">
+							Namespace
+						</span>
 						<Input
 							type="text"
 							value={namespace}
@@ -908,7 +928,9 @@ function KnowledgeAssignDrawer({
 					</label>
 
 					<label className="block text-sm">
-						<span className="block mb-1 text-muted-foreground">Scope</span>
+						<span className="block mb-1 text-muted-foreground">
+							Scope
+						</span>
 						<select
 							value={orgId}
 							onChange={(e) => setOrgId(e.target.value)}

--- a/client/src/pages/Roles.test.tsx
+++ b/client/src/pages/Roles.test.tsx
@@ -47,6 +47,14 @@ describe("Roles", () => {
 
 		expect(screen.getByText("Billing admins")).toBeInTheDocument();
 		expect(screen.getByText("1–25 of 30")).toBeInTheDocument();
+		expect(
+			screen
+				.getByRole("navigation", { name: /pagination/i })
+				.closest("tfoot"),
+		).not.toBeNull();
+		expect(
+			screen.getAllByRole("table")[0].parentElement?.parentElement,
+		).toHaveClass("max-h-full");
 		expect(mockUseRolesPage).toHaveBeenLastCalledWith(
 			expect.objectContaining({ limit: 25, offset: 0 }),
 		);

--- a/client/src/pages/Roles.test.tsx
+++ b/client/src/pages/Roles.test.tsx
@@ -1,0 +1,82 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { renderWithProviders, screen, waitFor } from "@/test-utils";
+
+const mockUseRolesPage = vi.fn();
+const mockDeleteMutate = vi.fn();
+
+vi.mock("@/hooks/useRoles", () => ({
+	useRolesPage: (...args: unknown[]) => mockUseRolesPage(...args),
+	useDeleteRole: () => ({ mutate: mockDeleteMutate, isPending: false }),
+}));
+
+vi.mock("@/components/roles/RoleDialog", () => ({
+	RoleDialog: () => null,
+}));
+
+import { Roles } from "./Roles";
+
+const role = {
+	id: "role-1",
+	name: "Billing admins",
+	description: "Manage billing",
+	permissions: {},
+	created_by: "admin@example.com",
+	created_at: "2026-01-01T00:00:00Z",
+	updated_at: "2026-01-01T00:00:00Z",
+	consumer_counts: {
+		users: 2,
+		forms: 0,
+		agents: 0,
+		apps: 0,
+		workflows: 0,
+		knowledge: 0,
+	},
+};
+
+describe("Roles", () => {
+	it("requests a bounded page and navigates to the next page", async () => {
+		mockUseRolesPage.mockReturnValue({
+			data: { items: [role], total: 30 },
+			isLoading: false,
+			isFetching: false,
+			isError: false,
+			refetch: vi.fn(),
+		});
+		const { user } = renderWithProviders(<Roles />);
+
+		expect(screen.getByText("Billing admins")).toBeInTheDocument();
+		expect(screen.getByText("1–25 of 30")).toBeInTheDocument();
+		expect(mockUseRolesPage).toHaveBeenLastCalledWith(
+			expect.objectContaining({ limit: 25, offset: 0 }),
+		);
+
+		await user.click(screen.getByRole("link", { name: /next page/i }));
+		await waitFor(() => {
+			expect(mockUseRolesPage).toHaveBeenLastCalledWith(
+				expect.objectContaining({ limit: 25, offset: 25 }),
+			);
+		});
+	});
+
+	it("sends debounced search to the server and resets the page", async () => {
+		mockUseRolesPage.mockReturnValue({
+			data: { items: [role], total: 30 },
+			isLoading: false,
+			isFetching: false,
+			isError: false,
+			refetch: vi.fn(),
+		});
+		const { user } = renderWithProviders(<Roles />);
+
+		await user.type(
+			screen.getByPlaceholderText(/search roles by name or description/i),
+			"billing",
+		);
+		await waitFor(() => {
+			expect(mockUseRolesPage).toHaveBeenLastCalledWith(
+				expect.objectContaining({ search: "billing", offset: 0 }),
+			);
+		});
+	});
+});

--- a/client/src/pages/Roles.tsx
+++ b/client/src/pages/Roles.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import {
 	ArrowDown,
@@ -43,15 +43,16 @@ import {
 	TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { SearchBox } from "@/components/search/SearchBox";
-import { useSearch } from "@/hooks/useSearch";
-import { useRoles, useDeleteRole } from "@/hooks/useRoles";
+import { useDeleteRole, useRolesPage } from "@/hooks/useRoles";
 import { RoleDialog } from "@/components/roles/RoleDialog";
+import { ListPagination } from "@/components/pagination/ListPagination";
 
 import type { components } from "@/lib/v1";
 type Role = components["schemas"]["RolePublic"];
 
 type SortColumn = "name" | "created";
 type SortDirection = "asc" | "desc";
+const PAGE_SIZE = 25;
 
 const CHIP_DEFS: {
 	key: "users" | "forms" | "agents" | "apps" | "workflows" | "knowledge";
@@ -91,33 +92,19 @@ export function Roles() {
 	const [searchTerm, setSearchTerm] = useState("");
 	const [sortColumn, setSortColumn] = useState<SortColumn>("name");
 	const [sortDirection, setSortDirection] = useState<SortDirection>("asc");
+	const [offset, setOffset] = useState(0);
 
 	const navigate = useNavigate();
-	const { data: roles, isLoading, refetch } = useRoles();
+	const rolesQuery = useRolesPage({
+		search: searchTerm,
+		sortBy: sortColumn,
+		sortDirection,
+		limit: PAGE_SIZE,
+		offset,
+	});
+	const roles = rolesQuery.data?.items ?? [];
+	const total = rolesQuery.data?.total ?? 0;
 	const deleteRole = useDeleteRole();
-
-	const filteredRoles = useSearch(roles || [], searchTerm, [
-		"name",
-		"description",
-	]);
-
-	const sortedRoles = useMemo(() => {
-		if (!filteredRoles) return [];
-		return [...filteredRoles].sort((a, b) => {
-			const dir = sortDirection === "asc" ? 1 : -1;
-			switch (sortColumn) {
-				case "name":
-					return dir * (a.name || "").localeCompare(b.name || "");
-				case "created": {
-					const aDate = a.created_at ? new Date(a.created_at).getTime() : 0;
-					const bDate = b.created_at ? new Date(b.created_at).getTime() : 0;
-					return dir * (aDate - bDate);
-				}
-				default:
-					return 0;
-			}
-		});
-	}, [filteredRoles, sortColumn, sortDirection]);
 
 	const handleSort = (column: SortColumn) => {
 		if (sortColumn === column) {
@@ -126,6 +113,7 @@ export function Roles() {
 			setSortColumn(column);
 			setSortDirection("asc");
 		}
+		setOffset(0);
 	};
 
 	const handleEdit = (role: Role) => {
@@ -155,29 +143,28 @@ export function Roles() {
 			{/* Header */}
 			<div className="flex items-center justify-between">
 				<div>
-					<h1 className="text-4xl font-extrabold tracking-tight">Roles</h1>
+					<h1 className="text-4xl font-extrabold tracking-tight">
+						Roles
+					</h1>
 					<p className="mt-2 text-muted-foreground">
-						Roles grant access to users, forms, agents, apps, workflows, and
-						knowledge namespaces. Click a count chip to manage that consumer
-						type.
+						Roles grant access to users, forms, agents, apps,
+						workflows, and knowledge namespaces. Click a count chip
+						to manage that consumer type.
 					</p>
 				</div>
 				<div className="flex gap-2">
 					<Button
 						variant="outline"
 						size="icon"
-						onClick={() => refetch()}
+						onClick={() => rolesQuery.refetch()}
 						title="Refresh"
+						aria-label="Refresh roles"
 					>
 						<RefreshCw className="h-4 w-4" />
 					</Button>
-					<Button
-						variant="outline"
-						size="icon"
-						onClick={handleAdd}
-						title="Create Role"
-					>
-						<Plus className="h-4 w-4" />
+					<Button onClick={handleAdd}>
+						<Plus className="h-4 w-4 mr-1.5" />
+						Create role
 					</Button>
 				</div>
 			</div>
@@ -186,7 +173,10 @@ export function Roles() {
 			<div className="flex items-center gap-4">
 				<SearchBox
 					value={searchTerm}
-					onChange={setSearchTerm}
+					onChange={(value) => {
+						setSearchTerm(value);
+						setOffset(0);
+					}}
 					placeholder="Search roles by name or description..."
 					className="flex-1"
 				/>
@@ -194,13 +184,31 @@ export function Roles() {
 
 			{/* Content */}
 			<div className="flex-1 min-h-0">
-				{isLoading ? (
+				{rolesQuery.isLoading ? (
 					<div className="space-y-2">
 						{[...Array(5)].map((_, i) => (
 							<Skeleton key={i} className="h-12 w-full" />
 						))}
 					</div>
-				) : sortedRoles.length === 0 ? (
+				) : rolesQuery.isError ? (
+					<Card>
+						<CardContent className="flex flex-col items-center justify-center py-12 text-center">
+							<h3 className="text-lg font-semibold">
+								Roles could not be loaded
+							</h3>
+							<p className="mt-2 text-sm text-muted-foreground">
+								Check your connection and try again.
+							</p>
+							<Button
+								className="mt-4"
+								variant="outline"
+								onClick={() => rolesQuery.refetch()}
+							>
+								Try again
+							</Button>
+						</CardContent>
+					</Card>
+				) : roles.length === 0 ? (
 					<Card>
 						<CardContent className="flex flex-col items-center justify-center py-12 text-center">
 							<UserCog className="h-12 w-12 text-muted-foreground" />
@@ -216,62 +224,70 @@ export function Roles() {
 							</p>
 							<Button
 								variant="outline"
-								size="icon"
 								onClick={handleAdd}
-								title="Create Role"
 								className="mt-4"
 							>
 								<Plus className="h-4 w-4" />
+								Create role
 							</Button>
 						</CardContent>
 					</Card>
 				) : (
-					<DataTable>
-						<DataTableHeader>
-							<DataTableRow>
-								<DataTableHead
-									className="w-0 whitespace-nowrap cursor-pointer select-none"
-									onClick={() => handleSort("name")}
-								>
-									Name
-									<SortIcon
-										column="name"
-										sortColumn={sortColumn}
-										sortDirection={sortDirection}
+					<div aria-busy={rolesQuery.isFetching}>
+						<DataTable>
+							<DataTableHeader>
+								<DataTableRow>
+									<DataTableHead
+										className="w-0 whitespace-nowrap cursor-pointer select-none"
+										onClick={() => handleSort("name")}
+									>
+										Name
+										<SortIcon
+											column="name"
+											sortColumn={sortColumn}
+											sortDirection={sortDirection}
+										/>
+									</DataTableHead>
+									<DataTableHead>Description</DataTableHead>
+									<DataTableHead className="whitespace-nowrap">
+										Consumers
+									</DataTableHead>
+									<DataTableHead
+										className="w-0 whitespace-nowrap cursor-pointer select-none"
+										onClick={() => handleSort("created")}
+									>
+										Created
+										<SortIcon
+											column="created"
+											sortColumn={sortColumn}
+											sortDirection={sortDirection}
+										/>
+									</DataTableHead>
+									<DataTableHead className="w-0 whitespace-nowrap text-right sticky right-0 bg-background">
+										Actions
+									</DataTableHead>
+								</DataTableRow>
+							</DataTableHeader>
+							<DataTableBody>
+								{roles.map((role) => (
+									<RoleRow
+										key={role.id}
+										role={role}
+										onEdit={() => handleEdit(role)}
+										onDelete={() => handleDelete(role)}
+										onNavigate={(to) => navigate(to)}
 									/>
-								</DataTableHead>
-								<DataTableHead>Description</DataTableHead>
-								<DataTableHead className="whitespace-nowrap">
-									Consumers
-								</DataTableHead>
-								<DataTableHead
-									className="w-0 whitespace-nowrap cursor-pointer select-none"
-									onClick={() => handleSort("created")}
-								>
-									Created
-									<SortIcon
-										column="created"
-										sortColumn={sortColumn}
-										sortDirection={sortDirection}
-									/>
-								</DataTableHead>
-								<DataTableHead className="w-0 whitespace-nowrap text-right sticky right-0 bg-background">
-									Actions
-								</DataTableHead>
-							</DataTableRow>
-						</DataTableHeader>
-						<DataTableBody>
-							{sortedRoles.map((role) => (
-								<RoleRow
-									key={role.id}
-									role={role}
-									onEdit={() => handleEdit(role)}
-									onDelete={() => handleDelete(role)}
-									onNavigate={(to) => navigate(to)}
-								/>
-							))}
-						</DataTableBody>
-					</DataTable>
+								))}
+							</DataTableBody>
+						</DataTable>
+						<ListPagination
+							offset={offset}
+							limit={PAGE_SIZE}
+							total={total}
+							isFetching={rolesQuery.isFetching}
+							onPageChange={setOffset}
+						/>
+					</div>
 				)}
 			</div>
 
@@ -289,8 +305,8 @@ export function Roles() {
 					<AlertDialogHeader>
 						<AlertDialogTitle>Delete Role</AlertDialogTitle>
 						<AlertDialogDescription>
-							Are you sure you want to delete the role "{roleToDelete?.name}"?
-							This action cannot be undone.
+							Are you sure you want to delete the role "
+							{roleToDelete?.name}"? This action cannot be undone.
 						</AlertDialogDescription>
 					</AlertDialogHeader>
 					<AlertDialogFooter>
@@ -299,7 +315,9 @@ export function Roles() {
 							onClick={handleConfirmDelete}
 							className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
 						>
-							{deleteRole.isPending ? "Deleting..." : "Delete Role"}
+							{deleteRole.isPending
+								? "Deleting..."
+								: "Delete Role"}
 						</AlertDialogAction>
 					</AlertDialogFooter>
 				</AlertDialogContent>
@@ -355,7 +373,9 @@ function RoleRow({
 										aria-label={`${count} ${label.toLowerCase()} — open ${label.toLowerCase()} tab`}
 									>
 										<Icon className="h-3 w-3" />
-										<span className="font-medium">{count}</span>
+										<span className="font-medium">
+											{count}
+										</span>
 									</Link>
 								</TooltipTrigger>
 								<TooltipContent>{label}</TooltipContent>

--- a/client/src/pages/Roles.tsx
+++ b/client/src/pages/Roles.tsx
@@ -22,6 +22,7 @@ import {
 	DataTable,
 	DataTableBody,
 	DataTableCell,
+	DataTableFooter,
 	DataTableHead,
 	DataTableHeader,
 	DataTableRow,
@@ -233,61 +234,68 @@ export function Roles() {
 						</CardContent>
 					</Card>
 				) : (
-					<div aria-busy={rolesQuery.isFetching}>
-						<DataTable>
-							<DataTableHeader>
-								<DataTableRow>
-									<DataTableHead
-										className="w-0 whitespace-nowrap cursor-pointer select-none"
-										onClick={() => handleSort("name")}
-									>
-										Name
-										<SortIcon
-											column="name"
-											sortColumn={sortColumn}
-											sortDirection={sortDirection}
-										/>
-									</DataTableHead>
-									<DataTableHead>Description</DataTableHead>
-									<DataTableHead className="whitespace-nowrap">
-										Consumers
-									</DataTableHead>
-									<DataTableHead
-										className="w-0 whitespace-nowrap cursor-pointer select-none"
-										onClick={() => handleSort("created")}
-									>
-										Created
-										<SortIcon
-											column="created"
-											sortColumn={sortColumn}
-											sortDirection={sortDirection}
-										/>
-									</DataTableHead>
-									<DataTableHead className="w-0 whitespace-nowrap text-right sticky right-0 bg-background">
-										Actions
-									</DataTableHead>
-								</DataTableRow>
-							</DataTableHeader>
-							<DataTableBody>
-								{roles.map((role) => (
-									<RoleRow
-										key={role.id}
-										role={role}
-										onEdit={() => handleEdit(role)}
-										onDelete={() => handleDelete(role)}
-										onNavigate={(to) => navigate(to)}
+					<DataTable
+						className="max-h-full"
+						aria-busy={rolesQuery.isFetching}
+					>
+						<DataTableHeader>
+							<DataTableRow>
+								<DataTableHead
+									className="w-0 whitespace-nowrap cursor-pointer select-none"
+									onClick={() => handleSort("name")}
+								>
+									Name
+									<SortIcon
+										column="name"
+										sortColumn={sortColumn}
+										sortDirection={sortDirection}
 									/>
-								))}
-							</DataTableBody>
-						</DataTable>
-						<ListPagination
-							offset={offset}
-							limit={PAGE_SIZE}
-							total={total}
-							isFetching={rolesQuery.isFetching}
-							onPageChange={setOffset}
-						/>
-					</div>
+								</DataTableHead>
+								<DataTableHead>Description</DataTableHead>
+								<DataTableHead className="whitespace-nowrap">
+									Consumers
+								</DataTableHead>
+								<DataTableHead
+									className="w-0 whitespace-nowrap cursor-pointer select-none"
+									onClick={() => handleSort("created")}
+								>
+									Created
+									<SortIcon
+										column="created"
+										sortColumn={sortColumn}
+										sortDirection={sortDirection}
+									/>
+								</DataTableHead>
+								<DataTableHead className="w-0 whitespace-nowrap text-right sticky right-0 bg-background">
+									Actions
+								</DataTableHead>
+							</DataTableRow>
+						</DataTableHeader>
+						<DataTableBody>
+							{roles.map((role) => (
+								<RoleRow
+									key={role.id}
+									role={role}
+									onEdit={() => handleEdit(role)}
+									onDelete={() => handleDelete(role)}
+									onNavigate={(to) => navigate(to)}
+								/>
+							))}
+						</DataTableBody>
+						<DataTableFooter>
+							<DataTableRow>
+								<DataTableCell colSpan={5} className="p-0">
+									<ListPagination
+										offset={offset}
+										limit={PAGE_SIZE}
+										total={total}
+										isFetching={rolesQuery.isFetching}
+										onPageChange={setOffset}
+									/>
+								</DataTableCell>
+							</DataTableRow>
+						</DataTableFooter>
+					</DataTable>
 				)}
 			</div>
 

--- a/client/src/pages/Users.test.tsx
+++ b/client/src/pages/Users.test.tsx
@@ -1,7 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { renderWithProviders, screen, waitFor, within } from "@/test-utils";
 
-const mockUseUsersFiltered = vi.fn();
+const mockUseUsersPage = vi.fn();
+const mockUseUser = vi.fn();
 const mockUseDeleteUser = vi.fn();
 const mockUseUpdateUser = vi.fn();
 const mockUseOrganizations = vi.fn();
@@ -17,7 +18,8 @@ const mockToastError = vi.fn();
 const mockRefetch = vi.fn();
 
 vi.mock("@/hooks/useUsers", () => ({
-	useUsersFiltered: (...args: unknown[]) => mockUseUsersFiltered(...args),
+	useUsersPage: (...args: unknown[]) => mockUseUsersPage(...args),
+	useUser: (...args: unknown[]) => mockUseUser(...args),
 	useDeleteUser: () => mockUseDeleteUser(),
 	useUpdateUser: () => mockUseUpdateUser(),
 }));
@@ -119,11 +121,14 @@ describe("Users — registration links", () => {
 		originalWriteText = navigator.clipboard?.writeText.bind(
 			navigator.clipboard,
 		);
-		mockUseUsersFiltered.mockReturnValue({
-			data: [pendingInviteUser()],
+		mockUseUsersPage.mockReturnValue({
+			data: { items: [pendingInviteUser()], total: 1 },
 			isLoading: false,
+			isFetching: false,
+			isError: false,
 			refetch: vi.fn(),
 		});
+		mockUseUser.mockReturnValue({ data: undefined });
 		mockUseDeleteUser.mockReturnValue({ mutateAsync: vi.fn() });
 		mockUseUpdateUser.mockReturnValue({ mutateAsync: vi.fn() });
 		mockUseOrganizations.mockReturnValue({
@@ -250,12 +255,15 @@ describe("Users — registration links", () => {
 describe("Users", () => {
 	beforeEach(() => {
 		mockRefetch.mockReset();
-		mockUseUsersFiltered.mockReset();
-		mockUseUsersFiltered.mockReturnValue({
-			data: [makeUser()],
+		mockUseUsersPage.mockReset();
+		mockUseUsersPage.mockReturnValue({
+			data: { items: [makeUser()], total: 1 },
 			isLoading: false,
+			isFetching: false,
+			isError: false,
 			refetch: mockRefetch,
 		});
+		mockUseUser.mockReturnValue({ data: undefined });
 		mockUseOrganizations.mockReset();
 		mockUseOrganizations.mockReturnValue({
 			data: [
@@ -298,12 +306,22 @@ describe("Users", () => {
 	it("includes inactive users when Show Inactive is enabled", async () => {
 		const { user } = renderWithProviders(<Users />);
 
-		expect(mockUseUsersFiltered).toHaveBeenLastCalledWith(undefined, false);
-
-		await user.click(
-			screen.getByRole("switch", { name: "Show Inactive" }),
+		expect(mockUseUsersPage).toHaveBeenLastCalledWith(
+			expect.objectContaining({
+				includeInactive: false,
+				offset: 0,
+				limit: 25,
+			}),
 		);
 
-		expect(mockUseUsersFiltered).toHaveBeenLastCalledWith(undefined, true);
+		await user.click(screen.getByRole("switch", { name: "Show Inactive" }));
+
+		expect(mockUseUsersPage).toHaveBeenLastCalledWith(
+			expect.objectContaining({
+				includeInactive: true,
+				offset: 0,
+				limit: 25,
+			}),
+		);
 	});
 });

--- a/client/src/pages/Users.test.tsx
+++ b/client/src/pages/Users.test.tsx
@@ -324,4 +324,24 @@ describe("Users", () => {
 			}),
 		);
 	});
+
+	it("keeps pagination in the bounded table footer", () => {
+		mockUseUsersPage.mockReturnValue({
+			data: { items: [makeUser()], total: 30 },
+			isLoading: false,
+			isFetching: false,
+			isError: false,
+			refetch: mockRefetch,
+		});
+
+		renderWithProviders(<Users />);
+
+		const pagination = screen.getByRole("navigation", {
+			name: /pagination/i,
+		});
+		expect(pagination.closest("tfoot")).not.toBeNull();
+		expect(
+			screen.getAllByRole("table")[0].parentElement?.parentElement,
+		).toHaveClass("max-h-full");
+	});
 });

--- a/client/src/pages/Users.test.tsx
+++ b/client/src/pages/Users.test.tsx
@@ -16,6 +16,7 @@ const mockUseEventSources = vi.fn();
 const mockToastSuccess = vi.fn();
 const mockToastError = vi.fn();
 const mockRefetch = vi.fn();
+const mockEditUserDialog = vi.fn();
 
 vi.mock("@/hooks/useUsers", () => ({
 	useUsersPage: (...args: unknown[]) => mockUseUsersPage(...args),
@@ -66,7 +67,12 @@ vi.mock("@/components/users/CreateUserDialog", () => ({
 }));
 
 vi.mock("@/components/users/EditUserDialog", () => ({
-	EditUserDialog: () => null,
+	EditUserDialog: (props: { open: boolean; user?: { id: string } }) => {
+		mockEditUserDialog(props);
+		return props.open ? (
+			<div role="dialog">Edit user test dialog</div>
+		) : null;
+	},
 }));
 
 vi.mock("@/components/users/BulkUserDialogs", () => ({
@@ -166,6 +172,18 @@ describe("Users — registration links", () => {
 		});
 		mockToastSuccess.mockReset();
 		mockToastError.mockReset();
+		mockEditUserDialog.mockClear();
+	});
+
+	it("waits for the route-selected user instead of pre-opening the dialog", async () => {
+		const { user } = renderWithProviders(<Users />);
+
+		await user.click(screen.getByText("Alice"));
+
+		expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+		expect(mockEditUserDialog).toHaveBeenLastCalledWith(
+			expect.objectContaining({ open: false, user: undefined }),
+		);
 	});
 
 	afterEach(() => {

--- a/client/src/pages/Users.tsx
+++ b/client/src/pages/Users.tsx
@@ -16,6 +16,7 @@ import {
 	DataTable,
 	DataTableBody,
 	DataTableCell,
+	DataTableFooter,
 	DataTableHead,
 	DataTableHeader,
 	DataTableRow,
@@ -165,7 +166,9 @@ export function Users() {
 		if (!orgId) return { name: "Platform", isProvider: false };
 		const org = organizations?.find((o: Organization) => o.id === orgId);
 		return {
-			name: org?.name || (organizations ? "Unknown organization" : "Loading…"),
+			name:
+				org?.name ||
+				(organizations ? "Unknown organization" : "Loading…"),
 			isProvider: org?.is_provider ?? false,
 		};
 	};
@@ -429,358 +432,346 @@ export function Users() {
 						</Button>
 					</div>
 				) : users.length > 0 ? (
-					<div>
-						<DataTable>
-							<DataTableHeader>
-								<DataTableRow>
-									<DataTableHead className="w-0 whitespace-nowrap">
-										<Checkbox
-											aria-label="Select all visible users"
-											checked={
-												selection.allVisibleSelected
-													? true
-													: selection.someVisibleSelected
-														? "indeterminate"
-														: false
-											}
-											onCheckedChange={() =>
-												selection.toggleAllVisible()
-											}
-										/>
-									</DataTableHead>
-									<DataTableHead className="w-0 whitespace-nowrap">
-										Organization
-									</DataTableHead>
-									<DataTableHead
-										className="w-0 whitespace-nowrap cursor-pointer select-none"
-										onClick={() => handleSort("name")}
+					<DataTable className="max-h-full">
+						<DataTableHeader>
+							<DataTableRow>
+								<DataTableHead className="w-0 whitespace-nowrap">
+									<Checkbox
+										aria-label="Select all visible users"
+										checked={
+											selection.allVisibleSelected
+												? true
+												: selection.someVisibleSelected
+													? "indeterminate"
+													: false
+										}
+										onCheckedChange={() =>
+											selection.toggleAllVisible()
+										}
+									/>
+								</DataTableHead>
+								<DataTableHead className="w-0 whitespace-nowrap">
+									Organization
+								</DataTableHead>
+								<DataTableHead
+									className="w-0 whitespace-nowrap cursor-pointer select-none"
+									onClick={() => handleSort("name")}
+								>
+									Name
+									<SortIcon
+										column="name"
+										sortColumn={sortColumn}
+										sortDirection={sortDirection}
+									/>
+								</DataTableHead>
+								<DataTableHead
+									className="cursor-pointer select-none"
+									onClick={() => handleSort("email")}
+								>
+									Email
+									<SortIcon
+										column="email"
+										sortColumn={sortColumn}
+										sortDirection={sortDirection}
+									/>
+								</DataTableHead>
+								<DataTableHead
+									className="w-0 whitespace-nowrap cursor-pointer select-none"
+									onClick={() => handleSort("status")}
+								>
+									Status
+									<SortIcon
+										column="status"
+										sortColumn={sortColumn}
+										sortDirection={sortDirection}
+									/>
+								</DataTableHead>
+								<DataTableHead
+									className="w-0 whitespace-nowrap cursor-pointer select-none"
+									onClick={() => handleSort("created")}
+								>
+									Created
+									<SortIcon
+										column="created"
+										sortColumn={sortColumn}
+										sortDirection={sortDirection}
+									/>
+								</DataTableHead>
+								<DataTableHead
+									className="w-0 whitespace-nowrap cursor-pointer select-none"
+									onClick={() => handleSort("last_login")}
+								>
+									Last Login
+									<SortIcon
+										column="last_login"
+										sortColumn={sortColumn}
+										sortDirection={sortDirection}
+									/>
+								</DataTableHead>
+								<DataTableHead className="w-0 whitespace-nowrap text-right sticky right-0 bg-background"></DataTableHead>
+							</DataTableRow>
+						</DataTableHeader>
+						<DataTableBody>
+							{users.map((user) => {
+								const orgInfo = getOrgInfo(
+									user.organization_id,
+								);
+								return (
+									<DataTableRow
+										key={user.id}
+										clickable
+										onClick={() => handleEditUser(user)}
+										className={
+											"group/row" +
+											(!user.is_active
+												? " opacity-60"
+												: "")
+										}
 									>
-										Name
-										<SortIcon
-											column="name"
-											sortColumn={sortColumn}
-											sortDirection={sortDirection}
-										/>
-									</DataTableHead>
-									<DataTableHead
-										className="cursor-pointer select-none"
-										onClick={() => handleSort("email")}
-									>
-										Email
-										<SortIcon
-											column="email"
-											sortColumn={sortColumn}
-											sortDirection={sortDirection}
-										/>
-									</DataTableHead>
-									<DataTableHead
-										className="w-0 whitespace-nowrap cursor-pointer select-none"
-										onClick={() => handleSort("status")}
-									>
-										Status
-										<SortIcon
-											column="status"
-											sortColumn={sortColumn}
-											sortDirection={sortDirection}
-										/>
-									</DataTableHead>
-									<DataTableHead
-										className="w-0 whitespace-nowrap cursor-pointer select-none"
-										onClick={() => handleSort("created")}
-									>
-										Created
-										<SortIcon
-											column="created"
-											sortColumn={sortColumn}
-											sortDirection={sortDirection}
-										/>
-									</DataTableHead>
-									<DataTableHead
-										className="w-0 whitespace-nowrap cursor-pointer select-none"
-										onClick={() => handleSort("last_login")}
-									>
-										Last Login
-										<SortIcon
-											column="last_login"
-											sortColumn={sortColumn}
-											sortDirection={sortDirection}
-										/>
-									</DataTableHead>
-									<DataTableHead className="w-0 whitespace-nowrap text-right sticky right-0 bg-background"></DataTableHead>
-								</DataTableRow>
-							</DataTableHeader>
-							<DataTableBody>
-								{users.map((user) => {
-									const orgInfo = getOrgInfo(
-										user.organization_id,
-									);
-									return (
-										<DataTableRow
-											key={user.id}
-											clickable
-											onClick={() => handleEditUser(user)}
-											className={
-												"group/row" +
-												(!user.is_active
-													? " opacity-60"
-													: "")
-											}
+										<DataTableCell
+											className="w-0 whitespace-nowrap"
+											onClick={(e) => e.stopPropagation()}
 										>
-											<DataTableCell
-												className="w-0 whitespace-nowrap"
-												onClick={(e) =>
-													e.stopPropagation()
-												}
-											>
-												{isSelf(user) ? (
+											{isSelf(user) ? (
+												<Tooltip>
+													<TooltipTrigger asChild>
+														<span>
+															<Checkbox
+																checked={false}
+																disabled
+																aria-label="Cannot select yourself"
+															/>
+														</span>
+													</TooltipTrigger>
+													<TooltipContent>
+														You can't include
+														yourself in a bulk
+														action
+													</TooltipContent>
+												</Tooltip>
+											) : (
+												<Checkbox
+													aria-label={`Select ${user.name || user.email}`}
+													checked={selection.isSelected(
+														user.id,
+													)}
+													onClick={(e) => {
+														selection.toggle(
+															user.id,
+															{
+																shiftKey:
+																	e.shiftKey,
+															},
+														);
+														e.preventDefault();
+													}}
+												/>
+											)}
+										</DataTableCell>
+										<DataTableCell className="w-0 whitespace-nowrap text-sm">
+											<span className="inline-flex items-center gap-1">
+												{orgInfo.isProvider ? (
+													<Star className="h-3.5 w-3.5 text-amber-500 fill-amber-500" />
+												) : (
+													<Building2 className="h-3.5 w-3.5 text-muted-foreground" />
+												)}
+												<span>{orgInfo.name}</span>
+											</span>
+										</DataTableCell>
+										<DataTableCell className="w-0 whitespace-nowrap">
+											<div className="flex items-center gap-1.5">
+												<span className="font-medium">
+													{user.name || user.email}
+												</span>
+												{user.is_superuser && (
 													<Tooltip>
 														<TooltipTrigger asChild>
-															<span>
-																<Checkbox
-																	checked={
-																		false
-																	}
-																	disabled
-																	aria-label="Cannot select yourself"
-																/>
-															</span>
+															<Crown className="h-4 w-4 shrink-0 text-amber-500 fill-amber-500" />
 														</TooltipTrigger>
 														<TooltipContent>
-															You can't include
-															yourself in a bulk
-															action
+															Platform Admin
 														</TooltipContent>
 													</Tooltip>
-												) : (
-													<Checkbox
-														aria-label={`Select ${user.name || user.email}`}
-														checked={selection.isSelected(
-															user.id,
-														)}
-														onClick={(e) => {
-															selection.toggle(
-																user.id,
-																{
-																	shiftKey:
-																		e.shiftKey,
-																},
-															);
-															e.preventDefault();
-														}}
-													/>
 												)}
-											</DataTableCell>
-											<DataTableCell className="w-0 whitespace-nowrap text-sm">
-												<span className="inline-flex items-center gap-1">
-													{orgInfo.isProvider ? (
-														<Star className="h-3.5 w-3.5 text-amber-500 fill-amber-500" />
-													) : (
-														<Building2 className="h-3.5 w-3.5 text-muted-foreground" />
-													)}
-													<span>{orgInfo.name}</span>
-												</span>
-											</DataTableCell>
-											<DataTableCell className="w-0 whitespace-nowrap">
-												<div className="flex items-center gap-1.5">
-													<span className="font-medium">
-														{user.name ||
-															user.email}
-													</span>
-													{user.is_superuser && (
-														<Tooltip>
-															<TooltipTrigger
-																asChild
+												{user.is_external && (
+													<Tooltip>
+														<TooltipTrigger asChild>
+															<Badge
+																variant="outline"
+																className="text-xs shrink-0"
 															>
-																<Crown className="h-4 w-4 shrink-0 text-amber-500 fill-amber-500" />
-															</TooltipTrigger>
-															<TooltipContent>
-																Platform Admin
-															</TooltipContent>
-														</Tooltip>
-													)}
-													{user.is_external && (
-														<Tooltip>
-															<TooltipTrigger
-																asChild
-															>
-																<Badge
-																	variant="outline"
-																	className="text-xs shrink-0"
-																>
-																	External
-																</Badge>
-															</TooltipTrigger>
-															<TooltipContent>
-																External user —
-																sees only what
-																the Everyone
-																tier or an
-																explicit role
-																grant allows
-															</TooltipContent>
-														</Tooltip>
-													)}
-												</div>
-											</DataTableCell>
-											<DataTableCell
-												className="text-muted-foreground max-w-0"
-												onClick={(e) =>
-													e.stopPropagation()
+																External
+															</Badge>
+														</TooltipTrigger>
+														<TooltipContent>
+															External user — sees
+															only what the
+															Everyone tier or an
+															explicit role grant
+															allows
+														</TooltipContent>
+													</Tooltip>
+												)}
+											</div>
+										</DataTableCell>
+										<DataTableCell
+											className="text-muted-foreground max-w-0"
+											onClick={(e) => e.stopPropagation()}
+										>
+											<UserEmailCell email={user.email} />
+										</DataTableCell>
+										<DataTableCell className="w-0 whitespace-nowrap">
+											<UserStatusBadge
+												status={
+													user.invite_status ??
+													"active"
 												}
-											>
-												<UserEmailCell
-													email={user.email}
-												/>
-											</DataTableCell>
-											<DataTableCell className="w-0 whitespace-nowrap">
-												<UserStatusBadge
-													status={
-														user.invite_status ??
-														"active"
-													}
-												/>
-											</DataTableCell>
-											<DataTableCell className="w-0 whitespace-nowrap text-sm text-muted-foreground">
-												{user.created_at
-													? new Date(
-															user.created_at,
-														).toLocaleDateString()
-													: "N/A"}
-											</DataTableCell>
-											<DataTableCell className="w-0 whitespace-nowrap text-sm text-muted-foreground">
-												{user.last_login
-													? new Date(
-															user.last_login,
-														).toLocaleDateString()
-													: "Never"}
-											</DataTableCell>
-											<DataTableCell
-												className="w-0 whitespace-nowrap text-right sticky right-0 bg-card group-hover/row:bg-[color-mix(in_oklch,var(--card),var(--muted)_50%)]"
-												onClick={(e) =>
-													e.stopPropagation()
+											/>
+										</DataTableCell>
+										<DataTableCell className="w-0 whitespace-nowrap text-sm text-muted-foreground">
+											{user.created_at
+												? new Date(
+														user.created_at,
+													).toLocaleDateString()
+												: "N/A"}
+										</DataTableCell>
+										<DataTableCell className="w-0 whitespace-nowrap text-sm text-muted-foreground">
+											{user.last_login
+												? new Date(
+														user.last_login,
+													).toLocaleDateString()
+												: "Never"}
+										</DataTableCell>
+										<DataTableCell
+											className="w-0 whitespace-nowrap text-right sticky right-0 bg-card group-hover/row:bg-[color-mix(in_oklch,var(--card),var(--muted)_50%)]"
+											onClick={(e) => e.stopPropagation()}
+										>
+											<UserActionsMenu
+												status={
+													user.invite_status ??
+													"active"
 												}
-											>
-												<UserActionsMenu
-													status={
-														user.invite_status ??
-														"active"
-													}
-													isActive={user.is_active}
-													isSelf={isSelf(user)}
-													onResend={() =>
-														resendMutation.mutate(
-															user.id,
-															{
-																onSuccess: (
-																	res,
-																) => {
-																	toast.success(
-																		res.event_emitted
-																			? `Invite automation triggered for ${user.email}`
-																			: "Invite regenerated (no automations — copy link from regenerate)",
-																	);
-																},
-																onError: (
-																	e: unknown,
-																) =>
-																	toast.error(
-																		e instanceof
-																			Error
-																			? e.message
-																			: "Failed to resend invite",
-																	),
+												isActive={user.is_active}
+												isSelf={isSelf(user)}
+												onResend={() =>
+													resendMutation.mutate(
+														user.id,
+														{
+															onSuccess: (
+																res,
+															) => {
+																toast.success(
+																	res.event_emitted
+																		? `Invite automation triggered for ${user.email}`
+																		: "Invite regenerated (no automations — copy link from regenerate)",
+																);
 															},
-														)
-													}
-													onRegenerate={() =>
-														regenerateMutation.mutate(
-															user.id,
-															{
-																onSuccess: (
-																	res,
-																) => {
-																	showRegistrationLink(
-																		user,
-																		res.registration_url,
-																	);
-																},
-																onError: (
-																	e: unknown,
-																) =>
-																	toast.error(
-																		e instanceof
-																			Error
-																			? e.message
-																			: "Failed to regenerate link",
-																	),
+															onError: (
+																e: unknown,
+															) =>
+																toast.error(
+																	e instanceof
+																		Error
+																		? e.message
+																		: "Failed to resend invite",
+																),
+														},
+													)
+												}
+												onRegenerate={() =>
+													regenerateMutation.mutate(
+														user.id,
+														{
+															onSuccess: (
+																res,
+															) => {
+																showRegistrationLink(
+																	user,
+																	res.registration_url,
+																);
 															},
-														)
-													}
-													onCopyLink={() =>
-														regenerateMutation.mutate(
-															user.id,
-															{
-																onSuccess: (
-																	res,
-																) => {
-																	showRegistrationLink(
-																		user,
-																		res.registration_url,
-																	);
-																},
-																onError: (
-																	e: unknown,
-																) =>
-																	toast.error(
-																		e instanceof
-																			Error
-																			? e.message
-																			: "Failed to copy link",
-																	),
+															onError: (
+																e: unknown,
+															) =>
+																toast.error(
+																	e instanceof
+																		Error
+																		? e.message
+																		: "Failed to regenerate link",
+																),
+														},
+													)
+												}
+												onCopyLink={() =>
+													regenerateMutation.mutate(
+														user.id,
+														{
+															onSuccess: (
+																res,
+															) => {
+																showRegistrationLink(
+																	user,
+																	res.registration_url,
+																);
 															},
-														)
-													}
-													onRevoke={() =>
-														revokeMutation.mutate(
-															user.id,
-															{
-																onSuccess: () =>
-																	toast.success(
-																		"Invite revoked",
-																	),
-																onError: (
-																	e: unknown,
-																) =>
-																	toast.error(
-																		e instanceof
-																			Error
-																			? e.message
-																			: "Failed to revoke invite",
-																	),
-															},
-														)
-													}
-													onToggleActive={() =>
-														handleToggleActive(user)
-													}
-													onDelete={() =>
-														handleDeleteUser(user)
-													}
-												/>
-											</DataTableCell>
-										</DataTableRow>
-									);
-								})}
-							</DataTableBody>
-						</DataTable>
-						<ListPagination
-							offset={offset}
-							limit={PAGE_SIZE}
-							total={total}
-							isFetching={usersQuery.isFetching}
-							onPageChange={setOffset}
-						/>
-					</div>
+															onError: (
+																e: unknown,
+															) =>
+																toast.error(
+																	e instanceof
+																		Error
+																		? e.message
+																		: "Failed to copy link",
+																),
+														},
+													)
+												}
+												onRevoke={() =>
+													revokeMutation.mutate(
+														user.id,
+														{
+															onSuccess: () =>
+																toast.success(
+																	"Invite revoked",
+																),
+															onError: (
+																e: unknown,
+															) =>
+																toast.error(
+																	e instanceof
+																		Error
+																		? e.message
+																		: "Failed to revoke invite",
+																),
+														},
+													)
+												}
+												onToggleActive={() =>
+													handleToggleActive(user)
+												}
+												onDelete={() =>
+													handleDeleteUser(user)
+												}
+											/>
+										</DataTableCell>
+									</DataTableRow>
+								);
+							})}
+						</DataTableBody>
+						<DataTableFooter>
+							<DataTableRow>
+								<DataTableCell colSpan={8} className="p-0">
+									<ListPagination
+										offset={offset}
+										limit={PAGE_SIZE}
+										total={total}
+										isFetching={usersQuery.isFetching}
+										onPageChange={setOffset}
+									/>
+								</DataTableCell>
+							</DataTableRow>
+						</DataTableFooter>
+					</DataTable>
 				) : (
 					<div className="flex flex-col items-center justify-center py-12 text-center">
 						<UserCog className="h-12 w-12 text-muted-foreground" />

--- a/client/src/pages/Users.tsx
+++ b/client/src/pages/Users.tsx
@@ -109,7 +109,6 @@ export function Users() {
 	const { userId } = useParams<{ userId?: string }>();
 	const [selectedUser, setSelectedUser] = useState<User | undefined>();
 	const [isCreateOpen, setIsCreateOpen] = useState(false);
-	const [isEditOpen, setIsEditOpen] = useState(false);
 	const [isDeleteOpen, setIsDeleteOpen] = useState(false);
 	const [isDisableOpen, setIsDisableOpen] = useState(false);
 	const [searchTerm, setSearchTerm] = useState("");
@@ -173,9 +172,6 @@ export function Users() {
 		};
 	};
 
-	const editDialogUser = selectedUser ?? routeSelectedUser;
-	const isEditDialogOpen = isEditOpen || Boolean(routeSelectedUser);
-
 	const handleSort = (column: SortColumn) => {
 		if (sortColumn === column) {
 			setSortDirection((d) => (d === "asc" ? "desc" : "asc"));
@@ -229,8 +225,6 @@ export function Users() {
 	};
 
 	const handleEditUser = (user: User) => {
-		setSelectedUser(user);
-		setIsEditOpen(true);
 		if (userId !== user.id) {
 			navigate(`/users/${user.id}`);
 		}
@@ -318,8 +312,6 @@ export function Users() {
 	};
 
 	const handleEditClose = () => {
-		setIsEditOpen(false);
-		setSelectedUser(undefined);
 		if (userId) navigate("/users", { replace: true });
 	};
 
@@ -842,9 +834,9 @@ export function Users() {
 			/>
 
 			<EditUserDialog
-				user={editDialogUser}
-				open={isEditDialogOpen}
-				onOpenChange={handleEditClose}
+				user={routeSelectedUser}
+				open={Boolean(userId && routeSelectedUser)}
+				onOpenChange={(open) => !open && handleEditClose()}
 			/>
 
 			<RegistrationLinkDialog

--- a/client/src/pages/Users.tsx
+++ b/client/src/pages/Users.tsx
@@ -39,10 +39,10 @@ import {
 	AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
 import { SearchBox } from "@/components/search/SearchBox";
-import { useSearch } from "@/hooks/useSearch";
 import {
-	useUsersFiltered,
 	useDeleteUser,
+	useUser,
+	useUsersPage,
 	useUpdateUser,
 } from "@/hooks/useUsers";
 import { useUserSelection } from "@/hooks/useUserSelection";
@@ -72,6 +72,7 @@ import {
 } from "@/hooks/useUserInvites";
 import { useEventSources } from "@/services/events";
 import { toast } from "sonner";
+import { ListPagination } from "@/components/pagination/ListPagination";
 import type { components, components as v1 } from "@/lib/v1";
 type User = components["schemas"]["UserPublic"];
 type Organization = components["schemas"]["OrganizationPublic"];
@@ -83,6 +84,7 @@ type RegistrationLinkDialogState = {
 
 type SortColumn = "name" | "email" | "status" | "created" | "last_login";
 type SortDirection = "asc" | "desc";
+const PAGE_SIZE = 25;
 
 function SortIcon({
 	column,
@@ -116,20 +118,25 @@ export function Users() {
 	);
 	const [sortColumn, setSortColumn] = useState<SortColumn>("name");
 	const [sortDirection, setSortDirection] = useState<SortDirection>("asc");
+	const [offset, setOffset] = useState(0);
 	const [registrationLinkDialog, setRegistrationLinkDialog] =
 		useState<RegistrationLinkDialogState>(null);
 
 	const { scope } = useOrgScope();
 	const { user: currentUser, isPlatformAdmin } = useAuth();
 
-	const {
-		data: users,
-		isLoading,
-		refetch,
-	} = useUsersFiltered(
-		isPlatformAdmin ? filterOrgId : undefined,
-		showDisabled,
-	);
+	const usersQuery = useUsersPage({
+		scope: isPlatformAdmin ? filterOrgId : undefined,
+		includeInactive: showDisabled,
+		search: searchTerm,
+		sortBy: sortColumn,
+		sortDirection,
+		limit: PAGE_SIZE,
+		offset,
+	});
+	const users = usersQuery.data?.items ?? [];
+	const total = usersQuery.data?.total ?? 0;
+	const { data: routeSelectedUser } = useUser(userId);
 	const deleteMutation = useDeleteUser();
 	const updateMutation = useUpdateUser();
 	const resendMutation = useResendInvite();
@@ -158,62 +165,13 @@ export function Users() {
 		if (!orgId) return { name: "Platform", isProvider: false };
 		const org = organizations?.find((o: Organization) => o.id === orgId);
 		return {
-			name: org?.name || orgId,
+			name: org?.name || (organizations ? "Unknown organization" : "Loading…"),
 			isProvider: org?.is_provider ?? false,
 		};
 	};
 
-	const filteredUsers = useSearch(users || [], searchTerm, ["email", "name"]);
-
-	const routeSelectedUser = useMemo(
-		() => users?.find((user) => user.id === userId),
-		[users, userId],
-	);
 	const editDialogUser = selectedUser ?? routeSelectedUser;
 	const isEditDialogOpen = isEditOpen || Boolean(routeSelectedUser);
-
-	const sortedUsers = useMemo(() => {
-		if (!filteredUsers) return [];
-		return [...filteredUsers].sort((a, b) => {
-			const dir = sortDirection === "asc" ? 1 : -1;
-			switch (sortColumn) {
-				case "name":
-					return (
-						dir *
-						(a.name || a.email || "").localeCompare(
-							b.name || b.email || "",
-						)
-					);
-				case "email":
-					return dir * (a.email || "").localeCompare(b.email || "");
-				case "status": {
-					const aVal = a.invite_status ?? "active";
-					const bVal = b.invite_status ?? "active";
-					return dir * aVal.localeCompare(bVal);
-				}
-				case "created": {
-					const aDate = a.created_at
-						? new Date(a.created_at).getTime()
-						: 0;
-					const bDate = b.created_at
-						? new Date(b.created_at).getTime()
-						: 0;
-					return dir * (aDate - bDate);
-				}
-				case "last_login": {
-					const aDate = a.last_login
-						? new Date(a.last_login).getTime()
-						: 0;
-					const bDate = b.last_login
-						? new Date(b.last_login).getTime()
-						: 0;
-					return dir * (aDate - bDate);
-				}
-				default:
-					return 0;
-			}
-		});
-	}, [filteredUsers, sortColumn, sortDirection]);
 
 	const handleSort = (column: SortColumn) => {
 		if (sortColumn === column) {
@@ -222,6 +180,7 @@ export function Users() {
 			setSortColumn(column);
 			setSortDirection("asc");
 		}
+		setOffset(0);
 	};
 
 	// ===== Bulk selection + actions =====
@@ -229,7 +188,7 @@ export function Users() {
 		() => (currentUser ? [currentUser.id] : []),
 		[currentUser],
 	);
-	const selection = useUserSelection(sortedUsers, disabledSelectionIds);
+	const selection = useUserSelection(users, disabledSelectionIds);
 
 	type BulkMode = "move_org" | "replace_roles" | "disable" | "enable" | null;
 	const [bulkMode, setBulkMode] = useState<BulkMode>(null);
@@ -389,18 +348,15 @@ export function Users() {
 					<Button
 						variant="outline"
 						size="icon"
-						onClick={() => refetch()}
+						onClick={() => usersQuery.refetch()}
 						title="Refresh"
+						aria-label="Refresh users"
 					>
 						<RefreshCw className="h-4 w-4" />
 					</Button>
-					<Button
-						variant="outline"
-						size="icon"
-						onClick={() => setIsCreateOpen(true)}
-						title="Create User"
-					>
-						<Plus className="h-4 w-4" />
+					<Button onClick={() => setIsCreateOpen(true)}>
+						<Plus className="h-4 w-4 mr-1.5" />
+						Create user
 					</Button>
 				</div>
 			</div>
@@ -409,7 +365,10 @@ export function Users() {
 			<div className="flex items-center gap-4">
 				<SearchBox
 					value={searchTerm}
-					onChange={setSearchTerm}
+					onChange={(value) => {
+						setSearchTerm(value);
+						setOffset(0);
+					}}
 					placeholder="Search users by email or name..."
 					className="flex-1"
 				/>
@@ -417,7 +376,10 @@ export function Users() {
 					<div className="w-64">
 						<OrganizationSelect
 							value={filterOrgId}
-							onChange={setFilterOrgId}
+							onChange={(value) => {
+								setFilterOrgId(value);
+								setOffset(0);
+							}}
 							showAll={true}
 							showGlobal={false}
 							placeholder="All users"
@@ -428,7 +390,10 @@ export function Users() {
 					<Switch
 						id="show-disabled"
 						checked={showDisabled}
-						onCheckedChange={setShowDisabled}
+						onCheckedChange={(checked) => {
+							setShowDisabled(checked);
+							setOffset(0);
+						}}
 					/>
 					<Label
 						htmlFor="show-disabled"
@@ -440,337 +405,382 @@ export function Users() {
 			</div>
 
 			{/* Content */}
-			<div className="flex-1 min-h-0">
-				{isLoading ? (
+			<div className="flex-1 min-h-0" aria-busy={usersQuery.isFetching}>
+				{usersQuery.isLoading ? (
 					<div className="space-y-2">
 						{[...Array(5)].map((_, i) => (
 							<Skeleton key={i} className="h-12 w-full" />
 						))}
 					</div>
-				) : sortedUsers && sortedUsers.length > 0 ? (
-					<DataTable>
-						<DataTableHeader>
-							<DataTableRow>
-								<DataTableHead className="w-0 whitespace-nowrap">
-									<Checkbox
-										aria-label="Select all visible users"
-										checked={
-											selection.allVisibleSelected
-												? true
-												: selection.someVisibleSelected
-													? "indeterminate"
-													: false
-										}
-										onCheckedChange={() =>
-											selection.toggleAllVisible()
-										}
-									/>
-								</DataTableHead>
-								<DataTableHead className="w-0 whitespace-nowrap">
-									Organization
-								</DataTableHead>
-								<DataTableHead
-									className="w-0 whitespace-nowrap cursor-pointer select-none"
-									onClick={() => handleSort("name")}
-								>
-									Name
-									<SortIcon
-										column="name"
-										sortColumn={sortColumn}
-										sortDirection={sortDirection}
-									/>
-								</DataTableHead>
-								<DataTableHead
-									className="cursor-pointer select-none"
-									onClick={() => handleSort("email")}
-								>
-									Email
-									<SortIcon
-										column="email"
-										sortColumn={sortColumn}
-										sortDirection={sortDirection}
-									/>
-								</DataTableHead>
-								<DataTableHead
-									className="w-0 whitespace-nowrap cursor-pointer select-none"
-									onClick={() => handleSort("status")}
-								>
-									Status
-									<SortIcon
-										column="status"
-										sortColumn={sortColumn}
-										sortDirection={sortDirection}
-									/>
-								</DataTableHead>
-								<DataTableHead
-									className="w-0 whitespace-nowrap cursor-pointer select-none"
-									onClick={() => handleSort("created")}
-								>
-									Created
-									<SortIcon
-										column="created"
-										sortColumn={sortColumn}
-										sortDirection={sortDirection}
-									/>
-								</DataTableHead>
-								<DataTableHead
-									className="w-0 whitespace-nowrap cursor-pointer select-none"
-									onClick={() => handleSort("last_login")}
-								>
-									Last Login
-									<SortIcon
-										column="last_login"
-										sortColumn={sortColumn}
-										sortDirection={sortDirection}
-									/>
-								</DataTableHead>
-								<DataTableHead className="w-0 whitespace-nowrap text-right sticky right-0 bg-background"></DataTableHead>
-							</DataTableRow>
-						</DataTableHeader>
-						<DataTableBody>
-							{sortedUsers.map((user) => {
-								const orgInfo = getOrgInfo(
-									user.organization_id,
-								);
-								return (
-									<DataTableRow
-										key={user.id}
-										clickable
-										onClick={() => handleEditUser(user)}
-										className={
-											"group/row" +
-											(!user.is_active
-												? " opacity-60"
-												: "")
-										}
+				) : usersQuery.isError ? (
+					<div className="flex flex-col items-center justify-center rounded-lg border py-12 text-center">
+						<h3 className="text-lg font-semibold">
+							Users could not be loaded
+						</h3>
+						<p className="mt-2 text-sm text-muted-foreground">
+							Check your connection and try again.
+						</p>
+						<Button
+							className="mt-4"
+							variant="outline"
+							onClick={() => usersQuery.refetch()}
+						>
+							Try again
+						</Button>
+					</div>
+				) : users.length > 0 ? (
+					<div>
+						<DataTable>
+							<DataTableHeader>
+								<DataTableRow>
+									<DataTableHead className="w-0 whitespace-nowrap">
+										<Checkbox
+											aria-label="Select all visible users"
+											checked={
+												selection.allVisibleSelected
+													? true
+													: selection.someVisibleSelected
+														? "indeterminate"
+														: false
+											}
+											onCheckedChange={() =>
+												selection.toggleAllVisible()
+											}
+										/>
+									</DataTableHead>
+									<DataTableHead className="w-0 whitespace-nowrap">
+										Organization
+									</DataTableHead>
+									<DataTableHead
+										className="w-0 whitespace-nowrap cursor-pointer select-none"
+										onClick={() => handleSort("name")}
 									>
-										<DataTableCell
-											className="w-0 whitespace-nowrap"
-											onClick={(e) => e.stopPropagation()}
+										Name
+										<SortIcon
+											column="name"
+											sortColumn={sortColumn}
+											sortDirection={sortDirection}
+										/>
+									</DataTableHead>
+									<DataTableHead
+										className="cursor-pointer select-none"
+										onClick={() => handleSort("email")}
+									>
+										Email
+										<SortIcon
+											column="email"
+											sortColumn={sortColumn}
+											sortDirection={sortDirection}
+										/>
+									</DataTableHead>
+									<DataTableHead
+										className="w-0 whitespace-nowrap cursor-pointer select-none"
+										onClick={() => handleSort("status")}
+									>
+										Status
+										<SortIcon
+											column="status"
+											sortColumn={sortColumn}
+											sortDirection={sortDirection}
+										/>
+									</DataTableHead>
+									<DataTableHead
+										className="w-0 whitespace-nowrap cursor-pointer select-none"
+										onClick={() => handleSort("created")}
+									>
+										Created
+										<SortIcon
+											column="created"
+											sortColumn={sortColumn}
+											sortDirection={sortDirection}
+										/>
+									</DataTableHead>
+									<DataTableHead
+										className="w-0 whitespace-nowrap cursor-pointer select-none"
+										onClick={() => handleSort("last_login")}
+									>
+										Last Login
+										<SortIcon
+											column="last_login"
+											sortColumn={sortColumn}
+											sortDirection={sortDirection}
+										/>
+									</DataTableHead>
+									<DataTableHead className="w-0 whitespace-nowrap text-right sticky right-0 bg-background"></DataTableHead>
+								</DataTableRow>
+							</DataTableHeader>
+							<DataTableBody>
+								{users.map((user) => {
+									const orgInfo = getOrgInfo(
+										user.organization_id,
+									);
+									return (
+										<DataTableRow
+											key={user.id}
+											clickable
+											onClick={() => handleEditUser(user)}
+											className={
+												"group/row" +
+												(!user.is_active
+													? " opacity-60"
+													: "")
+											}
 										>
-											{isSelf(user) ? (
-												<Tooltip>
-													<TooltipTrigger asChild>
-														<span>
-															<Checkbox
-																checked={false}
-																disabled
-																aria-label="Cannot select yourself"
-															/>
-														</span>
-													</TooltipTrigger>
-													<TooltipContent>
-														You can't include
-														yourself in a bulk
-														action
-													</TooltipContent>
-												</Tooltip>
-											) : (
-												<Checkbox
-													aria-label={`Select ${user.name || user.email}`}
-													checked={selection.isSelected(
-														user.id,
+											<DataTableCell
+												className="w-0 whitespace-nowrap"
+												onClick={(e) =>
+													e.stopPropagation()
+												}
+											>
+												{isSelf(user) ? (
+													<Tooltip>
+														<TooltipTrigger asChild>
+															<span>
+																<Checkbox
+																	checked={
+																		false
+																	}
+																	disabled
+																	aria-label="Cannot select yourself"
+																/>
+															</span>
+														</TooltipTrigger>
+														<TooltipContent>
+															You can't include
+															yourself in a bulk
+															action
+														</TooltipContent>
+													</Tooltip>
+												) : (
+													<Checkbox
+														aria-label={`Select ${user.name || user.email}`}
+														checked={selection.isSelected(
+															user.id,
+														)}
+														onClick={(e) => {
+															selection.toggle(
+																user.id,
+																{
+																	shiftKey:
+																		e.shiftKey,
+																},
+															);
+															e.preventDefault();
+														}}
+													/>
+												)}
+											</DataTableCell>
+											<DataTableCell className="w-0 whitespace-nowrap text-sm">
+												<span className="inline-flex items-center gap-1">
+													{orgInfo.isProvider ? (
+														<Star className="h-3.5 w-3.5 text-amber-500 fill-amber-500" />
+													) : (
+														<Building2 className="h-3.5 w-3.5 text-muted-foreground" />
 													)}
-													onClick={(e) => {
-														selection.toggle(
+													<span>{orgInfo.name}</span>
+												</span>
+											</DataTableCell>
+											<DataTableCell className="w-0 whitespace-nowrap">
+												<div className="flex items-center gap-1.5">
+													<span className="font-medium">
+														{user.name ||
+															user.email}
+													</span>
+													{user.is_superuser && (
+														<Tooltip>
+															<TooltipTrigger
+																asChild
+															>
+																<Crown className="h-4 w-4 shrink-0 text-amber-500 fill-amber-500" />
+															</TooltipTrigger>
+															<TooltipContent>
+																Platform Admin
+															</TooltipContent>
+														</Tooltip>
+													)}
+													{user.is_external && (
+														<Tooltip>
+															<TooltipTrigger
+																asChild
+															>
+																<Badge
+																	variant="outline"
+																	className="text-xs shrink-0"
+																>
+																	External
+																</Badge>
+															</TooltipTrigger>
+															<TooltipContent>
+																External user —
+																sees only what
+																the Everyone
+																tier or an
+																explicit role
+																grant allows
+															</TooltipContent>
+														</Tooltip>
+													)}
+												</div>
+											</DataTableCell>
+											<DataTableCell
+												className="text-muted-foreground max-w-0"
+												onClick={(e) =>
+													e.stopPropagation()
+												}
+											>
+												<UserEmailCell
+													email={user.email}
+												/>
+											</DataTableCell>
+											<DataTableCell className="w-0 whitespace-nowrap">
+												<UserStatusBadge
+													status={
+														user.invite_status ??
+														"active"
+													}
+												/>
+											</DataTableCell>
+											<DataTableCell className="w-0 whitespace-nowrap text-sm text-muted-foreground">
+												{user.created_at
+													? new Date(
+															user.created_at,
+														).toLocaleDateString()
+													: "N/A"}
+											</DataTableCell>
+											<DataTableCell className="w-0 whitespace-nowrap text-sm text-muted-foreground">
+												{user.last_login
+													? new Date(
+															user.last_login,
+														).toLocaleDateString()
+													: "Never"}
+											</DataTableCell>
+											<DataTableCell
+												className="w-0 whitespace-nowrap text-right sticky right-0 bg-card group-hover/row:bg-[color-mix(in_oklch,var(--card),var(--muted)_50%)]"
+												onClick={(e) =>
+													e.stopPropagation()
+												}
+											>
+												<UserActionsMenu
+													status={
+														user.invite_status ??
+														"active"
+													}
+													isActive={user.is_active}
+													isSelf={isSelf(user)}
+													onResend={() =>
+														resendMutation.mutate(
 															user.id,
 															{
-																shiftKey:
-																	e.shiftKey,
+																onSuccess: (
+																	res,
+																) => {
+																	toast.success(
+																		res.event_emitted
+																			? `Invite automation triggered for ${user.email}`
+																			: "Invite regenerated (no automations — copy link from regenerate)",
+																	);
+																},
+																onError: (
+																	e: unknown,
+																) =>
+																	toast.error(
+																		e instanceof
+																			Error
+																			? e.message
+																			: "Failed to resend invite",
+																	),
 															},
-														);
-														e.preventDefault();
-													}}
+														)
+													}
+													onRegenerate={() =>
+														regenerateMutation.mutate(
+															user.id,
+															{
+																onSuccess: (
+																	res,
+																) => {
+																	showRegistrationLink(
+																		user,
+																		res.registration_url,
+																	);
+																},
+																onError: (
+																	e: unknown,
+																) =>
+																	toast.error(
+																		e instanceof
+																			Error
+																			? e.message
+																			: "Failed to regenerate link",
+																	),
+															},
+														)
+													}
+													onCopyLink={() =>
+														regenerateMutation.mutate(
+															user.id,
+															{
+																onSuccess: (
+																	res,
+																) => {
+																	showRegistrationLink(
+																		user,
+																		res.registration_url,
+																	);
+																},
+																onError: (
+																	e: unknown,
+																) =>
+																	toast.error(
+																		e instanceof
+																			Error
+																			? e.message
+																			: "Failed to copy link",
+																	),
+															},
+														)
+													}
+													onRevoke={() =>
+														revokeMutation.mutate(
+															user.id,
+															{
+																onSuccess: () =>
+																	toast.success(
+																		"Invite revoked",
+																	),
+																onError: (
+																	e: unknown,
+																) =>
+																	toast.error(
+																		e instanceof
+																			Error
+																			? e.message
+																			: "Failed to revoke invite",
+																	),
+															},
+														)
+													}
+													onToggleActive={() =>
+														handleToggleActive(user)
+													}
+													onDelete={() =>
+														handleDeleteUser(user)
+													}
 												/>
-											)}
-										</DataTableCell>
-										<DataTableCell className="w-0 whitespace-nowrap text-sm">
-											<span className="inline-flex items-center gap-1">
-												{orgInfo.isProvider ? (
-													<Star className="h-3.5 w-3.5 text-amber-500 fill-amber-500" />
-												) : (
-													<Building2 className="h-3.5 w-3.5 text-muted-foreground" />
-												)}
-												<span>{orgInfo.name}</span>
-											</span>
-										</DataTableCell>
-										<DataTableCell className="w-0 whitespace-nowrap">
-											<div className="flex items-center gap-1.5">
-												<span className="font-medium">
-													{user.name || user.email}
-												</span>
-												{user.is_superuser && (
-													<Tooltip>
-														<TooltipTrigger asChild>
-															<Crown className="h-4 w-4 shrink-0 text-amber-500 fill-amber-500" />
-														</TooltipTrigger>
-														<TooltipContent>
-															Platform Admin
-														</TooltipContent>
-													</Tooltip>
-												)}
-												{user.is_external && (
-													<Tooltip>
-														<TooltipTrigger asChild>
-															<Badge
-																variant="outline"
-																className="text-xs shrink-0"
-															>
-																External
-															</Badge>
-														</TooltipTrigger>
-														<TooltipContent>
-															External user — sees only what the Everyone tier or an explicit role grant allows
-														</TooltipContent>
-													</Tooltip>
-												)}
-											</div>
-										</DataTableCell>
-										<DataTableCell
-											className="text-muted-foreground max-w-0"
-											onClick={(e) => e.stopPropagation()}
-										>
-											<UserEmailCell email={user.email} />
-										</DataTableCell>
-										<DataTableCell className="w-0 whitespace-nowrap">
-											<UserStatusBadge
-												status={
-													user.invite_status ??
-													"active"
-												}
-											/>
-										</DataTableCell>
-										<DataTableCell className="w-0 whitespace-nowrap text-sm text-muted-foreground">
-											{user.created_at
-												? new Date(
-														user.created_at,
-													).toLocaleDateString()
-												: "N/A"}
-										</DataTableCell>
-										<DataTableCell className="w-0 whitespace-nowrap text-sm text-muted-foreground">
-											{user.last_login
-												? new Date(
-														user.last_login,
-													).toLocaleDateString()
-												: "Never"}
-										</DataTableCell>
-										<DataTableCell
-											className="w-0 whitespace-nowrap text-right sticky right-0 bg-card group-hover/row:bg-[color-mix(in_oklch,var(--card),var(--muted)_50%)]"
-											onClick={(e) => e.stopPropagation()}
-										>
-											<UserActionsMenu
-												status={
-													user.invite_status ??
-													"active"
-												}
-												isActive={user.is_active}
-												isSelf={isSelf(user)}
-												onResend={() =>
-													resendMutation.mutate(
-														user.id,
-														{
-															onSuccess: (
-																res,
-															) => {
-																toast.success(
-																	res.event_emitted
-																		? `Invite automation triggered for ${user.email}`
-																		: "Invite regenerated (no automations — copy link from regenerate)",
-																);
-															},
-															onError: (
-																e: unknown,
-															) =>
-																toast.error(
-																	e instanceof
-																		Error
-																		? e.message
-																		: "Failed to resend invite",
-																),
-														},
-													)
-												}
-												onRegenerate={() =>
-													regenerateMutation.mutate(
-														user.id,
-														{
-															onSuccess: (
-																res,
-															) => {
-																showRegistrationLink(
-																	user,
-																	res.registration_url,
-																);
-															},
-															onError: (
-																e: unknown,
-															) =>
-																toast.error(
-																	e instanceof
-																		Error
-																		? e.message
-																		: "Failed to regenerate link",
-																),
-														},
-													)
-												}
-												onCopyLink={() =>
-													regenerateMutation.mutate(
-														user.id,
-														{
-															onSuccess: (
-																res,
-															) => {
-																showRegistrationLink(
-																	user,
-																	res.registration_url,
-																);
-															},
-															onError: (
-																e: unknown,
-															) =>
-																toast.error(
-																	e instanceof
-																		Error
-																		? e.message
-																		: "Failed to copy link",
-																),
-														},
-													)
-												}
-												onRevoke={() =>
-													revokeMutation.mutate(
-														user.id,
-														{
-															onSuccess: () =>
-																toast.success(
-																	"Invite revoked",
-																),
-															onError: (
-																e: unknown,
-															) =>
-																toast.error(
-																	e instanceof
-																		Error
-																		? e.message
-																		: "Failed to revoke invite",
-																),
-														},
-													)
-												}
-												onToggleActive={() =>
-													handleToggleActive(user)
-												}
-												onDelete={() =>
-													handleDeleteUser(user)
-												}
-											/>
-										</DataTableCell>
-									</DataTableRow>
-								);
-							})}
-						</DataTableBody>
-					</DataTable>
+											</DataTableCell>
+										</DataTableRow>
+									);
+								})}
+							</DataTableBody>
+						</DataTable>
+						<ListPagination
+							offset={offset}
+							limit={PAGE_SIZE}
+							total={total}
+							isFetching={usersQuery.isFetching}
+							onPageChange={setOffset}
+						/>
+					</div>
 				) : (
 					<div className="flex flex-col items-center justify-center py-12 text-center">
 						<UserCog className="h-12 w-12 text-muted-foreground" />

--- a/client/src/pages/Users.tsx
+++ b/client/src/pages/Users.tsx
@@ -606,10 +606,7 @@ export function Users() {
 												)}
 											</div>
 										</DataTableCell>
-										<DataTableCell
-											className="text-muted-foreground max-w-0"
-											onClick={(e) => e.stopPropagation()}
-										>
+										<DataTableCell className="text-muted-foreground max-w-0">
 											<UserEmailCell email={user.email} />
 										</DataTableCell>
 										<DataTableCell className="w-0 whitespace-nowrap">


### PR DESCRIPTION
Fixes #695

## Summary
- add server-side pagination, search, and sorting to the Users and Roles listings while preserving legacy unbounded API consumers
- batch user invite status resolution and scope role consumer counts to the requested page
- return hydrated user summaries from Role Detail so UUID placeholders never render
- lazy-load the assignment candidate directory and add shared accessible pagination controls

## Verification
- `./test.sh quality api`
- `./test.sh tests/unit/services/test_user_invite_service.py -v`
- `./test.sh tests/e2e/api/test_users.py::TestUserListing::test_user_listing_supports_server_pagination_search_and_sort tests/e2e/api/test_roles.py::TestRoleCRUD::test_role_listing_supports_server_pagination_search_and_sort tests/e2e/api/test_roles.py::TestRoleCRUD::test_assign_role_to_user -v`
- `./test.sh tests/unit/test_contract_version.py tests/unit/test_dto_flags.py -v`
- `./test.sh client unit src/components/pagination/ListPagination.test.tsx src/components/roles/ConsumerTab.test.tsx src/pages/Users.test.tsx src/pages/Roles.test.tsx`
- `(cd client && npm run tsc && npm run lint)`
- `./test.sh client e2e --screenshots e2e/roles.detail.admin.spec.ts`

## Scale review
Validated in the isolated debug stack with 10,000 synthetic users, 300 roles, 29,400 user-role assignments, and 2,500 invite records. Observed full navigation/render times were ~1.36s for Users, ~1.41s for Roles, and ~0.67s for Role Detail.