### PR TITLE
fix(artifacts): force browser-active content to download

### DIFF
--- a/api/src/routers/chat.py
+++ b/api/src/routers/chat.py
@@ -572,7 +572,7 @@ async def get_attachment_content(
     if attachment is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Attachment not found")
 
-    from src.services.artifacts import ArtifactService
+    from src.services.artifacts import ArtifactService, is_browser_active_content_type
 
     artifact = await db.get(Artifact, attachment.artifact_id)
     if artifact is None:
@@ -597,7 +597,11 @@ async def get_attachment_content(
                     "X-Content-Type-Options": "nosniff",
                 },
             )
-    disposition = "attachment" if download else "inline"
+    disposition = (
+        "attachment"
+        if download or is_browser_active_content_type(attachment.content_type)
+        else "inline"
+    )
     encoded_filename = quote(attachment.filename, safe="")
     return Response(
         content=content,

--- a/api/src/routers/cli.py
+++ b/api/src/routers/cli.py
@@ -2447,10 +2447,10 @@ async def sdk_artifact_download_url(
 ) -> ArtifactDownloadResponse:
     """Create a short-lived download URL for an opaque artifact."""
     from src.services.artifacts import ArtifactAccessError, ArtifactService
-    from src.services.file_storage.service import get_file_storage_service
 
     try:
-        artifact = await ArtifactService(db).get_authorized(
+        service = ArtifactService(db)
+        artifact = await service.get_authorized(
             artifact_id,
             user_id=current_user.user_id,
             organization_id=current_user.organization_id,
@@ -2460,9 +2460,7 @@ async def sdk_artifact_download_url(
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)
         ) from exc
-    url = await get_file_storage_service(db).generate_presigned_download_url(
-        artifact.s3_key
-    )
+    url = await service.generate_download_url(artifact)
     return ArtifactDownloadResponse(url=url)
 
 

--- a/api/src/routers/cli.py
+++ b/api/src/routers/cli.py
@@ -2391,7 +2391,11 @@ async def sdk_read_artifact(
     preview: bool = False,
 ) -> Response:
     """Read an opaque artifact after enforcing caller scope."""
-    from src.services.artifacts import ArtifactAccessError, ArtifactService
+    from src.services.artifacts import (
+        ArtifactAccessError,
+        ArtifactService,
+        is_browser_active_content_type,
+    )
 
     service = ArtifactService(db)
     try:
@@ -2425,10 +2429,13 @@ async def sdk_read_artifact(
                     "X-Content-Type-Options": "nosniff",
                 },
             )
+    headers = {"X-Content-Type-Options": "nosniff"}
+    if is_browser_active_content_type(artifact.content_type):
+        headers["Content-Disposition"] = "attachment"
     return Response(
         content=content,
         media_type=artifact.content_type,
-        headers={"X-Content-Type-Options": "nosniff"},
+        headers=headers,
     )
 
 

--- a/api/src/services/artifacts.py
+++ b/api/src/services/artifacts.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import mimetypes
 from pathlib import PurePosixPath
 from uuid import UUID, uuid4
 
@@ -11,6 +12,33 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from src.models.contracts.artifacts import ArtifactRef
 from src.models.orm import Artifact
 from src.services.file_storage.service import get_file_storage_service
+
+
+_BROWSER_ACTIVE_CONTENT_TYPES = {
+    "application/xhtml+xml",
+    "application/xml",
+    "image/svg+xml",
+    "text/html",
+    "text/xml",
+}
+
+
+def is_browser_active_content_type(content_type: str) -> bool:
+    """Return whether a media type can render active browser content."""
+    base_content_type = content_type.partition(";")[0].strip().lower()
+    return (
+        base_content_type in _BROWSER_ACTIVE_CONTENT_TYPES
+        or base_content_type.endswith("+xml")
+    )
+
+
+def artifact_requires_inert_storage(filename: str, content_type: str) -> bool:
+    """Return whether declared or filename-derived metadata is browser-active."""
+    inferred_content_type, _encoding = mimetypes.guess_type(filename)
+    return is_browser_active_content_type(content_type) or (
+        inferred_content_type is not None
+        and is_browser_active_content_type(inferred_content_type)
+    )
 
 
 class ArtifactAccessError(ValueError):
@@ -73,7 +101,17 @@ class ArtifactService:
             prefix = "_attachments" if storage_family == "upload" else "_artifacts"
             s3_key = f"{prefix}/{artifact_id}_{safe_name}"
         storage = get_file_storage_service(self.db)
-        await storage.write_raw_to_s3(s3_key, content)
+        if artifact_requires_inert_storage(filename, content_type):
+            async def content_chunks():
+                yield content
+
+            await storage.write_raw_chunks_to_s3(
+                s3_key,
+                content_chunks(),
+                content_type="application/octet-stream",
+            )
+        else:
+            await storage.write_raw_to_s3(s3_key, content)
         artifact = Artifact(
             id=artifact_id,
             organization_id=organization_id,

--- a/api/src/services/artifacts.py
+++ b/api/src/services/artifacts.py
@@ -209,6 +209,22 @@ class ArtifactService:
             artifact.s3_key
         )
 
+    async def generate_download_url(self, artifact: Artifact) -> str:
+        """Generate a URL that keeps browser-active artifacts inert."""
+        storage = get_file_storage_service(self.db)
+        if artifact_requires_inert_storage(
+            artifact.filename,
+            artifact.content_type,
+        ):
+            return await storage.generate_presigned_download_url(
+                artifact.s3_key,
+                response_content_type="application/octet-stream",
+                response_content_disposition="attachment",
+            )
+        return await storage.generate_presigned_download_url(
+            artifact.s3_key,
+        )
+
     async def delete(self, artifact: Artifact) -> None:
         await get_file_storage_service(self.db).delete_raw_from_s3(artifact.s3_key)
         await self.db.delete(artifact)

--- a/api/src/services/file_storage/s3_client.py
+++ b/api/src/services/file_storage/s3_client.py
@@ -132,6 +132,9 @@ class S3StorageClient:
         self,
         path: str,
         expires_in: int = 600,
+        *,
+        response_content_type: str | None = None,
+        response_content_disposition: str | None = None,
     ) -> str:
         """
         Generate a presigned GET URL for direct S3 download.
@@ -143,13 +146,19 @@ class S3StorageClient:
         Returns:
             Presigned GET URL for direct download
         """
