### PR TITLE
fix(execution): refresh workspace modules at shared boundary

### DIFF
--- a/api/src/jobs/consumers/__init__.py
+++ b/api/src/jobs/consumers/__init__.py
@@ -1,10 +1,5 @@
-# RabbitMQ message consumers
-from src.jobs.consumers.workflow_execution import WorkflowExecutionConsumer
-from src.jobs.consumers.package_install import PackageInstallConsumer
-from src.jobs.consumers.agent_run import AgentRunConsumer
+"""RabbitMQ consumer modules.
 
-__all__ = [
-    "WorkflowExecutionConsumer",
-    "PackageInstallConsumer",
-    "AgentRunConsumer",
-]
+Consumers are imported from their defining modules so importing one consumer
+does not eagerly load every worker runtime and its optional dependencies.
+"""

--- a/api/src/jobs/consumers/agent_run.py
+++ b/api/src/jobs/consumers/agent_run.py
@@ -24,7 +24,6 @@ from src.models.contracts.agents import ChatStreamChunk
 from src.models.enums import MessageRole
 from src.models.orm.agents import Agent, Conversation
 from src.models.orm.agent_runs import AgentRun
-from src.services.agent_executor import AgentExecutor
 
 logger = logging.getLogger(__name__)
 
@@ -653,6 +652,8 @@ class AgentRunConsumer(BaseConsumer):
             if chat_agent is not None and chat_agent.max_run_timeout
             else DEFAULT_RUN_TIMEOUT
         )
+        from src.services.agent_executor import AgentExecutor
+
         executor = AgentExecutor(self._session_factory)
         current_task = asyncio.current_task()
         if current_task is None:

--- a/api/src/services/execution/simple_worker.py
+++ b/api/src/services/execution/simple_worker.py
@@ -7,8 +7,6 @@ TemplateProcess via os.fork) use to run an execution:
 - install_requirements(): called once at pool startup to pip-install
   user requirements. All forked children inherit the resulting
   filesystem, so installing once in the parent is sufficient.
-- _clear_workspace_modules(): called before each execution so workflow
-  code changes are picked up from Redis.
 - _execute_sync() / _execute_async(): run a single execution using context
   assembled by the parent consumer and delivered over a private pipe.
 - _get_process_rss() / _get_pss_bytes() / _capture_resource_metrics():
@@ -32,10 +30,6 @@ import sys
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Any
-
-from src.services.execution.workspace_modules import (
-    clear_workspace_modules as _clear_workspace_modules,
-)
 
 logger = logging.getLogger(__name__)
 
