### PR TITLE
Fix placeholder icons showing through custom entity logos

### DIFF
--- a/client/src/components/EntityLogo.test.tsx
+++ b/client/src/components/EntityLogo.test.tsx
@@ -63,21 +63,22 @@ describe("EntityLogo", () => {
 		expect(img.getAttribute("src")).toBe(dataUrl);
 	});
 
-	it("crossfades a fetched logo over its fallback", () => {
+	it.each(["app", "agent", "solution", "integration", "form"] as const)("replaces the %s placeholder after its logo loads", (entityType) => {
 		render(
 			<EntityLogo
-				entityType="app"
+				entityType={entityType}
 				entityId="11111111-1111-1111-1111-111111111111"
 				logo="/images/app-logo.png"
-				fallback={<span data-testid="fallback">F</span>}
+				fallback={<span>F</span>}
 				size={32}
 			/>,
 		);
-		const img = screen.getByTestId("entity-logo");
+		const img = screen.getByRole("presentation");
 		expect(img).toHaveClass("opacity-0");
-		expect(screen.getByTestId("fallback")).toBeInTheDocument();
+		expect(screen.getByText("F")).toBeInTheDocument();
 		fireEvent.load(img);
 		expect(img).toHaveClass("opacity-100");
+		expect(screen.queryByText("F")).not.toBeInTheDocument();
 	});
 
 	it("falls back when a list-provided logo URL fails", () => {
@@ -106,6 +107,23 @@ describe("EntityLogo", () => {
 		);
 		expect(screen.getByTestId("fallback")).toBeInTheDocument();
 		expect(screen.queryByTestId("entity-logo")).toBeNull();
+	});
+
+	it("restores the placeholder while a replacement loads and when it fails", () => {
+		const props = { entityType: "app" as const, entityId: "app-1", size: 32, fallback: <span>App placeholder</span> };
+		const { rerender } = render(<EntityLogo {...props} logo="/first.svg" />);
+		fireEvent.load(screen.getByRole("presentation"));
+		expect(screen.queryByText("App placeholder")).not.toBeInTheDocument();
+		rerender(<EntityLogo {...props} logo="/replacement.svg" />);
+		expect(screen.getByText("App placeholder")).toBeInTheDocument();
+		fireEvent.error(screen.getByRole("presentation"));
+		expect(screen.getByText("App placeholder")).toBeInTheDocument();
+		expect(screen.queryByRole("presentation")).not.toBeInTheDocument();
+		rerender(<EntityLogo {...props} logo="/third.svg" />);
+		fireEvent.load(screen.getByRole("presentation"));
+		expect(screen.queryByText("App placeholder")).not.toBeInTheDocument();
+		rerender(<EntityLogo {...props} logo={null} />);
+		expect(screen.getByText("App placeholder")).toBeInTheDocument();
 	});
 
 	it("appends cacheKey to bust browser cache", () => {

--- a/client/src/components/EntityLogo.tsx
+++ b/client/src/components/EntityLogo.tsx
@@ -59,9 +59,11 @@ export function EntityLogo({
 			aria-label={ariaLabel}
 			aria-hidden={ariaHidden}
 		>
-			<span className="absolute inset-0 grid place-items-center">
-				{fallback}
-			</span>
+			{(!hasUsableSource || !imageLoaded) && (
+				<span className="absolute inset-0 grid place-items-center">
+					{fallback}
+				</span>
+			)}
 			{hasUsableSource ? (
 				<img
 					data-testid="entity-logo"


### PR DESCRIPTION
Custom entity images were rendered over a placeholder icon that remained visible through transparent pixels and around contained images. Remove the placeholder once the image loads, while retaining it during loading and after failures.

The shared fix applies to apps, agents, forms, integrations, and solutions. Regression tests cover all five entity types, replacement images, failures, and logo removal.

Validation: focused logo/upload/card tests (24 passed), TypeScript and ESLint, and the complete `./test.sh pre-pr` gate on `c075b26d2e7a`: 2,978 frontend tests, 6,042 backend unit tests, 1,850 live API tests, 14 zero-retry browser smoke tests, and production client/API builds.
