### PR TITLE
fix: preserve long-running workflow completion tracking

### DIFF
--- a/api/src/core/cache/invalidation.py
+++ b/api/src/core/cache/invalidation.py
@@ -24,6 +24,7 @@ from .keys import (
     CONFIG_GLOBAL_VERSION_KEY,
     TTL_CONFIG,
     TTL_ORGS,
+    active_execution_key,
     config_hash_key,
     config_hash_key_versioned,
     config_key,
@@ -35,6 +36,8 @@ from .keys import (
     role_key,
     role_users_key,
     roles_hash_key,
+    execution_logs_stream_key,
+    pending_changes_key,
 )
 from src.core.log_safety import log_safe
 
@@ -344,17 +347,18 @@ async def cleanup_execution_cache(execution_id: str) -> None:
     Called after execution completes to remove:
     - Pending changes (should already be flushed)
     - Log stream (if using Redis streams)
-    - Any other execution-scoped data
+    - Active execution lease
 
     Args:
         execution_id: Execution ID to clean up
     """
-    from .keys import execution_logs_stream_key, pending_changes_key
-
     try:
         r = await get_shared_redis()
-        await r.delete(pending_changes_key(execution_id))
-        await r.delete(execution_logs_stream_key(execution_id))
+        await r.delete(
+            pending_changes_key(execution_id),
+            execution_logs_stream_key(execution_id),
+            active_execution_key(execution_id),
+        )
         logger.debug(f"Cleaned up execution cache: execution_id={execution_id}")
     except Exception as e:
         logger.warning(f"Failed to cleanup execution cache: {e}")

--- a/api/src/core/cache/keys.py
+++ b/api/src/core/cache/keys.py
@@ -220,6 +220,11 @@ def execution_context_key(execution_id: str) -> str:
     return f"bifrost:exec:{execution_id}:context"
 
 
+def active_execution_key(execution_id: str) -> str:
+    """Compact parent-owned lease for an actively running execution."""
+    return f"bifrost:exec:{execution_id}:active"
+
+
 def execution_result_key(execution_id: str) -> str:
     """
     Key for execution result (written by worker process).
@@ -358,6 +363,7 @@ TTL_ROLES = 600  # 10 minutes
 TTL_ORGS = 3600  # 1 hour
 TTL_PENDING = 3600  # 1 hour (safety for orphaned changes)
 TTL_PENDING_EXECUTION = 3600  # 1 hour (safety for orphaned pending executions)
+TTL_ACTIVE_EXECUTION = 3600  # 1 hour (recreated while the child is active)
 
 # Embed TTLs
 TTL_EMBED_EXECUTION = 86400  # 24 hours (embed session → execution link)

--- a/api/src/core/redis_client.py
+++ b/api/src/core/redis_client.py
@@ -23,6 +23,7 @@ from typing import Any, Awaitable, TypedDict, cast
 import redis.asyncio as redis
 
 from src.config import get_settings
+from src.core.cache.keys import active_execution_key
 from src.core.log_safety import log_safe
 
 logger = logging.getLogger(__name__)
@@ -69,6 +70,20 @@ class PendingExecution(TypedDict):
     artifact_workspace_id: str | None
     created_at: str  # ISO format
     cancelled: bool
+
+
+class ActiveExecution(TypedDict):
+    """Compact completion metadata retained by the process-pool parent."""
+
+    execution_id: str
+    workflow_id: str | None
+    workflow_name: str
+    org_id: str | None
+    user_id: str | None
+    user_name: str
+    user_email: str | None
+    sync: bool
+    event: dict[str, Any] | None
 
 
 class RedisClient:
@@ -220,6 +235,17 @@ class RedisClient:
         except Exception as e:
             logger.error(f"Failed to delete pending execution: {e}")
             raise
+
+    async def get_active_execution(
+        self,
+        execution_id: str,
+    ) -> ActiveExecution | None:
+        """Read the compact parent-owned lease for a running execution."""
+        redis_client = await self._get_redis()
+        data = await redis_client.get(active_execution_key(execution_id))
+        if data is None:
+            return None
+        return cast(ActiveExecution, json.loads(data))
 
     async def set_pending_cancelled(self, execution_id: str) -> bool:
         """

--- a/api/src/jobs/consumers/workflow_execution.py
+++ b/api/src/jobs/consumers/workflow_execution.py
@@ -3,13 +3,13 @@ Workflow Execution Consumer
 
 Processes async workflow executions from RabbitMQ queue.
 
-Architecture (Redis-first):
+Architecture (PostgreSQL-durable with Redis acceleration):
 1. API stores pending execution in Redis, publishes to RabbitMQ
 2. Consumer reads pending execution from Redis
-3. Consumer creates PostgreSQL record when starting
-4. Consumer routes execution to ProcessPoolManager
-5. ProcessPoolManager executes in worker process, returns result via callback
-6. Consumer handles result: updates DB, flushes logs, cleans up Redis
+3. Consumer creates the durable PostgreSQL execution row when starting
+4. Consumer routes execution with a compact, parent-owned Redis lease
+5. ProcessPoolManager refreshes that lease while its child remains active
+6. Consumer records the result from the lease or reconstructs it from PostgreSQL
 
 For sync execution requests (sync=True in message):
 - Pushes result to Redis after completion
@@ -26,12 +26,17 @@ import logging
 import time
 from datetime import datetime, timezone
 from typing import Any
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.core.database import get_db_context
 from src.core.pubsub import publish_execution_update, publish_history_update
-from src.core.redis_client import get_redis_client
+from src.core.redis_client import ActiveExecution, get_redis_client
 from src.jobs.rabbitmq import BaseConsumer
 from src.models.enums import ExecutionStatus
+from src.models.orm import Execution, User
 from src.repositories.executions import create_execution, update_execution
 
 logger = logging.getLogger(__name__)
@@ -58,7 +63,7 @@ class WorkflowExecutionConsumer(BaseConsumer):
         "sync": false (optional, if true pushes result to Redis for API)
     }
 
-    Full execution context is read from Redis pending execution.
+    Full execution context is read from the initial Redis pending execution.
     """
 
     def __init__(self):
@@ -124,6 +129,82 @@ class WorkflowExecutionConsumer(BaseConsumer):
         except Exception as e:
             logger.error(f"Failed to process result for {execution_id}: {e}")
             raise
+
+    async def _load_completion_metadata(
+        self,
+        execution_id: str,
+        session: AsyncSession | None = None,
+    ) -> tuple[ActiveExecution | None, bool]:
+        """Load compact metadata, rebuilding it from PostgreSQL if Redis lost it.
+
+        Returns the metadata and whether PostgreSQL recovery was required. The
+        recovery bit lets callers reconcile event delivery defensively because
+        the durable execution row does not retain the triggering event payload.
+        """
+        try:
+            active = await self._redis_client.get_active_execution(execution_id)
+        except Exception as exc:  # noqa: BLE001 - PostgreSQL is the fallback
+            logger.warning(
+                "Could not read active execution lease for %s: %s",
+                execution_id,
+                exc,
+            )
+            active = None
+
+        if active is not None:
+            return active, False
+
+        if session is None:
+            from src.core.database import get_session_factory
+
+            session_factory = get_session_factory()
+            async with session_factory() as recovery_session:
+                return await self._load_completion_metadata_from_database(
+                    execution_id, recovery_session
+                )
+
+        return await self._load_completion_metadata_from_database(
+            execution_id, session
+        )
+
+    async def _load_completion_metadata_from_database(
+        self,
+        execution_id: str,
+        session: AsyncSession,
+    ) -> tuple[ActiveExecution | None, bool]:
+        """Reconstruct terminal bookkeeping metadata from its durable row."""
+
+        row = (
+            await session.execute(
+                select(Execution, User.email)
+                .outerjoin(User, Execution.executed_by == User.id)
+                .where(Execution.id == UUID(execution_id))
+            )
+        ).one_or_none()
+        if row is None:
+            return None, True
+
+        execution, user_email = row
+        return (
+            ActiveExecution(
+                execution_id=str(execution.id),
+                workflow_id=(
+                    str(execution.workflow_id) if execution.workflow_id else None
+                ),
+                workflow_name=execution.workflow_name,
+                org_id=(
+                    str(execution.organization_id)
+                    if execution.organization_id
+                    else None
+                ),
+                user_id=(str(execution.executed_by) if execution.executed_by else None),
+                user_name=execution.executed_by_name,
+                user_email=user_email,
+                sync=False,
+                event=None,
+            ),
+            True,
+        )
 
     async def _record_completion_metrics(
         self,
@@ -205,19 +286,23 @@ class WorkflowExecutionConsumer(BaseConsumer):
         workflow_result = result.get("result")
         duration_ms = result.get("duration_ms", 0)
 
-        # Redis read — no DB connection held
-        pending = await self._redis_client.get_pending_execution(execution_id)
-        if not pending:
-            logger.warning(f"No pending record found for result: {execution_id}")
+        metadata, recovered_from_database = await self._load_completion_metadata(
+            execution_id
+        )
+        if metadata is None:
+            logger.error(
+                "No active lease or durable execution row found for result: %s",
+                execution_id,
+            )
             return
-        pending_read_ms = (time.perf_counter() - completion_started) * 1000
+        metadata_read_ms = (time.perf_counter() - completion_started) * 1000
 
-        workflow_id = pending.get("workflow_id")
-        workflow_name = pending.get("workflow_name", "unknown")
-        org_id = pending.get("org_id")
-        user_id = pending.get("user_id")
-        user_name = pending.get("user_name")
-        is_sync = pending.get("sync", False)
+        workflow_id = metadata.get("workflow_id")
+        workflow_name = metadata.get("workflow_name", "unknown")
+        org_id = metadata.get("org_id")
+        user_id = metadata.get("user_id")
+        user_name = metadata.get("user_name")
+        is_sync = result["sync"]
 
         status_str = result.get("status", "Success")
         status = (
@@ -250,7 +335,7 @@ class WorkflowExecutionConsumer(BaseConsumer):
             )
             execution_update_ms = (time.perf_counter() - completion_started) * 1000
 
-            if pending.get("event") is not None:
+            if metadata.get("event") is not None or recovered_from_database:
                 try:
                     from src.services.events.processor import update_delivery_from_execution
                     await update_delivery_from_execution(
@@ -353,11 +438,11 @@ class WorkflowExecutionConsumer(BaseConsumer):
         await self._redis_client.delete_pending_execution(execution_id)
 
         logger.debug(
-            "Completion timing %s: pending=%.1fms execution_update=%.1fms "
+            "Completion timing %s: metadata=%.1fms execution_update=%.1fms "
             "changes=%.1fms logs=%.1fms durable=%.1fms result_ready=%.1fms "
             "metrics=%.1fms total=%.1fms",
             execution_id[:8],
-            pending_read_ms,
+            metadata_read_ms,
             execution_update_ms,
             changes_flushed_ms,
             logs_flushed_ms,
@@ -395,19 +480,23 @@ class WorkflowExecutionConsumer(BaseConsumer):
         error_type = result.get("error_type", "ExecutionError")
         duration_ms = result.get("duration_ms", 0)
 
-        # Redis read — no DB connection held
-        pending = await self._redis_client.get_pending_execution(execution_id)
-        if not pending:
-            logger.warning(f"No pending record found for failed result: {execution_id}")
+        metadata, recovered_from_database = await self._load_completion_metadata(
+            execution_id
+        )
+        if metadata is None:
+            logger.error(
+                "No active lease or durable execution row found for failed result: %s",
+                execution_id,
+            )
             return
 
-        workflow_id = pending.get("workflow_id")
-        workflow_name = pending.get("workflow_name", "unknown")
-        org_id = pending.get("org_id")
-        user_id = pending.get("user_id")
-        user_email = pending.get("user_email")
-        user_name = pending.get("user_name")
-        is_sync = pending.get("sync", False)
+        workflow_id = metadata.get("workflow_id")
+        workflow_name = metadata.get("workflow_name", "unknown")
+        org_id = metadata.get("org_id")
+        user_id = metadata.get("user_id")
+        user_email = metadata.get("user_email")
+        user_name = metadata.get("user_name")
+        is_sync = result["sync"]
 
         if error_type == "TimeoutError":
             status = ExecutionStatus.TIMEOUT
@@ -428,7 +517,7 @@ class WorkflowExecutionConsumer(BaseConsumer):
                 session=session,
             )
 
-            if pending.get("event") is not None:
+            if metadata.get("event") is not None or recovered_from_database:
                 try:
                     from src.services.events.processor import update_delivery_from_execution
                     await update_delivery_from_execution(
@@ -541,7 +630,7 @@ class WorkflowExecutionConsumer(BaseConsumer):
             error_type=error_type,
             error_message=error,
             status=status.value,
-            trigger_event=pending.get("event"),
+            trigger_event=metadata.get("event"),
         )
 
     async def process_message(self, message_data: dict[str, Any]) -> None:
@@ -762,17 +851,6 @@ class WorkflowExecutionConsumer(BaseConsumer):
                     return
             metadata_ready_ms = (time.perf_counter() - dispatch_started) * 1000
 
-            # Store additional context in pending record for result handler
-            # (needed when pool reports results asynchronously)
-            await self._redis_client.update_pending_execution(
-                execution_id=execution_id,
-                updates={
-                    "workflow_name": workflow_name,
-                    "workflow_id": workflow_id,
-                    "org_id": org_id,  # Resolved scope for result handlers
-                },
-            )
-
             # Create PostgreSQL record with RUNNING status
             await create_execution(
                 execution_id=execution_id,
@@ -877,6 +955,24 @@ class WorkflowExecutionConsumer(BaseConsumer):
             await self._pool.route_execution(
                 execution_id=execution_id,
                 context=context_data,
+                active_execution=ActiveExecution(
+                    execution_id=execution_id,
+                    workflow_id=str(workflow_id) if workflow_id else None,
+                    workflow_name=workflow_name,
+                    org_id=str(org_id) if org_id else None,
+                    user_id=str(user_id) if user_id else None,
+                    user_name=user_name,
+                    user_email=user_email,
+                    sync=is_sync,
+                    event=(
+                        {
+                            "id": event_data.get("id"),
+                            "type": event_data.get("type"),
+                        }
+                        if event_data
+                        else None
+                    ),
+                ),
             )
             logger.debug(
                 "Dispatch timing %s: pending=%.1fms metadata=%.1fms "

--- a/api/src/jobs/consumers/workflow_execution.py
+++ b/api/src/jobs/consumers/workflow_execution.py
@@ -178,7 +178,12 @@ class WorkflowExecutionConsumer(BaseConsumer):
             await session.execute(
                 select(Execution, User.email)
                 .outerjoin(User, Execution.executed_by == User.id)
-                .where(Execution.id == UUID(execution_id))
+                .where(
+                    Execution.id == UUID(execution_id),
+                    Execution.status.in_(
+                        [ExecutionStatus.RUNNING, ExecutionStatus.CANCELLING]
+                    ),
+                )
             )
         ).one_or_none()
         if row is None:

--- a/api/src/services/execution/process_pool.py
+++ b/api/src/services/execution/process_pool.py
@@ -47,8 +47,10 @@ import psutil
 import redis.asyncio as redis
 
 from src.config import get_settings
-from src.services.execution.memory_monitor import get_cgroup_memory, has_sufficient_memory_cgroup
+from src.core.cache.keys import TTL_ACTIVE_EXECUTION, active_execution_key
+from src.core.redis_client import ActiveExecution
 from src.models.contracts.notifications import NotificationCategory, NotificationCreate, NotificationStatus
+from src.services.execution.memory_monitor import get_cgroup_memory, has_sufficient_memory_cgroup
 from src.services.execution.simple_worker import install_requirements, RequirementsInstallResult
 from src.services.notification_service import get_notification_service
 from src.services.execution.template_process import TemplateProcess
@@ -56,6 +58,7 @@ from src.services.execution.template_process import TemplateProcess
 logger = logging.getLogger(__name__)
 
 _CLEAN_EXIT_RESULT_GRACE = timedelta(seconds=2)
+_ACTIVE_EXECUTION_REFRESH_SECONDS = 10 * 60
 
 
 async def _notify_requirements_failures(result: RequirementsInstallResult) -> None:
@@ -151,11 +154,13 @@ class ExecutionInfo:
         execution_id: Unique identifier for the execution
         started_at: When the execution started
         timeout_seconds: Execution timeout in seconds
+        active_execution: Compact metadata kept alive by the parent process
     """
 
     execution_id: str
     started_at: datetime
     timeout_seconds: int
+    active_execution: ActiveExecution
 
     @property
     def elapsed_seconds(self) -> float:
@@ -166,6 +171,10 @@ class ExecutionInfo:
     def is_timed_out(self) -> bool:
         """Check if execution has exceeded its timeout. 0 = no timeout."""
         return self.timeout_seconds > 0 and self.elapsed_seconds > self.timeout_seconds
+
+    def attach_transport_metadata(self, result: dict[str, Any]) -> dict[str, Any]:
+        """Attach parent-owned metadata required after Redis loss."""
+        return {**result, "sync": self.active_execution["sync"]}
 
 
 @dataclass
@@ -298,7 +307,7 @@ class ProcessPoolManager:
         await pool.start()
 
         # Route execution
-        await pool.route_execution(execution_id, context)
+        await pool.route_execution(execution_id, context, active_execution)
 
         # Shutdown
         await pool.stop()
@@ -342,6 +351,7 @@ class ProcessPoolManager:
         self._shutdown = False
         self._started = False
         self._started_at: datetime | None = None
+        self._last_active_execution_refresh: float | None = None
         self._requirements_installed: int = 0
         self._requirements_total: int = 0
 
@@ -667,6 +677,7 @@ class ProcessPoolManager:
         self,
         execution_id: str,
         context: dict[str, Any],
+        active_execution: ActiveExecution,
     ) -> None:
         """
         Fork a one-shot worker for this execution.
@@ -679,6 +690,7 @@ class ProcessPoolManager:
         Args:
             execution_id: Unique identifier for the execution
             context: Execution context sent to the child and retained in Redis
+            active_execution: Compact completion metadata retained by the parent
         """
         # Write context to Redis
         await self._write_context_to_redis(execution_id, context)
@@ -702,13 +714,14 @@ class ProcessPoolManager:
         # a restart could otherwise begin during the Redis write above and
         # retire the child just before this route sends it work.
         async with self._restart_lock:
-            await self._dispatch_to_child(execution_id, context, timeout)
+            await self._dispatch_to_child(execution_id, context, timeout, active_execution)
 
     async def _dispatch_to_child(
         self,
         execution_id: str,
         context: dict[str, Any],
         timeout: int,
+        active_execution: ActiveExecution,
     ) -> None:
         """Claim or fork one child and send its sole execution."""
         # Wait until a result frees a slot when every child is busy.
@@ -722,8 +735,18 @@ class ProcessPoolManager:
             execution_id=execution_id,
             started_at=datetime.now(timezone.utc),
             timeout_seconds=timeout,
+            active_execution=active_execution,
         )
         handle.result_reported = False
+
+        try:
+            await self._write_active_execution_lease(handle.current_execution)
+        except Exception as exc:  # noqa: BLE001 - execution must still be dispatched
+            logger.warning(
+                "Could not write active execution lease for %s: %s",
+                execution_id,
+                exc,
+            )
 
         self._register_result_reader(handle)
 
@@ -759,6 +782,51 @@ class ProcessPoolManager:
         r = await self._get_redis()
         context_key = f"bifrost:exec:{execution_id}:context"
         await r.setex(context_key, 3600, json.dumps(context, default=str))
+
+    async def _write_active_execution_lease(self, execution: ExecutionInfo) -> None:
+        """Create or recreate the compact Redis lease for one live execution."""
+        r = await self._get_redis()
+        await r.setex(
+            active_execution_key(execution.execution_id),
+            TTL_ACTIVE_EXECUTION,
+            json.dumps(execution.active_execution),
+        )
+
+    async def _refresh_active_execution_leases(self) -> None:
+        """Recreate all live execution leases with one Redis round trip."""
+        executions = [
+            handle.current_execution
+            for handle in self.processes.values()
+            if (
+                handle.state == ProcessState.BUSY
+                and not handle.result_reported
+                and handle.current_execution is not None
+            )
+        ]
+        if not executions:
+            return
+
+        r = await self._get_redis()
+        pipeline = r.pipeline(transaction=False)
+        for execution in executions:
+            pipeline.setex(
+                active_execution_key(execution.execution_id),
+                TTL_ACTIVE_EXECUTION,
+                json.dumps(execution.active_execution),
+            )
+        await pipeline.execute()
+
+    async def _refresh_active_execution_leases_if_due(self, now: float) -> None:
+        """Refresh live leases at a sparse cadence independent of pool heartbeat."""
+        last_refresh = self._last_active_execution_refresh
+        if (
+            last_refresh is not None
+            and now - last_refresh < _ACTIVE_EXECUTION_REFRESH_SECONDS
+        ):
+            return
+
+        await self._refresh_active_execution_leases()
+        self._last_active_execution_refresh = now
 
     async def _monitor_loop(self) -> None:
         """
@@ -895,14 +963,14 @@ class ProcessPoolManager:
             return
         handle.result_reported = True
         try:
-            await self.on_result({
+            await self.on_result(exec_info.attach_transport_metadata({
                 "type": "result",
                 "execution_id": exec_info.execution_id,
                 "success": False,
                 "error": f"Execution timed out after {exec_info.timeout_seconds}s",
                 "error_type": "TimeoutError",
                 "duration_ms": int(exec_info.elapsed_seconds * 1000),
-            })
+            }))
         except Exception as e:
             logger.exception(f"Error reporting timeout: {e}")
 
@@ -1123,14 +1191,14 @@ class ProcessPoolManager:
             return
         handle.result_reported = True
         try:
-            await self.on_result({
+            await self.on_result(exec_info.attach_transport_metadata({
                 "type": "result",
                 "execution_id": exec_info.execution_id,
                 "success": False,
                 "error": "Execution was cancelled",
                 "error_type": "CancelledError",
                 "duration_ms": int(exec_info.elapsed_seconds * 1000),
-            })
+            }))
         except Exception as e:
             logger.exception(f"Error reporting cancellation: {e}")
 
@@ -1258,14 +1326,14 @@ class ProcessPoolManager:
             return
         handle.result_reported = True
         try:
-            await self.on_result({
+            await self.on_result(exec_info.attach_transport_metadata({
                 "type": "result",
                 "execution_id": exec_info.execution_id,
                 "success": False,
                 "error": "Execution orphaned — process was killed but result was never reported",
                 "error_type": "OrphanedExecution",
                 "duration_ms": int(exec_info.elapsed_seconds * 1000),
-            })
+            }))
         except Exception as e:
             logger.exception(f"Error reporting orphan: {e}")
 
@@ -1284,14 +1352,14 @@ class ProcessPoolManager:
             return
         handle.result_reported = True
         try:
-            await self.on_result({
+            await self.on_result(exec_info.attach_transport_metadata({
                 "type": "result",
                 "execution_id": exec_info.execution_id,
                 "success": False,
                 "error": "Worker process crashed unexpectedly",
                 "error_type": "ProcessCrashError",
                 "duration_ms": int(exec_info.elapsed_seconds * 1000),
-            })
+            }))
         except Exception as e:
             logger.exception(f"Error reporting crash: {e}")
 
@@ -1368,6 +1436,12 @@ class ProcessPoolManager:
         self._unregister_result_reader(handle)
         handle.result_reported = True
 
+        execution = handle.current_execution
+        if execution is None:
+            logger.error("Result received without an active execution on %s", handle.id)
+            return
+        result = execution.attach_transport_metadata(result)
+
         # Clear current execution
         handle.current_execution = None
         handle.executions_completed += 1
@@ -1402,6 +1476,8 @@ class ProcessPoolManager:
 
         while not self._shutdown:
             try:
+                await self._refresh_active_execution_leases_if_due(time.monotonic())
+
                 # Refresh registration
                 await self._refresh_registration()
 

--- a/api/src/services/execution/process_pool.py
+++ b/api/src/services/execution/process_pool.py
@@ -522,6 +522,7 @@ class ProcessPoolManager:
         self._started = True
         self._shutdown = False
         self._started_at = datetime.now(timezone.utc)
+        self._last_active_execution_refresh = time.monotonic()
 
         # Install requirements once (shared filesystem — all child processes inherit)
         install_result = await asyncio.to_thread(install_requirements)
@@ -760,6 +761,18 @@ class ProcessPoolManager:
             self._unregister_result_reader(handle)
             self.processes.pop(handle.id, None)
             await self._notify_slot_free()
+            try:
+                r = await self._get_redis()
+                await r.delete(
+                    active_execution_key(execution_id),
+                    f"bifrost:exec:{execution_id}:context",
+                )
+            except Exception as cleanup_exc:  # noqa: BLE001 - preserve dispatch error
+                logger.warning(
+                    "Could not clean up failed dispatch %s: %s",
+                    execution_id,
+                    cleanup_exc,
+                )
             raise
 
         logger.info(

--- a/api/tests/e2e/api/test_executions.py
+++ b/api/tests/e2e/api/test_executions.py
@@ -211,6 +211,73 @@ class TestAsyncExecution:
         assert result is not None, "Async execution did not complete within timeout"
         assert result.get("status") == "Success", f"Execution failed: {result}"
 
+    def test_running_execution_completes_after_redis_tracking_loss(
+        self, e2e_client, platform_admin, async_workflow
+    ):
+        """Deleting both Redis tracking records must not orphan the DB row."""
+        import redis
+
+        from src.config import get_settings
+        from src.core.cache.keys import active_execution_key, execution_pending_key
+
+        response = e2e_client.post(
+            "/api/workflows/execute",
+            headers=platform_admin.headers,
+            json={
+                "workflow_id": async_workflow["id"],
+                "input_data": {"delay_seconds": 5},
+            },
+        )
+        assert response.status_code in [200, 202], response.text
+        execution_id = response.json().get("execution_id") or response.json().get(
+            "executionId"
+        )
+        assert execution_id
+
+        redis_client = redis.Redis.from_url(
+            get_settings().redis_url,
+            decode_responses=True,
+        )
+        try:
+            def check_running_with_lease():
+                detail = e2e_client.get(
+                    f"/api/executions/{execution_id}",
+                    headers=platform_admin.headers,
+                )
+                if (
+                    detail.status_code == 200
+                    and detail.json().get("status") == "Running"
+                    and redis_client.exists(active_execution_key(execution_id))
+                ):
+                    return detail.json()
+                return None
+
+            running = poll_until(check_running_with_lease, max_wait=10.0)
+            assert running is not None, "Execution never reached Running with a lease"
+
+            redis_client.delete(
+                active_execution_key(execution_id),
+                execution_pending_key(execution_id),
+            )
+
+            def check_completed():
+                detail = e2e_client.get(
+                    f"/api/executions/{execution_id}",
+                    headers=platform_admin.headers,
+                )
+                if detail.status_code == 200 and detail.json().get("status") in {
+                    "Success",
+                    "Failed",
+                }:
+                    return detail.json()
+                return None
+
+            completed = poll_until(check_completed, max_wait=15.0)
+            assert completed is not None, "Execution remained orphaned in Running"
+            assert completed["status"] == "Success", completed
+        finally:
+            redis_client.close()
+
 
 @pytest.mark.e2e
 class TestExecutionAccess:

--- a/api/tests/unit/cache/test_invalidation.py
+++ b/api/tests/unit/cache/test_invalidation.py
@@ -339,12 +339,15 @@ class TestExecutionCleanup:
 
     @pytest.mark.asyncio
     async def test_cleanup_execution_cache(self, mock_redis):
-        """cleanup_execution_cache deletes pending changes and logs."""
+        """Cleanup removes buffered data and the active execution lease."""
         with patch("src.core.cache.invalidation.get_shared_redis", return_value=mock_redis):
             await cleanup_execution_cache("exec-123")
 
-            # pending changes + logs stream
-            assert mock_redis.delete.call_count == 2
+            mock_redis.delete.assert_awaited_once_with(
+                "bifrost:pending:exec-123",
+                "bifrost:logs:exec-123",
+                "bifrost:exec:exec-123:active",
+            )
 
     @pytest.mark.asyncio
     async def test_cleanup_execution_cache_handles_error(self, mock_redis):

--- a/api/tests/unit/core/test_redis_client.py
+++ b/api/tests/unit/core/test_redis_client.py
@@ -122,6 +122,43 @@ class TestRedisClient:
         mock_redis.aclose.assert_called_once()
         assert client._redis is None
 
+    async def test_get_active_execution_returns_compact_lease(self, mock_redis):
+        """Active execution metadata is read from its dedicated lease key."""
+        from src.core.cache.keys import active_execution_key
+        from src.core.redis_client import RedisClient
+
+        lease = {
+            "execution_id": "exec-1",
+            "workflow_id": "workflow-1",
+            "workflow_name": "scan",
+            "org_id": "org-1",
+            "user_id": "user-1",
+            "user_name": "Operator",
+            "user_email": "operator@example.com",
+            "sync": False,
+            "event": None,
+        }
+        mock_redis.get.return_value = json.dumps(lease)
+        client = RedisClient()
+        client._redis = mock_redis
+
+        result = await client.get_active_execution("exec-1")
+
+        assert result == lease
+        mock_redis.get.assert_awaited_once_with(active_execution_key("exec-1"))
+
+    async def test_get_active_execution_returns_none_when_lease_is_missing(
+        self, mock_redis
+    ):
+        """Missing active leases are a normal recovery condition."""
+        from src.core.redis_client import RedisClient
+
+        mock_redis.get.return_value = None
+        client = RedisClient()
+        client._redis = mock_redis
+
+        assert await client.get_active_execution("exec-1") is None
+
     async def test_set_workflow_metadata_cache_serializes_decimal(self, mock_redis):
         """Workflow metadata cache should coerce Decimal values to JSON numbers."""
         from src.core.redis_client import RedisClient, WORKFLOW_METADATA_CACHE_PREFIX

--- a/api/tests/unit/execution/test_process_pool.py
+++ b/api/tests/unit/execution/test_process_pool.py
@@ -9,6 +9,7 @@ NOTE: These tests use mocks to avoid spawning real processes.
 """
 
 import asyncio
+import json
 from datetime import datetime, timedelta, timezone
 from queue import Empty
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -26,6 +27,20 @@ from src.services.execution.simple_worker import (
     FailedPackage,
     RequirementsInstallResult,
 )
+
+
+def _active_execution(execution_id: str, *, sync: bool = False) -> dict:
+    return {
+        "execution_id": execution_id,
+        "workflow_id": "workflow-1",
+        "workflow_name": "long_scan",
+        "org_id": "org-1",
+        "user_id": "user-1",
+        "user_name": "Operator",
+        "user_email": "operator@example.com",
+        "sync": sync,
+        "event": None,
+    }
 
 
 class TestProcessState:
@@ -53,6 +68,7 @@ class TestExecutionInfo:
             execution_id="exec-123",
             started_at=now,
             timeout_seconds=300,
+            active_execution=_active_execution("exec-123"),
         )
 
         assert info.execution_id == "exec-123"
@@ -67,6 +83,7 @@ class TestExecutionInfo:
             execution_id="exec-123",
             started_at=past,
             timeout_seconds=300,
+            active_execution=_active_execution("exec-123"),
         )
 
         elapsed = info.elapsed_seconds
@@ -80,6 +97,7 @@ class TestExecutionInfo:
             execution_id="exec-123",
             started_at=now,
             timeout_seconds=300,
+            active_execution=_active_execution("exec-123"),
         )
 
         assert info.is_timed_out is False
@@ -92,6 +110,7 @@ class TestExecutionInfo:
             execution_id="exec-123",
             started_at=past,
             timeout_seconds=5,
+            active_execution=_active_execution("exec-123"),
         )
 
         assert info.is_timed_out is True
@@ -298,7 +317,11 @@ class TestProcessPoolManagerRouting:
         with patch.object(pool, "_write_context_to_redis", new_callable=AsyncMock), \
              patch.object(pool, "_register_result_reader"), \
              patch("src.services.execution.process_pool.has_sufficient_memory_cgroup", return_value=True):
-            await pool.route_execution("exec-123", {"timeout_seconds": 300})
+            await pool.route_execution(
+                "exec-123",
+                {"timeout_seconds": 300},
+                _active_execution("exec-123"),
+            )
 
         assert len(forked) == 1
         h = forked[0]
@@ -344,7 +367,11 @@ class TestProcessPoolManagerRouting:
                  return_value=True,
              ):
             route_task = asyncio.create_task(
-                pool.route_execution("exec-during-restart", {"timeout_seconds": 300})
+                pool.route_execution(
+                    "exec-during-restart",
+                    {"timeout_seconds": 300},
+                    _active_execution("exec-during-restart"),
+                )
             )
             await context_write_started.wait()
 
@@ -406,7 +433,11 @@ class TestProcessPoolManagerRouting:
              patch("src.services.execution.process_pool.has_sufficient_memory_cgroup", return_value=True):
             # Kick off the route — it should park on _slot_condition.
             route_task = asyncio.create_task(
-                pool.route_execution("exec-456", {"timeout_seconds": 300})
+                pool.route_execution(
+                    "exec-456",
+                    {"timeout_seconds": 300},
+                    _active_execution("exec-456"),
+                )
             )
             await asyncio.sleep(0.1)
             assert not route_task.done(), "route should be parked while pool full"
@@ -440,6 +471,7 @@ class TestProcessPoolManagerTimeouts:
             execution_id="exec-timeout",
             started_at=datetime.now(timezone.utc) - timedelta(seconds=400),
             timeout_seconds=300,
+            active_execution=_active_execution("exec-timeout"),
         )
 
         handle = ProcessHandle(
@@ -508,6 +540,7 @@ class TestProcessPoolManagerCrashDetection:
             execution_id="exec-crash",
             started_at=datetime.now(timezone.utc) - timedelta(seconds=10),
             timeout_seconds=300,
+            active_execution=_active_execution("exec-crash"),
         )
 
         handle = ProcessHandle(
@@ -582,6 +615,7 @@ class TestProcessPoolManagerHeartbeat:
                 execution_id="exec-busy",
                 started_at=datetime.now(timezone.utc),
                 timeout_seconds=300,
+                active_execution=_active_execution("exec-busy"),
             ),
             executions_completed=10,
         )
@@ -601,6 +635,81 @@ class TestProcessPoolManagerHeartbeat:
         assert busy_info["state"] == "busy"
         assert "execution" in busy_info
         assert busy_info["execution"]["execution_id"] == "exec-busy"
+
+    @pytest.mark.asyncio
+    async def test_refresh_active_execution_leases_recreates_compact_records_in_one_pipeline(
+        self,
+    ):
+        from src.core.cache.keys import TTL_ACTIVE_EXECUTION, active_execution_key
+
+        pool = ProcessPoolManager()
+        pipeline = MagicMock()
+        pipeline.execute = AsyncMock()
+        redis = AsyncMock()
+        redis.pipeline = MagicMock(return_value=pipeline)
+        pool._redis = redis
+
+        for number in (1, 2):
+            execution_id = f"exec-{number}"
+            pool.processes[f"process-{number}"] = ProcessHandle(
+                id=f"process-{number}",
+                process=MagicMock(),
+                pid=12340 + number,
+                state=ProcessState.BUSY,
+                work_queue=MagicMock(),
+                result_queue=MagicMock(),
+                started_at=datetime.now(timezone.utc),
+                current_execution=ExecutionInfo(
+                    execution_id=execution_id,
+                    started_at=datetime.now(timezone.utc),
+                    timeout_seconds=14400,
+                    active_execution=_active_execution(execution_id),
+                ),
+            )
+        pool.processes["process-killed"] = ProcessHandle(
+            id="process-killed",
+            process=MagicMock(),
+            pid=12999,
+            state=ProcessState.KILLED,
+            work_queue=MagicMock(),
+            result_queue=MagicMock(),
+            started_at=datetime.now(timezone.utc),
+            current_execution=ExecutionInfo(
+                execution_id="exec-killed",
+                started_at=datetime.now(timezone.utc),
+                timeout_seconds=14400,
+                active_execution=_active_execution("exec-killed"),
+            ),
+        )
+
+        await pool._refresh_active_execution_leases()
+
+        redis.pipeline.assert_called_once_with(transaction=False)
+        assert pipeline.setex.call_count == 2
+        pipeline.setex.assert_any_call(
+            active_execution_key("exec-1"),
+            TTL_ACTIVE_EXECUTION,
+            json.dumps(_active_execution("exec-1")),
+        )
+        pipeline.setex.assert_any_call(
+            active_execution_key("exec-2"),
+            TTL_ACTIVE_EXECUTION,
+            json.dumps(_active_execution("exec-2")),
+        )
+        pipeline.execute.assert_awaited_once_with()
+        serialized = pipeline.setex.call_args_list[0].args[2]
+        assert not ({"parameters", "startup", "form_inputs", "embed"} & json.loads(serialized).keys())
+
+    @pytest.mark.asyncio
+    async def test_active_execution_lease_refresh_has_sparse_cadence(self):
+        pool = ProcessPoolManager()
+        pool._refresh_active_execution_leases = AsyncMock()
+
+        await pool._refresh_active_execution_leases_if_due(1000.0)
+        await pool._refresh_active_execution_leases_if_due(1599.0)
+        await pool._refresh_active_execution_leases_if_due(1600.0)
+
+        assert pool._refresh_active_execution_leases.await_count == 2
 
 
 class TestProcessPoolManagerResultHandling:
@@ -675,6 +784,7 @@ class TestProcessPoolManagerResultHandling:
                 execution_id="exec-123",
                 started_at=datetime.now(timezone.utc),
                 timeout_seconds=300,
+                active_execution=_active_execution("exec-123", sync=True),
             ),
         )
         pool.processes["process-1"] = handle
@@ -713,6 +823,7 @@ class TestProcessPoolManagerResultHandling:
                 execution_id="exec-123",
                 started_at=datetime.now(timezone.utc),
                 timeout_seconds=300,
+                active_execution=_active_execution("exec-123"),
             ),
         )
         pool.processes["process-1"] = handle
@@ -748,6 +859,7 @@ class TestProcessPoolManagerResultHandling:
                 execution_id="exec-123",
                 started_at=datetime.now(timezone.utc),
                 timeout_seconds=300,
+                active_execution=_active_execution("exec-123", sync=True),
             ),
         )
         pool.processes["process-1"] = handle
@@ -761,7 +873,48 @@ class TestProcessPoolManagerResultHandling:
 
         await pool._handle_result(handle, result_data)
 
-        callback.assert_called_once_with(result_data)
+        callback.assert_called_once_with({**result_data, "sync": True})
+
+
+class TestResultTransportMetadata:
+    """Every terminal path carries parent-owned sync routing metadata."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("report_method", "error_type"),
+        [
+            ("_report_timeout", "TimeoutError"),
+            ("_report_cancellation", "CancelledError"),
+            ("_report_crash", "ProcessCrashError"),
+            ("_report_orphan", "OrphanedExecution"),
+        ],
+    )
+    async def test_synthetic_results_carry_sync_flag(
+        self, report_method: str, error_type: str
+    ):
+        callback = AsyncMock()
+        pool = ProcessPoolManager(on_result=callback)
+        handle = ProcessHandle(
+            id="process-1",
+            process=MagicMock(),
+            pid=12345,
+            state=ProcessState.BUSY,
+            work_queue=MagicMock(),
+            result_queue=MagicMock(),
+            started_at=datetime.now(timezone.utc),
+            current_execution=ExecutionInfo(
+                execution_id="exec-123",
+                started_at=datetime.now(timezone.utc),
+                timeout_seconds=300,
+                active_execution=_active_execution("exec-123", sync=True),
+            ),
+        )
+
+        await getattr(pool, report_method)(handle)
+
+        terminal_result = callback.await_args.args[0]
+        assert terminal_result["sync"] is True
+        assert terminal_result["error_type"] == error_type
 
 
 class TestProcessPoolManagerStatus:
@@ -830,7 +983,11 @@ class TestProcessPoolManagerIntegration:
         with patch.object(pool, "_write_context_to_redis", new_callable=AsyncMock), \
              patch.object(pool, "_register_result_reader"), \
              patch("src.services.execution.process_pool.has_sufficient_memory_cgroup", return_value=True):
-            await pool.route_execution("exec-123", {"timeout_seconds": 300})
+            await pool.route_execution(
+                "exec-123",
+                {"timeout_seconds": 300},
+                _active_execution("exec-123"),
+            )
 
         handle = pool.processes["process-1"]
         assert handle.state == ProcessState.BUSY
@@ -849,7 +1006,7 @@ class TestProcessPoolManagerIntegration:
 
         # One-shot worker: handle is removed after completion.
         assert "process-1" not in pool.processes
-        callback.assert_called_once_with(result_data)
+        callback.assert_called_once_with({**result_data, "sync": False})
 
 
 class TestAdmissionControl:
@@ -867,13 +1024,18 @@ class TestAdmissionControl:
         ):
             with patch.object(pool, '_write_context_to_redis', new_callable=AsyncMock):
                 with pytest.raises(MemoryError, match="memory pressure"):
-                    await pool.route_execution("exec-123", {"timeout_seconds": 300})
+                    await pool.route_execution(
+                        "exec-123",
+                        {"timeout_seconds": 300},
+                        _active_execution("exec-123"),
+                    )
 
     @pytest.mark.asyncio
     async def test_route_execution_allows_when_memory_ok(self):
         """Should allow execution when memory is within threshold."""
         pool = ProcessPoolManager(max_workers=5)
         pool._started = True
+        lease_write = AsyncMock()
 
         mock_handle = ProcessHandle(
             id="process-1",
@@ -895,11 +1057,23 @@ class TestAdmissionControl:
         ):
             with patch.object(pool, '_write_context_to_redis', new_callable=AsyncMock):
                 with patch.object(pool, '_fork_process', side_effect=mock_spawn), \
-                     patch.object(pool, "_register_result_reader"):
-                    await pool.route_execution("exec-123", {"timeout_seconds": 300})
+                     patch.object(pool, "_register_result_reader"), \
+                     patch.object(
+                         pool,
+                         "_write_active_execution_lease",
+                         lease_write,
+                     ):
+                    await pool.route_execution(
+                        "exec-123",
+                        {"timeout_seconds": 300},
+                        _active_execution("exec-123"),
+                    )
                     assert mock_handle.state == ProcessState.BUSY
                     assert mock_handle.current_execution is not None
                     assert mock_handle.current_execution.execution_id == "exec-123"
+                    lease_write.assert_awaited_once_with(
+                        mock_handle.current_execution
+                    )
 
 
 class TestOrphanedKilledHandleSweep:
@@ -920,6 +1094,7 @@ class TestOrphanedKilledHandleSweep:
             execution_id="exec-orphan-123",
             started_at=datetime.now(timezone.utc) - timedelta(seconds=10),
             timeout_seconds=300,
+            active_execution=_active_execution("exec-orphan-123"),
         )
 
         handle = ProcessHandle(
@@ -963,6 +1138,7 @@ class TestOrphanedKilledHandleSweep:
             execution_id="exec-already-reported",
             started_at=datetime.now(timezone.utc) - timedelta(seconds=10),
             timeout_seconds=300,
+            active_execution=_active_execution("exec-already-reported"),
         )
 
         handle = ProcessHandle(
@@ -1014,6 +1190,7 @@ class TestOrphanedKilledHandleSweep:
                 execution_id="exec-mid-cancel",
                 started_at=datetime.now(timezone.utc),
                 timeout_seconds=300,
+                active_execution=_active_execution("exec-mid-cancel"),
             ),
             result_reported=False,
             killed_at=datetime.now(timezone.utc),  # JUST killed — inside grace window
@@ -1057,6 +1234,7 @@ class TestCrashedProcessReport:
             execution_id="exec-sigkill-789",
             started_at=datetime.now(timezone.utc) - timedelta(seconds=3),
             timeout_seconds=300,
+            active_execution=_active_execution("exec-sigkill-789"),
         )
 
         handle = ProcessHandle(
@@ -1103,6 +1281,7 @@ class TestCrashedProcessReport:
             execution_id="exec-already-done",
             started_at=datetime.now(timezone.utc) - timedelta(seconds=1),
             timeout_seconds=300,
+            active_execution=_active_execution("exec-already-done"),
         )
 
         handle = ProcessHandle(
@@ -1156,6 +1335,7 @@ class TestCrashedProcessReport:
                 execution_id="exec-clean",
                 started_at=datetime.now(timezone.utc),
                 timeout_seconds=300,
+                active_execution=_active_execution("exec-clean"),
             ),
         )
         pool.processes[handle.id] = handle