@@ -241,36 +235,15 @@ async def _execute_async(
     """
     start_time = datetime.now(timezone.utc)
 
-    # Activate THIS execution's Solution import root, THEN evict workspace
-    # modules — in that order. The cross-solution eviction in
-    # _clear_workspace_modules keys off the active install (get_solution_context);
-    # if it ran with no context (as the template_process fork path did), a prior
-    # install's same-name module could survive the hash check and shadow this
-    # install's file, breaking multi-install isolation (Codex #9). This context is
-    # temporary: _run_execution activates it again after credential bootstrap.
-    from src.core.module_cache_sync import clear_solution_context, set_solution_context
-
-    _exec_solution_id = context.get("solution_id")
-    if _exec_solution_id:
-        set_solution_context(
-            _exec_solution_id,
-            global_repo_access=bool(context.get("solution_global_repo_access", False)),
-        )
+    # Run the execution using the shared core, which owns Solution context and
+    # workspace-module freshness.
     try:
-        _clear_workspace_modules()
-    finally:
-        # Credential backend imports must run without Solution namespace probing;
-        # otherwise their own API credential lookup can recursively import them.
-        clear_solution_context()
-    # 2. Run the execution using existing worker logic
-    # This reuses the shared _run_execution() from worker.py
-    try:
-        from src.services.execution.worker import _run_execution
+        from src.services.execution.worker import run_execution
 
         # Capture baseline PSS before execution so we can measure the delta
         baseline_pss = _get_pss_bytes()
 
-        result = await _run_execution(execution_id, context)
+        result = await run_execution(execution_id, context)
 
         # Calculate duration
         duration_ms = int((datetime.now(timezone.utc) - start_time).total_seconds() * 1000)

--- a/api/src/services/execution/simple_worker.py
+++ b/api/src/services/execution/simple_worker.py
@@ -33,6 +33,10 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Any
 
+from src.services.execution.workspace_modules import (
+    clear_workspace_modules as _clear_workspace_modules,
+)
+
 logger = logging.getLogger(__name__)
 
 
@@ -177,109 +181,6 @@ def install_requirements() -> RequirementsInstallResult:
             logger.warning(f"[pool] Error installing '{pkg}': {e}")
 
     return result
-
-
-def _clear_workspace_modules() -> None:
-    """
-    Clear workspace modules from sys.modules only if their content changed.
-
-    Called before each execution. For each workspace module already loaded,
-    checks the content hash against Redis. If unchanged, the module stays
-    in sys.modules and the next `import` is a no-op. If changed (or if the
-    hash check fails), the module is evicted so it gets re-fetched.
-
-    This avoids re-exec'ing large unchanged modules on every execution.
-    """
-    from src.services.execution.virtual_import import VirtualModuleLoader, NamespacePackageLoader
-    from src.core.module_cache_sync import get_module_sync
-
-    # Find workspace modules currently loaded
-    workspace_modules = [
-        (name, module) for name, module in sys.modules.items()
-        if module is not None and (
-            (hasattr(module, '__loader__') and isinstance(
-                module.__loader__, (VirtualModuleLoader, NamespacePackageLoader)
-            ))
-        )
-    ]
-
-    # Check each module's hash — only clear if content changed
-    modules_to_clear: list[str] = []
-    modules_kept = 0
-
-    for name, module in workspace_modules:
-        cached_hash = getattr(module, '__content_hash__', None)
-
-        if not cached_hash:
-            # No hash stored — could be a namespace package or exec_from_db module.
-            # Namespace packages are kept if any child modules are kept (decided later).
-            # For now, check if this is a namespace package (has __path__ but no __file__).
-            if isinstance(getattr(module, '__loader__', None), NamespacePackageLoader):
-                # Defer — we'll keep it if any children survive
-                continue
-            # exec_from_db module with no hash — always clear
-            modules_to_clear.append(name)
-            continue
-
-        # Look up current hash using the exact file path loaded by the virtual loader.
-        file_path = getattr(module, "__file__", None)
-        if not file_path:
-            # Can't map to a file path — clear to be safe
-            modules_to_clear.append(name)
-            continue
-
-        cached = get_module_sync(file_path)
-        if not cached:
-            # Module removed from cache — clear
-            modules_to_clear.append(name)
-            continue
-
-        loaded_storage_path = getattr(module, "__storage_path__", file_path)
-        if cached.get("storage_path", cached.get("path")) != loaded_storage_path:
-            # The same logical import now resolves from a different Solution or
-            # from a different Solution/global scope. Equal bytes are not enough
-            # to reuse a module object whose mutable globals belong to another
-            # execution boundary.
-            modules_to_clear.append(name)
-            continue
-
-        if cached.get("hash") != cached_hash:
-            # Content changed — clear
-            modules_to_clear.append(name)
-        else:
-            # Unchanged — keep it
-            modules_kept += 1
-
-    # If ANY workspace module changed, clear ALL workspace modules.
-    # Reason: kept modules may hold stale references to cleared modules
-    # via `from X import Y` bindings captured at import time.
-    if modules_to_clear:
-        modules_to_clear = [name for name, _ in workspace_modules]
-        modules_kept = 0
-
-    # Clear namespace packages only if ALL their children were cleared
-    cleared_set = set(modules_to_clear)
-    for name, module in workspace_modules:
-        if not isinstance(getattr(module, '__loader__', None), NamespacePackageLoader):
-            continue
-        # Check if any child module survived (not in cleared_set and still in sys.modules)
-        prefix = name + "."
-        has_surviving_child = any(
-            n.startswith(prefix) and n not in cleared_set
-            for n in sys.modules
-        )
-        if not has_surviving_child:
-            modules_to_clear.append(name)
-
-    for name in modules_to_clear:
-        if name in sys.modules:
-            del sys.modules[name]
-
-    if modules_to_clear or modules_kept:
-        logger.debug(
-            f"Workspace modules: cleared={len(modules_to_clear)} kept={modules_kept}"
-            + (f" (cleared: {modules_to_clear})" if modules_to_clear else "")
-        )
 
 
 def _execute_sync(

--- a/api/src/services/execution/worker.py
+++ b/api/src/services/execution/worker.py
@@ -1,12 +1,8 @@
-"""
-Worker process entry point for isolated execution.
+"""Shared execution core for isolated worker processes.
 
-This module runs in a separate process and:
-1. Receives execution context from its parent (legacy entry points use Redis)
-2. Runs the workflow/script
-3. Writes logs to Redis Stream (already handled by engine)
-4. Returns a result with resource metrics
-5. Exits cleanly (or gets killed on timeout)
+The forked worker adapter supplies an execution context to ``run_execution``,
+which loads and runs the workflow or script and returns its result with
+resource metrics. Logs are written to Redis Stream by the execution engine.
 
 The worker imports minimal dependencies to keep memory footprint low.
 
@@ -17,11 +13,8 @@ modules from Redis cache instead of the filesystem.
 
 from __future__ import annotations
 
-import asyncio
-import json
 import logging
 import resource
-import signal
 import sys
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -111,33 +104,7 @@ def _capture_metrics(start_rss: int, start_utime: float, start_stime: float) -> 
     )
 
 
-def _setup_signal_handlers():
-    """Set up signal handlers for graceful shutdown."""
-    def handle_sigterm(signum, frame):
-        logger.info("Worker received SIGTERM, initiating graceful shutdown")
-        # Raise SystemExit to trigger cleanup
-        sys.exit(0)
-
-    signal.signal(signal.SIGTERM, handle_sigterm)
-
-
-async def _read_execution_context(redis_client, execution_id: str) -> dict[str, Any] | None:
-    """Read execution context from Redis."""
-    key = f"bifrost:exec:{execution_id}:context"
-    data = await redis_client.get(key)
-    if data:
-        return json.loads(data)
-    return None
-
-
-async def _write_execution_result(redis_client, execution_id: str, result: dict[str, Any]):
-    """Write execution result to Redis."""
-    key = f"bifrost:exec:{execution_id}:result"
-    # Set with 1 hour TTL (parent should read quickly, but safety margin)
-    await redis_client.setex(key, 3600, json.dumps(result, default=str))
-
-
-async def _run_execution(execution_id: str, context_data: dict[str, Any]) -> dict[str, Any]:
+async def run_execution(execution_id: str, context_data: dict[str, Any]) -> dict[str, Any]:
     """
     Run the actual execution.
 
@@ -376,93 +343,3 @@ async def _run_execution(execution_id: str, context_data: dict[str, Any]) -> dic
         # Always clear the solution import root before any final cleanup in this
         # execution process. Current pool children are one-shot.
         clear_solution_context()
-
-
-async def worker_main(execution_id: str):
-    """
-    Main entry point for worker process.
-
-    Called by the pool manager when spawning a new worker.
-    """
-    import redis.asyncio as redis
-    from src.config import get_settings
-
-    settings = get_settings()
-
-    # Set up signal handlers
-    _setup_signal_handlers()
-
-    logger.info(f"Worker starting for execution: {execution_id}")
-
-    # Note: No workspace directory needed - modules are loaded from Redis via virtual imports
-    # The virtual import hook is installed below before any workspace imports
-
-    # Connect to Redis
-    redis_client = redis.from_url(
-        settings.redis_url,
-        decode_responses=True,
-        socket_timeout=5.0,
-    )
-
-    try:
-        # Read context from Redis
-        context_data = await _read_execution_context(redis_client, execution_id)
-        if not context_data:
-            logger.error(f"No context found for execution: {execution_id}")
-            await _write_execution_result(redis_client, execution_id, {
-                "status": "Failed",
-                "error_message": "Execution context not found in Redis",
-                "error_type": "ContextNotFound",
-                "duration_ms": 0,
-                "metrics": None,
-            })
-            return
-
-        # Run the execution
-        result = await _run_execution(execution_id, context_data)
-
-        # Write result to Redis
-        await _write_execution_result(redis_client, execution_id, result)
-
-        # Log metrics
-        metrics = result.get("metrics")
-        if metrics:
-            logger.info(
-                f"Worker completed execution: {execution_id}, "
-                f"status: {result.get('status')}, "
-                f"memory: {metrics['peak_memory_bytes'] / 1024 / 1024:.1f}MB, "
-                f"cpu: {metrics['cpu_total_seconds']:.3f}s"
-            )
-        else:
-            logger.info(f"Worker completed execution: {execution_id}, status: {result.get('status')}")
-
-    except Exception as e:
-        logger.exception(f"Worker failed for execution {execution_id}: {e}")
-        try:
-            await _write_execution_result(redis_client, execution_id, {
-                "status": "Failed",
-                "error_message": str(e),
-                "error_type": type(e).__name__,
-                "duration_ms": 0,
-                "metrics": None,
-            })
-        except Exception:
-            pass  # Best effort
-    finally:
-        await redis_client.aclose()
-
-
-def run_in_worker(execution_id: str):
-    """
-    Synchronous entry point for multiprocessing.
-
-    This is called when the process is spawned.
-    """
-    # Configure logging for worker process
-    logging.basicConfig(
-        level=logging.INFO,
-        format=f"[Worker:{execution_id[:8]}] %(levelname)s - %(message)s"
-    )
-
-    # Run the async worker
-    asyncio.run(worker_main(execution_id))

--- a/api/src/services/execution/worker.py
+++ b/api/src/services/execution/worker.py
@@ -31,6 +31,9 @@ from typing import Any
 # This must happen before any workspace imports (e.g., from shared import ...)
 # The hook intercepts imports and loads modules from Redis cache.
 from src.services.execution.virtual_import import install_virtual_import_hook
+from src.services.execution.workspace_modules import (
+    clear_workspace_modules as _clear_workspace_modules,
+)
 
 install_virtual_import_hook()
 
@@ -175,6 +178,12 @@ async def _run_execution(execution_id: str, context_data: dict[str, Any]) -> dic
         )
 
     try:
+        # The shared execution boundary owns cache freshness so direct callers
+        # and alternate worker paths cannot inherit stale workspace imports.
+        # This must run after Solution context activation because resolution is
+        # scoped to the active install.
+        _clear_workspace_modules()
+
         # Reconstruct Organization
         org = None
         org_data = context_data.get("organization")

--- a/api/src/services/execution/workspace_modules.py
+++ b/api/src/services/execution/workspace_modules.py
@@ -1,0 +1,90 @@
+"""Workspace module cache isolation for reused execution processes."""
+
+from __future__ import annotations
+
+import logging
+import sys
+
+logger = logging.getLogger(__name__)
+
+
+def clear_workspace_modules() -> None:
+    """Evict loaded workspace modules when their cached source changed.
+
+    If one module changed, all workspace modules are evicted because unchanged
+    modules may still hold stale ``from X import Y`` references.
+    """
+    from src.core.module_cache_sync import get_module_sync
+    from src.services.execution.virtual_import import (
+        NamespacePackageLoader,
+        VirtualModuleLoader,
+    )
+
+    workspace_modules = [
+        (name, module)
+        for name, module in sys.modules.items()
+        if module is not None
+        and isinstance(
+            getattr(module, "__loader__", None),
+            (VirtualModuleLoader, NamespacePackageLoader),
+        )
+    ]
+
+    modules_to_clear: list[str] = []
+    modules_kept = 0
+
+    for name, module in workspace_modules:
+        cached_hash = getattr(module, "__content_hash__", None)
+
+        if not cached_hash:
+            if isinstance(getattr(module, "__loader__", None), NamespacePackageLoader):
+                continue
+            modules_to_clear.append(name)
+            continue
+
+        file_path = getattr(module, "__file__", None)
+        if not file_path:
+            modules_to_clear.append(name)
+            continue
+
+        cached = get_module_sync(file_path)
+        if not cached:
+            modules_to_clear.append(name)
+            continue
+
+        loaded_storage_path = getattr(module, "__storage_path__", file_path)
+        if cached.get("storage_path", cached.get("path")) != loaded_storage_path:
+            modules_to_clear.append(name)
+            continue
+
+        if cached.get("hash") != cached_hash:
+            modules_to_clear.append(name)
+        else:
+            modules_kept += 1
+
+    if modules_to_clear:
+        modules_to_clear = [name for name, _ in workspace_modules]
+        modules_kept = 0
+
+    cleared_set = set(modules_to_clear)
+    for name, module in workspace_modules:
+        if not isinstance(getattr(module, "__loader__", None), NamespacePackageLoader):
+            continue
+        prefix = name + "."
+        has_surviving_child = any(
+            candidate.startswith(prefix) and candidate not in cleared_set
+            for candidate in sys.modules
+        )
+        if not has_surviving_child:
+            modules_to_clear.append(name)
+
+    for name in modules_to_clear:
+        sys.modules.pop(name, None)
+
+    if modules_to_clear or modules_kept:
+        logger.debug(
+            "Workspace modules: cleared=%s kept=%s%s",
+            len(modules_to_clear),
+            modules_kept,
+            f" (cleared: {modules_to_clear})" if modules_to_clear else "",
+        )

