### PR TITLE
feat(tables): add indexed document ID batch queries

### DIFF
--- a/.claude/skills/bifrost-build/generated/python-sdk-signatures.md
+++ b/.claude/skills/bifrost-build/generated/python-sdk-signatures.md
@@ -214,7 +214,7 @@ Event publishing operations (async).
 
 **`tables.list(scope: str | None = None, app: str | None = None) -> list[TableInfo]`**
 
-**`tables.query(table: str, where: dict[str, Any] | None = None, order_by: str | None = None, order_dir: str = 'asc', limit: int = 100, offset: int = 0, scope: str | None = None, after_document_id: str | None = None, document_id_prefix: str | None = None, skip_count: bool = False) -> DocumentList`**
+**`tables.query(table: str, where: dict[str, Any] | None = None, order_by: str | None = None, order_dir: str = 'asc', limit: int = 100, offset: int = 0, scope: str | None = None, after_document_id: str | None = None, document_id_prefix: str | None = None, skip_count: bool = False, document_ids: list[str] | None = None) -> DocumentList`**
 
 **`tables.update(table: str, doc_id: str, data: dict[str, Any], scope: str | None = None, updated_by: str | None = None) -> DocumentData | None`**
 

--- a/api/bifrost/tables.py
+++ b/api/bifrost/tables.py
@@ -678,6 +678,7 @@ class tables:
         after_document_id: str | None = None,
         document_id_prefix: str | None = None,
         skip_count: bool = False,
+        document_ids: list[str] | None = None,
     ) -> DocumentList:
         """
         Query documents with filtering and pagination.
@@ -703,6 +704,10 @@ class tables:
             document_id_prefix: Restrict results to actual document IDs with
                 this prefix. Activates ascending document-ID ordering.
             skip_count: Skip the matching count query and return ``total=-1``.
+            document_ids: Up to 1000 actual document IDs to match. Duplicates
+                have set semantics; an empty list returns no documents. ANDed
+                with other filters. Results follow normal query ordering and
+                pagination rather than input order.
 
         Returns:
             DocumentList: Query results with documents, total count, and
@@ -724,6 +729,7 @@ class tables:
                 "after_document_id": after_document_id,
                 "document_id_prefix": document_id_prefix,
                 "skip_count": skip_count,
+                "document_ids": document_ids,
             },
         )
         if response.status_code == 404:

--- a/api/src/models/contracts/tables.py
+++ b/api/src/models/contracts/tables.py
@@ -6,7 +6,7 @@ Provides Pydantic models for API request/response handling.
 
 import warnings
 from datetime import datetime
-from typing import Any, Literal
+from typing import Annotated, Any, Literal
 from uuid import UUID
 
 from pydantic import (
@@ -374,6 +374,19 @@ class DocumentQuery(BaseModel):
         - NULL: {"deleted_at": {"is_null": true}}
         - Has field: {"field": {"has_key": true}}
         """,
