### PR TITLE
feat(tables): add document ID keyset pagination

### DIFF
--- a/.claude/skills/bifrost-build/generated/python-sdk-signatures.md
+++ b/.claude/skills/bifrost-build/generated/python-sdk-signatures.md
@@ -214,7 +214,7 @@ Event publishing operations (async).
 
 **`tables.list(scope: str | None = None, app: str | None = None) -> list[TableInfo]`**
 
-**`tables.query(table: str, where: dict[str, Any] | None = None, order_by: str | None = None, order_dir: str = 'asc', limit: int = 100, offset: int = 0, scope: str | None = None) -> DocumentList`**
+**`tables.query(table: str, where: dict[str, Any] | None = None, order_by: str | None = None, order_dir: str = 'asc', limit: int = 100, offset: int = 0, scope: str | None = None, after_document_id: str | None = None, document_id_prefix: str | None = None, skip_count: bool = False) -> DocumentList`**
 
 **`tables.update(table: str, doc_id: str, data: dict[str, Any], scope: str | None = None, updated_by: str | None = None) -> DocumentData | None`**
 

--- a/api/bifrost/tables.py
+++ b/api/bifrost/tables.py
@@ -675,6 +675,9 @@ class tables:
         limit: int = 100,
         offset: int = 0,
         scope: str | None = None,
+        after_document_id: str | None = None,
+        document_id_prefix: str | None = None,
+        skip_count: bool = False,
     ) -> DocumentList:
         """
         Query documents with filtering and pagination.
@@ -694,6 +697,12 @@ class tables:
             limit: Maximum documents to return (default 100).
             offset: Number of documents to skip.
             scope: Organization scope.
+            after_document_id: Exclusive cursor over the actual document ID.
+                Activates ascending document-ID ordering. Pass an empty string
+                to begin an unbounded document-ID scan.
+            document_id_prefix: Restrict results to actual document IDs with
+                this prefix. Activates ascending document-ID ordering.
+            skip_count: Skip the matching count query and return ``total=-1``.
 
         Returns:
             DocumentList: Query results with documents, total count, and
@@ -712,6 +721,9 @@ class tables:
                 "order_dir": order_dir,
                 "limit": limit,
                 "offset": offset,
+                "after_document_id": after_document_id,
+                "document_id_prefix": document_id_prefix,
+                "skip_count": skip_count,
             },
         )
         if response.status_code == 404:

--- a/api/src/models/contracts/tables.py
+++ b/api/src/models/contracts/tables.py
@@ -398,6 +398,24 @@ class DocumentQuery(BaseModel):
         default=False,
         description="Skip the total count query (returns total=-1). Use for faster paginated fetches after the first page.",
     )
+    after_document_id: str | None = Field(
+        default=None,
+        max_length=255,
+        description=(
+            "Return documents whose actual document ID is greater than this "
+            "exclusive cursor, ordered by document ID. Use an empty string "
+            "to begin an unbounded document-ID scan."
+        ),
+    )
+    document_id_prefix: str | None = Field(
+        default=None,
+        min_length=1,
+        max_length=255,
+        description=(
+            "Return only documents whose actual document ID starts with this "
+            "prefix, ordered by document ID."
+        ),
+    )
 
     @field_validator("order_by")
     @classmethod
@@ -408,6 +426,25 @@ class DocumentQuery(BaseModel):
             if not v.replace(".", "").replace("_", "").isalnum():
                 raise ValueError("order_by must be alphanumeric with dots and underscores")
         return v
+
+    @model_validator(mode="after")
+    def validate_document_id_pagination(self) -> "DocumentQuery":
+        """Keep document-ID keyset pagination unambiguous and index-friendly."""
+        if self.after_document_id is None and self.document_id_prefix is None:
+            return self
+        if self.order_by is not None:
+            raise ValueError(
+                "order_by cannot be combined with document-ID pagination"
+            )
+        if self.order_dir != "asc":
+            raise ValueError(
+                "document-ID pagination only supports ascending order"
+            )
+        if self.offset != 0:
+            raise ValueError(
+                "offset cannot be combined with document-ID pagination"
+            )
+        return self
 
 
 class DocumentListResponse(BaseModel):

--- a/api/src/routers/tables.py
+++ b/api/src/routers/tables.py
@@ -490,6 +490,22 @@ class DocumentRepository:
         """
         base_query = select(Document).where(Document.table_id == self.table.id)
 