--- a/api/tests/e2e/platform/test_cli_files.py
+++ b/api/tests/e2e/platform/test_cli_files.py
@@ -51,7 +51,7 @@ def _grant_workspace_e2e_policy(e2e_client, platform_admin):
 def engine_creds():
     """Populate ``~/.bifrost/credentials.json`` with an engine token.
 
-    Mirrors what ``_run_execution`` does at the top of every workflow
+    Mirrors what ``run_execution`` does at the top of every workflow
     invocation in the worker (`api/src/services/execution/worker.py:134`).
     Without this, the CLI has nothing to authenticate with.
 

--- a/api/tests/unit/services/test_agent_run_consumer.py
+++ b/api/tests/unit/services/test_agent_run_consumer.py
@@ -372,7 +372,7 @@ async def test_chat_run_publishes_stream_chunks_and_terminal_completion(
                 )
             ),
         ),
-        patch("src.jobs.consumers.agent_run.AgentExecutor", return_value=fake_executor),
+        patch("src.services.agent_executor.AgentExecutor", return_value=fake_executor),
         patch("src.jobs.consumers.agent_run.publish_chat_run_event", publish_chat),
         patch("src.jobs.consumers.agent_run.publish_agent_run_update", publish_run),
     ):
@@ -517,7 +517,7 @@ async def test_chat_run_interruption_persists_partial_output_and_terminal_event(
                 )
             ),
         ),
-        patch("src.jobs.consumers.agent_run.AgentExecutor", return_value=fake_executor),
+        patch("src.services.agent_executor.AgentExecutor", return_value=fake_executor),
         patch("src.jobs.consumers.agent_run.DEFAULT_RUN_TIMEOUT", 0.001),
         patch("src.jobs.consumers.agent_run.publish_chat_run_event", publish_chat),
         patch("src.jobs.consumers.agent_run.publish_agent_run_update", publish_run),

--- a/api/tests/unit/test_solution_module_isolation.py
+++ b/api/tests/unit/test_solution_module_isolation.py
@@ -4,7 +4,7 @@ Per-execution import root namespaces module RESOLUTION, but Python caches
 imported modules in ``sys.modules`` by bare name (``modules.foo``). Without
 eviction, after Solution A's execution imports ``modules.foo`` from
 ``_solutions/A/...``, a reused worker running Solution B would get A's cached
-``modules.foo`` instead of B's. ``_clear_workspace_modules`` must evict a
+``modules.foo`` instead of B's. ``clear_workspace_modules`` must evict a
 solution-rooted module when the active solution differs from the one that
 loaded it.
 """