@@ -1170,7 +1350,7 @@ class TestCrashedProcessReport:
         result_queue.get_nowait.return_value = result
         await pool._check_process_health()
 
-        callback.assert_awaited_once_with(result)
+        callback.assert_awaited_once_with({**result, "sync": False})
         assert handle.id not in pool.processes
 
     @pytest.mark.asyncio
@@ -1196,6 +1376,7 @@ class TestCrashedProcessReport:
                 execution_id="exec-clean-no-result",
                 started_at=datetime.now(timezone.utc),
                 timeout_seconds=300,
+                active_execution=_active_execution("exec-clean-no-result"),
             ),
             clean_exit_observed_at=(
                 datetime.now(timezone.utc) - timedelta(seconds=3)
@@ -1341,6 +1522,7 @@ class TestBurstRaceRegression:
             execution_id="exec-race",
             started_at=datetime.now(timezone.utc) - timedelta(seconds=1),
             timeout_seconds=300,
+            active_execution=_active_execution("exec-race"),
         )
         handle = ProcessHandle(
             id="process-race",
@@ -1397,6 +1579,7 @@ class TestBurstRaceRegression:
             execution_id="exec-race-2",
             started_at=datetime.now(timezone.utc) - timedelta(seconds=1),
             timeout_seconds=300,
+            active_execution=_active_execution("exec-race-2"),
         )
         handle = ProcessHandle(
             id="process-race-2",

--- a/api/tests/unit/execution/test_process_pool.py
+++ b/api/tests/unit/execution/test_process_pool.py
@@ -271,6 +271,7 @@ class TestProcessPoolManagerStart:
         assert spawned == [], "start() must not pre-spawn workers in on-demand mode"
         assert len(pool.processes) == 0
         assert pool._started is True
+        assert pool._last_active_execution_refresh is not None
 
         # Cleanup
         pool._shutdown = True
@@ -452,6 +453,45 @@ class TestProcessPoolManagerRouting:
         assert len(forked) == 1
         assert forked[0].current_execution is not None
         assert forked[0].current_execution.execution_id == "exec-456"
+
+    @pytest.mark.asyncio
+    async def test_dispatch_failure_removes_active_lease_and_context(self):
+        pool = ProcessPoolManager(max_workers=1)
+        redis = AsyncMock()
+        pool._redis = redis
+        handle = ProcessHandle(
+            id="process-1",
+            process=MagicMock(),
+            pid=12345,
+            state=ProcessState.BUSY,
+            work_queue=MagicMock(),
+            result_queue=MagicMock(),
+            started_at=datetime.now(timezone.utc),
+        )
+        handle.work_queue.put_nowait.side_effect = BrokenPipeError("closed")
+
+        def fork_process():
+            pool.processes[handle.id] = handle
+            return handle
+
+        with (
+            patch.object(pool, "_fork_process", side_effect=fork_process),
+            patch.object(pool, "_register_result_reader"),
+            patch.object(pool, "_unregister_result_reader"),
+        ):
+            with pytest.raises(BrokenPipeError, match="closed"):
+                await pool._dispatch_to_child(
+                    "exec-failed-dispatch",
+                    {"timeout_seconds": 300},
+                    300,
+                    _active_execution("exec-failed-dispatch"),
+                )
+
+        redis.delete.assert_awaited_once_with(
+            "bifrost:exec:exec-failed-dispatch:active",
+            "bifrost:exec:exec-failed-dispatch:context",
+        )
+        assert handle.id not in pool.processes
 
 
 

--- a/api/tests/unit/jobs/consumers/test_workflow_execution_session.py
+++ b/api/tests/unit/jobs/consumers/test_workflow_execution_session.py
@@ -5,6 +5,80 @@ Validates that the consumer uses short-lived sessions (no persistent session).
 
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import UUID
+
+
+class TestCompletionMetadataRecovery:
+    """PostgreSQL must recover terminal bookkeeping after Redis data loss."""
+
+    @pytest.mark.asyncio
+    async def test_missing_active_lease_reconstructs_metadata_from_execution_row(self):
+        from src.jobs.consumers.workflow_execution import WorkflowExecutionConsumer
+
+        execution = MagicMock()
+        execution.id = UUID("00000000-0000-0000-0000-000000000004")
+        execution.workflow_id = UUID("00000000-0000-0000-0000-000000000001")
+        execution.workflow_name = "long_scan"
+        execution.organization_id = UUID("00000000-0000-0000-0000-000000000002")
+        execution.executed_by = UUID("00000000-0000-0000-0000-000000000003")
+        execution.executed_by_name = "Test User"
+
+        query_result = MagicMock()
+        query_result.one_or_none.return_value = (execution, "test@example.com")
+        session = AsyncMock()
+        session.execute.return_value = query_result
+
+        with patch.object(WorkflowExecutionConsumer, "__init__", lambda self: None):
+            consumer = WorkflowExecutionConsumer()
+            consumer._redis_client = AsyncMock()
+            consumer._redis_client.get_active_execution.return_value = None
+
+            metadata, recovered = await consumer._load_completion_metadata(
+                str(execution.id), session
+            )
+
+        assert recovered is True
+        assert metadata == {
+            "execution_id": str(execution.id),
+            "workflow_id": str(execution.workflow_id),
+            "workflow_name": "long_scan",
+            "org_id": str(execution.organization_id),
+            "user_id": str(execution.executed_by),
+            "user_name": "Test User",
+            "user_email": "test@example.com",
+            "sync": False,
+            "event": None,
+        }
+
+    @pytest.mark.asyncio
+    async def test_active_lease_avoids_database_lookup(self):
+        from src.jobs.consumers.workflow_execution import WorkflowExecutionConsumer
+
+        active = {
+            "execution_id": "00000000-0000-0000-0000-000000000004",
+            "workflow_id": "00000000-0000-0000-0000-000000000001",
+            "workflow_name": "long_scan",
+            "org_id": "00000000-0000-0000-0000-000000000002",
+            "user_id": "00000000-0000-0000-0000-000000000003",
+            "user_name": "Test User",
+            "user_email": "test@example.com",
+            "sync": False,
+            "event": None,
+        }
+        session = AsyncMock()
+
+        with patch.object(WorkflowExecutionConsumer, "__init__", lambda self: None):
+            consumer = WorkflowExecutionConsumer()
+            consumer._redis_client = AsyncMock()
+            consumer._redis_client.get_active_execution.return_value = active
+
+            metadata, recovered = await consumer._load_completion_metadata(
+                active["execution_id"], session
+            )
+
+        assert metadata == active
+        assert recovered is False
+        session.execute.assert_not_awaited()
 
 
 class TestConsumerSessionLifecycle:
@@ -136,7 +210,7 @@ class TestSuccessfulExecutionCompletionOrder:
         with patch.object(WorkflowExecutionConsumer, "__init__", lambda self: None):
             consumer = WorkflowExecutionConsumer()
             consumer._redis_client = AsyncMock()
-            consumer._redis_client.get_pending_execution.return_value = {
+            consumer._redis_client.get_active_execution.return_value = {
                 "workflow_id": "00000000-0000-0000-0000-000000000001",
                 "workflow_name": "large_result_workflow",
                 "org_id": "00000000-0000-0000-0000-000000000002",
@@ -221,6 +295,7 @@ class TestSuccessfulExecutionCompletionOrder:
                         "status": "Success",
                         "result": {"rows": [{"value": "x" * 1000}]},
                         "duration_ms": 123,
+                        "sync": True,
                     },
                 )
 
@@ -267,7 +342,7 @@ class TestFailedExecutionCompletionOrder:
         with patch.object(WorkflowExecutionConsumer, "__init__", lambda self: None):
             consumer = WorkflowExecutionConsumer()
             consumer._redis_client = AsyncMock()
-            consumer._redis_client.get_pending_execution.return_value = {
+            consumer._redis_client.get_active_execution.return_value = {
                 "workflow_id": "00000000-0000-0000-0000-000000000001",
                 "workflow_name": "failed_workflow",
                 "org_id": "00000000-0000-0000-0000-000000000002",
@@ -353,6 +428,7 @@ class TestFailedExecutionCompletionOrder:
                         "error": "boom",
                         "error_type": "RuntimeError",
                         "duration_ms": 123,
+                        "sync": True,
                     },
                 )
 
@@ -385,7 +461,7 @@ class TestFailedExecutionCompletionOrder:
         with patch.object(WorkflowExecutionConsumer, "__init__", lambda self: None):
             consumer = WorkflowExecutionConsumer()
             consumer._redis_client = AsyncMock()
-            consumer._redis_client.get_pending_execution.return_value = {
+            consumer._redis_client.get_active_execution.return_value = {
                 "workflow_id": "00000000-0000-0000-0000-000000000001",
                 "workflow_name": "event_workflow",
                 "org_id": "00000000-0000-0000-0000-000000000002",
@@ -446,6 +522,7 @@ class TestFailedExecutionCompletionOrder:
                         "error": "boom",
                         "error_type": "RuntimeError",
                         "duration_ms": 123,
+                        "sync": False,
                         "logs": [{"message": "captured failure log"}],
                     },
                 )

--- a/api/tests/unit/jobs/consumers/test_workflow_execution_session.py
+++ b/api/tests/unit/jobs/consumers/test_workflow_execution_session.py
@@ -49,6 +49,8 @@ class TestCompletionMetadataRecovery:
             "sync": False,
             "event": None,
         }
