### PR TITLE
fix(chat): preserve null results and hide internal errors

### DIFF
--- a/api/src/core/pubsub.py
+++ b/api/src/core/pubsub.py
@@ -21,6 +21,7 @@ from uuid import UUID
 if TYPE_CHECKING:
     from fastapi import WebSocket
 
+    from src.models.contracts.agents import ChatStreamChunk
     from src.models.orm.agent_runs import AgentRun
 
 from src.config import get_settings
@@ -383,23 +384,37 @@ async def publish_agent_run_step(
     await manager.broadcast(f"agent-run:{run_id}", message)
 
 
+def serialize_chat_stream_chunk(chunk: ChatStreamChunk) -> dict[str, Any]:
+    """Serialize a sparse chunk without altering nested contract payloads."""
+    payload = chunk.model_dump(mode="json")
+    return {
+        field: value
+        for field, value in payload.items()
+        if value is not None or field in chunk.model_fields_set
+    }
+
+
 async def publish_chat_run_event(
     conversation_id: str | UUID,
     run_id: str | UUID,
     kind: str,
     status: str,
-    payload: dict[str, Any],
+    payload: ChatStreamChunk,
 ) -> dict[str, Any]:
     """Publish a versioned, replayable chat run event."""
     from uuid import uuid4
 
-    from src.models.contracts.agents import ChatStreamChunk
+    from src.services.chat_errors import public_chat_error_message
 
     event_id = uuid4()
     occurred_at = datetime.now(timezone.utc)
     conversation_id_str = str(conversation_id)
     run_id_str = str(run_id)
-    chunk = ChatStreamChunk.model_validate(payload)
+    chunk = payload
+    if chunk.type == "error":
+        chunk = chunk.model_copy(
+            update={"error": public_chat_error_message(chunk.run_status or status)}
+        )
     envelope: dict[str, Any] = {
         "type": "chat_run_event",
         "protocol_version": 1,
@@ -410,7 +425,7 @@ async def publish_chat_run_event(
         "occurred_at": occurred_at.isoformat(),
         "kind": kind,
         "status": status,
-        "payload": chunk.model_dump(mode="json", exclude_none=True),
+        "payload": serialize_chat_stream_chunk(chunk),
     }
 
     stream_key = chat_run_events_stream_key(conversation_id_str)
@@ -443,6 +458,8 @@ async def replay_chat_run_events(
     limit: int = 200,
 ) -> list[dict[str, Any]]:
     """Replay retained chat run events from the Redis stream."""
+    from src.services.chat_errors import public_chat_error_message
+
     conversation_id_str = str(conversation_id)
     stream_key = chat_run_events_stream_key(conversation_id_str)
     events: list[dict[str, Any]] = []
@@ -453,6 +470,14 @@ async def replay_chat_run_events(
         if not raw:
             continue
         event = json.loads(raw)
+        payload = event.get("payload")
+        if isinstance(payload, dict) and payload.get("type") == "error":
+            event["payload"] = {
+                **payload,
+                "error": public_chat_error_message(
+                    payload.get("run_status") or event.get("status")
+                ),
+            }
         sequence = int(event.get("sequence") or data.get("sequence") or 0)
         if after_sequence is not None and sequence <= after_sequence:
             continue

--- a/api/src/jobs/consumers/agent_run.py
+++ b/api/src/jobs/consumers/agent_run.py
@@ -228,7 +228,7 @@ class AgentRunConsumer(BaseConsumer):
                             type="run_status",
                             conversation_id=str(agent_run.conversation_id),
                             run_status="running",
-                        ).model_dump(mode="json", exclude_none=True),
+                        ),
                     )
                     await publish_agent_run_update(agent_run, "Unknown")
                     await self._process_chat_run(
@@ -527,7 +527,7 @@ class AgentRunConsumer(BaseConsumer):
                                     type="error",
                                     error=str(e),
                                     run_status="failed",
-                                ).model_dump(mode="json", exclude_none=True),
+                                ),
                             )
                         except Exception as pub_err:
                             logger.debug(
@@ -693,7 +693,7 @@ class AgentRunConsumer(BaseConsumer):
                                 run_id=run_id,
                                 kind=chunk.type,
                                 status=_chat_chunk_status(chunk.type),
-                                payload=chunk.model_dump(mode="json", exclude_none=True),
+                                payload=chunk,
                             )
 
                             if (
@@ -806,7 +806,7 @@ class AgentRunConsumer(BaseConsumer):
                                 type="title_update",
                                 title=title,
                                 run_status="completed",
-                            ).model_dump(mode="json", exclude_none=True),
+                            ),
                         )
 
                 if sync:
@@ -858,9 +858,7 @@ class AgentRunConsumer(BaseConsumer):
                     run_id=run_id,
                     kind=interrupted_kind,
                     status=interrupted_status,
-                    payload=interrupted_payload.model_dump(
-                        mode="json", exclude_none=True
-                    ),
+                    payload=interrupted_payload,
                 )
 
                 async with self._session_factory() as db:

--- a/api/src/jobs/schedulers/execution_cleanup.py
+++ b/api/src/jobs/schedulers/execution_cleanup.py
@@ -408,7 +408,7 @@ async def _cleanup_stale_agent_runs(now: datetime) -> dict[str, Any]:
                             type="error",
                             error=chat_event["error"],
                             run_status=chat_event["status"],
-                        ).model_dump(mode="json", exclude_none=True),
+                        ),
                     )
             except Exception:
                 logger.warning(

--- a/api/src/services/chat_errors.py
+++ b/api/src/services/chat_errors.py
@@ -1,0 +1,11 @@
+"""Public error copy for the Chat user experience."""
+
+CHAT_FAILURE_MESSAGE = "We couldn't complete this response. Please try again."
+CHAT_TIMEOUT_MESSAGE = "This response took too long to complete. Please try again."
+
+
+def public_chat_error_message(status: str | None) -> str:
+    """Return safe public copy for a terminal Chat failure."""
+    if status == "timeout":
+        return CHAT_TIMEOUT_MESSAGE
+    return CHAT_FAILURE_MESSAGE

--- a/api/src/services/chat_runs.py
+++ b/api/src/services/chat_runs.py
@@ -28,8 +28,9 @@ from src.models.contracts.agents import (
 from src.models.enums import MessageRole
 from src.models.orm import Agent, AgentRun, Conversation, Message
 from src.repositories.agents import AgentRepository
-from src.services.execution.agent_run_service import enqueue_agent_run
 from src.services.chat_attachments import ChatAttachmentError, ChatAttachmentService
+from src.services.chat_errors import public_chat_error_message
+from src.services.execution.agent_run_service import enqueue_agent_run
 
 
 def _conversation_public(conversation: Conversation, message_count: int) -> ConversationPublic:
@@ -50,7 +51,10 @@ def _conversation_public(conversation: Conversation, message_count: int) -> Conv
 def _run_public(run: AgentRun | None) -> ChatRunPublic | None:
     if run is None:
         return None
-    return ChatRunPublic.model_validate(run)
+    public_run = ChatRunPublic.model_validate(run)
+    if public_run.error is not None:
+        public_run.error = public_chat_error_message(public_run.status)
+    return public_run
 
 
 async def _load_conversation_or_404(db: DbSession, conversation_id: UUID, user: UserPrincipal) -> Conversation:
@@ -285,13 +289,13 @@ async def create_chat_run(
             run_id=run_id,
             kind="run_status",
             status="queued",
-            payload={
-                "type": "run_status",
-                "conversation_id": str(conversation.id),
-                "user_message_id": str(user_message.id),
-                "local_id": str(user_message.id),
-                "run_status": "queued",
-            },
+            payload=ChatStreamChunk(
+                type="run_status",
+                conversation_id=str(conversation.id),
+                user_message_id=str(user_message.id),
+                local_id=str(user_message.id),
+                run_status="queued",
+            ),
         )
 
     try:
@@ -335,12 +339,12 @@ async def create_chat_run(
             run_id=client_run_id,
             kind="error",
             status="failed",
-            payload={
-                "type": "error",
-                "conversation_id": str(conversation.id),
-                "run_status": "failed",
-                "error": "Chat run could not be queued",
-            },
+            payload=ChatStreamChunk(
+                type="error",
+                conversation_id=str(conversation.id),
+                run_status="failed",
+                error="Chat run could not be queued",
+            ),
         )
         raise
 
@@ -427,11 +431,11 @@ async def cancel_chat_run(
         run_id=run.id,
         kind="run_status",
         status=run.status,
-        payload={
-            "type": "run_status",
-            "conversation_id": str(run.conversation_id),
-            "run_status": run.status,
-        },
+        payload=ChatStreamChunk(
+            type="run_status",
+            conversation_id=str(run.conversation_id),
+            run_status=run.status,
+        ),
     )
 
     return ChatRunCancelResponse(run_id=run.id, status=run.status)

--- a/api/tests/unit/jobs/schedulers/test_execution_cleanup.py
+++ b/api/tests/unit/jobs/schedulers/test_execution_cleanup.py
@@ -192,4 +192,4 @@ class TestExecutionCleanupAgentRuns:
         assert kwargs["run_id"] == str(run.id)
         assert kwargs["kind"] == "error"
         assert kwargs["status"] == "timeout"
-        assert kwargs["payload"]["run_status"] == "timeout"
+        assert kwargs["payload"].run_status == "timeout"

--- a/api/tests/unit/services/test_agent_run_consumer.py
+++ b/api/tests/unit/services/test_agent_run_consumer.py
@@ -686,6 +686,6 @@ async def test_chat_outer_failure_publishes_terminal_error_envelope(
         "failed",
     ]
     terminal_payload = publish_chat.await_args_list[-1].kwargs["payload"]
-    assert terminal_payload["type"] == "error"
-    assert terminal_payload["run_status"] == "failed"
+    assert terminal_payload.type == "error"
+    assert terminal_payload.run_status == "failed"
     assert publish_run.await_args.args[0].status == "failed"

--- a/api/tests/unit/services/test_chat_runs.py
+++ b/api/tests/unit/services/test_chat_runs.py
@@ -1,0 +1,44 @@
+"""Unit tests for public Chat run state."""
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from uuid import uuid4
+
+from src.services.chat_errors import CHAT_FAILURE_MESSAGE, CHAT_TIMEOUT_MESSAGE
+from src.services.chat_runs import _run_public
+
+
+def _run(*, status: str, error: str | None) -> SimpleNamespace:
+    return SimpleNamespace(
+        id=uuid4(),
+        conversation_id=uuid4(),
+        agent_id=None,
+        status=status,
+        error=error,
+        created_at=datetime.now(timezone.utc),
+        started_at=None,
+        completed_at=None,
+    )
+
+
+def test_run_public_replaces_internal_failure_diagnostic() -> None:
+    public_run = _run_public(
+        _run(status="failed", error="Traceback: internal implementation detail")
+    )
+
+    assert public_run is not None
+    assert public_run.error == CHAT_FAILURE_MESSAGE
+
+
+def test_run_public_uses_timeout_copy() -> None:
+    public_run = _run_public(_run(status="timeout", error="Timed out after 300s"))
+
+    assert public_run is not None
+    assert public_run.error == CHAT_TIMEOUT_MESSAGE
+
+
+def test_run_public_preserves_empty_error() -> None:
+    public_run = _run_public(_run(status="running", error=None))
+
+    assert public_run is not None
+    assert public_run.error is None

--- a/api/tests/unit/test_chat_run_pubsub.py
+++ b/api/tests/unit/test_chat_run_pubsub.py
@@ -10,6 +10,8 @@ from src.core.pubsub import (
     publish_chat_run_event,
     replay_chat_run_events,
 )
+from src.models.contracts.agents import ChatStreamChunk
+from src.services.chat_errors import CHAT_FAILURE_MESSAGE
 
 
 @pytest.mark.asyncio
@@ -37,7 +39,7 @@ async def test_chat_run_event_is_retained_before_realtime_broadcast():
             run_id,
             kind="run_status",
             status="queued",
-            payload={"type": "run_status", "run_status": "queued"},
+            payload=ChatStreamChunk(type="run_status", run_status="queued"),
         )
 
     assert event["type"] == "chat_run_event"
@@ -49,6 +51,41 @@ async def test_chat_run_event_is_retained_before_realtime_broadcast():
     assert _PUBLISH_CHAT_RUN_EVENT_SCRIPT.index("'XADD'") < (
         _PUBLISH_CHAT_RUN_EVENT_SCRIPT.index("'PUBLISH'")
     )
+
+
+@pytest.mark.asyncio
+async def test_chat_run_event_replaces_internal_terminal_error_before_publish():
+    redis = AsyncMock()
+
+    async def eval_script(_script, _num_keys, *_args):
+        envelope = json.loads(_args[2])
+        envelope["sequence"] = 1
+        return json.dumps(envelope)
+
+    redis.eval.side_effect = eval_script
+
+    @asynccontextmanager
+    async def redis_context():
+        yield redis
+
+    raw_error = "1 validation error for ChatStreamChunk"
+    chunk = ChatStreamChunk(
+        type="error",
+        run_status="failed",
+        error=raw_error,
+    )
+    with patch("src.core.pubsub.get_redis", return_value=redis_context()):
+        event = await publish_chat_run_event(
+            uuid4(),
+            uuid4(),
+            kind="error",
+            status="failed",
+            payload=chunk,
+        )
+
+    assert event["payload"]["error"] == CHAT_FAILURE_MESSAGE
+    assert raw_error not in json.dumps(event)
+    assert chunk.error == raw_error
 
 
 @pytest.mark.asyncio
@@ -85,3 +122,44 @@ async def test_chat_run_event_replay_filters_by_conversation_sequence():
         events = await replay_chat_run_events(uuid4(), after_sequence=1)
 
     assert [event["sequence"] for event in events] == [2, 3]
+
+
+@pytest.mark.asyncio
+async def test_chat_run_event_replay_replaces_retained_internal_error():
+    raw_error = "Traceback: internal implementation detail"
+    redis = AsyncMock()
+    redis.xrange.return_value = [
+        (
+            "1-0",
+            {
+                "event": json.dumps(
+                    {
+                        "type": "chat_run_event",
+                        "protocol_version": 1,
+                        "event_id": str(uuid4()),
+                        "sequence": 1,
+                        "conversation_id": str(uuid4()),
+                        "run_id": str(uuid4()),
+                        "occurred_at": "2026-09-02T12:00:00+00:00",
+                        "kind": "error",
+                        "status": "failed",
+                        "payload": {
+                            "type": "error",
+                            "run_status": "failed",
+                            "error": raw_error,
+                        },
+                    }
+                )
+            },
+        )
+    ]
+
+    @asynccontextmanager
+    async def redis_context():
+        yield redis
+
+    with patch("src.core.pubsub.get_redis", return_value=redis_context()):
+        events = await replay_chat_run_events(uuid4())
+
+    assert events[0]["payload"]["error"] == CHAT_FAILURE_MESSAGE
+    assert raw_error not in json.dumps(events)

--- a/api/tests/unit/test_chat_stream_serialization.py
+++ b/api/tests/unit/test_chat_stream_serialization.py
@@ -1,22 +1,140 @@
-"""Regression coverage for JSON-safe chat stream events."""
+"""Regression coverage for contract-safe chat stream serialization."""
 
-from src.models.contracts.agents import ChatStreamChunk
+import pytest
+
+from src.core.pubsub import serialize_chat_stream_chunk
+from src.models.contracts.agents import (
+    AgentSwitch,
+    ChatStreamChunk,
+    ContextWarning,
+    ToolCall,
+    ToolProgress,
+    ToolProgressLog,
+    ToolResult,
+)
 from src.models.contracts.artifacts import ArtifactRef
 
 
-def test_artifact_ready_chunk_dumps_portable_reference() -> None:
-    chunk = ChatStreamChunk(
-        type="artifact_ready",
+CHUNKS = [
+    ChatStreamChunk(type="message_start", message_id="message-1"),
+    ChatStreamChunk(type="delta", content="Hello"),
+    ChatStreamChunk(
+        type="assistant_message_end",
         message_id="message-1",
+        stop_reason="end_turn",
+    ),
+    ChatStreamChunk(
+        type="tool_call",
+        tool_call=ToolCall(id="call-1", name="lookup", arguments={"id": 1}),
+    ),
+    ChatStreamChunk(
+        type="tool_progress",
+        tool_progress=ToolProgress(
+            tool_call_id="call-1",
+            status="running",
+            log=ToolProgressLog(level="info", message="Working"),
+        ),
+    ),
+    ChatStreamChunk(
+        type="tool_result",
+        tool_result=ToolResult(
+            tool_call_id="call-1",
+            tool_name="lookup",
+            result={"found": True},
+        ),
+    ),
+    ChatStreamChunk(
+        type="tool_result",
+        tool_result=ToolResult(
+            tool_call_id="call-2",
+            tool_name="update",
+            result=None,
+            duration_ms=10,
+        ),
+    ),
+    ChatStreamChunk(
+        type="artifact_started",
         artifact=ArtifactRef(
             id="attachment-1",
             filename="Welcome Page.html",
             content_type="text/html",
             size_bytes=1024,
         ),
+    ),
+    ChatStreamChunk(
+        type="artifact_ready",
+        artifact=ArtifactRef(
+            id="attachment-1",
+            filename="Welcome Page.html",
+            content_type="text/html",
+            size_bytes=1024,
+        ),
+    ),
+    ChatStreamChunk(type="artifact_failed", error="Artifact generation failed"),
+    ChatStreamChunk(
+        type="agent_switch",
+        agent_switch=AgentSwitch(
+            agent_id="agent-2",
+            agent_name="Specialist",
+            reason="routed",
+        ),
+    ),
+    ChatStreamChunk(
+        type="context_warning",
+        context_warning=ContextWarning(
+            current_tokens=900,
+            max_tokens=1000,
+            action="warning",
+            message="Context is nearly full",
+        ),
+    ),
+    ChatStreamChunk(type="run_status", run_status="running"),
+    ChatStreamChunk(type="title_update", title="Updated title"),
+    ChatStreamChunk(type="done", run_status="completed", duration_ms=100),
+    ChatStreamChunk(type="cancelled", run_status="cancelled"),
+    ChatStreamChunk(type="error", run_status="failed", error="Internal failure"),
+]
+
+
+@pytest.mark.parametrize("chunk", CHUNKS, ids=lambda chunk: chunk.type)
+def test_chat_stream_chunk_round_trips_through_wire_payload(
+    chunk: ChatStreamChunk,
+) -> None:
+    payload = serialize_chat_stream_chunk(chunk)
+
+    assert ChatStreamChunk.model_validate(payload) == chunk
+
+
+def test_successful_null_tool_result_remains_present_on_wire() -> None:
+    chunk = ChatStreamChunk(
+        type="tool_result",
+        tool_result=ToolResult(
+            tool_call_id="call-1",
+            tool_name="enable",
+            result=None,
+            duration_ms=10,
+        ),
     )
 
-    payload = chunk.model_dump(mode="json", exclude_none=True)
+    payload = serialize_chat_stream_chunk(chunk)
+
+    assert payload["tool_result"]["result"] is None
+
+
+def test_explicit_top_level_null_remains_present_on_wire() -> None:
+    payload = serialize_chat_stream_chunk(
+        ChatStreamChunk(type="done", content=None, run_status="completed")
+    )
+
+    assert "content" in payload
+    assert payload["content"] is None
+    assert "tool_result" not in payload
+
+
+def test_artifact_chunk_dumps_portable_reference() -> None:
+    chunk = CHUNKS[8]
+
+    payload = serialize_chat_stream_chunk(chunk)
 
     assert payload["artifact"] == {
         "type": "bifrost_artifact",

--- a/client/src/lib/chat-runtime.test.ts
+++ b/client/src/lib/chat-runtime.test.ts
@@ -672,4 +672,49 @@ describe("chat-runtime reducer", () => {
 			},
 		});
 	});
