### PR TITLE
Support base64 webhook HMAC signatures

### DIFF
--- a/api/bifrost/webhooks.py
+++ b/api/bifrost/webhooks.py
@@ -34,16 +34,15 @@ Usage in workspace/adapters/my_adapter.py:
             ...
 """
 
+import base64
+import hashlib
+import hmac
+import json
+import secrets
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from typing import Any, Callable, TypeVar
-
-import hashlib
-import hmac
-import secrets
-import json
-
 
 F = TypeVar("F", bound=type)
 
@@ -304,7 +303,7 @@ class WebhookAdapter(ABC):
         prefix: str = "sha256=",
     ) -> bool:
         """
-        Verify HMAC-SHA256 signature.
+        Verify a hex- or base64-encoded HMAC-SHA256 signature.
 
         Common pattern for webhook validation (GitHub, Stripe, etc.)
 
@@ -317,16 +316,25 @@ class WebhookAdapter(ABC):
         Returns:
             True if signature is valid
         """
-        expected = hmac.new(
+        signature = signature.strip()
+        if prefix:
+            if not signature.startswith(prefix):
+                return False
+            signature = signature[len(prefix) :].strip()
+
+        digest = hmac.new(
             secret.encode(),
             payload,
             hashlib.sha256,
-        ).hexdigest()
+        ).digest()
 
-        if prefix:
-            expected = f"{prefix}{expected}"
+        hex_matches = hmac.compare_digest(signature, digest.hex())
+        base64_matches = hmac.compare_digest(
+            signature,
+            base64.b64encode(digest).decode("ascii"),
+        )
 
-        return hmac.compare_digest(expected, signature)
+        return hex_matches or base64_matches
 
     @staticmethod
     def expiration_datetime(

--- a/api/src/services/webhooks/adapters/generic.py
+++ b/api/src/services/webhooks/adapters/generic.py
@@ -47,7 +47,7 @@ class GenericWebhookAdapter(WebhookAdapter):
                 "description": "HMAC secret for signature verification (optional)",
                 "format": "password",
                 "x-help": {
-                    "text": "Shared secret used to verify webhook signatures via HMAC-SHA256. Set the same secret in both Bifrost and the sending service.",
+                    "text": "Shared secret used to verify webhook signatures via HMAC-SHA256. Bifrost accepts hex- or base64-encoded digests. Set the same secret in both Bifrost and the sending service.",
                     "code": (
                         "# Python example: sign a webhook request\n"
                         "import hmac, hashlib\n"
@@ -73,7 +73,7 @@ class GenericWebhookAdapter(WebhookAdapter):
                 "description": "Prefix in signature value (e.g., 'sha256=')",
                 "default": "sha256=",
                 "x-help": {
-                    "text": "Prefix before the hex digest in the signature header value. Bifrost strips this before comparing. Use 'sha256=' for GitHub-style signatures, or leave empty if the header contains only the hex digest.",
+                    "text": "Prefix before the encoded digest in the signature header value. Bifrost strips the prefix and surrounding whitespace before comparing. Use 'sha256=' for GitHub-style signatures, or leave empty if the header contains only the digest.",
                 },
             },
             "event_type_header": {

--- a/api/src/services/webhooks/protocol.py
+++ b/api/src/services/webhooks/protocol.py
@@ -350,7 +350,7 @@ class WebhookAdapter(ABC):
         prefix: str = "",
     ) -> bool:
         """
-        Verify HMAC-SHA256 signature.
+        Verify a hex- or base64-encoded HMAC-SHA256 signature.
 
         Args:
             body: Request body bytes.
@@ -364,20 +364,29 @@ class WebhookAdapter(ABC):
         if not signature:
             return False
 
+        import base64
         import hashlib
         import hmac
 
-        # Remove prefix if present
+        # Header values may include optional whitespace around the prefix or
+        # encoded digest. Whitespace within the digest remains significant.
+        signature = signature.strip()
         if prefix and signature.startswith(prefix):
-            signature = signature[len(prefix) :]
+            signature = signature[len(prefix) :].strip()
 
-        expected = hmac.new(
+        digest = hmac.new(
             secret.encode("utf-8"),
             body,
             hashlib.sha256,
-        ).hexdigest()
+        ).digest()
 