+        document_id_pagination = (
+            query_params.after_document_id is not None
+            or query_params.document_id_prefix is not None
+        )
+        if query_params.document_id_prefix is not None:
+            prefix = query_params.document_id_prefix
+            # The lower bound seeks into the existing ``(table_id, id)``
+            # btree. Keep the startswith predicate for the exact prefix
+            # boundary: synthesizing a textual upper bound is incorrect under
+            # locale-aware PostgreSQL collations (for example, ``|`` and ``}``
+            # do not necessarily sort by code point).
+            base_query = base_query.where(Document.id >= prefix)
+            base_query = base_query.where(Document.id.startswith(prefix, autoescape=True))
+        if query_params.after_document_id is not None:
+            base_query = base_query.where(Document.id > query_params.after_document_id)
+
         # Apply where filters using JSON-native operators
         if query_params.where:
             base_query = _build_document_filters(base_query, query_params.where)
@@ -510,7 +526,9 @@ class DocumentRepository:
         # (e.g. rows inserted in the same transaction share `created_at`).
         # Without a tiebreaker, Postgres returns tied rows in arbitrary order
         # and the same id can appear on adjacent pages — or be skipped entirely.
-        if query_params.order_by:
+        if document_id_pagination:
+            base_query = base_query.order_by(Document.id)
+        elif query_params.order_by:
             # Order by JSONB field
             order_expr = Document.data[query_params.order_by].astext
             if query_params.order_dir == "desc":

--- a/api/tests/e2e/api-integration/test_tables.py
+++ b/api/tests/e2e/api-integration/test_tables.py
@@ -241,6 +241,82 @@ class TestDocumentRepositoryIntegration:
         assert len(documents) == 3
 
     @pytest.mark.asyncio
+    async def test_query_documents_by_actual_id_cursor_and_prefix(
+        self, db_session: AsyncSession, test_table, test_user_email
+    ):
+        """Document-ID pagination must not read or sort by ``data.id``."""
+        doc_repo = DocumentRepository(db_session, test_table)
+        await doc_repo.insert(
+            {"id": "json-z", "label": "first"},
+            created_by=test_user_email,
+            doc_id="tenant-a|001",
+        )
+        await doc_repo.insert(
+            {"id": "json-a", "label": "second"},
+            created_by=test_user_email,
+            doc_id="tenant-a|002",
+        )
+        await doc_repo.insert(
+            {"id": "json-m", "label": "other tenant"},
+            created_by=test_user_email,
+            doc_id="tenant-b|001",
+        )
+
+        from src.models.contracts.tables import DocumentQuery
+
+        first_page, total = await doc_repo.query(
+            DocumentQuery(
+                document_id_prefix="tenant-a|",
+                limit=1,
+                skip_count=True,
+            )
+        )
+        assert [doc.id for doc in first_page] == ["tenant-a|001"]
+        assert total == -1
+
+        unbounded_page, _ = await doc_repo.query(
+            DocumentQuery(after_document_id="", limit=10, skip_count=True)
+        )
+        assert [doc.id for doc in unbounded_page] == [
+            "tenant-a|001",
+            "tenant-a|002",
+            "tenant-b|001",
+        ]
+
+        second_page, total = await doc_repo.query(
+            DocumentQuery(
+                document_id_prefix="tenant-a|",
+                after_document_id=first_page[-1].id,
+                limit=10,
+                skip_count=True,
+            )
+        )
+        assert [doc.id for doc in second_page] == ["tenant-a|002"]
+        assert total == -1
+
+        legacy_json_query, _ = await doc_repo.query(
+            DocumentQuery(where={"id": "json-a"}, order_by="id")
+        )
+        assert [doc.id for doc in legacy_json_query] == ["tenant-a|002"]
+
+    @pytest.mark.parametrize(
+        "kwargs, message",
+        [
+            ({"order_by": "name"}, "order_by"),
+            ({"order_dir": "desc"}, "ascending"),
+            ({"offset": 1}, "offset"),
+        ],
+    )
+    def test_document_id_pagination_rejects_incompatible_pagination(
+        self, kwargs, message
+    ):
+        from pydantic import ValidationError
+        from src.models.contracts.tables import DocumentQuery
+
+        with pytest.raises(ValidationError, match=message):
+            DocumentQuery(after_document_id="cursor", **kwargs)
+
+    @pytest.mark.asyncio
     async def test_count_documents(self, db_session: AsyncSession, test_table, test_user_email):
         """Test counting documents."""
         doc_repo = DocumentRepository(db_session, test_table)