+        params = {
+            "Bucket": self.settings.s3_bucket,
+            "Key": path,
+        }
+        if response_content_type is not None:
+            params["ResponseContentType"] = response_content_type
+        if response_content_disposition is not None:
+            params["ResponseContentDisposition"] = response_content_disposition
+
         async with self.get_client() as s3:
             url = await s3.generate_presigned_url(
                 "get_object",
-                Params={
-                    "Bucket": self.settings.s3_bucket,
-                    "Key": path,
-                },
+                Params=params,
                 ExpiresIn=expires_in,
             )
         return self._rewrite_presigned_url(url)

--- a/api/src/services/file_storage/service.py
+++ b/api/src/services/file_storage/service.py
@@ -237,11 +237,16 @@ class FileStorageService:
         self,
         path: str,
         expires_in: int = 600,
+        *,
+        response_content_type: str | None = None,
+        response_content_disposition: str | None = None,
     ) -> str:
         """Generate a presigned GET URL for direct S3 download."""
         return await self._s3_storage.generate_presigned_download_url(
             path=path,
             expires_in=expires_in,
+            response_content_type=response_content_type,
+            response_content_disposition=response_content_disposition,
         )
 
     async def record_signed_upload_metadata(

--- a/api/src/services/mcp_server/server.py
+++ b/api/src/services/mcp_server/server.py
@@ -608,9 +608,6 @@ if HAS_FASTMCP:
                             ArtifactAccessError,
                             ArtifactService,
                         )
-                        from src.services.file_storage.service import (
-                            get_file_storage_service,
-                        )
 
                         content_blocks: list[Any] = [
                             TextContent(
@@ -619,7 +616,6 @@ if HAS_FASTMCP:
                             )
                         ]
                         async with get_db_context() as db:
-                            storage = get_file_storage_service(db)
                             artifact_service = ArtifactService(db)
                             for ref in artifact_refs:
                                 try:
@@ -648,8 +644,8 @@ if HAS_FASTMCP:
                                         )
                                     )
                                 else:
-                                    url = await storage.generate_presigned_download_url(
-                                        artifact.s3_key
+                                    url = await artifact_service.generate_download_url(
+                                        artifact
                                     )
                                     content_blocks.append(
                                         ResourceLink(

--- a/api/tests/e2e/api/test_chat.py
+++ b/api/tests/e2e/api/test_chat.py
@@ -206,6 +206,40 @@ class TestChatAttachments:
         missing = e2e_client.get(content_url, headers=platform_admin.headers)
         assert missing.status_code == 404
 
+    def test_html_attachment_content_is_always_downloaded(
+        self,
+        e2e_client,
+        platform_admin,
+        test_conversation,
+    ):
+        auth_headers = {"Authorization": platform_admin.headers["Authorization"]}
+        upload = e2e_client.post(
+            f"/api/chat/conversations/{test_conversation['id']}/attachments",
+            files=[
+                (
+                    "files",
+                    (
+                        "unsafe.html",
+                        b"<script>alert(1)</script>",
+                        "text/html; charset=utf-8",
+                    ),
+                )
+            ],
+            headers=auth_headers,
+        )
+        assert upload.status_code == 200, upload.text
+        attachment = upload.json()["attachments"][0]
+
+        content = e2e_client.get(
+            f"/api/chat/conversations/{test_conversation['id']}"
+            f"/attachments/{attachment['id']}/content",
+            headers=platform_admin.headers,
+        )
+
+        assert content.status_code == 200, content.text
+        assert content.headers["content-type"] == "text/html; charset=utf-8"
+        assert content.headers["content-disposition"].startswith("attachment;")
+
     def test_sdk_document_artifact_returns_readable_opaque_reference(
         self,
         e2e_client,
@@ -284,6 +318,67 @@ class TestChatAttachments:
         )
         assert workspace.status_code == 200, workspace.text
         assert workspace.json() == [ref]
+
+    def test_sdk_serves_html_artifacts_as_downloads(
+        self,
+        e2e_client,
+        platform_admin,
+    ):
+        upload_headers = {
+            key: value
+            for key, value in platform_admin.headers.items()
+            if key.lower() != "content-type"
+        }
+        stored = e2e_client.post(
+            "/api/sdk/artifacts",
+            files={
+                "file": (
+                    "Unsafe.html",
+                    b"<script>window.parent.location='/settings'</script>",
+                    "text/html; charset=utf-8",
+                )
+            },
+            headers=upload_headers,
+        )
+
+        assert stored.status_code == 200, stored.text
+        content = e2e_client.get(
+            f"/api/sdk/artifacts/{stored.json()['id']}/content",
+            headers=platform_admin.headers,
+        )
+        assert content.status_code == 200, content.text
+        assert content.headers["content-type"] == "text/html; charset=utf-8"
+        assert content.headers["content-disposition"] == "attachment"
+
+    def test_sdk_serves_browser_active_xml_artifacts_as_downloads(
+        self,
+        e2e_client,
+        platform_admin,
+    ):
+        upload_headers = {
+            key: value
+            for key, value in platform_admin.headers.items()
+            if key.lower() != "content-type"
+        }
+        stored = e2e_client.post(
+            "/api/sdk/artifacts",
+            files={
+                "file": (
+                    "active.xml",
+                    b"<svg></svg>",
+                    "text/xml; charset=utf-8",
+                )
+            },
+            headers=upload_headers,
+        )
+
+        assert stored.status_code == 200, stored.text
+        content = e2e_client.get(
+            f"/api/sdk/artifacts/{stored.json()['id']}/content",
+            headers=platform_admin.headers,
+        )
+        assert content.status_code == 200, content.text
+        assert content.headers["content-disposition"] == "attachment"
 
     @pytest.mark.asyncio
     async def test_artifact_library_lists_renames_and_deletes_owned_files(

--- a/api/tests/e2e/api/test_chat.py
+++ b/api/tests/e2e/api/test_chat.py
@@ -6,6 +6,7 @@ Requires LLM configuration to be set for message sending tests.
 """
 
 import logging
+from urllib.parse import parse_qs, urlparse
 from uuid import UUID, uuid4
 
 import pytest
@@ -349,6 +350,15 @@ class TestChatAttachments:
         assert content.status_code == 200, content.text
         assert content.headers["content-type"] == "text/html; charset=utf-8"
         assert content.headers["content-disposition"] == "attachment"
+
+        download = e2e_client.get(
+            f"/api/sdk/artifacts/{stored.json()['id']}/download-url",
+            headers=platform_admin.headers,
+        )
+        assert download.status_code == 200, download.text
+        query = parse_qs(urlparse(download.json()["url"]).query)
+        assert query["response-content-type"] == ["application/octet-stream"]
+        assert query["response-content-disposition"] == ["attachment"]
 
     def test_sdk_serves_browser_active_xml_artifacts_as_downloads(
         self,

--- a/api/tests/unit/scheduler/test_leadership.py
+++ b/api/tests/unit/scheduler/test_leadership.py
@@ -4,6 +4,7 @@ import asyncio
 from contextlib import asynccontextmanager
 from datetime import timedelta
 from typing import AsyncGenerator
+from uuid import uuid4
 
 import pytest
 import pytest_asyncio
@@ -12,10 +13,7 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from src.models.orm.scheduler_leases import SchedulerLease
 from src.scheduler import leadership
-from src.scheduler.leadership import (
-    TRIGGER_LEASE_NAME,
-    SchedulerLeadershipLease,
-)
+from src.scheduler.leadership import SchedulerLeadershipLease
 
 
 @pytest_asyncio.fixture(autouse=True)
@@ -23,6 +21,9 @@ async def scheduler_lease_context(
     async_session_factory: async_sessionmaker[AsyncSession],
     monkeypatch: pytest.MonkeyPatch,
 ):
+    test_lease_name = f"scheduler-triggers-test-{uuid4()}"
+    monkeypatch.setattr(leadership, "TRIGGER_LEASE_NAME", test_lease_name)
+
     @asynccontextmanager
     async def test_context() -> AsyncGenerator[AsyncSession, None]:
         async with async_session_factory() as session:
@@ -35,10 +36,14 @@ async def scheduler_lease_context(
 
     monkeypatch.setattr(leadership, "get_db_context", test_context)
     async with test_context() as db:
-        await db.execute(delete(SchedulerLease))
+        await db.execute(
+            delete(SchedulerLease).where(SchedulerLease.name == test_lease_name)
+        )
     yield
     async with test_context() as db:
-        await db.execute(delete(SchedulerLease))
+        await db.execute(
+            delete(SchedulerLease).where(SchedulerLease.name == test_lease_name)
+        )
 
 
 @pytest.mark.asyncio
@@ -70,7 +75,7 @@ async def test_expired_generation_cannot_renew_or_release_new_leader() -> None:
     async with leadership.get_db_context() as db:
         await db.execute(
             update(SchedulerLease)
-            .where(SchedulerLease.name == TRIGGER_LEASE_NAME)
+            .where(SchedulerLease.name == leadership.TRIGGER_LEASE_NAME)
             .values(lease_expires_at=func.now() - timedelta(seconds=1))
         )
 

--- a/api/tests/unit/services/mcp_server/test_artifact_results.py
+++ b/api/tests/unit/services/mcp_server/test_artifact_results.py
@@ -44,12 +44,6 @@ async def test_workflow_artifact_results_become_mcp_media_and_resources(
     async def fake_db_context():
         yield object()
 
-    storage = AsyncMock()
-    storage.read_uploaded_file.return_value = b"png-data"
-    storage.generate_presigned_download_url.return_value = (
-        "https://files.example.test/brief.pdf"
-    )
-
     class FakeArtifactService:
         def __init__(self, db) -> None:
             pass
@@ -64,16 +58,14 @@ async def test_workflow_artifact_results_become_mcp_media_and_resources(
         async def read(self, artifact):
             return b"png-data"
 
+        async def generate_download_url(self, artifact):
+            return "https://files.example.test/brief.pdf"
+
     monkeypatch.setattr("src.core.database.get_db_context", fake_db_context)
     monkeypatch.setattr(
         "src.services.artifacts.ArtifactService",
         FakeArtifactService,
     )
-    monkeypatch.setattr(
-        "src.services.file_storage.service.get_file_storage_service",
-        lambda db: storage,
-    )
-
     tool = server.WorkflowTool(
         name="create_brief",
         description="Create files",

--- a/api/tests/unit/test_artifact_storage_safety.py
+++ b/api/tests/unit/test_artifact_storage_safety.py
@@ -1,0 +1,130 @@
+from uuid import uuid4
+
+import pytest
+
+from src.services.artifacts import ArtifactService, is_browser_active_content_type
+
+
+class _FakeDB:
+    def __init__(self) -> None:
+        self.added = []
+
+    def add(self, value) -> None:
+        self.added.append(value)
+
+    async def flush(self) -> None:
+        return None
+
+
+class _FakeStorage:
+    def __init__(self) -> None:
+        self.raw_writes = []
+        self.chunk_writes = []
+
+    async def write_raw_to_s3(self, path: str, content: bytes) -> None:
+        self.raw_writes.append((path, content))
+
+    async def write_raw_chunks_to_s3(
+        self,
+        path: str,
+        chunks,
+        *,
+        content_type: str | None = None,
+    ):
+        payload = b"".join([chunk async for chunk in chunks])
+        self.chunk_writes.append((path, payload, content_type))
+        return "unused", len(payload)
+
+    async def delete_raw_from_s3(self, path: str) -> None:
+        return None
+
+
+@pytest.mark.parametrize(
+    "content_type",
+    [
+        "text/html; charset=utf-8",
+        "Text/XML",
+        "image/svg+xml",
+        "application/atom+xml",
+    ],
+)
+def test_browser_active_media_types_are_classified(content_type):
+    assert is_browser_active_content_type(content_type)
+
+
+@pytest.mark.asyncio
+async def test_html_artifacts_are_stored_with_inert_object_content_type(monkeypatch):
+    """Direct object-storage URLs must not render HTML as active browser content."""
+    storage = _FakeStorage()
+    monkeypatch.setattr(
+        "src.services.artifacts.get_file_storage_service",
+        lambda _db: storage,
+    )
+
+    artifact = await ArtifactService(_FakeDB()).store(
+        filename="Unsafe.html",
+        content_type="text/html; charset=utf-8",
+        content=b"<script>alert(document.domain)</script>",
+        created_by_user_id=uuid4(),
+        organization_id=None,
+    )
+
+    assert artifact.content_type == "text/html; charset=utf-8"
+    assert storage.raw_writes == []
+    assert len(storage.chunk_writes) == 1
+    _path, payload, object_content_type = storage.chunk_writes[0]
+    assert payload == b"<script>alert(document.domain)</script>"
+    assert object_content_type == "application/octet-stream"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("filename", "content_type"),
+    [
+        ("diagram.svg", "text/plain"),
+        ("feed.txt", "Application/Atom+XML; Charset=UTF-8"),
+    ],
+)
+async def test_browser_active_declared_or_inferred_types_use_inert_storage(
+    monkeypatch,
+    filename,
+    content_type,
+):
+    storage = _FakeStorage()
+    monkeypatch.setattr(
+        "src.services.artifacts.get_file_storage_service",
+        lambda _db: storage,
+    )
+
+    await ArtifactService(_FakeDB()).store(
+        filename=filename,
+        content_type=content_type,
+        content=b"<svg xmlns='http://www.w3.org/2000/svg'></svg>",
+        created_by_user_id=uuid4(),
+        organization_id=None,
+    )
+
+    assert storage.raw_writes == []
+    assert storage.chunk_writes[0][2] == "application/octet-stream"
+
+
+@pytest.mark.asyncio
+async def test_non_html_artifacts_keep_existing_storage_path(monkeypatch):
+    """The HTML hardening must not change ordinary artifact persistence."""
+    storage = _FakeStorage()
+    monkeypatch.setattr(
+        "src.services.artifacts.get_file_storage_service",
+        lambda _db: storage,
+    )
+
+    await ArtifactService(_FakeDB()).store(
+        filename="Notes.md",
+        content_type="text/markdown",
+        content=b"# Safe",
+        created_by_user_id=uuid4(),
+        organization_id=None,
+    )
+
+    assert len(storage.raw_writes) == 1
+    assert storage.raw_writes[0][1] == b"# Safe"
+    assert storage.chunk_writes == []

--- a/api/tests/unit/test_artifact_storage_safety.py
+++ b/api/tests/unit/test_artifact_storage_safety.py
@@ -1,3 +1,4 @@
+from types import SimpleNamespace
 from uuid import uuid4
 
 import pytest
@@ -20,6 +21,7 @@ class _FakeStorage:
     def __init__(self) -> None:
         self.raw_writes = []
         self.chunk_writes = []
+        self.download_urls = []
 
     async def write_raw_to_s3(self, path: str, content: bytes) -> None:
         self.raw_writes.append((path, content))
@@ -37,6 +39,10 @@ class _FakeStorage:
 
     async def delete_raw_from_s3(self, path: str) -> None:
         return None
+
+    async def generate_presigned_download_url(self, path: str, **kwargs) -> str:
+        self.download_urls.append((path, kwargs))
+        return "https://files.example.test/artifact"
 
 
 @pytest.mark.parametrize(
@@ -128,3 +134,51 @@ async def test_non_html_artifacts_keep_existing_storage_path(monkeypatch):
     assert len(storage.raw_writes) == 1
     assert storage.raw_writes[0][1] == b"# Safe"
     assert storage.chunk_writes == []
+
+
+@pytest.mark.asyncio
+async def test_existing_html_artifact_download_url_overrides_active_metadata(
+    monkeypatch,
+):
+    """Legacy objects must be inert even when their stored S3 metadata is active."""
+    storage = _FakeStorage()
+    monkeypatch.setattr(
+        "src.services.artifacts.get_file_storage_service",
+        lambda _db: storage,
+    )
+    artifact = SimpleNamespace(
+        s3_key="_artifacts/legacy_unsafe.html",
+        filename="unsafe.html",
+        content_type="text/html; charset=utf-8",
+    )
+
+    url = await ArtifactService(_FakeDB()).generate_download_url(artifact)
+
+    assert url == "https://files.example.test/artifact"
+    assert storage.download_urls == [
+        (
+            "_artifacts/legacy_unsafe.html",
+            {
+                "response_content_type": "application/octet-stream",
+                "response_content_disposition": "attachment",
+            },
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_safe_artifact_download_url_preserves_existing_metadata(monkeypatch):
+    storage = _FakeStorage()
+    monkeypatch.setattr(
+        "src.services.artifacts.get_file_storage_service",
+        lambda _db: storage,
+    )
+    artifact = SimpleNamespace(
+        s3_key="_artifacts/report.pdf",
+        filename="report.pdf",
+        content_type="application/pdf",
+    )
+
+    await ArtifactService(_FakeDB()).generate_download_url(artifact)
+
+    assert storage.download_urls == [("_artifacts/report.pdf", {})]


### PR DESCRIPTION
Supersedes #738 because GitHub rejected maintainer writes to the organization-owned fork even though `maintainerCanModify` is enabled.

Thomas Bray (@MTG-Thomas) authored the original artifact hardening in commit 3992287ac. This branch preserves that commit and its authorship, then adds the manual-review repair for already-stored browser-active artifacts reached through SDK/MCP presigned URLs. It also includes a scheduler leadership test-isolation repair exposed by the required pre-PR gate.

Validation for exact candidate `52214d992c0d4f3e3f971cb751c674f58fa96554`:
- focused artifact unit/E2E/MCP tests: 14 passed
- scheduler leadership tests: 2 passed
- API quality: passed
- `./test.sh pre-pr`: passed