### PR TITLE
fix(ci): publish releases past skipped candidate job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -849,7 +849,17 @@ jobs:
   # Build API Image - Only on version tags, after tests pass
   # =============================================================================
   build-api:
-    if: startsWith(github.ref, 'refs/tags/v')
+    # test-e2e-gate intentionally depends on build-dev-candidate, which is
+    # skipped for tag runs. GitHub propagates that skipped ancestor through the
+    # dependency chain unless this job uses a status function, even though the
+    # aggregate gate itself succeeds. Check every direct gate explicitly so a
+    # real test failure still blocks publication.
+    if: >-
+      always() &&
+      startsWith(github.ref, 'refs/tags/v') &&
+      needs.test-unit.result == 'success' &&
+      needs.test-e2e-gate.result == 'success' &&
+      needs.lint.result == 'success'
     needs: [test-unit, test-e2e-gate, lint]
     runs-on: ubuntu-latest
     name: Build API Image
@@ -974,7 +984,12 @@ jobs:
   # Build Client Image - Only on version tags, after tests pass
   # =============================================================================
   build-client:
-    if: startsWith(github.ref, 'refs/tags/v')
+    if: >-
+      always() &&
+      startsWith(github.ref, 'refs/tags/v') &&
+      needs.test-unit.result == 'success' &&
+      needs.test-e2e-gate.result == 'success' &&
+      needs.lint.result == 'success'
     needs: [test-unit, test-e2e-gate, lint]
     runs-on: ubuntu-latest
     name: Build Client Image
@@ -1078,7 +1093,11 @@ jobs:
   # action. Both feed Scorecard's Signed-Releases check.
   # =============================================================================
   create-release:
-    if: startsWith(github.ref, 'refs/tags/v')
+    if: >-
+      always() &&
+      startsWith(github.ref, 'refs/tags/v') &&
+      needs.build-api.result == 'success' &&
+      needs.build-client.result == 'success'
     needs: [build-api, build-client]
     runs-on: ubuntu-latest
     name: Create Release

--- a/api/tests/unit/test_ci_workflow_contract.py
+++ b/api/tests/unit/test_ci_workflow_contract.py
@@ -254,6 +254,19 @@ def test_release_tags_still_require_the_complete_suite() -> None:
     assert set(jobs["build-client"]["needs"]) == release_prerequisites
     assert set(jobs["create-release"]["needs"]) == {"build-api", "build-client"}
 
+    for job_name in ("build-api", "build-client"):
+        condition = _normalized(jobs[job_name]["if"])
+        assert "always()" in condition
+        assert "startsWith(github.ref, 'refs/tags/v')" in condition
+        for prerequisite in release_prerequisites:
+            assert f"needs.{prerequisite}.result == 'success'" in condition
+
+    release_condition = _normalized(jobs["create-release"]["if"])
+    assert "always()" in release_condition
+    assert "startsWith(github.ref, 'refs/tags/v')" in release_condition
+    assert "needs.build-api.result == 'success'" in release_condition
+    assert "needs.build-client.result == 'success'" in release_condition
+
 
 def test_nightly_owns_full_browser_slow_and_clean_build_discovery() -> None:
     workflow = _load_workflow(NIGHTLY_WORKFLOW)


### PR DESCRIPTION
## Summary

- let version-tag image jobs run past the intentionally skipped merge-candidate job
- keep publication fail-closed by requiring every direct test gate to succeed
- apply the same guarded skip override to GitHub Release creation
- extend the static CI contract so the release graph cannot regress

## Root cause

`test-e2e-gate` uses `always()` because it aggregates jobs that are intentionally skipped on some events. On tag pushes, `build-dev-candidate` is skipped by design. GitHub propagates a skipped ancestor through the dependency chain unless each downstream job has a status-function condition, so the successful aggregate gate was followed by skipped API image, client image, and release jobs.

## Verification

- `./test.sh tests/unit/test_ci_workflow_contract.py -v`
- `./test.sh pre-pr`

This unblocks the already-prepared v1.3.0 release. The tag will be moved to the repaired, merge-queue-verified `main` commit before publication because the original tag produced no images or GitHub Release.
