### PR TITLE
feat: add claim-backed file path containment

### DIFF
--- a/.claude/skills/bifrost-build/references/entities.md
+++ b/.claude/skills/bifrost-build/references/entities.md
@@ -79,7 +79,7 @@ Test missing mapping, expired/absent OAuth, API failure, pagination/rate limitin
 
 Roles are permission buckets assigned to users and entities. Permissions are a mapping, not a list. Read role membership and the protected entity before changing either side.
 
-Custom claims are org-scoped, query-derived user facts used by policy expressions. Design the backing query and policy together, and test users with empty, single, and multiple claim values.
+Custom claims are org-scoped, query-derived user facts used by policy expressions. Design the backing query, source-table read policy, and consuming policy together: claim resolution is restricted by the source table's policy. Claims select one scalar value per source row, so flatten list-valued grants into separate rows. Test users with empty, single, and multiple claim values.
 
 Table and file policies are deny-by-absence. Fresh resources commonly begin with an admin bypass only; ordinary users need explicit rules. Policy rules can be referenced by multiple resources, so inspect usages before updating or deleting a shared rule.
 

--- a/.claude/skills/bifrost-build/references/files.md
+++ b/.claude/skills/bifrost-build/references/files.md
@@ -77,6 +77,31 @@ The CLI read/write surface is text-only. `files write` replaces the complete fil
 
 File policy checks apply independently at every tier. Grant only the actions required for the path prefix: read, list, write, delete, or signed access as supported by the policy model.
 
+For many dynamic hierarchical grants, use one root file policy with the file-only `path_within_any` predicate and a list claim:
+
+```json
+{
+  "policies": [
+    {
+      "name": "read_granted_resources",
+      "actions": ["read"],
+      "when": {
+        "path_within_any": [
+          {"file": "path"},
+          {"claims": "allowed_resource_paths"}
+        ]
+      }
+    }
+  ]
+}
+```
+
+Back `allowed_resource_paths` with a flattened grant table containing one `user_id` and one `path_prefix` per row. The predicate matches the exact prefix or a slash-delimited descendant; sibling string prefixes do not match. Missing, malformed, non-list, and empty/root claim values fail closed.
+
+Build paths from immutable UUIDs, for example `documents/sites/<site UUID>/categories/<category UUID>/pdf/<document UUID>/file.pdf`. Keep view and source-download representations under different path segments so their grants can differ without per-file claim values. A label rename then changes only reference data.
+
+`path_within_any` is intentionally unavailable to table policies. Use indexed exact composite-key membership for table rows. Also treat `list` separately: permission to a descendant does not imply permission to enumerate every ancestor directory. Prefer an authorization-filtered table for navigation and grant file reads only when opening the selected resource.
+
 With `global_repo_access: false`, a Solution can access only its declared owned location. With it enabled, reads/list/exists/signed-read can fall back through eligible install-org and global file tiers. Writes and deletes still target the Solution-owned tier; the flag does not authorize modification of shared files.
 
 Read `solution-resource-access.md` for the exact runtime matrix.

--- a/.claude/skills/bifrost-build/references/tables.md
+++ b/.claude/skills/bifrost-build/references/tables.md
@@ -93,6 +93,35 @@ Missing rows normally return `None`/`null`; missing tables and denied access may
 
 Do not treat an empty Python `tables.query()` as proof that a shared table exists: Solution lookup can convert some missing-table reads into an empty list. Validate setup when absence would be an error.
 
+## Claim-backed authorization projections
+
+Use flattened grant rows when access depends on more than one resource dimension. Store immutable UUID components alongside one scalar composite key:
+
+```text
+document_access_grants
+├── user_id
+├── site_id
+├── category_id
+└── access_key       # "<site UUID>:<category UUID>"
+```
+
+The grant table must let a principal read only its own rows. A list claim can then select `access_key`, and the protected table compares it exactly:
+
+```json
+{
+  "in": [
+    {"row": "access_key"},
+    {"claims": "allowed_document_access_keys"}
+  ]
+}
+```
+
+Keep this composite boundary for protected rows. Separate `allowed_site_ids` and `allowed_category_ids` claims lose the original pairings and can create an unintended Cartesian product.
+
+The component claims are still useful for reference-data navigation. Policies on site, building, floor, or category catalog tables may compare their UUID field with the matching component claim so the app lists only entitled labels. Build cascading choices from the user's original grant rows to preserve which categories belong to each permitted site. A navigation result never replaces the composite policy on the protected table.
+
+Claims select one scalar field per source row and do not flatten a JSON list. Materialize one grant value per row. Use UUIDs in keys and references so renaming a display label does not rewrite policies, grants, or storage paths.
+
 ## Solution scope and shared fallback
 
 Solution context resolves its own table first. With `global_repo_access: true`, a miss may fall back by name to an eligible install-org and then global loose table. Shared fallback tables are read-only from the Solution; the flag does not permit row mutation outside the install. Policies still apply after resolution.

--- a/api/shared/file_policies.py
+++ b/api/shared/file_policies.py
@@ -8,6 +8,7 @@ from datetime import datetime
 from typing import Any, Protocol
 from uuid import UUID
 
+from shared.path_matching import normalize_path, path_matches_prefix
 from shared.policies.evaluate import evaluate
 from src.models.contracts.policies import FileAction, FilePolicies
 
