### PR TITLE
fix(artifacts): force browser-active content to download

### DIFF
--- a/api/src/routers/chat.py
+++ b/api/src/routers/chat.py
@@ -572,7 +572,7 @@ async def get_attachment_content(
     if attachment is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Attachment not found")
 
-    from src.services.artifacts import ArtifactService
+    from src.services.artifacts import ArtifactService, is_browser_active_content_type
 
     artifact = await db.get(Artifact, attachment.artifact_id)
     if artifact is None:
@@ -597,7 +597,11 @@ async def get_attachment_content(
                     "X-Content-Type-Options": "nosniff",
                 },
             )
-    disposition = "attachment" if download else "inline"
+    disposition = (
+        "attachment"
+        if download or is_browser_active_content_type(attachment.content_type)
+        else "inline"
+    )
     encoded_filename = quote(attachment.filename, safe="")
     return Response(
         content=content,

--- a/api/src/routers/cli.py
+++ b/api/src/routers/cli.py
@@ -2391,7 +2391,11 @@ async def sdk_read_artifact(
     preview: bool = False,
 ) -> Response:
     """Read an opaque artifact after enforcing caller scope."""
-    from src.services.artifacts import ArtifactAccessError, ArtifactService
+    from src.services.artifacts import (
+        ArtifactAccessError,
+        ArtifactService,
+        is_browser_active_content_type,
+    )
 
     service = ArtifactService(db)
     try:
@@ -2425,10 +2429,13 @@ async def sdk_read_artifact(
                     "X-Content-Type-Options": "nosniff",
                 },
             )
+    headers = {"X-Content-Type-Options": "nosniff"}
+    if is_browser_active_content_type(artifact.content_type):
+        headers["Content-Disposition"] = "attachment"
     return Response(
         content=content,
         media_type=artifact.content_type,
-        headers={"X-Content-Type-Options": "nosniff"},
+        headers=headers,
     )
 
 

--- a/api/src/services/artifacts.py
+++ b/api/src/services/artifacts.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import mimetypes
 from pathlib import PurePosixPath
 from uuid import UUID, uuid4
 
@@ -11,6 +12,33 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from src.models.contracts.artifacts import ArtifactRef
 from src.models.orm import Artifact
 from src.services.file_storage.service import get_file_storage_service
+
+
+_BROWSER_ACTIVE_CONTENT_TYPES = {
+    "application/xhtml+xml",
+    "application/xml",
+    "image/svg+xml",
+    "text/html",
+    "text/xml",
+}
+
+
+def is_browser_active_content_type(content_type: str) -> bool:
+    """Return whether a media type can render active browser content."""
+    base_content_type = content_type.partition(";")[0].strip().lower()
+    return (
+        base_content_type in _BROWSER_ACTIVE_CONTENT_TYPES
+        or base_content_type.endswith("+xml")
+    )
+
+
+def artifact_requires_inert_storage(filename: str, content_type: str) -> bool:
+    """Return whether declared or filename-derived metadata is browser-active."""
+    inferred_content_type, _encoding = mimetypes.guess_type(filename)
+    return is_browser_active_content_type(content_type) or (
+        inferred_content_type is not None
+        and is_browser_active_content_type(inferred_content_type)
+    )
 
 
 class ArtifactAccessError(ValueError):
@@ -73,7 +101,17 @@ class ArtifactService:
             prefix = "_attachments" if storage_family == "upload" else "_artifacts"
             s3_key = f"{prefix}/{artifact_id}_{safe_name}"
         storage = get_file_storage_service(self.db)
