### PR TITLE
chore(release): prepare v1.3.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "bifrost",
   "description": "Bifrost — MSP automation platform. Skills for building workflows, forms, agents, independent Apps, Solutions, tables, and files with the Bifrost SDK + CLI. Includes :build, :setup, :copilot-cowork-package, and :migrate for moving legacy v1 Apps into independent V2 projects or installable Solutions.",
-  "version": "1.2.3",
+  "version": "1.3.0",
   "author": {
     "name": "Jack Musick",
     "url": "https://github.com/gobifrost/bifrost"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "bifrost",
-  "version": "1.2.3",
+  "version": "1.3.0",
   "description": "Bifrost — MSP automation platform. Skills for building workflows, forms, agents, independent Apps, Solutions, tables, and files with the Bifrost SDK + CLI, including v1 migration into either V2 ownership model.",
   "author": {
     "name": "Jack Musick",

--- a/api/tests/e2e/api/test_builtin_events.py
+++ b/api/tests/e2e/api/test_builtin_events.py
@@ -333,6 +333,7 @@ class TestBuiltInIntegrationEvents:
 
         try:
             import src.core.redis_client as redis_module
+            from src.core.database import reset_db_state
             from src.jobs.rabbitmq import rabbitmq
             from src.routers.oauth_connections import _apply_callback_to_mapping
             from src.routers import integrations
@@ -341,6 +342,7 @@ class TestBuiltInIntegrationEvents:
             # Source/workflow setup above runs through TestClient, while the
             # emitter below runs on pytest-asyncio's function-scoped loop.
             # Rebuild loop-bound clients before crossing that boundary.
+            reset_db_state()
             redis_module._redis_client = None
             rabbitmq.reset_pools()
 

--- a/plugins/bifrost/.codex-plugin/plugin.json
+++ b/plugins/bifrost/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "bifrost",
-  "version": "1.2.3",
+  "version": "1.3.0",
   "description": "Bifrost — MSP automation platform. Skills for building workflows, forms, agents, independent Apps, Solutions, tables, and files with the Bifrost SDK + CLI, including v1 migration into either V2 ownership model.",
   "author": {
     "name": "Jack Musick",


### PR DESCRIPTION
## Summary

- bump the maintainer, public Codex plugin, and bundled Bifrost plugin manifests to `1.3.0`
- reset cached application database state when the built-in integration-event E2E test crosses from the TestClient loop to pytest's function loop
- prepare the repository for the `v1.3.0` release; the matching documentation refresh is merged in gobifrost/website#15

## Verification

Exact pre-PR candidate: `154d09a6dca8cefa254ca855f0d1c22c7ca78e56`

- `./test.sh tests/e2e/api/test_builtin_events.py::TestBuiltInIntegrationEvents::test_integration_events_run_subscribers -v` — 1 passed
- `./test.sh tests/e2e/api/test_builtin_events.py -v` — 3 passed
- `./test.sh pre-pr` — passed on the exact candidate; includes production client/API builds, TypeScript/ESLint, all 300 Vitest files, Pyright/Ruff, 5,888 backend unit/contract passes with 3 environment skips, 1,799 backend E2E passes with 1 environment skip, four zero-retry browser smoke tests, and production API candidate validation

No locally reproducible broader suite was omitted. No known failures.
