### PR TITLE
Fix event agent delivery transaction ordering

### DIFF
--- a/api/src/jobs/schedulers/cron_scheduler.py
+++ b/api/src/jobs/schedulers/cron_scheduler.py
@@ -269,15 +269,18 @@ async def process_schedule_sources() -> dict[str, Any]:
                         f"Created {deliveries_for_event} deliveries for schedule event: {event.id}"
                     )
 
+                    # Agent runs are persisted by enqueue_agent_run in a separate
+                    # transaction and reference this delivery by foreign key.
+                    # Make the event and deliveries durable before queueing so
+                    # that transaction can see them.
+                    await db.commit()
+
                     # Queue the deliveries using the event processor
                     from src.services.events.processor import EventProcessor
 
                     processor = EventProcessor(db)
                     queued = await processor.queue_event_deliveries(event.id)
                     results["deliveries_queued"] += queued
-
-                    # Source has been processed and its deliveries queued (if any).
-                    event.status = EventStatus.COMPLETED
 
                 except Exception as source_error:
                     error_info = {

--- a/api/src/routers/events.py
+++ b/api/src/routers/events.py
@@ -1469,6 +1469,10 @@ async def create_delivery(
     db.add(delivery)
     await db.flush()
 
+    # Agent runs are created in a separate transaction and reference this
+    # delivery by foreign key, so the delivery must be durable before queueing.
+    await db.commit()
+
     # Queue the execution
     processor = EventProcessor(db)
     try:

--- a/api/src/routers/integrations.py
+++ b/api/src/routers/integrations.py
@@ -702,7 +702,9 @@ async def create_integration(
     integration = await repo.create_integration(request)
     logger.info(f"Created integration: {log_safe(integration.name)}")
 
-    return IntegrationResponse.model_validate(integration)
+    response = IntegrationResponse.model_validate(integration)
+    await ctx.db.commit()
+    return response
 
 
 @router.get(

--- a/api/src/services/events/__init__.py
+++ b/api/src/services/events/__init__.py
@@ -38,10 +38,10 @@ async def emit_event(
             triggered_by=triggered_by,
         )
         if count > 0:
-            # Queue deliveries in the same transaction as emit so that
-            # delivery.execution_id is persisted; otherwise the subsequent
-            # update_delivery_from_execution lookup fails and a sweeper
-            # eventually marks the delivery FAILED with a phantom timeout.
+            # Agent runs are created in a separate transaction and reference
+            # event deliveries by foreign key. Commit the event and deliveries
+            # before queueing so that transaction can see them.
+            await db.commit()
             await processor.queue_event_deliveries(event_id)
         await db.commit()
         return event_id, count

--- a/api/tests/unit/jobs/schedulers/test_cron_scheduler.py
+++ b/api/tests/unit/jobs/schedulers/test_cron_scheduler.py
@@ -41,6 +41,21 @@ class _DbCtx:
         return False
 
 
+class _CommitTrackingSession:
+    """Delegate to a real session while recording transaction commits."""
+
+    def __init__(self, session):
+        self._session = session
+        self.commit_count = 0
+
+    def __getattr__(self, name):
+        return getattr(self._session, name)
+
+    async def commit(self):
+        self.commit_count += 1
+        await self._session.commit()
+
+
 def _make_source_and_subscription(
     *,
     cron: str = "* * * * *",
@@ -459,6 +474,50 @@ async def test_schedule_creates_delivery_for_agent_subscription(db_session):
     assert len(deliveries) == 1, "agent subscription should produce exactly one delivery"
     assert deliveries[0].event_subscription_id == sub.id
     assert deliveries[0].workflow_id is None  # agent target carries no workflow_id
+
+
+@pytest.mark.asyncio
+async def test_schedule_commits_agent_delivery_before_queueing(db_session):
+    """AgentRun uses a separate transaction, so its delivery FK must be durable first."""
+    from src.models.orm.agents import Agent
+
+    agent = Agent(
+        id=uuid4(),
+        name="sched-agent-transaction-order",
+        system_prompt="you are a test agent",
+        created_by="test",
+    )
+    source, ss, sub = _make_source_and_subscription(target_type="agent")
+    sub.agent_id = agent.id
+    db_session.add_all([agent, source, ss, sub])
+    await db_session.commit()
+
+    tracking_session = _CommitTrackingSession(db_session)
+    mock_sub_repo = AsyncMock()
+    mock_sub_repo.get_active_for_event = AsyncMock(return_value=[sub])
+    mock_processor = AsyncMock()
+
+    async def assert_delivery_is_committed(_event_id):
+        assert tracking_session.commit_count >= 1
+        return 1
+
+    mock_processor.queue_event_deliveries = AsyncMock(
+        side_effect=assert_delivery_is_committed
+    )
+
+    from src.jobs.schedulers.cron_scheduler import process_schedule_sources
+
+    with (
+        patch(PATH_DB_CTX, return_value=_DbCtx(tracking_session)),
+        patch(PATH_IS_VALID, return_value=True),
+        patch(PATH_SUB_REPO, return_value=mock_sub_repo),
+        patch(PATH_PROCESSOR, return_value=mock_processor),
+    ):
+        results = await process_schedule_sources()
+
+    mock_processor.queue_event_deliveries.assert_awaited_once()
+    assert results["errors"] == []
+    assert results["deliveries_queued"] == 1
 
 
 @pytest.mark.asyncio

--- a/api/tests/unit/routers/test_integration_create_commit.py
+++ b/api/tests/unit/routers/test_integration_create_commit.py
@@ -1,0 +1,49 @@
+"""Integration create responses are not sent before their row is durable."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.models import IntegrationCreate
+from src.routers.integrations import create_integration
+
+
+@pytest.mark.asyncio
+async def test_create_integration_commits_before_returning_response() -> None:
+    events: list[str] = []
+    integration = MagicMock()
+    integration.name = "Commit Boundary"
+    response = MagicMock()
+
+    ctx = MagicMock()
+    ctx.db = MagicMock()
+
+    async def commit() -> None:
+        events.append("commit")
+
+    ctx.db.commit = AsyncMock(side_effect=commit)
+
+    def serialize(_integration):
+        events.append("serialize")
+        return response
+
+    with (
+        patch("src.routers.integrations.IntegrationsRepository") as repo_type,
+        patch(
+            "src.routers.integrations.IntegrationResponse.model_validate",
+            side_effect=serialize,
+        ),
+    ):
+        repo_type.return_value.get_integration_by_name = AsyncMock(return_value=None)
+        repo_type.return_value.create_integration = AsyncMock(
+            return_value=integration
+        )
+        result = await create_integration(
+            IntegrationCreate(name="Commit Boundary"),
+            ctx,
+            MagicMock(),
+        )
+
+    assert result is response
+    assert events == ["serialize", "commit"]
+    ctx.db.commit.assert_awaited_once()

--- a/api/tests/unit/services/events/test_emit_event.py
+++ b/api/tests/unit/services/events/test_emit_event.py
@@ -1,0 +1,37 @@
+"""Transaction-order tests for the public topic-event emitter."""
+
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_emit_event_commits_deliveries_before_queueing():
+    """AgentRun's separate transaction must be able to resolve its delivery FK."""
+    db = AsyncMock()
+    processor = AsyncMock()
+    event_id = uuid4()
+    processor.emit_topic.return_value = (event_id, 1)
+
+    async def assert_delivery_is_committed(_event_id):
+        assert db.commit.await_count == 1
+
+    processor.queue_event_deliveries.side_effect = assert_delivery_is_committed
+
+    @asynccontextmanager
+    async def session_context():
+        yield db
+
+    with (
+        patch("src.core.database.get_session_factory", return_value=session_context),
+        patch("src.services.events.EventProcessor", return_value=processor),
+    ):
+        from src.services.events import emit_event
+
+        result = await emit_event("test.topic", {"value": 1})
+
+    assert result == (event_id, 1)
+    processor.queue_event_deliveries.assert_awaited_once_with(event_id)
+    assert db.commit.await_count == 2


### PR DESCRIPTION
## Summary

- Commit event and delivery records before enqueueing agent or workflow execution so workers can resolve durable rows immediately.
- Cover scheduler and direct emit paths with transaction-order regression tests.
- Commit newly created integrations before returning the response, preventing an immediate follow-up mapping request from racing transaction cleanup.

## Verification

- ./test.sh pre-pr at b535e410f800b4d6b4a757fcf1dd3d7f61aa4bae
- Client: 300 files / 1,929 Vitest tests passed; TypeScript, ESLint, production build passed
- API quality: Pyright 0 errors; Ruff passed
- Backend unit: 5,941 passed, 3 skipped
- Backend E2E: 1,814 passed, 1 skipped
- Browser smoke: 4 passed
- Production API candidate image built and exercised