### PR TITLE
fix(webhooks): queue the event created by each request

### DIFF
--- a/api/src/routers/hooks.py
+++ b/api/src/routers/hooks.py
@@ -205,26 +205,15 @@ async def receive_webhook(
         # Queue workflow executions asynchronously
         # This is done after commit to ensure delivery records exist
         try:
-            from sqlalchemy import select
-            from src.models.orm.events import Event
-
-            event_result = await db.execute(
-                select(Event)
-                .where(Event.event_source_id == event_source.id)
-                .order_by(Event.created_at.desc())
-                .limit(1)
-            )
-            event = event_result.scalar_one_or_none()
-
-            if event:
-                queued = await processor.queue_event_deliveries(event.id)
+            if result.event_id:
+                queued = await processor.queue_event_deliveries(result.event_id)
                 await db.commit()
 
                 logger.info(
                     f"Webhook accepted: {log_safe(source_id)}",
                     extra={
                         "source_id": log_safe(source_id),
-                        "event_id": str(event.id),
+                        "event_id": str(result.event_id),
                         "deliveries_queued": queued,
                     },
                 )

--- a/api/src/services/events/processor.py
+++ b/api/src/services/events/processor.py
@@ -513,6 +513,7 @@ class EventProcessor:
             return Deliver(
                 data=deliver.data,
                 event_type=deliver.event_type,
+                event_id=event.id,
             )
 
         deliveries_created = 0
@@ -564,6 +565,7 @@ class EventProcessor:
         return Deliver(
             data=deliver.data,
             event_type=deliver.event_type,
+            event_id=event.id,
         )
 
     async def _broadcast_event_update(

--- a/api/src/services/webhooks/protocol.py
+++ b/api/src/services/webhooks/protocol.py
@@ -145,6 +145,9 @@ class Deliver:
     raw_headers: dict[str, str] | None = None
     """Original request headers (for logging)."""
 
+    event_id: UUID | None = None
+    """Persisted event ID, populated by the event processor after ingestion."""
+
 
 @dataclass
 class Rejected:

--- a/api/tests/unit/routers/test_hooks_delivery_queueing.py
+++ b/api/tests/unit/routers/test_hooks_delivery_queueing.py
@@ -1,0 +1,54 @@
+"""Regression tests for exact webhook event-to-delivery queueing."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from src.routers.hooks import receive_webhook
+from src.services.webhooks.protocol import Deliver
+
+
+@pytest.mark.asyncio
+async def test_webhook_queues_the_exact_event_returned_by_the_processor():
+    """Concurrent webhooks must not re-query and queue the newest sibling event."""
+    source_id = uuid4()
+    exact_event_id = uuid4()
+    event_source = SimpleNamespace(id=source_id, is_active=True)
+    webhook_source = SimpleNamespace(
+        rate_limit_enabled=False,
+        rate_limit_per_minute=None,
+        rate_limit_window_seconds=60,
+    )
+    request = MagicMock()
+    request.method = "POST"
+    request.headers = {}
+    request.query_params = {}
+    request.client = None
+    request.body = AsyncMock(return_value=b"{}")
+    db = AsyncMock()
+
+    with (
+        patch(
+            "src.routers.hooks.resolve_webhook_source",
+            return_value=(event_source, webhook_source),
+        ),
+        patch("src.routers.hooks.EventProcessor") as processor_class,
+    ):
+        processor = processor_class.return_value
+        processor.process_webhook = AsyncMock(
+            return_value=Deliver(
+                data={"alert": "one of two simultaneous requests"},
+                event_type="alert",
+                event_id=exact_event_id,
+            )
+        )
+        processor.queue_event_deliveries = AsyncMock(return_value=1)
+
+        response = await receive_webhook(str(source_id), request, db)
+
+    assert response.status_code == 202
+    processor.queue_event_deliveries.assert_awaited_once_with(exact_event_id)
+    db.execute.assert_not_awaited()
+    assert db.commit.await_count == 2

--- a/api/tests/unit/services/events/test_processor_delivery.py
+++ b/api/tests/unit/services/events/test_processor_delivery.py
@@ -1,0 +1,42 @@
+import uuid
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.services.events import processor as p
+from src.services.webhooks.protocol import Deliver, WebhookRequest
+
+
+@pytest.mark.asyncio
+async def test_process_delivery_returns_the_exact_persisted_event_id():
+    session = AsyncMock()
+    session.add = MagicMock()
+    processor = p.EventProcessor(session)
+    workflow_id = uuid.uuid4()
+    subscription = SimpleNamespace(
+        id=uuid.uuid4(),
+        target_type="workflow",
+        agent_id=None,
+        filter_expression=None,
+        workflow_id=workflow_id,
+        workflow=SimpleNamespace(id=workflow_id),
+    )
+    processor._subscription_repo.get_active_for_event = AsyncMock(
+        return_value=[subscription]
+    )
+    processor._broadcast_event_update = AsyncMock()
+    event_source = SimpleNamespace(id=uuid.uuid4())
+    webhook_source = SimpleNamespace()
+    incoming = Deliver(data={"id": 1}, event_type="ticket.created")
+    request = WebhookRequest("POST", "/webhooks/source", {}, {}, b"{}")
+
+    result = await processor._process_delivery(
+        webhook_source=webhook_source,
+        event_source=event_source,
+        deliver=incoming,
+        request=request,
+    )
+
+    persisted_event = session.add.call_args_list[0].args[0]
+    assert result.event_id == persisted_event.id


### PR DESCRIPTION
Concurrent webhooks currently re-query the newest event for the source after ingestion. A sibling request can become that newest event, causing this request to queue the wrong delivery. Return the persisted event ID from the processor and queue that exact ID instead.

Includes regression tests for processor-to-router event correlation. Ported from Midtown-Technology-Group/bifrost commit de9aaf40b; only the relevant regression was retained from the deleted fork test file.

Sensitive path: webhook delivery and queue correlation. Subscription filtering and event transaction ordering are preserved.

Validation on pve-t340 VM 101: focused webhook regression tests and `./test.sh pre-pr` for the exact PR head.