-        return hmac.compare_digest(signature.lower(), expected.lower())
+        hex_matches = hmac.compare_digest(signature.lower(), digest.hex())
+        base64_matches = hmac.compare_digest(
+            signature,
+            base64.b64encode(digest).decode("ascii"),
+        )
+
+        return hex_matches or base64_matches
 
     @staticmethod
     def expiration_datetime(days: int = 3) -> str:

--- a/api/tests/e2e/api/test_events.py
+++ b/api/tests/e2e/api/test_events.py
@@ -9,6 +9,7 @@ Tests the full event lifecycle:
 - Delivery retry
 """
 
+import base64
 import hashlib
 import hmac
 import uuid
@@ -1148,6 +1149,12 @@ def _hmac_sign(body: bytes, secret: str, prefix: str = "sha256=") -> str:
     return f"{prefix}{sig}"
 
 
+def _hmac_sign_base64(body: bytes, secret: str, prefix: str = "sha256= ") -> str:
+    """Compute a base64-encoded HMAC-SHA256 signature."""
+    digest = hmac.new(secret.encode(), body, hashlib.sha256).digest()
+    return f"{prefix}{base64.b64encode(digest).decode('ascii')}"
+
+
 @pytest.mark.e2e
 class TestWebhookAuthentication:
     """Tests for webhook HMAC signature verification."""
@@ -1229,6 +1236,29 @@ class TestWebhookAuthentication:
             },
         )
         assert response.status_code == 202, f"Expected 202, got {response.status_code}: {response.text}"
+
+    def test_webhook_with_spaced_base64_hmac_accepted(
+        self, e2e_client, secret_source
+    ):
+        """A base64 HMAC separated from its prefix by a space is accepted."""
+        callback_url = secret_source["webhook"]["callback_url"]
+        from urllib.parse import urlparse
+
+        path = urlparse(callback_url).path
+        body = b'{"event": "test", "encoding": "base64"}'
+        signature = _hmac_sign_base64(body, secret_source["_secret"])
+
+        response = e2e_client.post(
+            path,
+            content=body,
+            headers={
+                "Content-Type": "application/json",
+                "X-Signature-256": signature,
+            },
+        )
+        assert response.status_code == 202, (
+            f"Expected 202, got {response.status_code}: {response.text}"
+        )
 
     def test_webhook_with_invalid_hmac_rejected(self, e2e_client, secret_source):
         """Invalid HMAC signature → 401."""

--- a/api/tests/unit/services/test_webhook_adapters.py
+++ b/api/tests/unit/services/test_webhook_adapters.py
@@ -5,6 +5,7 @@ Tests HMAC-SHA256 signature verification and the GenericWebhookAdapter
 request handling logic.
 """
 
+import base64
 import hashlib
 import hmac
 import json
@@ -17,13 +18,14 @@ import jwt
 import pytest
 from cryptography.hazmat.primitives.asymmetric import rsa
 
+from bifrost.webhooks import WebhookAdapter as SdkWebhookAdapter
+from src.services.webhooks import registry as webhook_registry
 from src.services.webhooks.adapters.generic import GenericWebhookAdapter
 from src.services.webhooks.adapters.local_fixture import LocalFixtureWebhookAdapter
 from src.services.webhooks.adapters.microsoft_bot_framework import (
     MicrosoftBotFrameworkAdapter,
 )
 from src.services.webhooks.adapters.microsoft_graph import MicrosoftGraphAdapter
-from src.services.webhooks import registry as webhook_registry
 from src.services.webhooks.protocol import (
     Deliver,
     Rejected,
@@ -364,6 +366,48 @@ class TestVerifyHmacSha256:
             WebhookAdapter.verify_hmac_sha256(b"body", "secret", None) is False
         )
 