+    )
+    document_ids: list[
+        Annotated[str, Field(min_length=1, max_length=255)]
+    ] | None = Field(
+        default=None,
+        max_length=1000,
+        description=(
+            "Filter by actual document IDs using the table's physical primary key. "
+            "At most 1000 IDs may be supplied. Duplicates have set semantics, "
+            "and an empty list matches no documents. This filter is ANDed with "
+            "where, document-ID pagination, and row policies. Results use the "
+            "normal query ordering and pagination, not input order."
+        ),
     )
     order_by: str | None = Field(
         default=None,

--- a/api/src/routers/tables.py
+++ b/api/src/routers/tables.py
@@ -16,7 +16,7 @@ from uuid import UUID
 
 from fastapi import APIRouter, Body, HTTPException, Query, status
 from pydantic import ValidationError
-from sqlalchemy import String, cast, func, select
+from sqlalchemy import String, cast, false, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.sql import ColumnElement
 
@@ -489,6 +489,14 @@ class DocumentRepository:
         down into the SQL query.
         """
         base_query = select(Document).where(Document.table_id == self.table.id)
+
+        if query_params.document_ids is not None:
+            unique_document_ids = list(dict.fromkeys(query_params.document_ids))
+            base_query = base_query.where(
+                Document.id.in_(unique_document_ids)
+                if unique_document_ids
+                else false()
+            )
 
         document_id_pagination = (
             query_params.after_document_id is not None

--- a/api/src/templates/llms.txt.md
+++ b/api/src/templates/llms.txt.md
@@ -367,7 +367,7 @@ Pick `useTable` for "Page X of Y" numbered-page UI; pick `useInfiniteTable` for 
 | `tables.upsert(table, item \| array, scope?)` | Insert or update by id. |
 | `tables.update(table, id, data, scope?)` | Patch a row's data fields. Returns `null` if missing. |
 | `tables.delete(table, id \| array, scope?)` | Delete by id; single-form is idempotent (returns `false` if missing). |
-| `tables.query(table, q?, scope?)` | One-shot read with `where`/`limit`/`offset`/`order_by`/`order_dir`/`skip_count`. |
+| `tables.query(table, q?, scope?)` | One-shot read with `document_ids`/`where`/`limit`/`offset`/`order_by`/`order_dir`/`skip_count`. |
 | `tables.count(table, scope?)` | Row count. Throws `TableNotFoundError` if missing. |
 | `tables.subscribe(tableId, filter, onEvent)` | Direct live subscription; advanced — `useTable` covers the common case. |
 

--- a/api/tests/e2e/api-integration/test_tables.py
+++ b/api/tests/e2e/api-integration/test_tables.py
@@ -299,6 +299,51 @@ class TestDocumentRepositoryIntegration:
         )
         assert [doc.id for doc in legacy_json_query] == ["tenant-a|002"]
 
+    @pytest.mark.asyncio
+    async def test_query_documents_by_actual_document_ids(
+        self, db_session: AsyncSession, test_table, test_user_email
+    ):
+        """Exact document IDs use the physical key and AND with JSON filters."""
+        doc_repo = DocumentRepository(db_session, test_table)
+        await doc_repo.insert(
+            {"id": "json-a", "tenant_id": "tenant-a"},
+            created_by=test_user_email,
+            doc_id="physical-a",
+        )
+        await doc_repo.insert(
+            {"id": "json-b", "tenant_id": "tenant-b"},
+            created_by=test_user_email,
+            doc_id="physical-b",
+        )
+
+        from src.models.contracts.tables import DocumentQuery
+
+        documents, total = await doc_repo.query(
+            DocumentQuery(
+                document_ids=["physical-a", "missing", "physical-a", "physical-b"],
+                where={"tenant_id": "tenant-a"},
+                skip_count=True,
+                limit=4,
+            )
+        )
+
+        assert [doc.id for doc in documents] == ["physical-a"]
+        assert total == -1
+
+        empty, empty_total = await doc_repo.query(
+            DocumentQuery(document_ids=[], skip_count=False)
+        )
+        assert empty == []
+        assert empty_total == 0
+
+    @pytest.mark.parametrize("document_ids", [[""], ["x" * 256], ["x"] * 1001])
+    def test_document_ids_validation(self, document_ids):
+        from pydantic import ValidationError
+        from src.models.contracts.tables import DocumentQuery
+
+        with pytest.raises(ValidationError):
+            DocumentQuery(document_ids=document_ids)
+
     @pytest.mark.parametrize(
         "kwargs, message",
         [

--- a/api/tests/e2e/platform/test_policies.py
+++ b/api/tests/e2e/platform/test_policies.py
@@ -213,6 +213,21 @@ class TestPoliciesMatrix:
             "tenant|001"
         ]
 
+        batch_response = e2e_client.post(
+            f"/api/tables/{table_id}/documents/query",
+            headers=alice_user.headers,
+            json={
+                "document_ids": ["tenant|001", "tenant|002", "missing"],
+                "skip_count": True,
+            },
+        )
+
+        assert batch_response.status_code == 200, batch_response.text
+        assert batch_response.json()["total"] == -1
+        assert [doc["id"] for doc in batch_response.json()["documents"]] == [
+            "tenant|001"
+        ]
+
     def test_state_locked_update(self, e2e_client, platform_admin, alice_user):
         """Owner can update while status=open; cannot once status=done (pre-update semantics)."""
         table_id = _create_table(

--- a/api/tests/e2e/platform/test_tables.py
+++ b/api/tests/e2e/platform/test_tables.py
@@ -1205,6 +1205,16 @@ class TestDocumentIdUniquePerTable:
         assert get_b.status_code == 200, get_b.text
         assert get_b.json()["data"] == {"table": "b"}
 
+        query_a = e2e_client.post(
+            f"/api/tables/{table_a}/documents/query",
+            headers=platform_admin.headers,
+            json={"document_ids": [doc_id], "skip_count": True},
+        )
+        assert query_a.status_code == 200, query_a.text
+        assert [doc["data"] for doc in query_a.json()["documents"]] == [
+            {"table": "a"}
+        ]
+
     def test_same_doc_id_in_two_tables_via_insert(
         self, e2e_client, platform_admin
     ):

--- a/api/tests/performance/test_table_document_id_pagination.py
+++ b/api/tests/performance/test_table_document_id_pagination.py
@@ -1,4 +1,4 @@
-"""Query-plan regression for actual document-ID keyset pagination."""
+"""Query-plan regressions for physical document-ID filtering."""
 
 from __future__ import annotations
 
@@ -98,3 +98,86 @@ async def test_document_id_keyset_query_uses_composite_index_without_sort(
         and node.get("Index Name") == "documents_pkey"
         for node in nodes
     )
+
+
+@pytest.mark.asyncio
+@pytest.mark.slow
+@pytest.mark.timeout(120)
+async def test_document_id_batch_query_uses_composite_index(
+    db_session: AsyncSession,
+) -> None:
+    """A large exact-ID batch is resolved through ``documents_pkey``."""
+    org = Organization(
+        id=uuid4(),
+        name=f"Document ID batch plan {uuid4().hex[:8]}",
+        domain=f"document-id-batch-plan-{uuid4().hex[:8]}.example.com",
+        created_by="test@example.com",
+    )
+    table = Table(
+        id=uuid4(),
+        name=f"document_id_batch_plan_{uuid4().hex[:8]}",
+        organization_id=org.id,
+        created_by="test@example.com",
+    )
+    db_session.add_all([org, table])
+    await db_session.flush()
+
+    await db_session.execute(
+        text(
+            """
+            INSERT INTO documents (
+                table_id, id, data, created_by, updated_by
+            )
+            SELECT
+                CAST(:table_id AS uuid),
+                'tenant|drive|item-' || lpad(item::text, 6, '0'),
+                jsonb_build_object('tenant_id', 'tenant', 'item', item),
+                'test@example.com',
+                'test@example.com'
+            FROM generate_series(0, 199999) AS item
+            """
+        ),
+        {"table_id": str(table.id)},
+    )
+    await db_session.commit()
+    await db_session.execute(text("ANALYZE documents"))
+
+    requested_ids = [
+        f"tenant|drive|item-{item:06d}" for item in range(0, 200_000, 400)
+    ]
+    captured = []
+
+    def capture_statement(orm_execute_state):
+        if orm_execute_state.is_select:
+            captured.append(orm_execute_state.statement)
+
+    event.listen(db_session.sync_session, "do_orm_execute", capture_statement)
+    try:
+        documents, total = await DocumentRepository(db_session, table).query(
+            DocumentQuery(
+                document_ids=requested_ids,
+                where={"tenant_id": "tenant"},
+                skip_count=True,
+                limit=500,
+            )
+        )
+    finally:
+        event.remove(db_session.sync_session, "do_orm_execute", capture_statement)
+
+    assert total == -1
+    assert len(documents) == 500
+    assert len(captured) == 1
+    sql = str(
+        captured[0].compile(
+            dialect=postgresql.dialect(),
+            compile_kwargs={"literal_binds": True},
+        )
+    )
+    result = await db_session.execute(text(f"EXPLAIN (FORMAT JSON) {sql}"))
+    nodes = list(_plan_nodes(result.scalar_one()[0]["Plan"]))
+
+    assert any(
+        node["Node Type"] in {"Index Scan", "Index Only Scan", "Bitmap Index Scan"}
+        and node.get("Index Name") == "documents_pkey"
+        for node in nodes
+    ), nodes

--- a/api/tests/unit/sdk/test_sdk_tables.py
+++ b/api/tests/unit/sdk/test_sdk_tables.py
@@ -217,6 +217,7 @@ async def test_tables_query_forwards_document_id_pagination_and_skip_count(monke
         scope="global",
         after_document_id="tenant|drive|item-001",
         document_id_prefix="tenant|",
+        document_ids=["tenant|drive|item-001", "tenant|drive|item-002"],
         skip_count=True,
         limit=500,
     )
@@ -232,6 +233,7 @@ async def test_tables_query_forwards_document_id_pagination_and_skip_count(monke
             "offset": 0,
             "after_document_id": "tenant|drive|item-001",
             "document_id_prefix": "tenant|",
+            "document_ids": ["tenant|drive|item-001", "tenant|drive|item-002"],
             "skip_count": True,
         },
     )

--- a/client/src/lib/app-sdk/tables.test.ts
+++ b/client/src/lib/app-sdk/tables.test.ts
@@ -74,9 +74,16 @@ describe("tables web SDK", () => {
       }),
     );
     vi.stubGlobal("fetch", fetchMock);
-    await tables.query("t1", { where: { x: { eq: 1 } } });
+    await tables.query("t1", {
+      document_ids: ["doc-1", "doc-2"],
+      where: { x: { eq: 1 } },
+    });
     const url = fetchMock.mock.calls[0][0];
     expect(url).toMatch(/\/api\/tables\/t1\/documents\/query$/);
+    expect(JSON.parse(fetchMock.mock.calls[0][1].body as string)).toEqual({
+      document_ids: ["doc-1", "doc-2"],
+      where: { x: { eq: 1 } },
+    });
   });
 
   it("delete returns true on 204", async () => {

--- a/client/src/lib/v1.d.ts
+++ b/client/src/lib/v1.d.ts
@@ -15339,6 +15339,11 @@ export interface components {
                 [key: string]: unknown;
             } | null;
             /**
+             * Document Ids
+             * @description Filter by actual document IDs using the table's physical primary key. Duplicates have set semantics. An empty list matches no documents.
+             */
+            document_ids?: string[] | null;
+            /**
              * Order By
              * @description Field to order by (data field name)
              */
@@ -15370,7 +15375,7 @@ export interface components {
             skip_count: boolean;
             /**
              * After Document Id
-             * @description Return documents whose actual document ID is greater than this exclusive cursor, ordered by document ID.
+             * @description Return documents whose actual document ID is greater than this exclusive cursor, ordered by document ID. Use an empty string to begin an unbounded document-ID scan.
              */
             after_document_id?: string | null;
             /**

--- a/plugins/bifrost/skills/bifrost-build/generated/python-sdk-signatures.md
+++ b/plugins/bifrost/skills/bifrost-build/generated/python-sdk-signatures.md
@@ -214,7 +214,7 @@ Event publishing operations (async).
 
 **`tables.list(scope: str | None = None, app: str | None = None) -> list[TableInfo]`**
 
-**`tables.query(table: str, where: dict[str, Any] | None = None, order_by: str | None = None, order_dir: str = 'asc', limit: int = 100, offset: int = 0, scope: str | None = None, after_document_id: str | None = None, document_id_prefix: str | None = None, skip_count: bool = False) -> DocumentList`**
+**`tables.query(table: str, where: dict[str, Any] | None = None, order_by: str | None = None, order_dir: str = 'asc', limit: int = 100, offset: int = 0, scope: str | None = None, after_document_id: str | None = None, document_id_prefix: str | None = None, skip_count: bool = False, document_ids: list[str] | None = None) -> DocumentList`**
 
 **`tables.update(table: str, doc_id: str, data: dict[str, Any], scope: str | None = None, updated_by: str | None = None) -> DocumentData | None`**
 


### PR DESCRIPTION
## Summary
- add a bounded `document_ids` filter for physical table document IDs
- preserve JSON `where` semantics, row policies, table isolation, ordering, pagination, and `skip_count`
- expose the filter through Python and web SDK contracts and documentation
- verify the composite primary-key index on a representative 200k-row table

## Validation
- `./test.sh pre-pr` passed for `7fbbfd598ad414987c0d4874b791b2975df0b198`
- focused document-ID, policy, isolation, SDK, validation, and query-plan coverage passed

## Rollout
Deploy platform support before switching the SharePoint Explorer consumers. This PR does not resume scans or create schedules.