+
+	it("never projects a server diagnostic into a user-visible chat error", () => {
+		const rawError =
+			"1 validation error for ChatStreamChunk tool_result.result Field required";
+		const projection = applyChatStreamEnvelope(
+			makeEmptyChatProjection("conversation-1"),
+			{
+				...makeEnvelope(1, "run-1", {
+					type: "error",
+					run_status: "failed",
+					error: rawError,
+				}),
+				status: "failed",
+			},
+		);
+
+		expect(projection.system_events).toContainEqual(
+			expect.objectContaining({
+				type: "error",
+				error: "We couldn't complete this response. Please try again.",
+			}),
+		);
+		expect(JSON.stringify(projection.system_events)).not.toContain(rawError);
+	});
+
+	it("uses safe timeout copy for timed-out chat runs", () => {
+		const projection = applyChatStreamEnvelope(
+			makeEmptyChatProjection("conversation-1"),
+			{
+				...makeEnvelope(1, "run-1", {
+					type: "error",
+					error: "Chat run timed out after 300s",
+				}),
+				status: "timeout",
+			},
+		);
+
+		expect(projection.system_events).toContainEqual(
+			expect.objectContaining({
+				type: "error",
+				error:
+					"This response took too long to complete. Please try again.",
+			}),
+		);
+	});
 });

