### PR TITLE
Add atomic bulk table upserts for metadata ingestion

### DIFF
--- a/.claude/skills/bifrost-build/generated/openapi-digest.md
+++ b/.claude/skills/bifrost-build/generated/openapi-digest.md
@@ -518,6 +518,7 @@
 | POST | `/api/tables/{table_id}/documents` |
 | POST | `/api/tables/{table_id}/documents/batch` |
 | POST | `/api/tables/{table_id}/documents/batch-delete` |
+| POST | `/api/tables/{table_id}/documents/bulk-upsert` |
 | GET | `/api/tables/{table_id}/documents/count` |
 | POST | `/api/tables/{table_id}/documents/query` |
 | POST | `/api/tables/{table_id}/documents/upsert` |

--- a/.claude/skills/bifrost-build/generated/python-sdk-signatures.md
+++ b/.claude/skills/bifrost-build/generated/python-sdk-signatures.md
@@ -194,6 +194,8 @@ Event publishing operations (async).
 
 
 
+**`tables.bulk_upsert(table: str, documents: list[dict[str, Any]], scope: str | None = None, created_by: str | None = None, updated_by: str | None = None, conflict_retries: int = 2) -> BulkUpsertResult`**
+
 **`tables.count(table: str, where: dict[str, Any] | None = None, scope: str | None = None) -> int`**
 
 **`tables.create(name: str, description: str | None = None, table_schema: dict[str, Any] | None = None, scope: str | None = None, app: str | None = None) -> TableInfo`**

--- a/api/bifrost/__init__.py
+++ b/api/bifrost/__init__.py
@@ -120,6 +120,7 @@ from .models import (
     DocumentList,
     BatchResult,
     BatchDeleteResult,
+    BulkUpsertResult,
 )
 
 # ExecutionContext lives in bifrost/ — available in both CLI and platform
@@ -278,6 +279,7 @@ __all__ = [
     'DocumentList',
     'BatchResult',
     'BatchDeleteResult',
+    'BulkUpsertResult',
     # Decorators
     'workflow',
     'data_provider',

--- a/api/bifrost/models.py
+++ b/api/bifrost/models.py
@@ -380,3 +380,9 @@ class BatchDeleteResult(BaseModel):
 
     deleted_ids: list[str]
     count: int
+
+
+class BulkUpsertResult(BaseModel):
+    """Count-only result for privileged table bulk upsert."""
+
+    count: int

--- a/api/bifrost/tables.py
+++ b/api/bifrost/tables.py
@@ -12,7 +12,14 @@ from typing import Any
 from urllib.parse import urlencode
 
 from .client import get_client, raise_for_status_with_detail
-from .models import TableInfo, DocumentData, DocumentList, BatchResult, BatchDeleteResult
+from .models import (
+    TableInfo,
+    DocumentData,
+    DocumentList,
+    BatchResult,
+    BatchDeleteResult,
+    BulkUpsertResult,
+)
 from ._context import resolve_scope, _execution_context
 
 
@@ -508,6 +515,70 @@ class tables:
             created_by=created_by,
             updated_by=updated_by,
         )