+        statement = str(session.execute.await_args.args[0])
+        assert "executions.status IN" in statement
 
     @pytest.mark.asyncio
     async def test_active_lease_avoids_database_lookup(self):

--- a/docs/superpowers/plans/2026-09-11-execution-tracking-heartbeat.md
+++ b/docs/superpowers/plans/2026-09-11-execution-tracking-heartbeat.md
@@ -1,0 +1,501 @@
+# Durable Workflow Completion and Execution Lease Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ensure every admitted workflow reaches a durable terminal PostgreSQL state even if its transient Redis records expire, while cheaply recreating a compact Redis lease for every execution that is still running.
+
+**Architecture:** The process-pool parent receives a compact `ActiveExecution` snapshot when it dispatches a child, stores that snapshot on `ExecutionInfo`, and recreates a one-hour Redis lease immediately and every ten minutes through a single pipeline. Completion reads the lease as a fast path and falls back to the existing PostgreSQL execution row; PostgreSQL receives only the existing start and terminal writes, never heartbeat writes.
+
+**Tech Stack:** Python 3.14, FastAPI worker services, Redis asyncio pipelines, SQLAlchemy async sessions, pytest, Dockerized Bifrost test stack.
+
+---
+
+## File Map
+
+- Modify `api/src/core/cache/keys.py`: define the active-execution key and TTL.
+- Modify `api/src/core/redis_client.py`: define the compact lease schema and provide read access for completion processing.
+- Modify `api/src/services/execution/process_pool.py`: retain completion metadata, create and sparsely refresh active leases, and preserve sync state on every result path.
+- Modify `api/src/jobs/consumers/workflow_execution.py`: pass compact metadata at dispatch and recover completion from PostgreSQL when Redis is absent.
+- Modify `api/src/core/cache/invalidation.py`: delete the active lease during terminal cleanup.
+- Modify `api/tests/unit/core/test_redis_client.py`: cover lease reads and missing leases.
+- Modify `api/tests/unit/execution/test_process_pool.py`: cover lease recreation, batching, refresh cadence, and real/synthetic result metadata.
+- Modify `api/tests/unit/jobs/consumers/test_workflow_execution_session.py`: cover success and failure after Redis metadata loss.
+- Modify `api/tests/e2e/api/test_executions.py`: prove a live delayed workflow completes after both tracking keys are deleted.
+
+### Task 1: Define the compact active-execution lease
+
+**Files:**
+- Modify: `api/src/core/cache/keys.py`
+- Modify: `api/src/core/redis_client.py`
+- Modify: `api/tests/unit/core/test_redis_client.py`
+
+- [ ] **Step 1: Write failing Redis lease read tests**
+
+Add tests that exercise the wished-for public API without waiting for TTL expiry:
+
+```python
+@pytest.mark.asyncio
+async def test_get_active_execution_returns_compact_lease():
+    client = RedisClient()
+    redis = AsyncMock()
+    redis.get.return_value = json.dumps({
+        "execution_id": "exec-1",
+        "workflow_id": "workflow-1",
+        "workflow_name": "scan",
+        "org_id": "org-1",
+        "user_id": "user-1",
+        "user_name": "Operator",
+        "user_email": "operator@example.com",
+        "sync": False,
+        "event": None,
+    })
+    client._redis = redis
+
+    lease = await client.get_active_execution("exec-1")
+
+    assert lease is not None
+    assert lease["workflow_name"] == "scan"
+    redis.get.assert_awaited_once_with(active_execution_key("exec-1"))
+
+
+@pytest.mark.asyncio
+async def test_get_active_execution_returns_none_when_lease_is_missing():
+    client = RedisClient()
+    redis = AsyncMock()
+    redis.get.return_value = None
+    client._redis = redis
+
+    assert await client.get_active_execution("exec-1") is None
+```
+
+- [ ] **Step 2: Run the tests and verify RED**
+
+Run:
+
+```bash
+./test.sh tests/unit/core/test_redis_client.py -q
+```
+
+Expected: collection or assertion failure because `active_execution_key` and `RedisClient.get_active_execution()` do not exist.
+
+- [ ] **Step 3: Add the key, schema, and read method**
+
+Add a key helper and constants:
+
+```python
+def active_execution_key(execution_id: str) -> str:
+    """Compact parent-owned lease for an actively running execution."""
+    return f"bifrost:exec:{execution_id}:active"
+
+
+TTL_ACTIVE_EXECUTION = 3600
+```
+
+Define the compact Redis payload in `redis_client.py`:
+
+```python
+class ActiveExecution(TypedDict):
+    execution_id: str
+    workflow_id: str | None
+    workflow_name: str
+    org_id: str | None
+    user_id: str | None
+    user_name: str
+    user_email: str | None
+    sync: bool
+    event: dict[str, Any] | None
+```
+
+Implement `get_active_execution()` by reading `active_execution_key(execution_id)`, returning `None` for a missing key, and JSON-decoding a present value. Do not make it fall back to the legacy pending key.
+
+- [ ] **Step 4: Run the focused Redis tests and verify GREEN**
+
+Run:
+
+```bash
+./test.sh tests/unit/core/test_redis_client.py -q
+```
+
+Expected: all tests in the file pass.
+
+- [ ] **Step 5: Commit the lease contract**
+
+```bash
+git add api/src/core/cache/keys.py api/src/core/redis_client.py api/tests/unit/core/test_redis_client.py
+git commit -m "feat(execution): define active execution lease"
+```
+
+### Task 2: Make the process-pool parent create and recreate leases
+
+**Files:**
+- Modify: `api/src/services/execution/process_pool.py`
+- Modify: `api/tests/unit/execution/test_process_pool.py`
+
+- [ ] **Step 1: Add failing tests for compact storage and batched recreation**
+
+Create a `_active_execution()` test helper containing only the nine compact fields. Add tests with two BUSY handles and one KILLED handle that assert:
+
+```python
+await pool._refresh_active_execution_leases()
+
+redis.pipeline.assert_called_once_with(transaction=False)
+assert pipeline.setex.call_count == 2
+pipeline.setex.assert_any_call(
+    active_execution_key("exec-1"),
+    TTL_ACTIVE_EXECUTION,
+    json.dumps(_active_execution("exec-1")),
+)
+pipeline.execute.assert_awaited_once()
+```
+
+Also assert the serialized value has no `parameters`, `startup`, `form_inputs`, or `embed` keys. Because `SETEX` is unconditional, this test proves an absent key is recreated rather than merely touched.
+
+Add a cadence test that calls one heartbeat iteration with monotonic time below and above the ten-minute boundary and asserts lease refresh runs only at or after the boundary.
+
+- [ ] **Step 2: Run the process-pool tests and verify RED**
+
+Run:
+
+```bash
+./test.sh tests/unit/execution/test_process_pool.py -q
+```
+
+Expected: failures because `ExecutionInfo` has no active metadata and `_refresh_active_execution_leases()` does not exist.
+
+- [ ] **Step 3: Retain compact metadata on each active handle**
+
+Change `ExecutionInfo` and the required production dispatch boundary:
+
+```python
+@dataclass
+class ExecutionInfo:
+    execution_id: str
+    started_at: datetime
+    timeout_seconds: int
+    active_execution: ActiveExecution
+```
+
+Add `active_execution: ActiveExecution` as a required argument immediately
+after `context` in `route_execution()` and `_dispatch_to_child()`. Update every
+unit-test construction and route call with explicit compact metadata. Do not
+add a default or synthesize identity data.
+
+- [ ] **Step 4: Implement immediate creation and sparse batched refresh**
+
+Add:
+
+```python
+ACTIVE_EXECUTION_REFRESH_SECONDS = 10 * 60
+
+async def _refresh_active_execution_leases(self) -> None:
+    active = [
+        handle.current_execution
+        for handle in self.processes.values()
+        if handle.state is ProcessState.BUSY and handle.current_execution is not None
+    ]
+    if not active:
+        return
+    redis_client = await self._get_redis()
+    pipeline = redis_client.pipeline(transaction=False)
+    for execution in active:
+        pipeline.setex(
+            active_execution_key(execution.execution_id),
+            TTL_ACTIVE_EXECUTION,
+            json.dumps(execution.active_execution),
+        )
+    await pipeline.execute()
+```
+
+Create the lease immediately after assigning `handle.current_execution`, before sending work to the child. A lease-write failure must be logged and must not prevent the already-admitted child from running. Track a monotonic last-refresh timestamp and invoke the batch refresh from the existing heartbeat loop only every ten minutes; continue publishing the worker-health heartbeat every ten seconds.
+
+- [ ] **Step 5: Add failing tests for sync state on every result path**
+
+For a real result, timeout, cancellation, crash, and orphan callback, construct
+`ExecutionInfo(active_execution=_active_execution("exec-1") | {"sync": True})`,
+invoke the relevant method, and assert the callback payload contains
+`"sync": True`.
+
+- [ ] **Step 6: Run the new result tests and verify RED**
+
+Run:
+
+```bash
+./test.sh tests/unit/execution/test_process_pool.py -q
+```
+
+Expected: callback assertions fail because result payloads do not yet carry `sync`.
+
+- [ ] **Step 7: Attach sync transport state before every callback**
+
+Use one helper so real and synthetic paths cannot drift:
+
+```python
+def _attach_transport_metadata(
+    result: dict[str, Any], execution: ExecutionInfo
+) -> dict[str, Any]:
+    return {**result, "sync": execution.active_execution["sync"]}
+```
+
+Call it from `_handle_result`, `_report_timeout`, `_report_cancellation`, `_report_crash`, and `_report_orphan` before invoking `on_result`.
+
+- [ ] **Step 8: Run the process-pool tests and verify GREEN**
+
+Run:
+
+```bash
+./test.sh tests/unit/execution/test_process_pool.py -q
+```
+
+Expected: all process-pool tests pass.
+
+- [ ] **Step 9: Commit parent-owned lease management**
+
+```bash
+git add api/src/services/execution/process_pool.py api/tests/unit/execution/test_process_pool.py
+git commit -m "feat(execution): recreate leases for active workers"
+```
+
+### Task 3: Make terminal persistence independent of Redis
+
+**Files:**
+- Modify: `api/src/jobs/consumers/workflow_execution.py`
+- Modify: `api/tests/unit/jobs/consumers/test_workflow_execution_session.py`
+- Modify: `api/tests/e2e/api/test_executions.py`
+
+- [ ] **Step 1: Add failing success and failure recovery tests**
+
+For each terminal path, configure `get_active_execution()` to return `None`, configure the durable session query to return an `Execution` row plus user email, and assert `update_execution()` is awaited with the incoming terminal status and the same session. The success test must retain result, variables, execution context, metrics, ROI, and duration. The failure test must retain error type, error message, and duration.
+
+The durable fixture should resemble:
+
+```python
+execution = MagicMock(
+    workflow_id=UUID("00000000-0000-0000-0000-000000000001"),
+    workflow_name="long_scan",
+    organization_id=UUID("00000000-0000-0000-0000-000000000002"),
+    executed_by=UUID("00000000-0000-0000-0000-000000000003"),
+    executed_by_name="Test User",
+)
+row_result = MagicMock()
+row_result.one_or_none.return_value = (execution, "test@example.com")
+durable_session.execute.return_value = row_result
+consumer._redis_client.get_active_execution.return_value = None
+```
+
+Assert the fallback path reconciles event delivery by `execution_id`, while the lease-backed non-event path avoids that extra query.
+
+Add the live regression at the same failure-first stage. Use the existing
+delayed async workflow fixture, start a five-second execution, poll until the
+API reports `Running` and `active_execution_key(execution_id)` exists, then
+delete both the active lease and legacy pending key through the real test Redis
+service. Poll the execution endpoint and assert:
+
+```python
+assert execution["status"] == "Success"
+assert execution["result"] == {"status": "completed", "delayed": 5}
+```
+
+- [ ] **Step 2: Run consumer tests and verify RED**
+
+Run:
+
+```bash
+./test.sh tests/unit/jobs/consumers/test_workflow_execution_session.py -q
+./test.sh tests/e2e/api/test_executions.py::TestAsyncExecution::test_running_execution_completes_after_redis_tracking_loss -q
+```
+
+Expected: the unit test shows the early return prevents `update_execution()`;
+the live execution remains `Running` rather than reaching `Success`.
+
+- [ ] **Step 3: Add compact metadata at dispatch**
+
+Immediately before `route_execution`, build:
+
+```python
+active_execution: ActiveExecution = {
+    "execution_id": execution_id,
+    "workflow_id": workflow_id,
+    "workflow_name": workflow_name,
+    "org_id": org_id,
+    "user_id": user_id,
+    "user_name": user_name,
+    "user_email": user_email,
+    "sync": is_sync,
+    "event": (
+        {"id": event_data.get("id"), "type": event_data.get("type")}
+        if event_data is not None
+        else None
+    ),
+}
+await self._pool.route_execution(
+    execution_id=execution_id,
+    context=context_data,
+    active_execution=active_execution,
+)
+```
+
+Remove the pre-dispatch update that enriches the pending record solely for result handling; the pending record is no longer completion authority.
+
+- [ ] **Step 4: Implement lease-first, PostgreSQL-authoritative metadata loading**
+
+Add a private loader that catches Redis read errors, then queries `Execution` with an outer join to `User` only when the lease is absent. Return both the metadata and a boolean indicating that event delivery must be reconciled defensively:
+
+```python
+async def _load_completion_metadata(
+    self,
+    execution_id: str,
+    session: AsyncSession,
+) -> tuple[ActiveExecution | None, bool]:
+    try:
+        lease = await self._redis_client.get_active_execution(execution_id)
+    except Exception:
+        logger.warning("Could not read active execution lease for %s", execution_id, exc_info=True)
+        lease = None
+    if lease is not None:
+        return lease, lease["event"] is not None
+
+    result = await session.execute(
+        select(Execution, User.email)
+        .outerjoin(User, Execution.executed_by == User.id)
+        .where(Execution.id == UUID(execution_id))
+    )
+    row = result.one_or_none()
+    if row is None:
+        return None, False
+    execution, user_email = row
+    return {
+        "execution_id": execution_id,
+        "workflow_id": str(execution.workflow_id) if execution.workflow_id else None,
+        "workflow_name": execution.workflow_name,
+        "org_id": str(execution.organization_id) if execution.organization_id else None,
+        "user_id": str(execution.executed_by) if execution.executed_by else None,
+        "user_name": execution.executed_by_name,
+        "user_email": user_email or "",
+        "sync": False,
+        "event": None,
+    }, True
+```
+
+Use `result["sync"]` as the authoritative transport bit after loading metadata. If both the lease and database row are absent, log an error and return because there is no durable execution to update. Do not create a replacement row.
+
+- [ ] **Step 5: Refactor success and failure through the loader**
+
+Open the existing durable session before loading metadata. Remove both early returns based on `get_pending_execution()`. Preserve the current transaction order: terminal execution update and buffered writes commit first; sync result push happens second; aggregate metrics and pub/sub fan-out remain derived work afterward.
+
+Call `update_delivery_from_execution()` when the compact lease marks an event execution or when the database fallback was required. The latter is intentionally defensive and is a no-op for ordinary executions.
+
+- [ ] **Step 6: Run consumer tests and verify GREEN**
+
+Run:
+
+```bash
+./test.sh tests/unit/jobs/consumers/test_workflow_execution_session.py -q
+./test.sh tests/e2e/api/test_executions.py::TestAsyncExecution::test_running_execution_completes_after_redis_tracking_loss -q
+```
+
+Expected: all consumer tests pass and the live workflow reaches `Success`
+after its Redis tracking records are explicitly deleted.
+
+- [ ] **Step 7: Commit durable terminal recovery**
+
+```bash
+git add api/src/jobs/consumers/workflow_execution.py api/tests/unit/jobs/consumers/test_workflow_execution_session.py api/tests/e2e/api/test_executions.py
+git commit -m "fix(execution): persist results after Redis state loss"
+```
+
+### Task 4: Clean up leases and verify the complete boundary
+
+**Files:**
+- Modify: `api/src/core/cache/invalidation.py`
+- Modify: `api/tests/unit/cache/test_invalidation.py`
+
+- [ ] **Step 1: Write a failing terminal-cleanup assertion**
+
+Extend the existing cache invalidation test with an exact key assertion:
+
+```python
+redis.delete.assert_awaited_once_with(
+    pending_changes_key(execution_id),
+    execution_logs_stream_key(execution_id),
+    active_execution_key(execution_id),
+)
+```
+
+- [ ] **Step 2: Run the cleanup test and verify RED**
+
+Run:
+
+```bash
+./test.sh tests/unit/cache/test_invalidation.py -q
+```
+
+Expected: the delete call is missing `active_execution_key(execution_id)`.
+
+- [ ] **Step 3: Delete the compact lease during terminal cleanup**
+
+Extend `cleanup_execution_cache()`:
+
+```python
+await r.delete(
+    pending_changes_key(execution_id),
+    execution_logs_stream_key(execution_id),
+    active_execution_key(execution_id),
+)
+```
+
+Keep legacy pending deletion in the consumer until its existing dispatch lifecycle is separately redesigned.
+
+- [ ] **Step 4: Run focused unit and E2E verification**
+
+Run:
+
+```bash
+./test.sh tests/unit/core/test_redis_client.py tests/unit/execution/test_process_pool.py tests/unit/jobs/consumers/test_workflow_execution_session.py -q
+./test.sh tests/e2e/api/test_executions.py::TestAsyncExecution::test_running_execution_completes_after_redis_tracking_loss -q
+./test.sh quality api
+```
+
+Expected: all selected tests pass and API lint/type checks exit zero.
+
+- [ ] **Step 5: Commit cleanup coverage**
+
+```bash
+git add api/src/core/cache/invalidation.py api/tests/unit/cache/test_invalidation.py
+git commit -m "fix(execution): clean up active leases"
+```
+
+### Task 5: Final candidate verification
+
+**Files:**
+- Verify all files listed above.
+
+- [ ] **Step 1: Review the candidate diff and invariants**
+
+Run:
+
+```bash
+git diff origin/main...HEAD --check
+git diff --stat origin/main...HEAD
+rg -n "get_pending_execution\(execution_id\)" api/src/jobs/consumers/workflow_execution.py
+git status --short
+```
+
+Expected: no whitespace errors; result handlers no longer depend on the pending dispatch record; the worktree is clean.
+
+- [ ] **Step 2: Rebase onto current upstream if needed**
+
+Fetch and compare `HEAD` with `origin/main`. If upstream advanced, rebase the branch, rerun the targeted tests, and commit any conflict resolution before the broad gate.
+
+- [ ] **Step 3: Run the required clean-commit PR gate**
+
+Run:
+
+```bash
+./test.sh pre-pr
+```
+
+Expected: the complete locally reproducible PR suite passes for the exact clean `HEAD` SHA reported by the command.
+
+- [ ] **Step 4: Report exact evidence**
+
+Record the candidate SHA, targeted unit and E2E commands, API quality result, and `pre-pr` result. Report any unrun external-only checks as owned by GitHub rather than implying they ran locally.