--- a/api/tests/e2e/platform/test_policies.py
+++ b/api/tests/e2e/platform/test_policies.py
@@ -29,9 +29,12 @@ def _set_policies(e2e_client, headers, table_id, policies):
     assert r.status_code == 200, r.text
 
 
-def _insert(e2e_client, headers, table_id, data):
+def _insert(e2e_client, headers, table_id, data, doc_id=None):
+    body = {"data": data}
+    if doc_id is not None:
+        body["id"] = doc_id
     return e2e_client.post(
-        f"/api/tables/{table_id}/documents", headers=headers, json={"data": data}
+        f"/api/tables/{table_id}/documents", headers=headers, json=body
     )
 
 
@@ -146,6 +149,69 @@ class TestPoliciesMatrix:
         # Admin queries — sees both
         admin_q = _query(e2e_client, platform_admin.headers, table_id).json()["documents"]
         assert len(admin_q) == 2
+
+    def test_own_row_policy_filters_document_id_keyset_query(
+        self, e2e_client, platform_admin, alice_user, bob_user
+    ):
+        table_id = _create_table(
+            e2e_client,
+            platform_admin.headers,
+            f"own_keyset_{uuid.uuid4().hex[:8]}",
+        )
+        _set_policies(
+            e2e_client,
+            platform_admin.headers,
+            table_id,
+            {
+                "policies": [
+                    {
+                        "name": "admin_bypass",
+                        "actions": ["read", "create", "update", "delete"],
+                        "when": {"user": "is_platform_admin"},
+                    },
+                    {
+                        "name": "own_row_full",
+                        "actions": ["read", "create", "update", "delete"],
+                        "when": {
+                            "eq": [
+                                {"row": "created_by"},
+                                {"user": "user_id"},
+                            ]
+                        },
+                    },
+                ]
+            },
+        )
+        assert _insert(
+            e2e_client,
+            alice_user.headers,
+            table_id,
+            {"who": "alice"},
+            "tenant|001",
+        ).status_code == 201
+        assert _insert(
+            e2e_client,
+            bob_user.headers,
+            table_id,
+            {"who": "bob"},
+            "tenant|002",
+        ).status_code == 201
+
+        response = e2e_client.post(
+            f"/api/tables/{table_id}/documents/query",
+            headers=alice_user.headers,
+            json={
+                "document_id_prefix": "tenant|",
+                "after_document_id": "tenant|000",
+                "skip_count": True,
+            },
+        )
+
+        assert response.status_code == 200, response.text
+        assert response.json()["total"] == -1
+        assert [doc["id"] for doc in response.json()["documents"]] == [
+            "tenant|001"
+        ]
 
     def test_state_locked_update(self, e2e_client, platform_admin, alice_user):
         """Owner can update while status=open; cannot once status=done (pre-update semantics)."""

--- a/api/tests/e2e/platform/test_table_solution_cascade_gated.py
+++ b/api/tests/e2e/platform/test_table_solution_cascade_gated.py
@@ -95,11 +95,12 @@ def _query_labels(
     *,
     solution_id: str,
     scope: str,
+    query: dict | None = None,
 ) -> list[str]:
     response = e2e_client.post(
         f"/api/tables/{table_name}/documents/query?solution={solution_id}&scope={scope}",
         headers=headers,
-        json={"where": {}, "order_by": "label"},
+        json=query or {"where": {}, "order_by": "label"},
     )
     assert response.status_code == 200, response.text
     return [row["data"]["label"] for row in response.json()["documents"]]
