### PR TITLE
fix(events): give delivery retries a fresh timeout window

### DIFF
--- a/api/alembic/versions/20260825_event_delivery_attempt_started.py
+++ b/api/alembic/versions/20260825_event_delivery_attempt_started.py
@@ -1,0 +1,36 @@
+"""Track the active attempt age for retried event deliveries.
+
+Revision ID: 20260825_delivery_attempt
+Revises: 20260912_document_prefix_index
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "20260825_delivery_attempt"
+down_revision: str | Sequence[str] = "20260912_document_prefix_index"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "event_deliveries",
+        sa.Column("attempt_started_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.create_index(
+        "ix_event_deliveries_active_attempt_age",
+        "event_deliveries",
+        [sa.text("COALESCE(attempt_started_at, created_at)")],
+        postgresql_where=sa.text("status IN ('pending', 'queued')"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_event_deliveries_active_attempt_age",
+        table_name="event_deliveries",
+    )
+    op.drop_column("event_deliveries", "attempt_started_at")

--- a/api/src/models/orm/events.py
+++ b/api/src/models/orm/events.py
@@ -430,6 +430,9 @@ class EventDelivery(Base):
     # Retry tracking (for future use)
     attempt_count: Mapped[int] = mapped_column(Integer, default=0)
     next_retry_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), default=None)
+    attempt_started_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), default=None
+    )
     completed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), default=None)
 
     # Audit

--- a/api/src/repositories/events.py
+++ b/api/src/repositories/events.py
@@ -587,6 +587,12 @@ class EventDeliveryRepository(BaseRepository[EventDelivery]):
                     EventDeliveryStatus.QUEUED,
                 ])
             )
-            .where(EventDelivery.created_at < cutoff)
+            .where(
+                func.coalesce(
+                    EventDelivery.attempt_started_at,
+                    EventDelivery.created_at,
+                )
+                < cutoff
+            )
         )
         return result.unique().scalars().all()

--- a/api/src/routers/events.py
+++ b/api/src/routers/events.py
@@ -1554,26 +1554,8 @@ async def retry_delivery(
         )
 
     # Reset delivery status to pending
-    delivery.status = EventDeliveryStatus.PENDING
-    delivery.error_message = None
-    delivery.execution_id = None
-    await db.flush()
-
-    # Queue the execution
     processor = EventProcessor(db)
-    try:
-        await processor.queue_event_deliveries(delivery.event_id)
-        message = "Delivery queued for retry"
-    except Exception as e:
-        error_message = format_exception_message(
-            e,
-            context="queueing event delivery retry",
-        )
-        logger.error(f"Failed to queue retry: {error_message}", exc_info=True)
-        delivery.status = EventDeliveryStatus.FAILED
-        delivery.error_message = error_message
-        await db.flush()
-        message = f"Failed to queue retry: {error_message}"
+    message = await processor.retry_delivery(delivery)
 
     logger.info(f"Retried delivery {log_safe(delivery_id)}")
 

--- a/api/src/services/events/processor.py
+++ b/api/src/services/events/processor.py
@@ -280,6 +280,27 @@ class EventProcessor:
             filter_decision.matches,
         )
 
+    async def retry_delivery(self, delivery: EventDelivery) -> str:
+        """Reset and queue one failed delivery as a new timed attempt."""
+        delivery.status = EventDeliveryStatus.PENDING
+        delivery.error_message = None
+        delivery.execution_id = None
+        delivery.completed_at = None
+        delivery.attempt_started_at = datetime.now(timezone.utc)
+        await self.session.flush()
+
+        try:
+            await self.queue_event_deliveries(delivery.event_id)
+            return "Delivery queued for retry"
+        except Exception as exc:
+            error_message = format_exception_message(exc, context="queueing event delivery retry")
+            logger.error("Failed to queue retry: %s", error_message, exc_info=True)
+            delivery.status = EventDeliveryStatus.FAILED
+            delivery.error_message = error_message
+            delivery.completed_at = datetime.now(timezone.utc)
+            await self.session.flush()
+            return f"Failed to queue retry: {error_message}"
+
     async def process_webhook(
         self,
         event_source: EventSource,

--- a/api/tests/e2e/api/test_event_retry_attempt_age.py
+++ b/api/tests/e2e/api/test_event_retry_attempt_age.py
@@ -1,0 +1,60 @@
+"""An old delivery must receive a fresh timeout window when retried."""
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock
+from uuid import UUID, uuid4
+
+import pytest
+
+from src.models.enums import EventDeliveryStatus
+from src.models.orm.events import Event, EventDelivery
+from src.repositories.events import EventDeliveryRepository
+from src.routers.events import retry_delivery
+from src.services.events.processor import EventProcessor
+from tests.e2e.api.test_events import (
+    event_source as event_source,
+    subscription as subscription,
+    test_workflow as test_workflow,
+)
+
+
+@pytest.mark.e2e
+@pytest.mark.asyncio
+async def test_retry_timeout_uses_attempt_age(
+    event_source, subscription, test_workflow, db_session, monkeypatch
+):
+    old = datetime.now(timezone.utc) - timedelta(days=1)
+    event = Event(
+        id=uuid4(),
+        event_source_id=UUID(event_source["id"]),
+        event_type="retry.age",
+        received_at=old,
+        data={},
+    )
+    delivery = EventDelivery(
+        id=uuid4(),
+        event_id=event.id,
+        event_subscription_id=UUID(subscription["id"]),
+        workflow_id=UUID(test_workflow["id"]),
+        status=EventDeliveryStatus.FAILED,
+        created_at=old,
+        completed_at=old,
+    )
+    db_session.add_all([event, delivery])
+    await db_session.flush()
+    monkeypatch.setattr(EventProcessor, "queue_event_deliveries", AsyncMock(return_value=1))
+
+    response = await retry_delivery(delivery.id, None, None, db_session)
+
+    assert response.status == "pending"
+    assert delivery.completed_at is None
+    repo = EventDeliveryRepository(db_session)
+    assert delivery.id not in {row.id for row in await repo.get_stuck_deliveries(15)}
+
+    delivery.attempt_started_at = old
+    await db_session.flush()
+    assert delivery.id in {row.id for row in await repo.get_stuck_deliveries(15)}
+
+    delivery.attempt_started_at = None
+    await db_session.flush()
+    assert delivery.id in {row.id for row in await repo.get_stuck_deliveries(15)}

--- a/api/tests/unit/services/test_event_delivery_retry.py
+++ b/api/tests/unit/services/test_event_delivery_retry.py
@@ -1,0 +1,44 @@
+"""Regression coverage for delivery attempt timestamps."""
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+
+from src.models.enums import EventDeliveryStatus
+from src.services.events.processor import EventProcessor
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("queue_error", [None, RuntimeError("queue down")])
+async def test_retry_delivery_starts_a_fresh_attempt(queue_error):
+    delivery = SimpleNamespace(
+        event_id=uuid4(),
+        status=EventDeliveryStatus.FAILED,
+        error_message="previous failure",
+        execution_id=uuid4(),
+        completed_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        attempt_started_at=None,
+    )
+    session = AsyncMock()
+    processor = EventProcessor(session)
+    processor.queue_event_deliveries = AsyncMock(side_effect=queue_error)
+    before = datetime.now(timezone.utc)
+
+    message = await processor.retry_delivery(delivery)
+
+    assert before <= delivery.attempt_started_at <= datetime.now(timezone.utc)
+    assert delivery.execution_id is None
+    processor.queue_event_deliveries.assert_awaited_once_with(delivery.event_id)
+    if queue_error is None:
+        assert message == "Delivery queued for retry"
+        assert delivery.status is EventDeliveryStatus.PENDING
+        assert delivery.error_message is None
+        assert delivery.completed_at is None
+    else:
+        assert message == "Failed to queue retry: queue down"
+        assert delivery.status is EventDeliveryStatus.FAILED
+        assert delivery.error_message == "queue down"
+        assert delivery.completed_at >= delivery.attempt_started_at


### PR DESCRIPTION
Retrying an old failed delivery resets its status but leaves timeout detection measuring from the original creation time. The cleanup scheduler can therefore immediately treat the new attempt as stuck.

Record the current attempt start, clear previous completion state, and measure active-delivery timeouts from the attempt timestamp with creation time retained for legacy rows. Keep retry lifecycle logic in the event processor and preserve upstream error formatting. The migration adds a nullable timestamp and a partial index and follows the current upstream migration head.

Includes unit coverage for successful and failed queueing plus a database regression covering a fresh retry, an expired attempt, and a legacy row. Ported from Midtown-Technology-Group/bifrost commit 07c5a7fa9; unrelated chat-test changes and deleted legacy test suites were excluded.

Sensitive paths: database migration and event delivery lifecycle. No API response contract change.

Validation on pve-t340 VM 101: delivery retry unit/database regressions and `./test.sh pre-pr` for the exact PR head.