--- a/docs/superpowers/specs/2026-09-11-execution-tracking-heartbeat-design.md
+++ b/docs/superpowers/specs/2026-09-11-execution-tracking-heartbeat-design.md
@@ -20,32 +20,49 @@ out.
 After an execution has a PostgreSQL row, loss or expiry of transient Redis
 state must never prevent Bifrost from recording its terminal result.
 
+The process-pool parent owns the durable execution lifecycle. It records the
+transition to `Running`, retains the minimum completion metadata needed while
+the child is active, and records the terminal outcome returned by the child.
+The child owns only execution of user code. Redis transports and caches state;
+it is never the source of truth for whether admitted work is still running or
+has finished.
+
 ## Design
 
-### Refresh active execution state
+### Recreate a compact active-execution lease
 
 The process-pool parent already owns the authoritative in-memory set of active
-children and emits a heartbeat every ten seconds. During that heartbeat it will
-refresh the TTL of each active execution's existing Redis keys:
+children. Each active handle will retain a compact completion snapshot:
+workflow identity, organization identity, initiating user identity and email,
+display name, event-delivery presence, and the synchronous transport bit. It
+will not retain parameters, startup data, form inputs, embed data, or other
+potentially large workflow payloads.
 
-- pending execution metadata;
-- retained execution context; and
-- buffered SDK changes, when that key exists.
+On a sparse interval independent of the ten-second worker-health heartbeat,
+the parent will batch `SET ... EX` commands for active executions into one
+Redis pipeline per worker replica. `SET`, rather than `EXPIRE`, deliberately
+recreates a missing lease after expiry, eviction, or Redis restart while the
+child is still active. A ten-minute refresh interval leaves ample margin inside
+the one-hour lease TTL without producing constant Redis traffic.
 