--- a/client/src/lib/chat-runtime.ts
+++ b/client/src/lib/chat-runtime.ts
@@ -3,6 +3,11 @@ import type { ChatStreamChunk, ChatToolProgress } from "@/services/websocket";
 
 type MessagePublic = components["schemas"]["MessagePublic"];
 
+const CHAT_FAILURE_MESSAGE =
+	"We couldn't complete this response. Please try again.";
+const CHAT_TIMEOUT_MESSAGE =
+	"This response took too long to complete. Please try again.";
+
 export interface ChatContextWarningPayload {
 	current_tokens: number;
 	max_tokens: number;
@@ -981,11 +986,15 @@ function applyError(
 	projection: ChatProjection,
 	run: ChatRunProjection,
 	chunk: ChatStreamChunk,
+	status: string | null,
 	sequence: number,
 	occurredAt: string,
 	eventId: string | null,
 ): void {
-	const error = chunk.error ?? "Unknown error occurred";
+	const error =
+		(chunk.run_status ?? status) === "timeout"
+			? CHAT_TIMEOUT_MESSAGE
+			: CHAT_FAILURE_MESSAGE;
 	addSystemEvent(projection, {
 		type: "error",
 		id: eventId ?? makeSyntheticEventId("error", run.run_id, sequence),
@@ -1438,7 +1447,15 @@ function applyEnvelopeToProjection(
 			);
 			break;
 		case "error":
-			applyError(projection, run, chunk, sequence, occurredAt, dedupeId);
+			applyError(
+				projection,
+				run,
+				chunk,
+				envelope.status ?? null,
+				sequence,
+				occurredAt,
+				dedupeId,
+			);
 			break;
 		case "artifact_ready":
 			applyArtifactReady(projection, run, chunk, sequence);


### PR DESCRIPTION
## Summary

- serialize typed `ChatStreamChunk` values through one contract-safe boundary, preserving required null fields such as successful tool results while keeping the outer event union sparse
- replace raw terminal diagnostics with safe Chat copy for live events, retained replay, and run-state responses while preserving the original diagnostic in internal records and logs
- add client-side defense in depth and round-trip coverage for every Chat event variant

## Verification

- `./test.sh pre-pr` — passed for `b2dd41dcc12fcf77bfcdf4276e45a1cf9f2c333d`
- `./test.sh tests/unit/test_chat_stream_serialization.py tests/unit/test_chat_run_pubsub.py tests/unit/services/test_chat_runs.py -v` — 26 passed
- `./test.sh tests/unit/services/test_agent_run_consumer.py -v` — 9 passed
- `./test.sh client unit src/lib/chat-runtime.test.ts` — 12 passed
- `./test.sh quality api` — passed
- `(cd client && npm run tsc)` — passed
- `(cd client && npm run lint)` — passed

Fixes #703