-        await storage.write_raw_to_s3(s3_key, content)
+        if artifact_requires_inert_storage(filename, content_type):
+            async def content_chunks():
+                yield content
+
+            await storage.write_raw_chunks_to_s3(
+                s3_key,
+                content_chunks(),
+                content_type="application/octet-stream",
+            )
+        else:
+            await storage.write_raw_to_s3(s3_key, content)
         artifact = Artifact(
             id=artifact_id,
             organization_id=organization_id,

--- a/api/tests/e2e/api/test_chat.py
+++ b/api/tests/e2e/api/test_chat.py
@@ -206,6 +206,40 @@ class TestChatAttachments:
         missing = e2e_client.get(content_url, headers=platform_admin.headers)
         assert missing.status_code == 404
 
+    def test_html_attachment_content_is_always_downloaded(
+        self,
+        e2e_client,
+        platform_admin,
+        test_conversation,
+    ):
+        auth_headers = {"Authorization": platform_admin.headers["Authorization"]}
+        upload = e2e_client.post(
+            f"/api/chat/conversations/{test_conversation['id']}/attachments",
+            files=[
+                (
+                    "files",
+                    (
+                        "unsafe.html",
+                        b"<script>alert(1)</script>",
+                        "text/html; charset=utf-8",
+                    ),
+                )
+            ],
+            headers=auth_headers,
+        )
+        assert upload.status_code == 200, upload.text
+        attachment = upload.json()["attachments"][0]
+
+        content = e2e_client.get(
+            f"/api/chat/conversations/{test_conversation['id']}"
+            f"/attachments/{attachment['id']}/content",
+            headers=platform_admin.headers,
+        )
+
+        assert content.status_code == 200, content.text
+        assert content.headers["content-type"] == "text/html; charset=utf-8"
+        assert content.headers["content-disposition"].startswith("attachment;")
+
     def test_sdk_document_artifact_returns_readable_opaque_reference(
         self,
         e2e_client,
@@ -284,6 +318,67 @@ class TestChatAttachments:
         )
         assert workspace.status_code == 200, workspace.text
         assert workspace.json() == [ref]
+
+    def test_sdk_serves_html_artifacts_as_downloads(
+        self,
+        e2e_client,
+        platform_admin,
+    ):
+        upload_headers = {
+            key: value
+            for key, value in platform_admin.headers.items()
+            if key.lower() != "content-type"
+        }
+        stored = e2e_client.post(
+            "/api/sdk/artifacts",
+            files={
+                "file": (
+                    "Unsafe.html",
+                    b"<script>window.parent.location='/settings'</script>",
+                    "text/html; charset=utf-8",
+                )
+            },
+            headers=upload_headers,
+        )
+
+        assert stored.status_code == 200, stored.text
+        content = e2e_client.get(
+            f"/api/sdk/artifacts/{stored.json()['id']}/content",
+            headers=platform_admin.headers,
+        )
+        assert content.status_code == 200, content.text
+        assert content.headers["content-type"] == "text/html; charset=utf-8"
+        assert content.headers["content-disposition"] == "attachment"
+
+    def test_sdk_serves_browser_active_xml_artifacts_as_downloads(
+        self,
+        e2e_client,
+        platform_admin,
+    ):
+        upload_headers = {
+            key: value
+            for key, value in platform_admin.headers.items()
+            if key.lower() != "content-type"
+        }
+        stored = e2e_client.post(
+            "/api/sdk/artifacts",
+            files={
+                "file": (
+                    "active.xml",
+                    b"<svg></svg>",
+                    "text/xml; charset=utf-8",
+                )
+            },
+            headers=upload_headers,
+        )
+
+        assert stored.status_code == 200, stored.text
+        content = e2e_client.get(
+            f"/api/sdk/artifacts/{stored.json()['id']}/content",
+            headers=platform_admin.headers,
+        )
+        assert content.status_code == 200, content.text
+        assert content.headers["content-disposition"] == "attachment"
 
     @pytest.mark.asyncio
     async def test_artifact_library_lists_renames_and_deletes_owned_files(

--- a/api/tests/unit/test_artifact_storage_safety.py
+++ b/api/tests/unit/test_artifact_storage_safety.py
@@ -1,0 +1,130 @@
+from uuid import uuid4
+
+import pytest
+
+from src.services.artifacts import ArtifactService, is_browser_active_content_type
+
+
+class _FakeDB:
+    def __init__(self) -> None:
+        self.added = []
+
+    def add(self, value) -> None:
+        self.added.append(value)
+
+    async def flush(self) -> None:
+        return None
+
+
+class _FakeStorage:
+    def __init__(self) -> None:
+        self.raw_writes = []
+        self.chunk_writes = []
+
+    async def write_raw_to_s3(self, path: str, content: bytes) -> None:
+        self.raw_writes.append((path, content))
+
+    async def write_raw_chunks_to_s3(
+        self,
+        path: str,
+        chunks,
+        *,
+        content_type: str | None = None,
+    ):
+        payload = b"".join([chunk async for chunk in chunks])
+        self.chunk_writes.append((path, payload, content_type))
+        return "unused", len(payload)
+
+    async def delete_raw_from_s3(self, path: str) -> None:
+        return None
+
+
+@pytest.mark.parametrize(
+    "content_type",
+    [
+        "text/html; charset=utf-8",
+        "Text/XML",
+        "image/svg+xml",
+        "application/atom+xml",
+    ],
+)
+def test_browser_active_media_types_are_classified(content_type):
+    assert is_browser_active_content_type(content_type)
+
+
+@pytest.mark.asyncio
+async def test_html_artifacts_are_stored_with_inert_object_content_type(monkeypatch):
+    """Direct object-storage URLs must not render HTML as active browser content."""
+    storage = _FakeStorage()
+    monkeypatch.setattr(
+        "src.services.artifacts.get_file_storage_service",
+        lambda _db: storage,
+    )
+
+    artifact = await ArtifactService(_FakeDB()).store(
+        filename="Unsafe.html",
+        content_type="text/html; charset=utf-8",
+        content=b"<script>alert(document.domain)</script>",
+        created_by_user_id=uuid4(),
+        organization_id=None,
+    )
+
+    assert artifact.content_type == "text/html; charset=utf-8"
+    assert storage.raw_writes == []
+    assert len(storage.chunk_writes) == 1
+    _path, payload, object_content_type = storage.chunk_writes[0]
+    assert payload == b"<script>alert(document.domain)</script>"
+    assert object_content_type == "application/octet-stream"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("filename", "content_type"),
+    [
+        ("diagram.svg", "text/plain"),
+        ("feed.txt", "Application/Atom+XML; Charset=UTF-8"),
+    ],
+)
+async def test_browser_active_declared_or_inferred_types_use_inert_storage(
+    monkeypatch,
+    filename,
+    content_type,
+):
+    storage = _FakeStorage()
+    monkeypatch.setattr(
+        "src.services.artifacts.get_file_storage_service",
+        lambda _db: storage,
+    )
+
+    await ArtifactService(_FakeDB()).store(
+        filename=filename,
+        content_type=content_type,
+        content=b"<svg xmlns='http://www.w3.org/2000/svg'></svg>",
+        created_by_user_id=uuid4(),
+        organization_id=None,
+    )
+
+    assert storage.raw_writes == []
+    assert storage.chunk_writes[0][2] == "application/octet-stream"
+
+
+@pytest.mark.asyncio
+async def test_non_html_artifacts_keep_existing_storage_path(monkeypatch):
+    """The HTML hardening must not change ordinary artifact persistence."""
+    storage = _FakeStorage()
+    monkeypatch.setattr(
+        "src.services.artifacts.get_file_storage_service",
+        lambda _db: storage,
+    )
+
+    await ArtifactService(_FakeDB()).store(
+        filename="Notes.md",
+        content_type="text/markdown",
+        content=b"# Safe",
+        created_by_user_id=uuid4(),
+        organization_id=None,
+    )
+
+    assert len(storage.raw_writes) == 1
+    assert storage.raw_writes[0][1] == b"# Safe"
+    assert storage.chunk_writes == []


### PR DESCRIPTION
Browser-active artifacts can currently render inline under the application origin. Force active HTML/XML/SVG content to download at chat and SDK artifact endpoints, and store active artifacts with inert object-storage metadata so direct object URLs also remain inert.

Recognizes parameterized media types, XML suffixes, and filename-derived types for storage safety. Ordinary artifact behavior remains unchanged. Includes unit coverage and chat/SDK artifact endpoint regressions. Ported from Midtown-Technology-Group/bifrost commit 9b36bdc34.

Sensitive path: untrusted artifact content and browser-origin isolation.

Validation on pve-t340 VM 101: artifact storage regression tests and `./test.sh pre-pr` for the exact PR head.