-Refreshing uses `EXPIRE`, not recreation. A missing key remains missing so the
-heartbeat cannot fabricate incomplete context. Once a child completes,
-crashes, times out, or is cancelled, its handle leaves the active set and the
-parent stops refreshing its keys. Normal terminal cleanup remains responsible
-for deleting the keys promptly.
+Once a child completes, crashes, times out, or is cancelled, its handle leaves
+the active set and the parent stops recreating its lease. Normal terminal
+cleanup deletes the lease promptly. PostgreSQL receives no heartbeat writes.
+
+The existing pending-dispatch and retained-context keys keep their current
+lifecycle. They may contain large inputs and are not duplicated into parent
+memory merely to make them recreatable. The compact active lease is the
+parent-owned record used for completion after dispatch.
 
 ### Recover completion from PostgreSQL
 
-Success and failure processing will treat Redis metadata as a fast-path, not an
-authority. When the pending record is missing or cannot be read, the consumer
-will load the durable execution row and reconstruct the metadata needed for the
-terminal commit and notifications: workflow identity, organization, initiating
-user, and display name. The initiating user's email will be loaded for failure
-event emission.
+Success and failure processing will read the compact active lease first and
+treat it as a fast-path, not an authority. The existing pending record returns
+to its intended role as dispatch-only state. When the active lease is not
+available or readable, the consumer will load the durable execution row and
+reconstruct the metadata needed for the terminal commit and notifications:
+workflow identity, organization, initiating user, and display name. The
+initiating user's email will be loaded for failure event emission.
 
 The callback will always persist the terminal status and result when the
 durable execution row exists. Event-delivery reconciliation can use
