### PR TITLE
Validate generic workflow MCP execution

### DIFF
--- a/api/src/services/mcp_server/tools/workflow.py
+++ b/api/src/services/mcp_server/tools/workflow.py
@@ -21,6 +21,10 @@ from fastmcp.tools import ToolResult
 from src.services.mcp_server.tool_result import error_result, success_result
 from src.services.mcp_server.tools._http_bridge import call_rest, rest_client
 from src.services.mcp_server.tools.db import get_tool_db
+from src.services.tool_schema import (
+    parameters_json_schema,
+    validate_arguments_against_schema,
+)
 
 # MCPContext is imported where needed to avoid circular imports
 
@@ -67,6 +71,37 @@ async def execute_workflow(
 
             if not workflow:
                 return error_result(f"Workflow '{workflow_id}' not found. Use list_workflows to see available workflows.")
+
+            input_schema = parameters_json_schema(
+                workflow.parameters_schema or [],
+                allow_unknown_when_empty=True,
+            )
+            issues, schema_error = validate_arguments_against_schema(
+                input_schema,
+                params,
+            )
+            if schema_error:
+                return error_result(
+                    "The workflow's live input schema is invalid and cannot be executed.",
+                    {
+                        "code": "TOOL_SCHEMA_INVALID",
+                        "workflow_id": str(workflow.id),
+                        "workflow_name": workflow.name,
+                        "schema_error": schema_error,
+                    },
+                )
+            if issues:
+                return error_result(
+                    "Arguments do not match the workflow's live input schema. "
+                    "Inspect input_schema or call get_workflow before retrying.",
+                    {
+                        "code": "INVALID_ARGUMENTS",
+                        "workflow_id": str(workflow.id),
+                        "workflow_name": workflow.name,
+                        "issues": issues,
+                        "input_schema": input_schema,
+                    },
+                )
 
             result = await execute_tool(
                 workflow_id=str(workflow.id),
@@ -660,7 +695,12 @@ async def revoke_workflow_role(
 
 # Tool metadata for registration
 TOOLS = [
-    ("execute_workflow", "Execute Workflow", "Execute a Bifrost workflow by ID or name and return the results. Use list_workflows to get workflow IDs."),
+    (
+        "execute_workflow",
+        "Execute Workflow",
+        "Execute a Bifrost workflow by ID or name using its live input schema. "
+        "Use list_workflows to find workflows and get_workflow to inspect parameters.",
+    ),
     ("list_workflows", "List Workflows", "List workflows registered in Bifrost."),
     ("validate_workflow", "Validate Workflow", "Validate a workflow Python file for syntax and decorator issues."),
     ("get_workflow", "Get Workflow", "Get detailed metadata for a specific workflow by ID or name."),

--- a/api/tests/unit/services/mcp_server/test_gateway.py
+++ b/api/tests/unit/services/mcp_server/test_gateway.py
@@ -617,6 +617,36 @@ async def test_execute_validates_before_dispatch():
 
 
 @pytest.mark.asyncio
+async def test_execute_keeps_legacy_empty_schema_permissive():
+    service = MCPAgentGatewayService(_context())
+    agent = _agent()
+    tool = _resolved_tool(
+        parameters={
+            "type": "object",
+            "properties": {},
+            "additionalProperties": True,
+        }
+    )
+    snapshot = AgentToolSnapshot(agent=agent, tools=[tool])
+    arguments = {"existing_solution_argument": "still accepted"}
+
+    with patch.object(
+        service,
+        "_dispatch",
+        new=AsyncMock(return_value={"output": "ok"}),
+    ) as dispatch:
+        result = await service.execute_tool(snapshot, tool, arguments)
+
+    assert result["result"] == {"output": "ok"}
+    dispatch.assert_awaited_once_with(
+        agent,
+        tool,
+        arguments,
+        async_execution=False,
+    )
+
+
+@pytest.mark.asyncio
 async def test_execute_returns_auditable_envelope():
     service = MCPAgentGatewayService(_context())
     agent = _agent()

--- a/api/tests/unit/services/test_mcp_tools.py
+++ b/api/tests/unit/services/test_mcp_tools.py
@@ -68,6 +68,7 @@ def mock_workflow():
     mock.endpoint_enabled = True
     mock.path = "/tmp/bifrost/workspace/workflows/test_workflow.py"
     mock.is_active = True
+    mock.parameters_schema = []
     return mock
 
 
@@ -655,6 +656,92 @@ class TestExecuteWorkflow:
         assert data["status"] == "Failed"
         assert data["error"] == "Division by zero"
         assert data["error_type"] == "ValueError"
+
+    @pytest.mark.asyncio
+    async def test_rejects_invalid_registered_arguments_before_execution(
+        self, org_user_context, mock_workflow
+    ):
+        """A generic workflow call must enforce the selected live contract."""
+        mock_workflow.parameters_schema = [
+            {
+                "name": "query",
+                "type": "string",
+                "required": True,
+            }
+        ]
+
+        with patch("src.core.database.get_db_context") as mock_db_ctx:
+            mock_session = AsyncMock()
+            mock_db_ctx.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+            mock_db_ctx.return_value.__aexit__ = AsyncMock(return_value=None)
+
+            with patch(
+                "src.repositories.workflows.WorkflowRepository"
+            ) as mock_repo_cls:
+                mock_repo = MagicMock()
+                mock_repo.resolve = AsyncMock(return_value=mock_workflow)
+                mock_repo_cls.return_value = mock_repo
+
+                with patch(
+                    "src.services.execution.service.execute_tool"
+                ) as mock_execute:
+                    result = await execute_workflow(
+                        org_user_context,
+                        str(mock_workflow.id),
+                        {"sql": "SELECT 1"},
+                    )
+
+        data = result.structured_content
+        assert data["code"] == "INVALID_ARGUMENTS"
+        assert data["workflow_id"] == str(mock_workflow.id)
+        assert data["workflow_name"] == mock_workflow.name
+        assert data["input_schema"]["required"] == ["query"]
+        assert {issue["validator"] for issue in data["issues"]} == {
+            "additionalProperties",
+            "required",
+        }
+        mock_execute.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_legacy_empty_schema_remains_permissive(
+        self, org_user_context, mock_workflow
+    ):
+        """Old Solution registrations keep working before they are redeployed."""
+        mock_workflow.parameters_schema = []
+        mock_result = MagicMock()
+        mock_result.status.value = "Success"
+        mock_result.duration_ms = 100
+        mock_result.result = {"output": "ok"}
+        mock_result.error = None
+        mock_result.error_type = None
+
+        with patch("src.core.database.get_db_context") as mock_db_ctx:
+            mock_session = AsyncMock()
+            mock_db_ctx.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+            mock_db_ctx.return_value.__aexit__ = AsyncMock(return_value=None)
+
+            with patch(
+                "src.repositories.workflows.WorkflowRepository"
+            ) as mock_repo_cls:
+                mock_repo = MagicMock()
+                mock_repo.resolve = AsyncMock(return_value=mock_workflow)
+                mock_repo_cls.return_value = mock_repo
+
+                with patch(
+                    "src.services.execution.service.execute_tool"
+                ) as mock_execute:
+                    mock_execute.return_value = mock_result
+                    result = await execute_workflow(
+                        org_user_context,
+                        str(mock_workflow.id),
+                        {"existing_solution_argument": "still accepted"},
+                    )
+
+        assert result.structured_content["success"] is True
+        mock_execute.assert_awaited_once()
+        assert mock_execute.call_args.kwargs["parameters"] == {
+            "existing_solution_argument": "still accepted"
+        }
 
     @pytest.mark.asyncio
     async def test_handles_missing_workflow_id(self, org_user_context):


### PR DESCRIPTION
## Summary
- validate the legacy generic execute_workflow system tool against the selected workflow live schema before execution
- preserve permissive argument forwarding for legacy Solution registrations with empty schemas
- add an explicit compatibility regression at the default unscoped MCP gateway bifrost_execute_tool boundary
- point callers to get_workflow when arguments need repair

## Endpoint distinction
The default unscoped /mcp endpoint exposes bifrost_execute_tool, not execute_workflow. The earlier merged gateway change already performs live-schema validation there. This follow-up covers the older execute_workflow system tool, which can be exposed on agent-scoped /mcp/{agent_id} endpoints, and adds explicit no-redeploy coverage for both paths.

## Compatibility
Existing Solution registrations whose parameters_schema is empty remain permissive and continue forwarding their current argument objects. No Solution redeploy is required to keep existing behavior. A redeploy after the platform update is only needed to backfill a rich schema and opt that workflow into early validation.

## Validation
- focused MCP/tool-schema suites: 149 passed
- ./test.sh pre-pr on commit 2b141a4de3a59bc1ba33472044f62c0d7befcb4c: passed
  - frontend: 1929 passed
  - Python unit/integration: 5933 passed, 3 skipped
  - API end-to-end: 1769 passed, 40 skipped
  - browser smoke: 4 passed
  - production API image startup: passed