+
+    @staticmethod
+    async def bulk_upsert(
+        table: str,
+        documents: list[dict[str, Any]],
+        scope: str | None = None,
+        created_by: str | None = None,
+        updated_by: str | None = None,
+        conflict_retries: int = 2,
+    ) -> BulkUpsertResult:
+        """
+        Bulk upsert explicit-id documents with full replacement semantics.
+
+        This privileged ingestion method uses the count-only
+        ``POST /documents/bulk-upsert`` route. Each document must have
+        ``id`` and ``data`` keys. The server enforces a maximum of 1000 rows
+        per request and rejects duplicate IDs.
+
+        Args:
+            table: Table name or UUID.
+            documents: List of dicts, each with "id" (str) and "data" (dict).
+            scope: Organization scope.
+            created_by: Override attribution on inserted rows.
+            updated_by: Override attribution on inserted and updated rows.
+            conflict_retries: Number of bounded retries when the server detects
+                a concurrent insert between policy preflight and the guarded
+                upsert statement.
+
+        Returns:
+            BulkUpsertResult: Count of rows inserted or updated.
+        """
+        ctx = _current_context()
+        if created_by is None and ctx is not None and getattr(ctx, "user_id", None) is not None:
+            created_by = str(ctx.user_id)
+        if updated_by is None and ctx is not None and getattr(ctx, "user_id", None) is not None:
+            updated_by = str(ctx.user_id)
+        effective_scope = resolve_scope(scope)
+
+        items: list[dict[str, Any]] = []
+        for doc in documents:
+            item: dict[str, Any] = {"id": doc["id"], "data": doc["data"]}
+            if created_by is not None:
+                item["created_by"] = created_by
+            if updated_by is not None:
+                item["updated_by"] = updated_by
+            items.append(item)
+
+        client = get_client()
+        url = f"/api/tables/{table}/documents/bulk-upsert{_scope_query(effective_scope)}"
+        body = {"documents": items}
+        attempts = max(0, conflict_retries) + 1
+        ensured_table = False
+        response = None
+        for attempt in range(attempts):
+            response = await client.post(url, json=body)
+            if response.status_code == 404 and not _has_solution_context() and not ensured_table:
+                await _ensure_table_exists(table, effective_scope)
+                ensured_table = True
+                response = await client.post(url, json=body)
+            if response.status_code != 409 or attempt == attempts - 1:
+                break
+        assert response is not None
+        raise_for_status_with_detail(response)
+        return BulkUpsertResult.model_validate(response.json())
 
     @staticmethod
     async def _batch_write(

--- a/api/src/models/contracts/tables.py
+++ b/api/src/models/contracts/tables.py
@@ -215,6 +215,32 @@ class DocumentBatchCreate(BaseModel):
     )
 
 
+class DocumentBulkUpsertItem(BaseModel):
+    """A single explicit-id document for the privileged bulk upsert endpoint."""
+
+    id: str = Field(..., min_length=1, max_length=255, description="Document ID to upsert")
+    data: dict[str, Any] = Field(..., description="Replacement document data")
+    created_by: str | None = Field(
+        default=None,
+        description="Override attribution for inserted rows. Platform-admin callers only.",
+    )
+    updated_by: str | None = Field(
+        default=None,
+        description="Override attribution for inserted and updated rows. Platform-admin callers only.",
+    )
+
+
+class DocumentBulkUpsertRequest(BaseModel):
+    """Input for set-based, explicit-id bulk upsert."""
+
+    documents: list[DocumentBulkUpsertItem] = Field(
+        ...,
+        min_length=1,
+        max_length=1000,
+        description="Documents to upsert. Maximum 1000 rows per request.",
+    )
+
+
 class DocumentBatchCreateResponse(BaseModel):
     """Response for a batch insert or upsert."""
 
@@ -234,6 +260,12 @@ class DocumentBatchUpsertResponse(BaseModel):
 
     upserted: int
     errors: list[dict[str, Any]] = Field(default_factory=list)
+
+
+class DocumentBulkUpsertResponse(BaseModel):
+    """Count-only response for privileged bulk upsert."""
+
+    count: int
 
 
 class DocumentBatchDeleteRequest(BaseModel):