@@ -59,15 +76,15 @@ invent a replacement row from a partial result.
 ### Preserve synchronous completion semantics
 
 Whether a caller is waiting synchronously is transport state and is not stored
-on the execution row. The process pool will retain that boolean with the active
-child and attach it to real and synthetic results before invoking the result
-callback. Consequently, Redis metadata loss cannot prevent a synchronous
-caller from receiving its terminal result.
+on the execution row. The process pool retains that boolean in the compact
+active lease and with the active handle, then attaches it to real and synthetic
+results before invoking the result callback. Consequently, Redis metadata loss
+cannot prevent a synchronous caller from receiving its terminal result.
 
 ## Error Handling
 
-Redis read or heartbeat failures are logged with the execution identifier. A
-heartbeat failure does not affect the child process, and completion falls back
+Redis read or lease-refresh failures are logged with the execution identifier.
+A refresh failure does not affect the child process, and completion falls back
 to PostgreSQL. PostgreSQL failure remains an authoritative completion failure
 and continues through the existing result-callback error path.
 
@@ -79,15 +96,17 @@ is unchanged.
 
 Tests use explicit key loss rather than wall-clock waits:
 
-1. Construct active and inactive process handles, execute one heartbeat refresh,
-   and assert that only active execution keys receive renewed TTLs.
-2. Return no pending Redis record to success processing, provide a durable
-   execution row, and assert that the terminal result is committed and
-   published.
-3. Repeat the missing-record test for failure processing.
-4. Verify that real and synthetic process-pool results retain the synchronous
+1. Construct active and inactive process handles, execute one lease refresh,
+   and assert that only active executions are written through one Redis
+   pipeline with a fresh TTL.
+2. Begin with no lease key, run a refresh for an active handle, and assert that
+   the compact lease is recreated without large workflow inputs.
+3. Return no Redis lease to success processing, provide a durable execution
+   row, and assert that the terminal result is committed and published.
+4. Repeat the missing-record test for failure processing.
+5. Verify that real and synthetic process-pool results retain the synchronous
    transport bit.