@@ -69,9 +70,9 @@ def select_longest_prefix(
     for candidate in candidates:
         if candidate.location != location:
             continue
-        if not _path_matches(candidate.path, path):
+        if not path_matches_prefix(candidate.path, path):
             continue
-        normalized_len = len(_normalize_path(candidate.path))
+        normalized_len = len(normalize_path(candidate.path))
         if normalized_len > best_len:
             best = candidate
             best_len = normalized_len
@@ -98,18 +99,3 @@ def evaluate_file_action(
         ):
             return True
     return False
-
-
-def _path_matches(prefix: str, path: str) -> bool:
-    normalized_prefix = _normalize_path(prefix)
-    normalized_path = _normalize_path(path)
-    if normalized_prefix == "":
-        return True
-    return (
-        normalized_path == normalized_prefix
-        or normalized_path.startswith(f"{normalized_prefix}/")
-    )
-
-
-def _normalize_path(path: str) -> str:
-    return path.strip("/")

--- a/api/shared/path_matching.py
+++ b/api/shared/path_matching.py
@@ -1,0 +1,50 @@
+"""Path-containment helpers shared by policy selection and evaluation."""
+
+from __future__ import annotations
+
+
+def normalize_path(path: str) -> str:
+    """Remove surrounding separators without changing path segments."""
+    return path.strip("/")
+
+
+def path_matches_prefix(prefix: str, path: str) -> bool:
+    """Return whether ``path`` equals or descends from ``prefix``.
+
+    An empty prefix intentionally matches every path because file-policy
+    selection uses it for a location's root policy. Claim-backed authorization
+    must use :func:`path_within_any`, which rejects empty grant prefixes.
+    """
+    normalized_prefix = normalize_path(prefix)
+    normalized_path = normalize_path(path)
+    if normalized_prefix == "":
+        return True
+    return normalized_path == normalized_prefix or normalized_path.startswith(
+        f"{normalized_prefix}/"
+    )
+
+
+def path_within_any(path: object, prefixes: object) -> bool:
+    """Return whether a string path is within any non-empty string prefix.
+
+    Invalid values fail closed. Ancestor lookup makes matching scale with path
+    depth after one linear normalization of the user's claim values.
+    """
+    if not isinstance(path, str) or not isinstance(prefixes, list):
+        return False
+
+    allowed = {
+        normalized
+        for prefix in prefixes
+        if isinstance(prefix, str) and (normalized := normalize_path(prefix))
+    }
+    if not allowed:
+        return False
+
+    candidate = normalize_path(path)
+    while True:
+        if candidate in allowed:
+            return True
+        if "/" not in candidate:
+            return False
+        candidate = candidate.rsplit("/", 1)[0]

--- a/api/shared/policies/evaluate.py
+++ b/api/shared/policies/evaluate.py
@@ -11,6 +11,7 @@ from collections.abc import Callable, Mapping
 from typing import Any
 from uuid import UUID
 
+from shared.path_matching import path_within_any
 from shared.policies.functions import FUNCTIONS
 from src.models.contracts.policies import Expr
 
@@ -171,6 +172,10 @@ def _eval_op(
         if not isinstance(b, list):
             return False
         return a in b
+    if op == "path_within_any":
+        path = _eval_node(value[0], row, user, resolvers)
+        prefixes = _eval_node(value[1], row, user, resolvers)
+        return path_within_any(path, prefixes)
     if op == "is_null":
         return _eval_node(value, row, user, resolvers) is None
     raise ValueError(f"unknown operator {op!r}")

--- a/api/src/models/contracts/policies.py
+++ b/api/src/models/contracts/policies.py
@@ -33,6 +33,7 @@ _LOGIC_OPS: Final[frozenset[str]] = frozenset({"and", "or", "not"})
 _COMPARE_OPS: Final[frozenset[str]] = frozenset({"eq", "neq", "lt", "lte", "gt", "gte"})
 _OTHER_OPS: Final[frozenset[str]] = frozenset({"in", "is_null", "call"})
 _ALL_OPS: Final[frozenset[str]] = _LOGIC_OPS | _COMPARE_OPS | _OTHER_OPS
+_FILE_ONLY_OPS: Final[frozenset[str]] = frozenset({"path_within_any"})
 
 # Bound on AST recursion depth. Prevents pathological deeply-nested imports
 # (e.g., manifest expressions from an untrusted source) from hitting Python's
@@ -111,7 +112,10 @@ def _validate_operand(
             f"{path}: operator node must have exactly one key, got {sorted(keys)}"
         )
     op = next(iter(keys))
-    if op not in _ALL_OPS:
+    allowed_ops = _ALL_OPS
+    if extra_ref_namespaces and "file" in extra_ref_namespaces:
+        allowed_ops |= _FILE_ONLY_OPS
+    if op not in allowed_ops:
         raise ValueError(f"{path}: unknown operator {op!r}")
     _validate_op_node(
         op,
@@ -171,12 +175,12 @@ def _validate_op_node(
                 extra_ref_namespaces=extra_ref_namespaces,
             )
         return
-    if op == "in":
+    if op in {"in", "path_within_any"}:
         if not isinstance(value, list) or len(value) != 2:
             raise ValueError(
-                f"{path}.{op}: in requires [operand, [literal, ...]] or "
+                f"{path}.{op}: {op} requires [operand, [literal, ...]] or "
                 f"[operand, {{claims: <name>}}]"
-        )
+            )
         left, right = value
         _validate_operand(
             left,
@@ -197,11 +201,20 @@ def _validate_op_node(
 
         if not isinstance(right, list) or not right:
             raise ValueError(
-                f"{path}.{op}: in requires a non-empty literal list or "
+                f"{path}.{op}: {op} requires a non-empty literal list or "
                 f"{{claims: <name>}} as RHS"
             )
         for i, item in enumerate(right):
-            if not isinstance(item, (str, int, float, bool)) and item is not None:
+            if op == "path_within_any" and not isinstance(item, str):
+                raise ValueError(
+                    f"{path}.{op}[1][{i}]: path_within_any literal list items "
+                    "must be strings"
+                )
+            if (
+                op == "in"
+                and not isinstance(item, (str, int, float, bool))
+                and item is not None
+            ):
                 raise ValueError(
                     f"{path}.{op}[1][{i}]: in literal list items must be scalars or null"
                 )

--- a/api/src/templates/llms.txt.md
+++ b/api/src/templates/llms.txt.md
@@ -576,6 +576,29 @@ Tables provide structured data storage with schema validation and multi-tenancy.
 
 Scope is resolved via cascade: org-specific first, then global fallback. The SDK `scope` parameter accepts `None` for global or an org UUID for a specific org. Omit it to use the execution context's org (default, with global cascade).
 
+### Claim-backed policies
+
+For multi-dimensional row access, materialize a scalar key from immutable UUIDs, such as `<site UUID>:<category UUID>`, and compare it with a list claim:
+
+```json
+{"in": [{"row": "access_key"}, {"claims": "allowed_access_keys"}]}
+```
+
+Keep component UUIDs on each grant row for filtered reference-data navigation, but preserve the composite key for document authorization so independent claims cannot create a Cartesian product.
+
+For managed files, a file policy may match an exact or slash-delimited descendant path against claim scopes:
+
+```json
+{
+  "path_within_any": [
+    {"file": "path"},
+    {"claims": "allowed_resource_paths"}
+  ]
+}
+```
+
+`path_within_any` is file-only and fails closed for missing, malformed, or empty scopes. Store one path prefix per grant row and use UUID path segments so display-name changes do not move files.
+
 ## Data Providers
 
 Data providers are workflows that return label/value pairs for form dropdowns.

--- a/api/tests/e2e/platform/test_custom_claims.py
+++ b/api/tests/e2e/platform/test_custom_claims.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from uuid import uuid4
+from uuid import UUID, uuid4
 
 import pytest
 
@@ -243,6 +243,119 @@ class TestCustomClaims:
 
         assert {row["data"]["title"] for row in alice_rows} == {"alice"}
         assert {row["data"]["title"] for row in bob_rows} == {"bob"}
+
+    @pytest.mark.asyncio
+    async def test_claim_scoped_file_path_reads_real_object_storage(
+        self,
+        e2e_client,
+        db_session,
+        platform_admin,
+        org_admin,
+        org1,
+        alice_user,
+        bob_user,
+    ):
+        from src.models.contracts.policies import FilePolicies
+        from src.services.file_policy_service import FilePolicyService
+
+        source_table, source_id = _create_claim_source(e2e_client, org_admin, org1)
+        claim_name = f"allowed_resource_paths_{uuid4().hex[:8]}"
+        created = e2e_client.post(
+            "/api/claims",
+            headers=org_admin.headers,
+            json={
+                "name": claim_name,
+                "type": "list",
+                "query": {
+                    "table": source_table,
+                    "where": {"eq": [{"row": "user_id"}, {"user": "user_id"}]},
+                    "select": "path_prefix",
+                },
+            },
+        )
+        assert created.status_code == 201, created.text
+
+        root = f"site-a:category-1/{uuid4().hex[:8]}"
+        allowed_prefix = f"{root}/pdf"
+        allowed_path = f"{allowed_prefix}/document-001/drawing.pdf"
+        denied_path = f"{root}/download/document-001/drawing.dwg"
+        _insert(
+            e2e_client,
+            org_admin.headers,
+            source_id,
+            {
+                "user_id": str(alice_user.user_id),
+                "path_prefix": allowed_prefix,
+            },
+        )
+
+        await FilePolicyService(db_session).upsert_policy(
+            organization_id=UUID(org1["id"]),
+            location="temp",
+            path=root,
+            policies=FilePolicies.model_validate(
+                {
+                    "policies": [
+                        {
+                            "name": "seed_objects",
+                            "actions": ["write"],
+                            "when": {"user": "is_platform_admin"},
+                        },
+                        {
+                            "name": "claim_scoped_read",
+                            "actions": ["read"],
+                            "when": {
+                                "path_within_any": [
+                                    {"file": "path"},
+                                    {"claims": claim_name},
+                                ]
+                            },
+                        },
+                    ]
+                }
+            ),
+        )
+        await db_session.commit()
+
+        for path in (allowed_path, denied_path):
+            write = e2e_client.post(
+                "/api/files/write",
+                headers=platform_admin.headers,
+                json={
+                    "path": path,
+                    "content": "synthetic document",
+                    "location": "temp",
+                    "scope": org1["id"],
+                    "mode": "cloud",
+                },
+            )
+            assert write.status_code == 204, write.text
+
+        allowed = e2e_client.post(
+            "/api/files/read",
+            headers=alice_user.headers,
+            json={
+                "path": allowed_path,
+                "location": "temp",
+                "scope": org1["id"],
+                "mode": "cloud",
+            },
+        )
+        assert allowed.status_code == 200, allowed.text
+        assert allowed.json()["content"] == "synthetic document"
+
+        for user, path in ((alice_user, denied_path), (bob_user, allowed_path)):
+            denied = e2e_client.post(
+                "/api/files/read",
+                headers=user.headers,
+                json={
+                    "path": path,
+                    "location": "temp",
+                    "scope": org1["id"],
+                    "mode": "cloud",
+                },
+            )
+            assert denied.status_code == 403, denied.text
 
     def test_delete_referenced_claim_refused(self, e2e_client, org_admin, org1):
         source_table, _source_id = _create_claim_source(e2e_client, org_admin, org1)

--- a/api/tests/e2e/platform/test_custom_claims.py
+++ b/api/tests/e2e/platform/test_custom_claims.py
@@ -605,3 +605,189 @@ class TestCustomClaims:
         bob_titles = {row["data"]["title"] for row in _query(e2e_client, bob_user.headers, docs_id)}
         assert alice_titles == {"c1-d1"}
         assert bob_titles == {"c2-d2"}
+
+    def test_composite_grants_secure_documents_and_navigation(
+        self,
+        e2e_client,
+        org_admin,
+        org1,
+        alice_user,
+        bob_user,
+    ):
+        """One user's disjoint UUID pairs cannot widen into a cross-product."""
+        grants_table, grants_id = _create_claim_source(
+            e2e_client, org_admin, org1
+        )
+        claim_suffix = uuid4().hex[:8]
+        claims = {
+            "access_key": f"allowed_document_access_keys_{claim_suffix}",
+            "campus_id": f"allowed_campus_ids_{claim_suffix}",
+            "document_type_id": f"allowed_document_type_ids_{claim_suffix}",
+        }
+        for selected_field, claim_name in claims.items():
+            response = e2e_client.post(
+                "/api/claims",
+                headers=org_admin.headers,
+                json={
+                    "name": claim_name,
+                    "type": "list",
+                    "query": {
+                        "table": grants_table,
+                        "where": {
+                            "eq": [
+                                {"row": "user_id"},
+                                {"user": "user_id"},
+                            ]
+                        },
+                        "select": selected_field,
+                    },
+                },
+            )
+            assert response.status_code == 201, response.text
+
+        def claim_policy(row_field: str, claim_name: str) -> dict:
+            return {
+                "policies": [
+                    *_admin_bypass_policies()["policies"],
+                    {
+                        "name": "read_accessible_reference_rows",
+                        "actions": ["read"],
+                        "when": {
+                            "in": [
+                                {"row": row_field},
+                                {"claims": claim_name},
+                            ]
+                        },
+                    },
+                ]
+            }
+
+        campus_table_id = _create_table(
+            e2e_client,
+            org_admin.headers,
+            f"campuses_{claim_suffix}",
+            org1["id"],
+            policies=claim_policy("campus_id", claims["campus_id"]),
+        )
+        type_table_id = _create_table(
+            e2e_client,
+            org_admin.headers,
+            f"document_types_{claim_suffix}",
+            org1["id"],
+            policies=claim_policy(
+                "document_type_id", claims["document_type_id"]
+            ),
+        )
+        building_table_id = _create_table(
+            e2e_client,
+            org_admin.headers,
+            f"buildings_{claim_suffix}",
+            org1["id"],
+            policies=claim_policy("campus_id", claims["campus_id"]),
+        )
+        floor_table_id = _create_table(
+            e2e_client,
+            org_admin.headers,
+            f"floors_{claim_suffix}",
+            org1["id"],
+            policies=claim_policy("campus_id", claims["campus_id"]),
+        )
+
+        campus_ids = {name: str(uuid4()) for name in ("north", "south", "hidden")}
+        type_ids = {name: str(uuid4()) for name in ("drawing", "manual", "hidden")}
+        for name, campus_id in campus_ids.items():
+            _insert(
+                e2e_client,
+                org_admin.headers,
+                campus_table_id,
+                {"campus_id": campus_id, "name": name},
+            )
+            _insert(
+                e2e_client,
+                org_admin.headers,
+                building_table_id,
+                {
+                    "building_id": str(uuid4()),
+                    "campus_id": campus_id,
+                    "name": f"{name} building",
+                },
+            )
+            _insert(
+                e2e_client,
+                org_admin.headers,
+                floor_table_id,
+                {
+                    "floor_id": str(uuid4()),
+                    "campus_id": campus_id,
+                    "name": f"{name} floor",
+                },
+            )
+        for name, document_type_id in type_ids.items():
+            _insert(
+                e2e_client,
+                org_admin.headers,
+                type_table_id,
+                {"document_type_id": document_type_id, "name": name},
+            )
+
+        allowed_pairs = [
+            (campus_ids["north"], type_ids["drawing"]),
+            (campus_ids["south"], type_ids["manual"]),
+        ]
+        for campus_id, document_type_id in allowed_pairs:
+            _insert(
+                e2e_client,
+                org_admin.headers,
+                grants_id,
+                {
+                    "user_id": str(alice_user.user_id),
+                    "campus_id": campus_id,
+                    "document_type_id": document_type_id,
+                    "access_key": f"{campus_id}:{document_type_id}",
+                },
+            )
+
+        documents_id = _create_table(
+            e2e_client,
+            org_admin.headers,
+            f"documents_{claim_suffix}",
+            org1["id"],
+            policies=claim_policy("access_key", claims["access_key"]),
+        )
+        for campus_name in ("north", "south"):
+            for type_name in ("drawing", "manual"):
+                campus_id = campus_ids[campus_name]
+                document_type_id = type_ids[type_name]
+                _insert(
+                    e2e_client,
+                    org_admin.headers,
+                    documents_id,
+                    {
+                        "campus_id": campus_id,
+                        "document_type_id": document_type_id,
+                        "access_key": f"{campus_id}:{document_type_id}",
+                        "title": f"{campus_name}-{type_name}",
+                    },
+                )
+
+        assert {
+            row["data"]["title"]
+            for row in _query(e2e_client, alice_user.headers, documents_id)
+        } == {"north-drawing", "south-manual"}
+        assert _query(e2e_client, bob_user.headers, documents_id) == []
+        assert {
+            row["data"]["name"]
+            for row in _query(e2e_client, alice_user.headers, campus_table_id)
+        } == {"north", "south"}
+        assert {
+            row["data"]["name"]
+            for row in _query(e2e_client, alice_user.headers, type_table_id)
+        } == {"drawing", "manual"}
+        assert {
+            row["data"]["name"]
+            for row in _query(e2e_client, alice_user.headers, building_table_id)
+        } == {"north building", "south building"}
+        assert {
+            row["data"]["name"]
+            for row in _query(e2e_client, alice_user.headers, floor_table_id)
+        } == {"north floor", "south floor"}

--- a/api/tests/performance/test_policy_path_containment.py
+++ b/api/tests/performance/test_policy_path_containment.py
@@ -1,0 +1,399 @@
+"""Opt-in scale benchmark for claim-backed hierarchical policy scopes.
+
+This module is intentionally outside the default unit/e2e suites. Run it with:
+
+    ./test.sh tests/performance/test_policy_path_containment.py -s
+
+It prints machine-specific measurements without imposing brittle latency
+thresholds on CI. Assertions cover fixture size and authorization correctness.
+"""
+
+from __future__ import annotations
+
+import json
+import statistics
+import time
+import tracemalloc
+from types import SimpleNamespace
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import insert, select, text
+from sqlalchemy.dialects import postgresql
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from shared.path_matching import path_within_any
+from shared.policies.compile import compile_to_sql
+from src.models.contracts.policies import Expr
+from src.models.orm.custom_claims import CustomClaim
+from src.models.orm.file_metadata import FileMetadata, FilePolicy
+from src.models.orm.organizations import Organization
+from src.models.orm.tables import Document, Table
+from src.services.file_policy_service import FilePolicyService
+
+SITE_COUNT = 150
+CATEGORY_COUNT = 8
+DOCUMENTS_PER_CATEGORY = 50
+DOCUMENT_COUNT = SITE_COUNT * CATEGORY_COUNT * DOCUMENTS_PER_CATEGORY
+FILE_COUNT = DOCUMENT_COUNT * 2
+LEGACY_PREFIX_COUNT = SITE_COUNT * CATEGORY_COUNT * 2
+PROFILE_SITE_COUNTS = {"sparse": 1, "medium": 10, "broad": 40}
+
+
+def _chunks(items: list[dict], size: int = 5_000):
+    for offset in range(0, len(items), size):
+        yield items[offset : offset + size]
+
+
+def _path(site: int, category: int, mode: str, document: int) -> str:
+    suffix = "pdf" if mode == "pdf" else "dwg"
+    return (
+        f"site-{site:03d}:category-{category:02d}/{mode}/"
+        f"document-{document:03d}/drawing.{suffix}"
+    )
+
+
+def _percentile(values: list[float], fraction: float) -> float:
+    ordered = sorted(values)
+    return ordered[min(int(len(ordered) * fraction), len(ordered) - 1)]
+
+
+async def _explain(db: AsyncSession, stmt, *, dialect: postgresql.dialect) -> dict:
+    sql = str(stmt.compile(dialect=dialect, compile_kwargs={"literal_binds": True}))
+    result = await db.execute(text(f"EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON) {sql}"))
+    return result.scalar_one()[0]
+
+
+def _plan_summary(result: dict) -> dict:
+    plan = result["Plan"]
+    return {
+        "node_type": plan["Node Type"],
+        "actual_rows": plan["Actual Rows"],
+        "planning_ms": round(result["Planning Time"], 3),
+        "execution_ms": round(result["Execution Time"], 3),
+        "shared_hit_blocks": plan.get("Shared Hit Blocks", 0),
+    }
+
+
+@pytest.mark.asyncio
+@pytest.mark.slow
+@pytest.mark.timeout(180)
+async def test_large_claim_backed_policy_benchmark(
+    db_session: AsyncSession,
+) -> None:
+    started = time.perf_counter()
+    org_id = uuid4()
+    user_ids = {profile: str(uuid4()) for profile in PROFILE_SITE_COUNTS}
+    user_id = user_ids["broad"]
+    documents_table_id = uuid4()
+    grants_table_id = uuid4()
+
+    db_session.add(
+        Organization(
+            id=org_id, name=f"Policy benchmark {uuid4().hex[:8]}", created_by="test"
+        )
+    )
+    db_session.add_all(
+        [
+            Table(
+                id=documents_table_id,
+                name=f"benchmark_documents_{uuid4().hex[:8]}",
+                organization_id=org_id,
+            ),
+            Table(
+                id=grants_table_id,
+                name=f"benchmark_grants_{uuid4().hex[:8]}",
+                organization_id=org_id,
+                access={
+                    "policies": [
+                        {
+                            "name": "own_rows",
+                            "actions": ["read"],
+                            "when": {"eq": [{"row": "user_id"}, {"user": "user_id"}]},
+                        }
+                    ]
+                },
+            ),
+        ]
+    )
+    await db_session.flush()
+
+    document_rows: list[dict] = []
+    metadata_rows: list[dict] = []
+    for site in range(SITE_COUNT):
+        for category in range(CATEGORY_COUNT):
+            access_key = f"site-{site:03d}:category-{category:02d}"
+            for document in range(DOCUMENTS_PER_CATEGORY):
+                document_rows.append(
+                    {
+                        "id": f"document-{site:03d}-{category:02d}-{document:03d}",
+                        "table_id": documents_table_id,
+                        "data": {
+                            "access_key": access_key,
+                            "resource_path": _path(site, category, "pdf", document),
+                        },
+                    }
+                )
+                for mode in ("pdf", "download"):
+                    path = _path(site, category, mode, document)
+                    metadata_rows.append(
+                        {
+                            "id": uuid4(),
+                            "organization_id": org_id,
+                            "location": "documents",
+                            "path": path,
+                            "s3_key": f"benchmark/{path}",
+                            "content_type": (
+                                "application/pdf"
+                                if mode == "pdf"
+                                else "application/octet-stream"
+                            ),
+                            "size_bytes": 1,
+                            "sha256": "0" * 64,
+                            "created_by": uuid4(),
+                        }
+                    )
+
+    for chunk in _chunks(document_rows):
+        await db_session.execute(insert(Document), chunk)
+    for chunk in _chunks(metadata_rows):
+        await db_session.execute(insert(FileMetadata), chunk)
+
+    # Sparse, medium, and broad principals exercise growing permission sets.
+    # Half the sites include a separate download capability.
+    grant_rows: list[dict] = []
+    access_keys_by_profile: dict[str, list[str]] = {}
+    paths_by_profile: dict[str, list[str]] = {}
+    for profile, site_count in PROFILE_SITE_COUNTS.items():
+        access_keys: list[str] = []
+        paths: list[str] = []
+        for site in range(site_count):
+            for category in range(CATEGORY_COUNT):
+                access_key = f"site-{site:03d}:category-{category:02d}"
+                access_keys.append(access_key)
+                prefixes = [f"{access_key}/pdf"]
+                if site % 2 == 0:
+                    prefixes.append(f"{access_key}/download")
+                for mode, prefix in enumerate(prefixes):
+                    paths.append(prefix)
+                    grant_rows.append(
+                        {
+                            "id": f"grant-{profile}-{site:03d}-{category:02d}-{mode}",
+                            "table_id": grants_table_id,
+                            "data": {
+                                "user_id": user_ids[profile],
+                                "path_prefix": prefix,
+                            },
+                        }
+                    )
+        access_keys_by_profile[profile] = access_keys
+        paths_by_profile[profile] = paths
+    await db_session.execute(insert(Document), grant_rows)
+    allowed_access_keys = access_keys_by_profile["broad"]
+    allowed_paths = paths_by_profile["broad"]
+
+    grant_table_name = (
+        await db_session.execute(select(Table.name).where(Table.id == grants_table_id))
+    ).scalar_one()
+    db_session.add(
+        CustomClaim(
+            organization_id=org_id,
+            name="allowed_resource_paths",
+            type="list",
+            query={
+                "table": grant_table_name,
+                "where": {"eq": [{"row": "user_id"}, {"user": "user_id"}]},
+                "select": "path_prefix",
+            },
+        )
+    )
+
+    root_policies = {
+        "policies": [
+            {
+                "name": "claim_read",
+                "actions": ["read"],
+                "when": {
+                    "path_within_any": [
+                        {"file": "path"},
+                        {"claims": "allowed_resource_paths"},
+                    ]
+                },
+            }
+        ]
+    }
+    db_session.add(
+        FilePolicy(
+            organization_id=org_id,
+            location="documents",
+            path="",
+            policies=root_policies,
+            created_by=uuid4(),
+        )
+    )
+
+    legacy_rows = [
+        {
+            "id": uuid4(),
+            "organization_id": org_id,
+            "location": "legacy-documents",
+            "path": "",
+            "policies": {"policies": []},
+            "created_by": uuid4(),
+        }
+    ]
+    for site in range(SITE_COUNT):
+        for category in range(CATEGORY_COUNT):
+            for mode in ("pdf", "download"):
+                prefix = f"site-{site:03d}:category-{category:02d}/{mode}"
+                legacy_rows.append(
+                    {
+                        "id": uuid4(),
+                        "organization_id": org_id,
+                        "location": "legacy-documents",
+                        "path": prefix,
+                        "policies": {
+                            "policies": [
+                                {
+                                    "name": "claim_read",
+                                    "actions": ["read"],
+                                    "when": {
+                                        "in": [
+                                            prefix,
+                                            {"claims": "allowed_resource_paths"},
+                                        ]
+                                    },
+                                }
+                            ]
+                        },
+                        "created_by": uuid4(),
+                    }
+                )
+    for chunk in _chunks(legacy_rows):
+        await db_session.execute(insert(FilePolicy), chunk)
+    await db_session.flush()
+    seed_seconds = time.perf_counter() - started
+
+    assert len(document_rows) == DOCUMENT_COUNT
+    assert len(metadata_rows) == FILE_COUNT
+    assert len(legacy_rows) - 1 == LEGACY_PREFIX_COUNT
+    assert len(allowed_access_keys) == 320
+    assert len(allowed_paths) == 480
+    assert len(grant_rows) == 616
+
+    user = SimpleNamespace(
+        user_id=user_id,
+        email="benchmark@example.com",
+        organization_id=str(org_id),
+        is_platform_admin=False,
+        is_provider_org=False,
+        is_external=True,
+        role_ids=[],
+        role_names=[],
+        claims={},
+    )
+    service = FilePolicyService(db_session)
+
+    async def authorize(location: str, path: str) -> bool:
+        return await service.is_allowed(
+            "read",
+            organization_id=org_id,
+            location=location,
+            path=path,
+            user=user,
+        )
+
+    assert await authorize("documents", _path(0, 0, "pdf", 0)) is True
+    assert await authorize("documents", _path(0, 0, "download", 0)) is True
+    assert await authorize("documents", _path(1, 0, "download", 0)) is False
+    assert await authorize("documents", _path(40, 0, "pdf", 0)) is False
+    assert (
+        await authorize(
+            "documents", "site-000-annex:category-00/pdf/document-000/drawing.pdf"
+        )
+        is False
+    )
+
+    assert await authorize("legacy-documents", _path(0, 0, "pdf", 0)) is True
+    assert await authorize("legacy-documents", _path(1, 0, "download", 0)) is False
+
+    new_latencies: list[float] = []
+    legacy_latencies: list[float] = []
+    for sample in range(20):
+        path = _path(sample % 40, sample % CATEGORY_COUNT, "pdf", sample)
+        before = time.perf_counter()
+        assert await authorize("documents", path) is True
+        new_latencies.append((time.perf_counter() - before) * 1_000)
+
+        before = time.perf_counter()
+        assert await authorize("legacy-documents", path) is True
+        legacy_latencies.append((time.perf_counter() - before) * 1_000)
+
+    exact_expr = Expr.model_validate(
+        {
+            "in": [
+                {"row": "access_key"},
+                {"claims": "allowed_document_access_keys"},
+            ]
+        }
+    )
+    claims_user = SimpleNamespace(
+        claims={
+            "allowed_document_access_keys": allowed_access_keys,
+            "allowed_resource_paths": allowed_paths,
+        }
+    )
+    exact_stmt = select(Document.id).where(
+        Document.table_id == documents_table_id,
+        compile_to_sql(exact_expr, claims_user),
+    )
+    dialect = postgresql.dialect()
+    exact_plan = await _explain(db_session, exact_stmt, dialect=dialect)
+
+    iterations = 20_000
+    evaluator_results: dict[str, dict] = {}
+    for profile, paths in paths_by_profile.items():
+        tracemalloc.start()
+        before = time.perf_counter()
+        for i in range(iterations):
+            path_within_any(_path(i % 150, i % 8, "pdf", i % 50), paths)
+        evaluator_seconds = time.perf_counter() - before
+        _, peak_bytes = tracemalloc.get_traced_memory()
+        tracemalloc.stop()
+        evaluator_results[profile] = {
+            "resolved_path_scopes": len(paths),
+            "seconds": round(evaluator_seconds, 3),
+            "evaluations_per_second": round(iterations / evaluator_seconds),
+            "peak_bytes": peak_bytes,
+        }
+
+    report = {
+        "fixture": {
+            "sites": SITE_COUNT,
+            "categories": CATEGORY_COUNT,
+            "documents": DOCUMENT_COUNT,
+            "file_metadata": FILE_COUNT,
+            "compound_grants": len(allowed_access_keys),
+            "resolved_path_scopes": len(allowed_paths),
+            "permission_rows": len(grant_rows),
+            "legacy_policy_prefixes": LEGACY_PREFIX_COUNT,
+            "new_policy_prefixes": 1,
+        },
+        "seed_seconds": round(seed_seconds, 3),
+        "file_authorization_ms": {
+            "root_claim_policy_median": round(statistics.median(new_latencies), 3),
+            "root_claim_policy_p95": round(_percentile(new_latencies, 0.95), 3),
+            "legacy_prefix_policy_median": round(
+                statistics.median(legacy_latencies), 3
+            ),
+            "legacy_prefix_policy_p95": round(_percentile(legacy_latencies, 0.95), 3),
+        },
+        "in_memory_evaluator": {
+            "iterations_per_profile": iterations,
+            "profiles": evaluator_results,
+        },
+        "table_sql": {
+            "composite_in": _plan_summary(exact_plan),
+        },
+    }
+    print("POLICY_PATH_BENCHMARK=" + json.dumps(report, default=str))

--- a/api/tests/unit/policies/test_path_within_any.py
+++ b/api/tests/unit/policies/test_path_within_any.py
@@ -1,0 +1,102 @@
+"""Segment-aware path containment for claim-backed policies."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from pydantic import ValidationError
+
+from shared.path_matching import path_matches_prefix, path_within_any
+from shared.policies.evaluate import evaluate
+from src.models.contracts.policies import Expr, FileExpr
+
+
+@pytest.mark.parametrize(
+    ("path", "prefixes", "expected"),
+    [
+        ("site-a:category-1/pdf", ["site-a:category-1/pdf"], True),
+        ("site-a:category-1/pdf/doc-1/file.pdf", ["site-a:category-1/pdf"], True),
+        ("/site-a:category-1/pdf/doc-1/", ["/site-a:category-1/pdf/"], True),
+        ("site-annex:category-1/pdf/doc-1/file.pdf", ["site-a"], False),
+        ("site-a:category-1/pdf2/doc-1/file.pdf", ["site-a:category-1/pdf"], False),
+        ("anything", ["", "/", None, 7], False),
+        ("anything", [], False),
+        ("anything", "anything", False),
+        (None, ["anything"], False),
+    ],
+)
+def test_path_within_any_is_segment_aware_and_fails_closed(
+    path: object, prefixes: object, expected: bool
+) -> None:
+    assert path_within_any(path, prefixes) is expected
+
+
+def test_root_prefix_is_reserved_for_policy_selection() -> None:
+    assert path_matches_prefix("", "any/path") is True
+    assert path_within_any("any/path", [""]) is False
+
+
+def test_contract_accepts_claim_rhs_only_for_file_expressions() -> None:
+    with pytest.raises(ValidationError, match="unknown operator 'path_within_any'"):
+        Expr.model_validate(
+            {
+                "path_within_any": [
+                    {"row": "resource_path"},
+                    {"claims": "allowed_resource_paths"},
+                ]
+            }
+        )
+
+    FileExpr.model_validate(
+        {
+            "path_within_any": [
+                {"file": "path"},
+                {"claims": "allowed_resource_paths"},
+            ]
+        }
+    )
+
+
+def test_contract_rejects_non_string_literal_prefix() -> None:
+    with pytest.raises(ValidationError, match="must be strings"):
+        FileExpr.model_validate({"path_within_any": [{"file": "path"}, ["valid", 7]]})
+
+
+def test_evaluator_uses_claim_backed_prefixes() -> None:
+    user = SimpleNamespace(claims={"allowed_resource_paths": ["site-a:category-1/pdf"]})
+    expr = FileExpr.model_validate(
+        {
+            "path_within_any": [
+                {"file": "path"},
+                {"claims": "allowed_resource_paths"},
+            ]
+        }
+    )
+
+    assert (
+        evaluate(
+            expr,
+            {"path": "site-a:category-1/pdf/doc-1/file.pdf"},
+            user,
+            resolvers={
+                "file": lambda field: {
+                    "path": "site-a:category-1/pdf/doc-1/file.pdf"
+                }.get(field)
+            },
+        )
+        is True
+    )
+    assert (
+        evaluate(
+            expr,
+            {"path": "site-a:category-1/download/doc-1/file.dwg"},
+            user,
+            resolvers={
+                "file": lambda field: {
+                    "path": "site-a:category-1/download/doc-1/file.dwg"
+                }.get(field)
+            },
+        )
+        is False
+    )

--- a/api/tests/unit/services/test_file_policy_service.py
+++ b/api/tests/unit/services/test_file_policy_service.py
@@ -74,7 +74,6 @@ async def test_service_selects_longest_prefix_and_ignores_siblings(db_session) -
         user=_user(org.id),
     ) is False
 
-
 @pytest.mark.asyncio
 async def test_service_isolates_organization_scoped_policies(db_session) -> None:
     org_a = Organization(id=uuid4(), name=f"FilesA-{uuid4().hex[:8]}", created_by="test")
@@ -692,6 +691,66 @@ async def test_service_preresolves_custom_claims_before_evaluation(
         path="claims/denied.txt",
         user=_user(org.id),
     ) is False
+
+
+@pytest.mark.asyncio
+async def test_service_applies_one_root_policy_to_compound_claim_scopes(
+    db_session, monkeypatch
+) -> None:
+    from src.services import file_policy_service as service_module
+
+    org = Organization(id=uuid4(), name=f"Files-{uuid4().hex[:8]}", created_by="test")
+    db_session.add(org)
+    await db_session.flush()
+    service = FilePolicyService(db_session)
+    await service.upsert_policy(
+        organization_id=org.id,
+        location="documents",
+        path="",
+        policies=FilePolicies.model_validate(
+            {
+                "policies": [
+                    {
+                        "name": "claim_read",
+                        "actions": ["read"],
+                        "when": {
+                            "path_within_any": [
+                                {"file": "path"},
+                                {"claims": "allowed_resource_paths"},
+                            ]
+                        },
+                    }
+                ]
+            }
+        ),
+        created_by=uuid4(),
+    )
+
+    async def fake_preresolve(user, policies, db, org_id, solution_id=None):
+        assert org_id == org.id
+        user.claims["allowed_resource_paths"] = [
+            "site-a:category-1/pdf",
+            "site-b:category-2/pdf",
+            "site-b:category-2/download",
+        ]
+
+    monkeypatch.setattr(service_module, "preresolve_for_policies", fake_preresolve)
+    user = _user(org.id)
+
+    async def allowed(path: str) -> bool:
+        return await service.is_allowed(
+            "read",
+            organization_id=org.id,
+            location="documents",
+            path=path,
+            user=user,
+        )
+
+    assert await allowed("site-a:category-1/pdf/doc-1/file.pdf") is True
+    assert await allowed("site-a:category-1/download/doc-1/file.dwg") is False
+    assert await allowed("site-a:category-2/pdf/doc-1/file.pdf") is False
+    assert await allowed("site-annex:category-1/pdf/doc-1/file.pdf") is False
+    assert await allowed("site-b:category-2/download/doc-2/file.dwg") is True
 
 
 @pytest.mark.asyncio

--- a/docs/plans/2026-09-03-claim-backed-resource-scopes-spike.md
+++ b/docs/plans/2026-09-03-claim-backed-resource-scopes-spike.md
@@ -1,0 +1,157 @@
+# Claim-backed resource scopes: spike decision
+
+## Decision
+
+Use two authorization projections because table rows and file paths have different query shapes:
+
+1. **Tables:** store a composite access key on each protected document and compare it with an exact list claim using the existing `in` operator.
+2. **Files:** store one path prefix per granted capability and evaluate a file-only `path_within_any` operator from one root policy.
+
+Do not compile path containment into table SQL. In the scale experiment, the prefix expansion took 18,067 ms over 60,000 rows while composite exact membership took 16 ms. A single operator for both surfaces looks simpler but puts the expensive operation on the hottest data path.
+
+This design is attribute-based access control (ABAC): the principal has resolved grant attributes and the resource has either an exact access key or a hierarchical path. The file predicate follows the shape of [OPA's `strings.any_prefix_match`](https://www.openpolicyagent.org/docs/policy-reference/builtins/strings) and XACML 3.0's [`string-starts-with`](https://docs.oasis-open.org/xacml/3.0/xacml-3.0-core-spec-cos01-en.html), with stricter slash-segment boundaries for resource paths.
+
+## Authorization projection
+
+The source-of-truth assignment model may remain normalized for editing. Authorization should read flattened projection rows so a grant resolver performs indexed equality filters and selects one scalar value per row.
+
+### Protected documents
+
+| Field | Example | Purpose |
+|---|---|---|
+| `site_id` | `site-017` | Business dimension |
+| `category_id` | `category-03` | Business dimension |
+| `document_access_key` | `site-017:category-03` | Exact authorization key |
+| `pdf_path` | `documents/site-017/category-03/pdf/document-104/file.pdf` | View representation |
+| `download_path` | `documents/site-017/category-03/download/document-104/source.dwg` | Download representation |
+
+`document_access_key` must be generated from immutable identifiers, not display names. It prevents independent site and category claims from accidentally granting their Cartesian product.
+
+### Table grant projection
+
+`document_access_grants` contains one row per principal and permitted site/category pair:
+
+| Field | Index |
+|---|---|
+| `user_id` | composite index with `document_access_key` |
+| `document_access_key` | composite index with `user_id` |
+
+The custom claim is:
+
+```json
+{
+  "name": "allowed_document_access_keys",
+  "type": "list",
+  "query": {
+    "table": "document_access_grants",
+    "where": {"eq": [{"row": "user_id"}, {"user": "user_id"}]},
+    "select": "document_access_key"
+  }
+}
+```
+
+The documents table policy is:
+
+```json
+{
+  "policies": [
+    {
+      "name": "read_granted_documents",
+      "actions": ["read"],
+      "when": {
+        "in": [
+          {"row": "document_access_key"},
+          {"claims": "allowed_document_access_keys"}
+        ]
+      }
+    }
+  ]
+}
+```
+
+The same exact predicate should cover query, get, update, and delete actions as appropriate. Create should validate the submitted access key against the claim before insertion.
+
+### File grant projection
+
+`file_access_grants` contains one row per principal and permitted path scope:
+
+| Field | Example |
+|---|---|
+| `user_id` | principal identifier |
+| `path_prefix` | `documents/site-017/category-03/pdf` |
+
+A view-only assignment emits the `pdf` prefix. An assignment with source-download permission emits both `pdf` and `download` prefixes. This deliberately duplicates a small amount of derived data so authorization does not need to join dimensions or flatten JSON arrays on every request.
+
+The custom claim is:
+
+```json
+{
+  "name": "allowed_resource_paths",
+  "type": "list",
+  "query": {
+    "table": "file_access_grants",
+    "where": {"eq": [{"row": "user_id"}, {"user": "user_id"}]},
+    "select": "path_prefix"
+  }
+}
+```
+
+One file policy at the location root replaces a generated policy row for every possible scope:
+
+```json
+{
+  "policies": [
+    {
+      "name": "read_granted_resources",
+      "actions": ["read"],
+      "when": {
+        "path_within_any": [
+          {"file": "path"},
+          {"claims": "allowed_resource_paths"}
+        ]
+      }
+    }
+  ]
+}
+```
+
+`path_within_any` matches an exact path or slash-delimited descendant. It does not use raw `startswith`: a grant for `site-017` cannot match `site-017-annex`. Missing claims, non-list claims, non-string values, and empty/root prefixes fail closed.
+
+## Performance evidence
+
+The opt-in benchmark seeds 150 sites, 8 categories, 60,000 document rows, 120,000 file metadata rows, 616 permission rows across sparse/medium/broad principals, and 2,400 legacy file-policy prefixes.
+
+Measured in the Dockerized test environment on 2026-09-03:
+
+| Measurement | Result |
+|---|---:|
+| Seed time | 11.453 s |
+| One root file policy, median | 2.397 ms |
+| One root file policy, p95 | 3.549 ms |
+| 2,400 literal-prefix policies, median | 51.827 ms |
+| 2,400 literal-prefix policies, p95 | 232.105 ms |
+| In-memory predicate, 16 scopes | 53,216 evaluations/s |
+| In-memory predicate, 120 scopes | 27,394 evaluations/s |
+| In-memory predicate, 480 scopes | 13,862 evaluations/s |
+| Composite table `IN`, 320 keys / 60,000 rows | 16.302 ms, 16,000 matches |
+
+The final table query used a PostgreSQL bitmap heap scan, planned in 0.132 ms and hit 1,513 shared blocks. These timings are diagnostic evidence, not CI thresholds.
+
+An earlier experimental implementation compiled 480 path prefixes into an OR of segment-aware SQL `LIKE` predicates. It returned the same 16,000 rows but took 18,067 ms, compared with 16 ms for composite `IN` in that run. The SQL implementation was removed and the operator is rejected by table-policy validation.
+
+## Verification scope
+
+The spike proves:
+
+- exact and descendant file matches;
+- sibling-prefix isolation;
+- view-only denial of a download path;
+- different users resolving different grant rows;
+- a real object written to and read from the object-storage boundary through REST;
+- large metadata and permission fixtures without timing assertions in CI.
+
+The large fixture intentionally inserts file metadata rather than 120,000 object bodies. Bulk object upload would primarily measure object-store ingestion and obscure authorization cost. The focused end-to-end test covers actual object I/O separately.
+
+## Remaining boundary
+
+Custom claims currently select one scalar field per source row; they do not flatten a list-valued JSON field. Keep flattened authorization projections for this design. General list flattening may be useful platform work, but it is independent of hierarchical file containment and should be evaluated separately.

--- a/docs/plans/2026-09-03-claim-backed-resource-scopes-spike.md
+++ b/docs/plans/2026-09-03-claim-backed-resource-scopes-spike.md
@@ -25,7 +25,7 @@ The source-of-truth assignment model may remain normalized for editing. Authoriz
 | `pdf_path` | `documents/site-017/category-03/pdf/document-104/file.pdf` | View representation |
 | `download_path` | `documents/site-017/category-03/download/document-104/source.dwg` | Download representation |
 
-`document_access_key` must be generated from immutable identifiers, not display names. It prevents independent site and category claims from accidentally granting their Cartesian product.
+`document_access_key` must be generated from immutable UUIDs, not display names. Stable file paths use the same UUIDs as segments. Renaming a site or category therefore changes only its reference row; it does not rewrite grants, keys, or stored paths. The composite key prevents independent site and category claims from accidentally granting their Cartesian product.
 
 ### Table grant projection
 
@@ -70,6 +70,16 @@ The documents table policy is:
 ```
 
 The same exact predicate should cover query, get, update, and delete actions as appropriate. Create should validate the submitted access key against the claim before insertion.
+
+### Entitlement-filtered navigation
+
+Keep `site_id` and `category_id` on every `document_access_grants` row alongside the composite key. Component claims may safely filter reference tables for navigation:
+
+```json
+{"in": [{"row": "site_id"}, {"claims": "allowed_site_ids"}]}
+```
+
+Buildings and floors that inherit site access should also carry `site_id`, making their policies the same indexed membership check without a runtime join. The UI queries its own grant rows once, groups the original site/category pairs, and batch-resolves names for only those UUIDs. Component claims control label visibility; they never replace the composite document policy.
 
 ### File grant projection
 

--- a/plugins/bifrost/skills/bifrost-build/references/entities.md
+++ b/plugins/bifrost/skills/bifrost-build/references/entities.md
@@ -79,7 +79,7 @@ Test missing mapping, expired/absent OAuth, API failure, pagination/rate limitin
 
 Roles are permission buckets assigned to users and entities. Permissions are a mapping, not a list. Read role membership and the protected entity before changing either side.
 
-Custom claims are org-scoped, query-derived user facts used by policy expressions. Design the backing query and policy together, and test users with empty, single, and multiple claim values.
+Custom claims are org-scoped, query-derived user facts used by policy expressions. Design the backing query, source-table read policy, and consuming policy together: claim resolution is restricted by the source table's policy. Claims select one scalar value per source row, so flatten list-valued grants into separate rows. Test users with empty, single, and multiple claim values.
 
 Table and file policies are deny-by-absence. Fresh resources commonly begin with an admin bypass only; ordinary users need explicit rules. Policy rules can be referenced by multiple resources, so inspect usages before updating or deleting a shared rule.
 

--- a/plugins/bifrost/skills/bifrost-build/references/files.md
+++ b/plugins/bifrost/skills/bifrost-build/references/files.md
@@ -77,6 +77,31 @@ The CLI read/write surface is text-only. `files write` replaces the complete fil
 
 File policy checks apply independently at every tier. Grant only the actions required for the path prefix: read, list, write, delete, or signed access as supported by the policy model.
 
+For many dynamic hierarchical grants, use one root file policy with the file-only `path_within_any` predicate and a list claim:
+
+```json
+{
+  "policies": [
+    {
+      "name": "read_granted_resources",
+      "actions": ["read"],
+      "when": {
+        "path_within_any": [
+          {"file": "path"},
+          {"claims": "allowed_resource_paths"}
+        ]
+      }
+    }
+  ]
+}
+```
+
+Back `allowed_resource_paths` with a flattened grant table containing one `user_id` and one `path_prefix` per row. The predicate matches the exact prefix or a slash-delimited descendant; sibling string prefixes do not match. Missing, malformed, non-list, and empty/root claim values fail closed.
+
+Build paths from immutable UUIDs, for example `documents/sites/<site UUID>/categories/<category UUID>/pdf/<document UUID>/file.pdf`. Keep view and source-download representations under different path segments so their grants can differ without per-file claim values. A label rename then changes only reference data.
+
+`path_within_any` is intentionally unavailable to table policies. Use indexed exact composite-key membership for table rows. Also treat `list` separately: permission to a descendant does not imply permission to enumerate every ancestor directory. Prefer an authorization-filtered table for navigation and grant file reads only when opening the selected resource.
+
 With `global_repo_access: false`, a Solution can access only its declared owned location. With it enabled, reads/list/exists/signed-read can fall back through eligible install-org and global file tiers. Writes and deletes still target the Solution-owned tier; the flag does not authorize modification of shared files.
 
 Read `solution-resource-access.md` for the exact runtime matrix.

--- a/plugins/bifrost/skills/bifrost-build/references/tables.md
+++ b/plugins/bifrost/skills/bifrost-build/references/tables.md
@@ -93,6 +93,35 @@ Missing rows normally return `None`/`null`; missing tables and denied access may
 
 Do not treat an empty Python `tables.query()` as proof that a shared table exists: Solution lookup can convert some missing-table reads into an empty list. Validate setup when absence would be an error.
 
+## Claim-backed authorization projections
+
+Use flattened grant rows when access depends on more than one resource dimension. Store immutable UUID components alongside one scalar composite key:
+
+```text
+document_access_grants
+├── user_id
+├── site_id
+├── category_id
+└── access_key       # "<site UUID>:<category UUID>"
+```
+
+The grant table must let a principal read only its own rows. A list claim can then select `access_key`, and the protected table compares it exactly:
+
+```json
+{
+  "in": [
+    {"row": "access_key"},
+    {"claims": "allowed_document_access_keys"}
+  ]
+}
+```
+
+Keep this composite boundary for protected rows. Separate `allowed_site_ids` and `allowed_category_ids` claims lose the original pairings and can create an unintended Cartesian product.
+
+The component claims are still useful for reference-data navigation. Policies on site, building, floor, or category catalog tables may compare their UUID field with the matching component claim so the app lists only entitled labels. Build cascading choices from the user's original grant rows to preserve which categories belong to each permitted site. A navigation result never replaces the composite policy on the protected table.
+
+Claims select one scalar field per source row and do not flatten a JSON list. Materialize one grant value per row. Use UUIDs in keys and references so renaming a display label does not rewrite policies, grants, or storage paths.
+
 ## Solution scope and shared fallback
 
 Solution context resolves its own table first. With `global_repo_access: true`, a miss may fall back by name to an eligible install-org and then global loose table. Shared fallback tables are read-only from the Solution; the flag does not permit row mutation outside the install. Policies still apply after resolution.


### PR DESCRIPTION
## Summary

- add a file-policy-only `path_within_any` predicate for claim-backed hierarchical resource scopes
- retain exact composite-key `in` policies for table rows after benchmarking and rejecting SQL path expansion
- prove UUID-backed composite grants and filtered site/category/building/floor navigation without cross-product widening
- prove the file design with a real object-storage boundary test and an opt-in 60,000-document / 120,000-file-record benchmark
- update Claude/Codex plugin guidance, the platform `/llms.txt`, and the architecture decision record

## Performance

Final local Docker benchmark:

- one root claim policy: 2.397 ms median, 3.549 ms p95
- 2,400 literal-prefix policies: 51.827 ms median, 232.105 ms p95
- 480-scope in-memory containment: 13,862 evaluations/second
- composite table `IN` with 320 keys over 60,000 rows: 16.302 ms
- rejected experimental SQL path expansion: 18,067 ms in the earlier comparison run

Timings are evidence only; the benchmark asserts correctness and fixture sizes, not machine-specific thresholds.

## Verification

- `./test.sh tests/e2e/platform/test_custom_claims.py -v` — 11 passed
- `./test.sh tests/unit/test_skill_appendix_fresh.py tests/unit/test_codex_mirror_sync.py tests/unit/test_docs_router.py tests/unit/policies/test_path_within_any.py tests/unit/services/test_file_policy_service.py tests/unit/policies/test_claims_refs_validation.py tests/unit/test_contract_version.py -q` — 43 passed; 2 repo-mount-dependent mirror checks skipped in Docker and their underlying host invariants passed directly
- `./test.sh tests/performance/test_policy_path_containment.py -s` — 1 passed
- `BIFROST_SKIP_BUILD=1 ./test.sh quality api` — pyright and ruff passed
- `bash scripts/sync-codex-skills.sh` plus canonical/public mirror diff — clean

There is no client source change, so no local Playwright run was selected. GitHub's full required checks passed on the first revision and will rerun for this update.

Fixes #699