--- a/api/src/routers/tables.py
+++ b/api/src/routers/tables.py
@@ -42,6 +42,8 @@ from src.models.contracts.tables import (
     DocumentBatchCreateResponse,
     DocumentBatchDeleteRequest,
     DocumentBatchDeleteResponse,
+    DocumentBulkUpsertRequest,
+    DocumentBulkUpsertResponse,
     DocumentCountResponse,
     DocumentCreate,
     DocumentListResponse,
@@ -321,6 +323,22 @@ class DocumentRepository:
         result = await self.session.execute(query)
         return result.scalar_one_or_none()
 
+    async def get_many_for_update(self, doc_ids: list[str]) -> dict[str, Document]:
+        """Get existing documents by ID and lock them for a bulk write."""
+        if not doc_ids:
+            return {}
+        query = (
+            select(Document)
+            .where(
+                Document.id.in_(doc_ids),
+                Document.table_id == self.table.id,
+            )
+            .order_by(Document.id)
+            .with_for_update()
+        )
+        result = await self.session.execute(query)
+        return {doc.id: doc for doc in result.scalars().all()}
+
     async def update(
         self,
         doc_id: str,
@@ -395,6 +413,58 @@ class DocumentRepository:
         doc = await self.get(doc_id)
         assert doc is not None  # we just upserted it
         return doc, inserted
+
+    async def bulk_upsert(
+        self,
+        rows: list[tuple[str, dict[str, Any], str | None, str | None]],
+        *,
+        update_ids: set[str],
+    ) -> int:
+        """Set-based upsert for privileged ingestion.
+
+        ``rows`` contains ``(id, data, created_by, updated_by)`` tuples. On
+        conflict the JSONB ``data`` column is replaced; insert-only fields such
+        as ``created_by`` and ``created_at`` are preserved for existing rows.
+        Only IDs present in ``update_ids`` may take the update branch; a row
+        inserted concurrently after the policy preflight returns no row so the
+        caller can roll back and report a race.
+        """
+        from sqlalchemy.dialects.postgresql import insert as pg_insert
+
+        now = datetime.now(timezone.utc)
+        values = [
+            {
+                "id": doc_id,
+                "table_id": self.table.id,
+                "data": data,
+                "created_by": created_by,
+                "updated_by": updated_by if updated_by is not None else created_by,
+                "created_at": now,
+                "updated_at": now,
+            }
+            for doc_id, data, created_by, updated_by in sorted(
+                rows, key=lambda row: row[0]
+            )
+        ]
+        insert_stmt = pg_insert(Document).values(values)
+        stmt = (
+            insert_stmt
+            .on_conflict_do_update(
+                index_elements=["table_id", "id"],
+                set_={
+                    "data": insert_stmt.excluded.data,
+                    "updated_by": insert_stmt.excluded.updated_by,
+                    "updated_at": now,
+                },
+                where=(
+                    (Document.table_id == self.table.id)
+                    & (Document.id.in_(update_ids))
+                ),
+            )
+            .returning(Document.id)
+        )
+        result = await self.session.execute(stmt)
+        return len(result.all())
 
     async def delete(self, doc_id: str) -> bool:
         """Delete a document."""
@@ -1123,6 +1193,95 @@ async def upsert_document(
         new_row=_row_from_doc(doc),
     )
     return DocumentPublic.model_validate(doc)
+
+
+@router.post(
+    "/{table_id}/documents/bulk-upsert",
+    response_model=DocumentBulkUpsertResponse,
+    summary="Bulk upsert documents by explicit id",
+)
+async def bulk_upsert_documents(
+    table_id: str,
+    body: DocumentBulkUpsertRequest,
+    ctx: Context,
+    _user: CurrentSuperuser,
+    scope: str | None = Query(
+        None,
+        description="Target organization scope: 'global' or org UUID. Defaults to caller's home org. Provider admins only for non-self orgs.",
+    ),
+) -> DocumentBulkUpsertResponse:
+    """Set-based privileged ingestion path for explicit-id full replacements.
+
+    This route enforces normal table resolution, solution ownership, and table
+    row policies before issuing one guarded upsert statement. It intentionally
+    skips per-row realtime publishing; callers that need progress events
+    publish them separately.
+    """
+    table = await get_table_or_404(ctx, table_id, scope=scope)
+    await _assert_solution_write_targets_owned_table(ctx, table)
+
+    seen: set[str] = set()
+    duplicates: list[str] = []
+    for item in body.documents:
+        if item.id in seen and item.id not in duplicates:
+            duplicates.append(item.id)
+        seen.add(item.id)
+    if duplicates:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail={"duplicate_ids": duplicates},
+        )
+
+    rows: list[tuple[str, dict[str, Any], str | None, str | None]] = []
+    for item in body.documents:
+        created_by, updated_by = _resolve_attribution(
+            ctx.user, item.created_by, item.updated_by
+        )
+        rows.append((item.id, item.data, created_by, updated_by))
+    repo = DocumentRepository(ctx.db, table)
+    existing = await repo.get_many_for_update([item.id for item in body.documents])
+
+    policies = await load_resolved_table_policies(table, ctx.db)
+    await preresolve_for_policies(
+        ctx.user,
+        policies,
+        ctx.db,
+        table.organization_id,
+        table.solution_id,
+    )
+    denied: list[int] = []
+    for index, item in enumerate(body.documents):
+        existing_doc = existing.get(item.id)
+        if existing_doc is not None:
+            if not evaluate_action(
+                "update", policies, _row_from_doc(existing_doc), ctx.user
+            ):
+                denied.append(index)
+            continue
+        created_by, updated_by = rows[index][2], rows[index][3]
+        candidate_row: dict[str, Any] = {
+            **item.data,
+            "id": item.id,
+            "created_by": created_by,
+            "updated_by": updated_by,
+        }
+        if not evaluate_action("create", policies, candidate_row, ctx.user):
+            denied.append(index)
+    if denied:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail={"denied_row_indices": denied},
+        )
+
+    count = await repo.bulk_upsert(rows, update_ids=set(existing))
+    if count != len(rows):
+        await ctx.db.rollback()
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Bulk upsert conflicted with a concurrent insert; retry the request",
+        )
+    await ctx.db.commit()
+    return DocumentBulkUpsertResponse(count=count)
 
 
 @router.get(

--- a/api/tests/e2e/test_table_bulk_upsert.py
+++ b/api/tests/e2e/test_table_bulk_upsert.py
@@ -1,0 +1,220 @@
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from sqlalchemy import delete, select
+
+from src.models.orm.solutions import Solution
+from src.models.orm.tables import Document, Table
+
+pytestmark = pytest.mark.e2e
+
+
+def _admin_policy(actions: list[str] | None = None) -> dict:
+    return {
+        "policies": [
+            {
+                "name": "admin_bypass",
+                "actions": actions or ["read", "create", "update", "delete"],
+                "when": {"user": "is_platform_admin"},
+            }
+        ]
+    }
+
+
+def _create_table(
+    e2e_client,
+    platform_admin,
+    *,
+    organization_id=None,
+    policy_actions: list[str] | None = None,
+) -> str:
+    response = e2e_client.post(
+        "/api/tables",
+        headers=platform_admin.headers,
+        json={
+            "name": f"bulk_{uuid.uuid4().hex[:8]}",
+            "organization_id": organization_id,
+            "policies": _admin_policy(policy_actions),
+        },
+    )
+    assert response.status_code == 201, response.text
+    return response.json()["id"]
+
+
+def _bulk_body(*rows: tuple[str, dict]) -> dict:
+    return {"documents": [{"id": doc_id, "data": data} for doc_id, data in rows]}
+
+
+def test_bulk_upsert_requires_platform_admin(e2e_client, platform_admin, org1_user):
+    table_id = _create_table(e2e_client, platform_admin)
+    try:
+        response = e2e_client.post(
+            f"/api/tables/{table_id}/documents/bulk-upsert",
+            headers=org1_user.headers,
+            json=_bulk_body(("a", {"value": 1})),
+        )
+        assert response.status_code == 403, response.text
+    finally:
+        e2e_client.delete(f"/api/tables/{table_id}", headers=platform_admin.headers)
+
+
+def test_bulk_upsert_honors_table_policies_for_platform_admin(
+    e2e_client,
+    platform_admin,
+):
+    table_id = _create_table(e2e_client, platform_admin, policy_actions=["read"])
+    try:
+        response = e2e_client.post(
+            f"/api/tables/{table_id}/documents/bulk-upsert",
+            headers=platform_admin.headers,
+            json=_bulk_body(("denied", {"value": 1})),
+        )
+        assert response.status_code == 403, response.text
+        assert response.json()["detail"] == {"denied_row_indices": [0]}
+
+        count = e2e_client.get(
+            f"/api/tables/{table_id}/documents/count",
+            headers=platform_admin.headers,
+        )
+        assert count.status_code == 200, count.text
+        assert count.json()["count"] == 0
+    finally:
+        e2e_client.delete(f"/api/tables/{table_id}", headers=platform_admin.headers)
+
+
+def test_bulk_upsert_rejects_duplicate_ids_atomically(e2e_client, platform_admin):
+    table_id = _create_table(e2e_client, platform_admin)
+    try:
+        response = e2e_client.post(
+            f"/api/tables/{table_id}/documents/bulk-upsert",
+            headers=platform_admin.headers,
+            json=_bulk_body(("dup", {"value": 1}), ("dup", {"value": 2})),
+        )
+        assert response.status_code == 422, response.text
+        assert response.json()["detail"] == {"duplicate_ids": ["dup"]}
+
+        count = e2e_client.get(
+            f"/api/tables/{table_id}/documents/count",
+            headers=platform_admin.headers,
+        )
+        assert count.status_code == 200, count.text
+        assert count.json()["count"] == 0
+    finally:
+        e2e_client.delete(f"/api/tables/{table_id}", headers=platform_admin.headers)
+
+
+def test_bulk_upsert_idempotent_replay_replaces_data_and_counts(
+    e2e_client,
+    platform_admin,
+):
+    table_id = _create_table(e2e_client, platform_admin)
+    try:
+        first = e2e_client.post(
+            f"/api/tables/{table_id}/documents/bulk-upsert",
+            headers=platform_admin.headers,
+            json=_bulk_body(
+                ("alpha", {"keep": "first", "remove": "gone"}),
+                ("beta", {"nullable": None}),
+            ),
+        )
+        assert first.status_code == 200, first.text
+        assert first.json() == {"count": 2}
+
+        replay = e2e_client.post(
+            f"/api/tables/{table_id}/documents/bulk-upsert",
+            headers=platform_admin.headers,
+            json=_bulk_body(
+                ("alpha", {"keep": "second", "nullable": None}),
+                ("gamma", {"created": True}),
+            ),
+        )
+        assert replay.status_code == 200, replay.text
+        assert replay.json() == {"count": 2}
+
+        alpha = e2e_client.get(
+            f"/api/tables/{table_id}/documents/alpha",
+            headers=platform_admin.headers,
+        )
+        assert alpha.status_code == 200, alpha.text
+        assert alpha.json()["data"] == {"keep": "second", "nullable": None}
+
+        count = e2e_client.get(
+            f"/api/tables/{table_id}/documents/count",
+            headers=platform_admin.headers,
+        )
+        assert count.status_code == 200, count.text
+        assert count.json()["count"] == 3
+    finally:
+        e2e_client.delete(f"/api/tables/{table_id}", headers=platform_admin.headers)
+
+
+def test_bulk_upsert_rolls_back_when_request_validation_fails(
+    e2e_client,
+    platform_admin,
+):
+    table_id = _create_table(e2e_client, platform_admin)
+    try:
+        response = e2e_client.post(
+            f"/api/tables/{table_id}/documents/bulk-upsert",
+            headers=platform_admin.headers,
+            json={"documents": [{"id": "valid", "data": {"x": 1}}, {"id": "bad", "data": []}]},
+        )
+        assert response.status_code == 422, response.text
+
+        count = e2e_client.get(
+            f"/api/tables/{table_id}/documents/count",
+            headers=platform_admin.headers,
+        )
+        assert count.status_code == 200, count.text
+        assert count.json()["count"] == 0
+    finally:
+        e2e_client.delete(f"/api/tables/{table_id}", headers=platform_admin.headers)
+
+
+@pytest.mark.asyncio
+async def test_bulk_upsert_solution_context_cannot_write_foreign_solution_table(
+    db_session,
+    e2e_client,
+    platform_admin,
+):
+    owning_solution = Solution(
+        id=uuid.uuid4(),
+        slug=f"bulk-own-{uuid.uuid4().hex[:8]}",
+        name="Bulk Owner",
+    )
+    foreign_solution = Solution(
+        id=uuid.uuid4(),
+        slug=f"bulk-foreign-{uuid.uuid4().hex[:8]}",
+        name="Bulk Foreign",
+    )
+    table = Table(
+        id=uuid.uuid4(),
+        name=f"bulk_solution_{uuid.uuid4().hex[:8]}",
+        organization_id=None,
+        solution_id=owning_solution.id,
+        access=_admin_policy(),
+    )
+    db_session.add_all([owning_solution, foreign_solution, table])
+    await db_session.commit()
+    try:
+        response = e2e_client.post(
+            f"/api/tables/{table.id}/documents/bulk-upsert?solution={foreign_solution.id}",
+            headers=platform_admin.headers,
+            json=_bulk_body(("blocked", {"value": 1})),
+        )
+        assert response.status_code == 404, response.text
+
+        rows = (
+            await db_session.execute(
+                select(Document).where(Document.table_id == table.id)
+            )
+        ).scalars().all()
+        assert rows == []
+    finally:
+        await db_session.execute(delete(Table).where(Table.id == table.id))
+        await db_session.execute(
+            delete(Solution).where(Solution.id.in_([owning_solution.id, foreign_solution.id]))
+        )
+        await db_session.commit()

--- a/api/tests/unit/sdk/test_sdk_tables.py
+++ b/api/tests/unit/sdk/test_sdk_tables.py
@@ -5,6 +5,9 @@ Tests SDK module structure and API method signatures.
 Integration tests for actual API calls are in tests/integration/platform/.
 """
 
+import importlib
+from unittest.mock import AsyncMock, MagicMock
+
 import pytest
 
 
@@ -32,6 +35,7 @@ class TestTablesSDKImports:
 
         assert hasattr(tables, 'insert_batch')
         assert hasattr(tables, 'upsert_batch')
+        assert hasattr(tables, 'bulk_upsert')
         assert hasattr(tables, 'delete_batch')
 
     def test_import_table_models(self):
@@ -44,10 +48,11 @@ class TestTablesSDKImports:
 
     def test_import_batch_models(self):
         """Test importing batch result models."""
-        from bifrost import BatchResult, BatchDeleteResult
+        from bifrost import BatchResult, BatchDeleteResult, BulkUpsertResult
 
         assert BatchResult is not None
         assert BatchDeleteResult is not None
+        assert BulkUpsertResult is not None
 
     def test_table_info_model_fields(self):
         """Test TableInfo model has expected fields."""
@@ -135,6 +140,82 @@ class TestTablesSDKImports:
 
         assert result.deleted_ids == ["id-1", "id-2"]
         assert result.count == 2
+
+    def test_bulk_upsert_result_model_fields(self):
+        """Test BulkUpsertResult model has expected fields."""
+        from bifrost import BulkUpsertResult
+
+        result = BulkUpsertResult(count=3)
+
+        assert result.count == 3
+
+
+@pytest.mark.asyncio
+async def test_tables_bulk_upsert_posts_count_only_request(monkeypatch):
+    module = importlib.import_module("bifrost.tables")
+    from bifrost import tables
+
+    response = MagicMock(status_code=200)
+    response.json.return_value = {"count": 2}
+    client = MagicMock()
+    client.post = AsyncMock(return_value=response)
+    monkeypatch.setattr(module, "get_client", lambda: client)
+    monkeypatch.setattr(module, "raise_for_status_with_detail", MagicMock())
+
+    result = await tables.bulk_upsert(
+        "customers",
+        [
+            {"id": "a", "data": {"x": 1}},
+            {"id": "b", "data": {"y": None}},
+        ],
+        scope="global",
+        created_by="importer",
+        updated_by="importer",
+    )
+
+    assert result.count == 2
+    client.post.assert_awaited_once_with(
+        "/api/tables/customers/documents/bulk-upsert?scope=global",
+        json={
+            "documents": [
+                {
+                    "id": "a",
+                    "data": {"x": 1},
+                    "created_by": "importer",
+                    "updated_by": "importer",
+                },
+                {
+                    "id": "b",
+                    "data": {"y": None},
+                    "created_by": "importer",
+                    "updated_by": "importer",
+                },
+            ]
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_tables_bulk_upsert_retries_bounded_conflict(monkeypatch):
+    module = importlib.import_module("bifrost.tables")
+    from bifrost import tables
+
+    conflict = MagicMock(status_code=409)
+    success = MagicMock(status_code=200)
+    success.json.return_value = {"count": 1}
+    client = MagicMock()
+    client.post = AsyncMock(side_effect=[conflict, success])
+    monkeypatch.setattr(module, "get_client", lambda: client)
+    monkeypatch.setattr(module, "raise_for_status_with_detail", MagicMock())
+
+    result = await tables.bulk_upsert(
+        "customers",
+        [{"id": "a", "data": {"x": 1}}],
+        conflict_retries=1,
+    )
+
+    assert result.count == 1
+    assert client.post.await_count == 2
 
 
 class TestTablesSDKWithoutContext:

--- a/api/tests/unit/test_table_bulk_upsert_route.py
+++ b/api/tests/unit/test_table_bulk_upsert_route.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from uuid import uuid4
+
+import pytest
+from fastapi import HTTPException
+
+from src.core.principal import UserPrincipal
+from src.models.contracts.policies import TablePolicies
+from src.models.contracts.tables import DocumentBulkUpsertRequest
+
+
+class _FakeDb:
+    def __init__(self) -> None:
+        self.committed = False
+        self.rolled_back = False
+
+    async def commit(self) -> None:
+        self.committed = True
+
+    async def rollback(self) -> None:
+        self.rolled_back = True
+
+
+class _RaceRepo:
+    async def get_many_for_update(self, doc_ids):
+        return {}
+
+    async def bulk_upsert(self, rows, *, update_ids):
+        assert update_ids == set()
+        return 0
+
+
+@pytest.mark.asyncio
+async def test_bulk_upsert_rolls_back_and_409s_on_guarded_count_mismatch(monkeypatch):
+    import src.routers.tables as router
+
+    table = SimpleNamespace(
+        id=uuid4(),
+        name="bulk_race",
+        organization_id=None,
+        solution_id=None,
+    )
+    db = _FakeDb()
+    user = UserPrincipal(
+        user_id=uuid4(),
+        email="admin@example.com",
+        organization_id=None,
+        is_superuser=True,
+        roles=["authenticated"],
+    )
+    ctx = SimpleNamespace(
+        db=db,
+        user=user,
+        org_id=None,
+        solution_id=None,
+        app_id=None,
+    )
+
+    async def fake_get_table_or_404(*args, **kwargs):
+        return table
+
+    async def fake_solution_gate(*args, **kwargs):
+        return None
+
+    async def fake_load_policies(*args, **kwargs):
+        return TablePolicies()
+
+    async def fake_preresolve(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(router, "get_table_or_404", fake_get_table_or_404)
+    monkeypatch.setattr(router, "_assert_solution_write_targets_owned_table", fake_solution_gate)
+    monkeypatch.setattr(router, "DocumentRepository", lambda db, table: _RaceRepo())
+    monkeypatch.setattr(router, "load_resolved_table_policies", fake_load_policies)
+    monkeypatch.setattr(router, "preresolve_for_policies", fake_preresolve)
+    monkeypatch.setattr(router, "evaluate_action", lambda *args, **kwargs: True)
+
+    body = DocumentBulkUpsertRequest(
+        documents=[{"id": "new-row", "data": {"value": 1}}]
+    )
+    with pytest.raises(HTTPException) as exc_info:
+        await router.bulk_upsert_documents(
+            "bulk_race",
+            body,
+            ctx,
+            user,
+        )
+
+    assert exc_info.value.status_code == 409
+    assert db.rolled_back is True
+    assert db.committed is False

--- a/client/src/lib/v1.d.ts
+++ b/client/src/lib/v1.d.ts
@@ -8144,6 +8144,31 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/tables/{table_id}/documents/bulk-upsert": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Bulk upsert documents by explicit id
+         * @description Set-based privileged ingestion path for explicit-id full replacements.
+         *
+         *     This route enforces normal table resolution, solution ownership, and table
+         *     row policies before issuing one guarded upsert statement. It intentionally
+         *     skips per-row realtime publishing; callers that need progress events
+         *     publish them separately.
+         */
+        post: operations["bulk_upsert_documents_api_tables__table_id__documents_bulk_upsert_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/tables/{table_id}/documents/count": {
         parameters: {
             query?: never;
@@ -15142,6 +15167,53 @@ export interface components {
              * @description Override attribution for updated_by (upsert-update branch). Engine and platform-admin callers only.
              */
             updated_by?: string | null;
+        };
+        /**
+         * DocumentBulkUpsertItem
+         * @description A single explicit-id document for the privileged bulk upsert endpoint.
+         */
+        DocumentBulkUpsertItem: {
+            /**
+             * Id
+             * @description Document ID to upsert
+             */
+            id: string;
+            /**
+             * Data
+             * @description Replacement document data
+             */
+            data: {
+                [key: string]: unknown;
+            };
+            /**
+             * Created By
+             * @description Override attribution for inserted rows. Platform-admin callers only.
+             */
+            created_by?: string | null;
+            /**
+             * Updated By
+             * @description Override attribution for inserted and updated rows. Platform-admin callers only.
+             */
+            updated_by?: string | null;
+        };
+        /**
+         * DocumentBulkUpsertRequest
+         * @description Input for set-based, explicit-id bulk upsert.
+         */
+        DocumentBulkUpsertRequest: {
+            /**
+             * Documents
+             * @description Documents to upsert. Maximum 1000 rows per request.
+             */
+            documents: components["schemas"]["DocumentBulkUpsertItem"][];
+        };
+        /**
+         * DocumentBulkUpsertResponse
+         * @description Count-only response for privileged bulk upsert.
+         */
+        DocumentBulkUpsertResponse: {
+            /** Count */
+            count: number;
         };
         /**
          * DocumentCountResponse
@@ -27306,6 +27378,12 @@ export interface components {
             options?: {
                 [key: string]: string;
             }[] | null;
+            /** Python Type */
+            python_type?: string | null;
+            /** Json Schema */
+            json_schema?: {
+                [key: string]: unknown;
+            } | null;
         };
         /**
          * WorkflowROIEntry
@@ -37282,6 +37360,8 @@ export interface operations {
                 metadata_filter?: string | null;
                 limit?: number;
                 offset?: number;
+                /** @description Opaque page position returned as next_cursor; offset remains supported. */
+                cursor?: string | null;
             };
             header?: never;
             path?: never;
@@ -42055,6 +42135,44 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["DocumentPublic"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    bulk_upsert_documents_api_tables__table_id__documents_bulk_upsert_post: {
+        parameters: {
+            query?: {
+                /** @description Target organization scope: 'global' or org UUID. Defaults to caller's home org. Provider admins only for non-self orgs. */
+                scope?: string | null;
+            };
+            header?: never;
+            path: {
+                table_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["DocumentBulkUpsertRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DocumentBulkUpsertResponse"];
                 };
             };
             /** @description Validation Error */

--- a/plugins/bifrost/skills/bifrost-build/generated/openapi-digest.md
+++ b/plugins/bifrost/skills/bifrost-build/generated/openapi-digest.md
@@ -518,6 +518,7 @@
 | POST | `/api/tables/{table_id}/documents` |
 | POST | `/api/tables/{table_id}/documents/batch` |
 | POST | `/api/tables/{table_id}/documents/batch-delete` |
+| POST | `/api/tables/{table_id}/documents/bulk-upsert` |
 | GET | `/api/tables/{table_id}/documents/count` |
 | POST | `/api/tables/{table_id}/documents/query` |
 | POST | `/api/tables/{table_id}/documents/upsert` |

--- a/plugins/bifrost/skills/bifrost-build/generated/python-sdk-signatures.md
+++ b/plugins/bifrost/skills/bifrost-build/generated/python-sdk-signatures.md
@@ -194,6 +194,8 @@ Event publishing operations (async).
 
 
 
+**`tables.bulk_upsert(table: str, documents: list[dict[str, Any]], scope: str | None = None, created_by: str | None = None, updated_by: str | None = None, conflict_retries: int = 2) -> BulkUpsertResult`**
+
 **`tables.count(table: str, where: dict[str, Any] | None = None, scope: str | None = None) -> int`**
 
 **`tables.create(name: str, description: str | None = None, table_schema: dict[str, Any] | None = None, scope: str | None = None, app: str | None = None) -> TableInfo`**


### PR DESCRIPTION
Large metadata imports currently call the document upsert path once per record, even when using the batch SDK method. Add `tables.bulk_upsert()` and a count-only API for up to 1,000 explicit-ID document replacements in one database statement. This lets the SharePoint inventory keep one ordinary record per file while advancing its checkpoint only after the whole write succeeds.

The endpoint requires platform-admin or engine access, preserves table policies and Solution ownership checks, rejects duplicate IDs atomically, and preserves insert attribution on updates. Existing rows are locked in a consistent order before policy evaluation; a competing insert causes rollback and a bounded SDK retry. Bulk ingestion omits per-record realtime events so callers can publish separate progress records. The existing batch API is unchanged.

Validation on candidate `306e8a0c1cf5a7907542f9cf8a4a74a05dfbd6c3`:

- Focused SDK/route tests: 17 passed; new endpoint integration tests: 6 passed.
- API pyright and ruff passed; client lint had no errors.
- Full backend unit suite: 5,937 passed, 3 skipped, 21 deselected.
- Full backend integration suite: 1,814 passed, 1 skipped.
- Client suite: 1,929 passed across 300 files; browser smoke: 4 passed with no retries.
- Client production build passed. Generated OpenAPI types and API/SDK reference mirrors are current.

The `./test.sh pre-pr` process was terminated during its final production image export after all test suites passed. The remaining production image build/import/version check and unchanged-commit/clean-worktree checks were completed separately on the same candidate; no test or source changes were made between those steps.