-5. Run the focused consumer and process-pool unit tests, the affected execution
+6. Run the focused consumer and process-pool unit tests, the affected execution
    tests, and API quality checks. Before a PR is opened, commit the exact
    candidate on current `origin/main` and run `./test.sh pre-pr`.
 

--- a/docs/superpowers/specs/2026-09-11-execution-tracking-heartbeat-design.md
+++ b/docs/superpowers/specs/2026-09-11-execution-tracking-heartbeat-design.md
@@ -1,0 +1,96 @@
+# Durable Workflow Completion and Execution Tracking Heartbeat
+
+## Problem
+
+Workflow dispatch stores completion metadata in
+`bifrost:exec:{execution_id}:pending` with a fixed one-hour TTL. The TTL starts
+when the API enqueues the workflow. Once the worker starts, Bifrost creates a
+durable PostgreSQL execution row in `Running` state, but the success and failure
+callbacks still require the Redis pending record before they will update that
+row.
+
+A workflow may run for up to 24 hours, or without a timeout. If its pending
+record expires or Redis loses the key, the child continues running and reports
+its result, but the callback discards that result. Execution history therefore
+remains `Running` until a later cleanup may incorrectly classify it as timed
+out.
+
+## Invariant
+
+After an execution has a PostgreSQL row, loss or expiry of transient Redis
+state must never prevent Bifrost from recording its terminal result.
+
+## Design
+
+### Refresh active execution state
+
+The process-pool parent already owns the authoritative in-memory set of active
+children and emits a heartbeat every ten seconds. During that heartbeat it will
+refresh the TTL of each active execution's existing Redis keys:
+
+- pending execution metadata;
+- retained execution context; and
+- buffered SDK changes, when that key exists.
+
+Refreshing uses `EXPIRE`, not recreation. A missing key remains missing so the
+heartbeat cannot fabricate incomplete context. Once a child completes,
+crashes, times out, or is cancelled, its handle leaves the active set and the
+parent stops refreshing its keys. Normal terminal cleanup remains responsible
+for deleting the keys promptly.
+
+### Recover completion from PostgreSQL
+
+Success and failure processing will treat Redis metadata as a fast-path, not an
+authority. When the pending record is missing or cannot be read, the consumer
+will load the durable execution row and reconstruct the metadata needed for the
+terminal commit and notifications: workflow identity, organization, initiating
+user, and display name. The initiating user's email will be loaded for failure
+event emission.
+
+The callback will always persist the terminal status and result when the
+durable execution row exists. Event-delivery reconciliation can use
+`execution_id` directly; on the fallback path it will run without relying on
+the original Redis event payload and remain a no-op for non-event executions.
+
+If neither Redis metadata nor a PostgreSQL row exists, the consumer will emit a
+high-signal error because it has no durable execution to update. It will not
+invent a replacement row from a partial result.
+
+### Preserve synchronous completion semantics
+
+Whether a caller is waiting synchronously is transport state and is not stored
+on the execution row. The process pool will retain that boolean with the active
+child and attach it to real and synthetic results before invoking the result
+callback. Consequently, Redis metadata loss cannot prevent a synchronous
+caller from receiving its terminal result.
+
+## Error Handling
+
+Redis read or heartbeat failures are logged with the execution identifier. A
+heartbeat failure does not affect the child process, and completion falls back
+to PostgreSQL. PostgreSQL failure remains an authoritative completion failure
+and continues through the existing result-callback error path.
+
+The heartbeat refresh does not extend queued work indefinitely. It begins only
+after the parent admits a child, so existing queue expiry and cleanup behavior
+is unchanged.
+
+## Testing
+
+Tests use explicit key loss rather than wall-clock waits:
+
+1. Construct active and inactive process handles, execute one heartbeat refresh,
+   and assert that only active execution keys receive renewed TTLs.
+2. Return no pending Redis record to success processing, provide a durable
+   execution row, and assert that the terminal result is committed and
+   published.
+3. Repeat the missing-record test for failure processing.
+4. Verify that real and synthetic process-pool results retain the synchronous
+   transport bit.
+5. Run the focused consumer and process-pool unit tests, the affected execution
+   tests, and API quality checks. Before a PR is opened, commit the exact
+   candidate on current `origin/main` and run `./test.sh pre-pr`.
+
+No test sleeps for the production TTL. Expiry is modeled by making the Redis
+lookup return no record, which is the exact boundary the production callback
+observes after one hour.


### PR DESCRIPTION
## Summary
- keep a compact parent-owned Redis lease alive for every running workflow execution
- batch lease refreshes without adding periodic PostgreSQL writes
- recover terminal processing from the authoritative PostgreSQL execution row when Redis state is missing
- clean up leases on completion and dispatch failure

## Verification
- focused execution recovery suite: 91 passed
- backend unit and contract suite: 5,950 passed, 3 skipped
- backend E2E suite: 1,821 passed, 1 skipped
- client unit suite: 1,929 passed
- browser smoke suite: 4 passed
- API quality, TypeScript, lint, and production builds passed
- full `./test.sh pre-pr` passed for `581f0bde563fad34ab27fd0ca16358dbf5195475`

Fixes #728