@@ -139,7 +140,12 @@ async def test_open_solution_reads_own_then_org_then_global_tables_by_name(
     _insert_row(e2e_client, headers, global_shadow_id, "row", "global-shadow")
 
     assert _query_labels(
-        e2e_client, headers, own_name, solution_id=solution_id, scope=org1["id"]
+        e2e_client,
+        headers,
+        own_name,
+        solution_id=solution_id,
+        scope=org1["id"],
+        query={"document_id_prefix": "row", "skip_count": True},
     ) == ["own"]
 
     org_name = f"open_org_{uuid.uuid4().hex[:8]}"

--- a/api/tests/performance/test_table_document_id_pagination.py
+++ b/api/tests/performance/test_table_document_id_pagination.py
@@ -1,0 +1,100 @@
+"""Query-plan regression for actual document-ID keyset pagination."""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import event, insert, text
+from sqlalchemy.dialects import postgresql
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.models.contracts.tables import DocumentQuery
+from src.models.orm.organizations import Organization
+from src.models.orm.tables import Document, Table
+from src.routers.tables import DocumentRepository
+
+
+def _plan_nodes(plan: dict):
+    yield plan
+    for child in plan.get("Plans", []):
+        yield from _plan_nodes(child)
+
+
+@pytest.mark.asyncio
+@pytest.mark.slow
+@pytest.mark.timeout(120)
+async def test_document_id_keyset_query_uses_composite_index_without_sort(
+    db_session: AsyncSession,
+) -> None:
+    """A production-shaped tenant page seeks through ``documents_pkey``."""
+    org = Organization(
+        id=uuid4(),
+        name=f"Document ID plan {uuid4().hex[:8]}",
+        domain=f"document-id-plan-{uuid4().hex[:8]}.example.com",
+        created_by="test@example.com",
+    )
+    table = Table(
+        id=uuid4(),
+        name=f"document_id_plan_{uuid4().hex[:8]}",
+        organization_id=org.id,
+        created_by="test@example.com",
+    )
+    db_session.add_all([org, table])
+    await db_session.flush()
+
+    rows = []
+    for tenant in range(5):
+        prefix = f"tenant-{tenant:02d}|"
+        rows.extend(
+            {
+                "table_id": table.id,
+                "id": f"{prefix}drive|item-{item:05d}",
+                "data": {"tenant": tenant, "item": item},
+                "created_by": "test@example.com",
+                "updated_by": "test@example.com",
+            }
+            for item in range(4_000)
+        )
+    await db_session.execute(insert(Document), rows)
+    await db_session.commit()
+    await db_session.execute(text("ANALYZE documents"))
+
+    captured = []
+
+    def capture_statement(orm_execute_state):
+        if orm_execute_state.is_select:
+            captured.append(orm_execute_state.statement)
+
+    event.listen(db_session.sync_session, "do_orm_execute", capture_statement)
+    try:
+        documents, total = await DocumentRepository(db_session, table).query(
+            DocumentQuery(
+                document_id_prefix="tenant-03|",
+                after_document_id="tenant-03|drive|item-01999",
+                skip_count=True,
+                limit=500,
+            )
+        )
+    finally:
+        event.remove(db_session.sync_session, "do_orm_execute", capture_statement)
+
+    assert total == -1
+    assert len(documents) == 500
+    statement = captured[-1]
+    sql = str(
+        statement.compile(
+            dialect=postgresql.dialect(),
+            compile_kwargs={"literal_binds": True},
+        )
+    )
+    result = await db_session.execute(text(f"EXPLAIN (FORMAT JSON) {sql}"))
+    plan = result.scalar_one()[0]["Plan"]
+    nodes = list(_plan_nodes(plan))
+
+    assert all(node["Node Type"] != "Sort" for node in nodes)
+    assert any(
+        node["Node Type"] in {"Index Scan", "Index Only Scan"}
+        and node.get("Index Name") == "documents_pkey"
+        for node in nodes
+    )

--- a/api/tests/unit/sdk/test_sdk_tables.py
+++ b/api/tests/unit/sdk/test_sdk_tables.py
@@ -196,6 +196,48 @@ async def test_tables_bulk_upsert_posts_count_only_request(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_tables_query_forwards_document_id_pagination_and_skip_count(monkeypatch):
+    module = importlib.import_module("bifrost.tables")
+    from bifrost import tables
+
+    response = MagicMock(status_code=200)
+    response.json.return_value = {
+        "documents": [],
+        "total": -1,
+        "limit": 500,
+        "offset": 0,
+    }
+    client = MagicMock()
+    client.post = AsyncMock(return_value=response)
+    monkeypatch.setattr(module, "get_client", lambda: client)
+    monkeypatch.setattr(module, "raise_for_status_with_detail", MagicMock())
+
+    result = await tables.query(
+        "inventory",
+        scope="global",
+        after_document_id="tenant|drive|item-001",
+        document_id_prefix="tenant|",
+        skip_count=True,
+        limit=500,
+    )
+
+    assert result.total == -1
+    client.post.assert_awaited_once_with(
+        "/api/tables/inventory/documents/query?scope=global",
+        json={
+            "where": None,
+            "order_by": None,
+            "order_dir": "asc",
+            "limit": 500,
+            "offset": 0,
+            "after_document_id": "tenant|drive|item-001",
+            "document_id_prefix": "tenant|",
+            "skip_count": True,
+        },
+    )
+
+
+@pytest.mark.asyncio
 async def test_tables_bulk_upsert_retries_bounded_conflict(monkeypatch):
     module = importlib.import_module("bifrost.tables")
     from bifrost import tables

--- a/client/src/lib/v1.d.ts
+++ b/client/src/lib/v1.d.ts
@@ -15368,6 +15368,16 @@ export interface components {
              * @default false
              */
             skip_count: boolean;
+            /**
+             * After Document Id
+             * @description Return documents whose actual document ID is greater than this exclusive cursor, ordered by document ID.
+             */
+            after_document_id?: string | null;
+            /**
+             * Document Id Prefix
+             * @description Return only documents whose actual document ID starts with this prefix, ordered by document ID.
+             */
+            document_id_prefix?: string | null;
         };
         /**
          * DocumentSection

--- a/plugins/bifrost/skills/bifrost-build/generated/python-sdk-signatures.md
+++ b/plugins/bifrost/skills/bifrost-build/generated/python-sdk-signatures.md
@@ -214,7 +214,7 @@ Event publishing operations (async).
 
 **`tables.list(scope: str | None = None, app: str | None = None) -> list[TableInfo]`**
 
-**`tables.query(table: str, where: dict[str, Any] | None = None, order_by: str | None = None, order_dir: str = 'asc', limit: int = 100, offset: int = 0, scope: str | None = None) -> DocumentList`**
+**`tables.query(table: str, where: dict[str, Any] | None = None, order_by: str | None = None, order_dir: str = 'asc', limit: int = 100, offset: int = 0, scope: str | None = None, after_document_id: str | None = None, document_id_prefix: str | None = None, skip_count: bool = False) -> DocumentList`**
 
 **`tables.update(table: str, doc_id: str, data: dict[str, Any], scope: str | None = None, updated_by: str | None = None) -> DocumentData | None`**
 


### PR DESCRIPTION
## Summary

- add first-class document ID prefix and cursor parameters to table queries
- expose the parameters through the Python tables SDK, including optional count skipping
- verify the PostgreSQL plan uses the documents primary-key index without a sort
- preserve table policy filtering and Solution-scoped table resolution

## Verification

- `./test.sh pre-pr` (passed for `ab5b3dd806b624d846abd2bc4b33557421bb5c34`)
- targeted table/SDK/policy/performance tests: 57 passed
- contract and generated-skill tripwires: 184 passed, 2 skipped
- API quality, client typecheck, and client lint passed

Fixes #722