@@ -64,7 +64,7 @@ def _clean_sys_modules():
 
 def test_switching_solution_evicts_other_solutions_module(_clean_sys_modules, monkeypatch):
     import src.core.module_cache_sync as mcs
-    import src.services.execution.simple_worker as sw
+    from src.services.execution.workspace_modules import clear_workspace_modules
 
     sid_b = str(uuid.uuid4())
 
@@ -87,7 +87,7 @@ def test_switching_solution_evicts_other_solutions_module(_clean_sys_modules, mo
     # Now Solution B is the active execution.
     mcs.set_solution_context(sid_b, global_repo_access=False)
     try:
-        sw._clear_workspace_modules()
+        clear_workspace_modules()
     finally:
         mcs._solution_ctx.value = None
 
@@ -99,7 +99,7 @@ def test_switching_solution_evicts_other_solutions_module(_clean_sys_modules, mo
 
 def test_same_solution_keeps_its_module(_clean_sys_modules, monkeypatch):
     import src.core.module_cache_sync as mcs
-    import src.services.execution.simple_worker as sw
+    from src.services.execution.workspace_modules import clear_workspace_modules
 
     sid = str(uuid.uuid4())
     storage_path = f"_solutions/{sid}/modules/foo.py"
@@ -117,7 +117,7 @@ def test_same_solution_keeps_its_module(_clean_sys_modules, monkeypatch):
 
     mcs.set_solution_context(sid, global_repo_access=False)
     try:
-        sw._clear_workspace_modules()
+        clear_workspace_modules()
     finally:
         mcs._solution_ctx.value = None
 
@@ -125,57 +125,29 @@ def test_same_solution_keeps_its_module(_clean_sys_modules, monkeypatch):
     assert "modules.foo" in sys.modules
 
 
-async def test_execute_async_sets_solution_context_before_clearing_modules(monkeypatch):
-    """Codex #9: the persistent-worker path must activate the execution's
-    Solution context BEFORE evicting workspace modules, or the cross-solution
-    eviction runs blind and a prior install's same-name module survives. Assert
-    set_solution_context runs before _clear_workspace_modules, with the context's
-    own solution_id."""
+async def test_execute_async_delegates_once_to_shared_execution_core(monkeypatch):
+    """The fork adapter delegates once; the shared core owns execution setup."""
     import src.services.execution.simple_worker as sw
-    import src.core.module_cache_sync as mcs
 
-    sid = str(uuid.uuid4())
-    calls: list[tuple[str, object]] = []
+    calls: list[tuple[str, dict[str, object]]] = []
 
-    context = {"solution_id": sid, "solution_global_repo_access": False}
-
-    def _fake_set_ctx(solution_id, global_repo_access=False):
-        calls.append(("set_context", solution_id))
-
-    def _fake_clear():
-        calls.append(("clear_modules", None))
-
-    def _fake_clear_ctx():
-        calls.append(("clear_context", None))
+    context: dict[str, object] = {"solution_id": str(uuid.uuid4())}
 
     async def _fake_run(_eid, _ctx):
-        calls.append(("run", None))
+        calls.append((_eid, _ctx))
         return {"status": "Success", "result": {}, "metrics": {}}
 
-    monkeypatch.setattr(mcs, "set_solution_context", _fake_set_ctx)
-    monkeypatch.setattr(mcs, "clear_solution_context", _fake_clear_ctx)
-    monkeypatch.setattr(sw, "_clear_workspace_modules", _fake_clear)
     monkeypatch.setattr(sw, "_get_pss_bytes", lambda: 0)
-    # _run_execution is imported inside the function from worker; patch there.
     import src.services.execution.worker as worker_mod
-    monkeypatch.setattr(worker_mod, "_run_execution", _fake_run)
+    monkeypatch.setattr(worker_mod, "run_execution", _fake_run)
 
     await sw._execute_async("exec-1", "worker-1", context)
 
-    order = [name for name, _ in calls]
-    assert order.index("set_context") < order.index("clear_modules"), (
-        f"context must be set before clearing modules; got {order}"
-    )
-    assert order.index("clear_modules") < order.index("clear_context")
-    assert order.index("clear_context") < order.index("run"), (
-        f"eviction-only context must be clear before credential bootstrap; got {order}"
-    )
-    # The context activated is THIS execution's install.
-    assert ("set_context", sid) in calls
+    assert calls == [("exec-1", context)]
 
 
 async def test_run_execution_refreshes_modules_and_clears_context_on_failure(monkeypatch):
-    """The shared boundary refreshes modules even when simple_worker is bypassed."""
+    """The shared core refreshes modules and cleans up when refresh fails."""
     import src.core.module_cache_sync as mcs
     import src.services.execution.worker as worker
 
@@ -209,7 +181,7 @@ async def test_run_execution_refreshes_modules_and_clears_context_on_failure(mon
 
     monkeypatch.setattr(worker, "_clear_workspace_modules", _fail_refresh)
 
-    result = await worker._run_execution(
+    result = await worker.run_execution(
         "exec-direct",
         {
             "solution_id": sid,

--- a/api/tests/unit/test_solution_module_isolation.py
+++ b/api/tests/unit/test_solution_module_isolation.py
@@ -172,3 +172,60 @@ async def test_execute_async_sets_solution_context_before_clearing_modules(monke
     )
     # The context activated is THIS execution's install.
     assert ("set_context", sid) in calls
+
+
+async def test_run_execution_refreshes_modules_and_clears_context_on_failure(monkeypatch):
+    """The shared boundary refreshes modules even when simple_worker is bypassed."""
+    import src.core.module_cache_sync as mcs
+    import src.services.execution.worker as worker
+
+    sid = str(uuid.uuid4())
+    calls: list[tuple[str, object]] = []
+
+    monkeypatch.setattr(worker, "_set_process_engine_credentials", lambda _ctx: True)
+    monkeypatch.setattr(worker, "_get_resource_usage", lambda: (0, 0.0, 0.0))
+    monkeypatch.setattr(worker, "_capture_metrics", lambda *_args: types.SimpleNamespace(
+        peak_memory_bytes=0,
+        cpu_user_seconds=0.0,
+        cpu_system_seconds=0.0,
+        cpu_total_seconds=0.0,
+    ))
+    monkeypatch.setattr(
+        mcs,
+        "set_solution_context",
+        lambda solution_id, global_repo_access=False: calls.append(
+            ("set_context", solution_id)
+        ),
+    )
+    monkeypatch.setattr(
+        mcs,
+        "clear_solution_context",
+        lambda: calls.append(("clear_context", None)),
+    )
+
+    def _fail_refresh():
+        calls.append(("clear_modules", None))
+        raise RuntimeError("refresh failed")
+
+    monkeypatch.setattr(worker, "_clear_workspace_modules", _fail_refresh)
+
+    result = await worker._run_execution(
+        "exec-direct",
+        {
+            "solution_id": sid,
+            "solution_global_repo_access": False,
+            "caller": {
+                "user_id": str(uuid.uuid4()),
+                "email": "user@example.com",
+                "name": "User",
+            },
+        },
+    )
+
+    assert result["status"] == "Failed"
+    assert result["error_type"] == "RuntimeError"
+    assert calls == [
+        ("set_context", sid),
+        ("clear_modules", None),
+        ("clear_context", None),
+    ]


### PR DESCRIPTION
## Summary

- make `run_execution` the single shared execution core and enforce workspace-module refresh there after Solution context activation
- remove the duplicate `simple_worker` refresh plus the unreferenced legacy standalone worker entry point and Redis transport helpers
- prevent worker startup from eagerly importing the agent/LLM stack, preserving the worker import-hygiene boundary exposed by targeted verification

## Why

Solution-installed Python modules can remain in a long-lived worker process after their backing files change. Refreshing at the shared execution core guarantees every live execution path sees current module code while preserving the active Solution scope. `simple_worker` now only handles process transport and delegates exactly once.

## Performance

A warm-cache microbenchmark in the isolated test stack measured one refresh at:

- 0–1 loaded modules: about 1.3 ms median
- 10 loaded modules: about 2.6 ms median
- 50 loaded modules: about 6.5 ms median

Removing the duplicate preflight avoids paying that cost twice. Actual module eviction/loading remains conditional on a changed cache version.

## Testing

Exact candidate: `1914f6324eef15df49df9f5083a207c191a7c62c`

Targeted checks:

- `./test.sh tests/unit/test_solution_module_isolation.py -v` — 4 passed
- `./test.sh tests/unit/test_import_hygiene.py::test_worker_app_closure_has_no_heavyweights -v` — passed
- `./test.sh tests/unit/test_solution_module_isolation.py tests/unit/test_import_hygiene.py tests/unit/execution/test_worker_credentials.py tests/unit/execution/test_template_process.py tests/unit/services/test_agent_run_consumer.py -v` — 32 passed
- `./test.sh tests/e2e/api/test_executions.py::TestCodeHotReload::test_workflow_code_update_reflected_in_execution tests/e2e/api/test_executions.py::TestCodeHotReload::test_module_code_update_reflected_in_execution tests/e2e/api/test_executions.py::TestCodeHotReload::test_nested_module_package_update_reflected -v` — 3 passed
- `./test.sh quality api` — Pyright and Ruff passed

Full local PR gate:

- `./test.sh pre-pr` — passed for the exact candidate
- client: 300 files / 1,929 tests passed; TypeScript/build/lint gates passed
- backend unit/contract: 5,938 passed, 3 skipped
- backend E2E: 1,814 passed, 1 skipped
- browser smoke: 4 passed
- production API image build/runtime probe: passed

Fixes #705