### PR TITLE
fix(schedules): resolve the legacy Indianapolis timezone

### DIFF
--- a/api/src/jobs/schedulers/cron_scheduler.py
+++ b/api/src/jobs/schedulers/cron_scheduler.py
@@ -12,7 +12,6 @@ import logging
 import uuid
 from datetime import datetime, timezone
 from typing import Any
-from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 import sqlalchemy as sa
 from croniter import croniter
@@ -23,19 +22,13 @@ from src.core.database import get_db_context
 from src.models.enums import EventDeliveryStatus, EventSourceType, EventStatus, ScheduleOverlapPolicy
 from src.models.orm.events import Event, EventDelivery, EventSource
 from src.repositories.events import EventSubscriptionRepository
+from src.services.cron_parser import get_schedule_zone
 
 logger = logging.getLogger(__name__)
 
 
-def _get_schedule_zone(timezone_name: str) -> ZoneInfo:
-    try:
-        return ZoneInfo(timezone_name)
-    except ZoneInfoNotFoundError as exc:
-        raise ValueError(f"Unknown timezone: {timezone_name}") from exc
-
-
 def _next_interval_seconds(cron_expression: str, now_utc: datetime, timezone_name: str) -> float:
-    zone = _get_schedule_zone(timezone_name)
+    zone = get_schedule_zone(timezone_name)
     local_now = now_utc.astimezone(zone)
     cron = croniter(cron_expression, local_now)
     first_run = cron.get_next(datetime)
@@ -51,7 +44,7 @@ def _latest_due_run_utc(
     now_utc: datetime,
     timezone_name: str,
 ) -> datetime | None:
-    zone = _get_schedule_zone(timezone_name)
+    zone = get_schedule_zone(timezone_name)
     local_now = now_utc.astimezone(zone)
     cron_iter = croniter(cron_expression, local_now)
     prev_run = cron_iter.get_prev(datetime)

--- a/api/src/routers/schedules.py
+++ b/api/src/routers/schedules.py
@@ -7,7 +7,6 @@ Provides CRON expression validation for the event source UI.
 import logging
 from datetime import datetime, timezone
 from typing import Literal
-from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from fastapi import APIRouter
 
@@ -16,6 +15,7 @@ from src.core.auth import Context, CurrentSuperuser
 from src.core.log_safety import log_safe
 from src.services.cron_parser import (
     cron_to_human_readable,
+    get_schedule_zone,
     is_cron_expression_valid,
 )
 
@@ -27,13 +27,6 @@ router = APIRouter(prefix="/api/schedules", tags=["Schedules"])
 MIN_INTERVAL_SECONDS = 300
 
 
-def _get_schedule_zone(timezone_name: str) -> ZoneInfo:
-    try:
-        return ZoneInfo(timezone_name)
-    except ZoneInfoNotFoundError as exc:
-        raise ValueError(f"Unknown timezone: {timezone_name}") from exc
-
-
 def _validate_cron(
     expression: str,
     timezone_name: str,
@@ -43,7 +36,7 @@ def _validate_cron(
         return "error", "Invalid CRON expression"
 
     try:
-        zone = _get_schedule_zone(timezone_name)
+        zone = get_schedule_zone(timezone_name)
     except ValueError as e:
         return "error", str(e)
 
@@ -90,7 +83,7 @@ async def validate_cron_expression(
         )
 
     try:
-        zone = _get_schedule_zone(body.timezone)
+        zone = get_schedule_zone(body.timezone)
     except ValueError as e:
         return CronValidationResponse(
             valid=False,

--- a/api/src/services/cron_parser.py
+++ b/api/src/services/cron_parser.py
@@ -4,12 +4,28 @@ Provides validation, next run calculation, and human-readable descriptions for C
 """
 
 import logging
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from croniter import croniter
 
 from src.core.log_safety import log_safe
 
 logger = logging.getLogger(__name__)
+
+SCHEDULE_TIMEZONE_ALIASES = {
+    # Legacy Bifrost schedules used this common tzdb link. Some slim runtime
+    # images ship only the canonical zone file.
+    "America/Indianapolis": "America/Indiana/Indianapolis",
+}
+
+
+def get_schedule_zone(timezone_name: str) -> ZoneInfo:
+    """Resolve supported legacy timezone names to their canonical IANA zone."""
+    resolved_name = SCHEDULE_TIMEZONE_ALIASES.get(timezone_name, timezone_name)
+    try:
+        return ZoneInfo(resolved_name)
+    except ZoneInfoNotFoundError as exc:
+        raise ValueError(f"Unknown timezone: {timezone_name}") from exc
 
 
 def validate_cron_expression(expression: str) -> bool:

--- a/api/tests/unit/jobs/schedulers/test_cron_scheduler.py
+++ b/api/tests/unit/jobs/schedulers/test_cron_scheduler.py
@@ -174,6 +174,18 @@ async def test_schedule_evaluates_cron_in_configured_timezone(db_session):
     assert events[0].data["timezone"] == "America/New_York"
 
 
+def test_scheduler_resolves_legacy_indianapolis_alias():
+    from src.jobs.schedulers.cron_scheduler import _latest_due_run_utc
+
+    due = _latest_due_run_utc(
+        "0 9 * * *",
+        datetime(2026, 7, 22, 13, 0, 30, tzinfo=timezone.utc),
+        "America/Indianapolis",
+    )
+
+    assert due == datetime(2026, 7, 22, 13, 0, tzinfo=timezone.utc)
+
+
 @pytest.mark.asyncio
 async def test_schedule_fires_when_no_active_executions(db_session):
     """Happy path: no prior executions → event is created for this source."""

--- a/api/tests/unit/routers/test_schedules.py
+++ b/api/tests/unit/routers/test_schedules.py
@@ -46,3 +46,18 @@ async def test_validate_cron_rejects_unknown_timezone():
     assert result.valid is False
     assert result.human_readable == "Invalid timezone"
     assert result.error == "Unknown timezone: Not/AZone"
+
+
+@pytest.mark.asyncio
+async def test_validate_cron_accepts_legacy_indianapolis_alias():
+    result = await validate_cron_expression(
+        CronValidationRequest(
+            expression="0 9 * * *",
+            timezone="America/Indianapolis",
+        ),
+        ctx=object(),
+        user=object(),
+    )
+
+    assert result.valid is True
+    assert result.next_runs is not None


### PR DESCRIPTION
Existing schedules using America/Indianapolis can fail in slim runtimes that ship only the canonical America/Indiana/Indianapolis zone. Resolve the legacy name through one shared schedule-zone helper used by cron validation and scheduler calculations.

Preserves rejection of unknown zones and covers both schedule validation and the calculated UTC due time. Ported from Midtown-Technology-Group/bifrost commit 572fccd3c.

Validation on pve-t340 VM 101: schedule validation and cron scheduler tests and `./test.sh pre-pr` for the exact PR head.