+    def test_base64_signature_with_whitespace_after_prefix(self):
+        body = b"hello world"
+        secret = "mysecret"
+        digest = hmac.new(secret.encode(), body, hashlib.sha256).digest()
+        signature = base64.b64encode(digest).decode("ascii")
+
+        assert (
+            WebhookAdapter.verify_hmac_sha256(
+                body,
+                secret,
+                f"  sha256= {signature}  ",
+                prefix="sha256=",
+            )
+            is True
+        )
+
+    def test_whitespace_within_base64_signature_is_rejected(self):
+        body = b"hello world"
+        secret = "mysecret"
+        digest = hmac.new(secret.encode(), body, hashlib.sha256).digest()
+        signature = base64.b64encode(digest).decode("ascii")
+        signature = f"{signature[:10]} {signature[10:]}"
+
+        assert (
+            WebhookAdapter.verify_hmac_sha256(body, secret, signature) is False
+        )
+
+    def test_sdk_helper_accepts_base64_with_whitespace_after_prefix(self):
+        body = b"hello world"
+        secret = "mysecret"
+        digest = hmac.new(secret.encode(), body, hashlib.sha256).digest()
+        signature = base64.b64encode(digest).decode("ascii")
+
+        assert (
+            SdkWebhookAdapter.verify_hmac_sha256(
+                body,
+                secret,
+                f"sha256= {signature}",
+            )
+            is True
+        )
+
 
 # =============================================================================
 # TestGenericWebhookAdapterHandleRequest
@@ -395,6 +439,24 @@ class TestGenericWebhookAdapterHandleRequest:
         request = _make_request(
             body=body,
             headers={"x-signature-256": sig},
+        )
+        result = await adapter.handle_request(
+            request, config={}, state={"secret": secret}
+        )
+
+        assert isinstance(result, Deliver)
+
+    @pytest.mark.asyncio
+    async def test_base64_signature_with_whitespace_accepted(self, adapter):
+        """A base64 HMAC separated from its prefix by whitespace is valid."""
+        body = b'{"event": "push"}'
+        secret = "test-secret"
+        digest = hmac.new(secret.encode(), body, hashlib.sha256).digest()
+        signature = base64.b64encode(digest).decode("ascii")
+
+        request = _make_request(
+            body=body,
+            headers={"x-signature-256": f"sha256= {signature}"},
         )
         result = await adapter.handle_request(
             request, config={}, state={"secret": secret}


### PR DESCRIPTION
## Summary

Webhook HMAC verification previously computed `hexdigest()` and compared it to the incoming header, so only hex-encoded signatures could ever match. Senders that base64-encode the same HMAC-SHA256 digest were rejected as invalid even with a correctly configured shared secret.

This widens the accepted input to either canonical encoding of the same digest, and tolerates the whitespace HaloPSA emits after the `sha256=` prefix.

Fixes #726

## Changes

- **`api/src/services/webhooks/protocol.py`** — `WebhookAdapter.verify_hmac_signature` now computes the raw digest once and accepts either `digest.hex()` or `base64.b64encode(digest)`. The header value is stripped, and stripped again after the configured prefix is removed.
- **`api/bifrost/webhooks.py`** — the public SDK helper mirrors the same hex-or-base64 acceptance and whitespace handling.
- **`api/src/services/webhooks/adapters/generic.py`** — configuration help text no longer claims the header must contain a hex digest.

## Design notes

- The incoming signature is compared against **canonically encoded expected values**; attacker-supplied input is never decoded. This avoids accepting alternate encodings of the same bytes (unpadded, base64url, whitespace-injected) as equivalent.
- Only standard **padded** base64 of the raw digest is accepted — not base64url, unpadded base64, or base64-of-hex. Those can be added if a real provider needs them.
- Whitespace is tolerated only around the whole value and immediately after the prefix. Whitespace *within* the digest is still rejected.
- Hex remains case-insensitive in the runtime verifier and case-sensitive in the SDK helper, preserving each one's prior behaviour. Base64 is case-sensitive in both.
- Both comparisons use `hmac.compare_digest`, so verification stays constant-time. Two comparisons run unconditionally rather than short-circuiting on encoding shape.
- The SDK helper continues to *require* the prefix when one is configured (its prior behaviour); the runtime verifier continues to strip the prefix only when present (its prior behaviour). Neither is changed by this PR.

No migration, DTO, generated TypeScript, or configuration change is required — this is purely a widening of accepted input, so existing hex senders are unaffected.

## Tests

`api/tests/unit/services/test_webhook_adapters.py`
- `test_base64_signature_with_whitespace_after_prefix`
- `test_whitespace_within_base64_signature_is_rejected`
- `test_sdk_helper_accepts_base64_with_whitespace_after_prefix`
- `test_base64_signature_with_whitespace_accepted`

`api/tests/e2e/api/test_events.py`
- `test_webhook_with_spaced_base64_hmac_accepted` — endpoint-level happy path for Halo's `sha256= <base64>` form

Existing hex coverage is unchanged and still passing.
