### PR TITLE
fix(oauth): serialize concurrent SDK token refreshes

### DIFF
--- a/api/src/repositories/oauth.py
+++ b/api/src/repositories/oauth.py
@@ -344,7 +344,7 @@ class OAuthTokenRepository(OrgScopedRepository[OAuthToken]):
         super().__init__(session, org_id, user_id, is_superuser, is_external)
 
     async def get_org_level_for_provider(
-        self, provider_id: UUID
+        self, provider_id: UUID, *, for_update: bool = False
     ) -> Any:
         """Get the org-level OAuth token for a provider (``user_id IS NULL``).
 
@@ -362,19 +362,23 @@ class OAuthTokenRepository(OrgScopedRepository[OAuthToken]):
 
         Args:
             provider_id: ``OAuthProvider`` UUID.
+            for_update: Lock the selected token row until the current
+                transaction completes. OAuth refresh callers use this to
+                serialize rotating refresh tokens.
 
         Returns:
             ``OAuthToken`` or ``None`` if not found in either scope.
         """
         # Try org-specific first (if we have an org).
         if self.org_id is not None:
-            result = await self.session.execute(
-                select(OAuthToken).where(
-                    OAuthToken.provider_id == provider_id,
-                    OAuthToken.organization_id == self.org_id,
-                    OAuthToken.user_id.is_(None),
-                )
+            query = select(OAuthToken).where(
+                OAuthToken.provider_id == provider_id,
+                OAuthToken.organization_id == self.org_id,
+                OAuthToken.user_id.is_(None),
             )
+            if for_update:
+                query = query.with_for_update()
+            result = await self.session.execute(query)
             token = result.scalars().first()
             if token is not None:
                 return token
@@ -385,11 +389,12 @@ class OAuthTokenRepository(OrgScopedRepository[OAuthToken]):
             return None
 
         # Fall back to global.
-        result = await self.session.execute(
-            select(OAuthToken).where(
-                OAuthToken.provider_id == provider_id,
-                OAuthToken.organization_id.is_(None),
-                OAuthToken.user_id.is_(None),
-            )
+        query = select(OAuthToken).where(
+            OAuthToken.provider_id == provider_id,
+            OAuthToken.organization_id.is_(None),
+            OAuthToken.user_id.is_(None),
         )
+        if for_update:
+            query = query.with_for_update()
+        result = await self.session.execute(query)
         return result.scalars().first()

--- a/api/src/routers/cli.py
+++ b/api/src/routers/cli.py
@@ -1401,7 +1401,13 @@ async def sdk_integrations_refresh_token(
         )
         stored_token = None
         if provider.oauth_flow_type == "authorization_code":
-            stored_token = await token_repo.get_org_level_for_provider(provider.id)
+            # Providers may rotate refresh tokens. Hold a row lock through
+            # refresh + persistence so concurrent workflow 401 retries cannot
+            # both submit the same one-time refresh token.
+            stored_token = await token_repo.get_org_level_for_provider(
+                provider.id,
+                for_update=True,
+            )
             if not stored_token or not stored_token.encrypted_refresh_token:
                 raise HTTPException(
                     status_code=status.HTTP_400_BAD_REQUEST,

--- a/api/tests/unit/repositories/test_oauth_repository.py
+++ b/api/tests/unit/repositories/test_oauth_repository.py
@@ -158,6 +158,41 @@ class TestOAuthTokenRepositoryCrossTenantIsolation:
         # Only the global query; org-specific is skipped when org_id is None.
         assert session.execute.call_count == 1
 
+    async def test_for_update_locks_the_selected_token_row(self, session) -> None:
+        """Rotating refresh-token callers can serialize on the token row."""
+        provider_id = uuid4()
+        global_token = MagicMock(organization_id=None)
+        session.execute.return_value = _result_returning(global_token)
+
+        repo = OAuthTokenRepository(session, org_id=None, is_superuser=True)
+        result = await repo.get_org_level_for_provider(
+            provider_id,
+            for_update=True,
+        )
+
+        assert result is global_token
+        query = str(session.execute.call_args.args[0])
+        assert "FOR UPDATE" in query
+
+    async def test_for_update_locks_org_token_without_global_fallback(
+        self, session
+    ) -> None:
+        """An org token wins and is locked before any global lookup."""
+        provider_id = uuid4()
+        org_token = MagicMock(organization_id=ORG_A)
+        session.execute.return_value = _result_returning(org_token)
+
+        repo = OAuthTokenRepository(session, org_id=ORG_A, is_superuser=True)
+        result = await repo.get_org_level_for_provider(
+            provider_id,
+            for_update=True,
+        )
+
+        assert result is org_token
+        assert session.execute.call_count == 1
+        query = str(session.execute.call_args.args[0])
+        assert "FOR UPDATE" in query
+
 
 class TestOAuthProviderRepositoryCascade:
     """Provider lookup also gets cascade for the same reasons as token."""

--- a/api/tests/unit/routers/test_cli_refresh_token.py
+++ b/api/tests/unit/routers/test_cli_refresh_token.py
@@ -250,6 +250,8 @@ class TestRefreshTokenAuthorizationCode:
             result = await sdk_integrations_refresh_token(request, mock_user, mock_db)
 
         assert result.access_token == "refreshed-ms-token"
+        token_query = str(mock_db.execute.call_args_list[1].args[0])
+        assert "FOR UPDATE" in token_query
         mock_instance.refresh_access_token.assert_called_once()
 
     @pytest.mark.asyncio


### PR DESCRIPTION
Concurrent SDK refresh requests can submit the same rotating OAuth refresh token before either request persists its replacement. Lock the selected authorization-code token row through refresh and commit so SDK refresh requests serialize against the latest persisted token.

Preserves organization-token precedence, external-caller scope restrictions, client-credentials behavior, and upstream response contracts. Includes repository and SDK endpoint regression coverage. Ported from Midtown-Technology-Group/bifrost commit b9e206ad1.

Sensitive path: OAuth token refresh and multi-tenant token selection. This patch addresses concurrent SDK refresh requests; it does not redesign the other refresh entry points.

Validation on pve-t340 VM 101: OAuth repository and SDK refresh tests and `./test.sh pre-pr` for the exact PR head.
